### PR TITLE
Migrate changeCSS() use of sidebarTextActiveBorder to CSS variable in utils/utils.jsx

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -187,6 +187,11 @@
     .team-sidebar {
         .team-wrapper {
             .team-container {
+                &::before,
+                &.active::before,
+                &.unread::before {
+                    background: var(--sidebar-text-active-border);
+                }
             }
         }
     }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -529,12 +529,6 @@ export function applyTheme(theme) {
         changeCss('.sidebar--left .nav-pills__container li .sidebar-item:hover, .sidebar--left .nav-pills__container li > .nav-more:hover, .app__body .modal .settings-modal .nav-pills>li:hover button', 'background:' + theme.sidebarTextHoverBg);
     }
 
-    if (theme.sidebarTextActiveBorder) {
-        changeCss('.multi-teams .team-sidebar .team-wrapper .team-container:before', 'background:' + theme.sidebarTextActiveBorder);
-        changeCss('.multi-teams .team-sidebar .team-wrapper .team-container.active:before', 'background:' + theme.sidebarTextActiveBorder);
-        changeCss('.multi-teams .team-sidebar .team-wrapper .team-container.unread:before', 'background:' + theme.sidebarTextActiveBorder);
-    }
-
     if (theme.sidebarTextActiveColor) {
         changeCss('.sidebar--left .nav-pills__container li.active .sidebar-item, .sidebar--left .nav-pills__container li.active .sidebar-item:hover, .sidebar--left .nav-pills__container li.active .sidebar-item:focus, .app__body .modal .settings-modal .nav-pills>li.active button, .app__body .modal .settings-modal .nav-pills>li.active button:hover, .app__body .modal .settings-modal .nav-pills>li.active button:active', 'color:' + theme.sidebarTextActiveColor);
         changeCss('.sidebar--left .nav li.active .sidebar-item, .sidebar--left .nav li.active .sidebar-item:hover, .sidebar--left .nav li.active .sidebar-item:focus', 'background:' + changeOpacity(theme.sidebarTextActiveColor, 0.1));


### PR DESCRIPTION
#### Summary

I've also deleted the last reference to sidebarTextActiveBorder in that statement even if there's no related ticket and updated CSS accordingly

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/15865
Fixes https://github.com/mattermost/mattermost-server/issues/15866

JIRA tickets:

* https://mattermost.atlassian.net/browse/MM-29454
* https://mattermost.atlassian.net/browse/MM-29455
