### PR TITLE
[MM-28714] Check if subscription is paid before showing any upgrade warnings

### DIFF
--- a/components/announcement_bar/cloud_announcement_bar/index.ts
+++ b/components/announcement_bar/cloud_announcement_bar/index.ts
@@ -9,6 +9,7 @@ import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general
 import {GenericAction} from 'mattermost-redux/types/actions';
 import {getStandardAnalytics} from 'mattermost-redux/actions/admin';
 import {makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
+import {getCloudSubscription} from 'mattermost-redux/actions/cloud';
 
 import {getCurrentUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 
@@ -28,6 +29,7 @@ function mapStateToProps(state: GlobalState) {
         userIsAdmin: isCurrentUserSystemAdmin(state),
         currentUser: getCurrentUser(state),
         isCloud: getLicense(state).Cloud === 'true',
+        subscription: state.entities.cloud.subscription,
         preferences: getCategory(state, Preferences.CLOUD_UPGRADE_BANNER),
     };
 }
@@ -39,6 +41,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
                 savePreferences,
                 getStandardAnalytics,
                 openModal,
+                getCloudSubscription,
             },
             dispatch,
         ),

--- a/components/announcement_bar/cloud_announcement_bar/user_limit_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_announcement_bar/user_limit_announcement_bar.tsx
@@ -29,7 +29,7 @@ type Props = {
     preferences: PreferenceType[];
     isCloud: boolean;
     analytics?: Dictionary<number | AnalyticsRow[]>;
-    subscription: Subscription;
+    subscription?: Subscription;
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => void;
         getStandardAnalytics: () => void;

--- a/components/announcement_bar/cloud_announcement_bar/user_limit_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_announcement_bar/user_limit_announcement_bar.tsx
@@ -65,6 +65,7 @@ export default class UserLimitAnnouncementBar extends React.PureComponent<Props>
     shouldShowBanner = () => {
         const {userLimit, analytics, userIsAdmin, isCloud, subscription} = this.props;
 
+        // Prevents banner flashes if the subscription hasn't been loaded yet
         if (subscription === null) {
             return false;
         }

--- a/components/announcement_bar/cloud_announcement_bar/user_limit_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_announcement_bar/user_limit_announcement_bar.tsx
@@ -7,6 +7,7 @@ import {PreferenceType} from 'mattermost-redux/types/preferences';
 import {UserProfile} from 'mattermost-redux/types/users';
 import {Dictionary} from 'mattermost-redux/types/utilities';
 import {AnalyticsRow} from 'mattermost-redux/types/admin';
+import {Subscription} from 'mattermost-redux/types/cloud';
 import {isEmpty} from 'lodash';
 
 import {t} from 'utils/i18n';
@@ -28,10 +29,12 @@ type Props = {
     preferences: PreferenceType[];
     isCloud: boolean;
     analytics?: Dictionary<number | AnalyticsRow[]>;
+    subscription: Subscription;
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => void;
         getStandardAnalytics: () => void;
-        openModal: (modalData: {modalId: string; dialogType: any; dialogProps?: any}) => void;
+        getCloudSubscription: () => void;
+        openModal: (modalData: { modalId: string; dialogType: any; dialogProps?: any }) => void;
     };
 };
 
@@ -39,6 +42,10 @@ export default class UserLimitAnnouncementBar extends React.PureComponent<Props>
     async componentDidMount() {
         if (isEmpty(this.props.analytics)) {
             await this.props.actions.getStandardAnalytics();
+        }
+
+        if (isEmpty(this.props.subscription)) {
+            await this.props.actions.getCloudSubscription();
         }
     }
 
@@ -56,7 +63,16 @@ export default class UserLimitAnnouncementBar extends React.PureComponent<Props>
     }
 
     shouldShowBanner = () => {
-        const {userLimit, analytics, userIsAdmin, isCloud} = this.props;
+        const {userLimit, analytics, userIsAdmin, isCloud, subscription} = this.props;
+
+        if (subscription === null) {
+            return false;
+        }
+
+        if (subscription?.is_paid_tier === 'true') {
+            return false;
+        }
+
         if (!isCloud) {
             return false;
         }

--- a/components/main_menu/index.jsx
+++ b/components/main_menu/index.jsx
@@ -14,6 +14,7 @@ import {
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {haveITeamPermission, haveICurrentTeamPermission, haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
+import {getCloudSubscription} from 'mattermost-redux/actions/cloud';
 
 import {isAdmin} from 'utils/utils.jsx';
 
@@ -103,6 +104,7 @@ function mapStateToProps(state) {
         showGettingStarted: showOnboarding(state),
         showNextStepsTips: showNextStepsTips(state),
         showNextSteps: showNextSteps(state),
+        subscription: state.entities.cloud.subscription,
     };
 }
 
@@ -115,6 +117,7 @@ function mapDispatchToProps(dispatch) {
             closeRightHandSide,
             closeRhsMenu,
             unhideNextSteps,
+            getCloudSubscription,
         }, dispatch),
     };
 }

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -130,7 +130,7 @@ class MainMenu extends React.PureComponent {
     }
 
     shouldShowUpgradeModal = () => {
-        if (this.props.subscription?.is_paid_tier === 'true') {
+        if (this.props.subscription?.is_paid_tier === 'true') { // eslint-disable-line camelcase
             return false;
         }
 

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -130,7 +130,7 @@ class MainMenu extends React.PureComponent {
     }
 
     shouldShowUpgradeModal = () => {
-        if (this.props.subscription.is_paid_tier === 'true') {
+        if (this.props.subscription?.is_paid_tier === 'true') {
             return false;
         }
 

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 import {injectIntl} from 'react-intl';
 import {Permissions} from 'mattermost-redux/constants';
 
+import {isEmpty} from 'lodash';
+
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {Constants, ModalIdentifiers} from 'utils/constants';
 import {intlShape} from 'utils/react_intl';
@@ -66,6 +68,7 @@ class MainMenu extends React.PureComponent {
         showGettingStarted: PropTypes.bool.isRequired,
         intl: intlShape.isRequired,
         showNextStepsTips: PropTypes.bool,
+        subscription: PropTypes.object,
         actions: PropTypes.shape({
             openModal: PropTypes.func.isRequred,
             showMentions: PropTypes.func,
@@ -73,6 +76,7 @@ class MainMenu extends React.PureComponent {
             closeRightHandSide: PropTypes.func.isRequired,
             closeRhsMenu: PropTypes.func.isRequired,
             unhideNextSteps: PropTypes.func.isRequired,
+            getCloudSubscription: PropTypes.func,
         }).isRequired,
     };
 
@@ -87,8 +91,11 @@ class MainMenu extends React.PureComponent {
         GlobalActions.toggleShortcutsModal();
     }
 
-    componentDidMount() {
+    async componentDidMount() {
         document.addEventListener('keydown', this.handleKeyDown);
+        if (isEmpty(this.props.subscription)) {
+            await this.props.actions.getCloudSubscription();
+        }
     }
 
     componentWillUnmount() {
@@ -123,6 +130,10 @@ class MainMenu extends React.PureComponent {
     }
 
     shouldShowUpgradeModal = () => {
+        if (this.props.subscription.is_paid_tier === 'true') {
+            return false;
+        }
+
         return (this.props.currentUsers >= this.props.userLimit) && (this.props.userLimit !== '0') && this.props.userIsAdmin;
     }
 


### PR DESCRIPTION
#### Summary
Now that we're storing whether a subscription is paid (upgraded) or not in stripe metadata, we can use that field override the displaying of any upgrade warnings. This PR will hide the banners along the top of the screen, as well as the upgrade modal (when clicking the invite people button when at or over the limit, as an administrator)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28714

#### Related Pull Requests
n/a
#### Screenshots
n/a