### PR TITLE
[MM-29453] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 533

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -188,6 +188,10 @@
         .team-wrapper {
             .team-container {
             }
+
+            .team-container::before {
+                background: var(--sidebar-text-active-border);
+            }
         }
     }
 }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -530,7 +530,6 @@ export function applyTheme(theme) {
     }
 
     if (theme.sidebarTextActiveBorder) {
-        changeCss('.multi-teams .team-sidebar .team-wrapper .team-container:before', 'background:' + theme.sidebarTextActiveBorder);
         changeCss('.multi-teams .team-sidebar .team-wrapper .team-container.active:before', 'background:' + theme.sidebarTextActiveBorder);
         changeCss('.multi-teams .team-sidebar .team-wrapper .team-container.unread:before', 'background:' + theme.sidebarTextActiveBorder);
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 533.
Change use of js variable `theme.sidebarTextActiveBorder` to css variable `--sidebar-text-active-border`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/15864
https://mattermost.atlassian.net/browse/MM-29453
