### PR TITLE
[GH-15899] migrated changeCss() to CSS variable

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1837,6 +1837,7 @@
     .post-collapse__show-more-button {
         @include single-transition(all, .15s, ease);
         @include border-radius(2px);
+        background: var(--center-channel-bg);
         border: 1px solid transparent;
         display: inline-block;
         flex-shrink: 0;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -666,7 +666,6 @@ export function applyTheme(theme) {
         );
 
         changeCss('.app__body .post-collapse__show-more-button:hover', `color:${theme.centerChannelBg}`);
-        changeCss('.app__body .post-collapse__show-more-button', `background:${theme.centerChannelBg}`);
     }
 
     if (theme.centerChannelColor) {


### PR DESCRIPTION
#### Summary
migrated changeCss() to CSS variable for `post-collapse__show-more-button`

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/15899

#### Related Pull Requests

#### Screenshots