### PR TITLE
migrate post and corresponding components to ts

### DIFF
--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -14,8 +14,8 @@ import * as Utils from 'utils/utils';
 export default class PostProfilePicture extends React.PureComponent {
     static propTypes = {
         compactDisplay: PropTypes.bool.isRequired,
-        enablePostIconOverride: PropTypes.bool.isRequired,
-        hasImageProxy: PropTypes.bool.isRequired,
+        enablePostIconOverride: PropTypes.bool,
+        hasImageProxy: PropTypes.bool,
         isBusy: PropTypes.bool,
         isRHS: PropTypes.bool,
         post: PropTypes.object.isRequired,
@@ -24,6 +24,7 @@ export default class PostProfilePicture extends React.PureComponent {
         isBot: PropTypes.bool,
         postIconOverrideURL: PropTypes.string,
         overwriteIcon: PropTypes.string,
+        userId: PropTypes.string,
     };
 
     static defaultProps = {

--- a/components/post_view/post/__snapshots__/post.test.tsx.snap
+++ b/components/post_view/post/__snapshots__/post.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Post should handle highlighting properly when jumping to pinned or flag
     onMouseOver={[Function]}
     onTouchStart={[Function]}
     role="listitem"
-    tabIndex="0"
+    tabIndex={0}
   >
     <Connect(injectIntl(PostPreHeader))
       isFlagged={true}
@@ -100,7 +100,7 @@ exports[`Post should handle highlighting properly when jumping to pinned or flag
     onMouseOver={[Function]}
     onTouchStart={[Function]}
     role="listitem"
-    tabIndex="0"
+    tabIndex={0}
   >
     <Connect(injectIntl(PostPreHeader))
       isFlagged={true}
@@ -180,7 +180,7 @@ exports[`Post should not remove post--highlight class after timeout so the class
     onMouseOver={[Function]}
     onTouchStart={[Function]}
     role="listitem"
-    tabIndex="0"
+    tabIndex={0}
   >
     <Connect(injectIntl(PostPreHeader))
       isFlagged={false}
@@ -260,7 +260,7 @@ exports[`Post should not remove post--highlight class after timeout so the class
     onMouseOver={[Function]}
     onTouchStart={[Function]}
     role="listitem"
-    tabIndex="0"
+    tabIndex={0}
   >
     <Connect(injectIntl(PostPreHeader))
       isFlagged={false}

--- a/components/post_view/post/index.test.ts
+++ b/components/post_view/post/index.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Post} from 'mattermost-redux/types/posts';
+
 import {isFirstReply} from './index';
 
 describe('isFirstReply', () => {
@@ -55,7 +57,7 @@ describe('isFirstReply', () => {
         },
     ]) {
         test(testCase.name, () => {
-            expect(isFirstReply(testCase.post, testCase.previousPost)).toBe(testCase.expected);
+            expect(isFirstReply(testCase.post as Post, (testCase.previousPost as any) as Post)).toBe(testCase.expected);
         });
     }
 });

--- a/components/post_view/post/index.ts
+++ b/components/post_view/post/index.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
 
 import {Posts} from 'mattermost-redux/constants';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
@@ -11,17 +10,26 @@ import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
+import {bindActionCreators, Dispatch} from 'redux';
+
+import {GenericAction} from 'mattermost-redux/types/actions';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+
+import {Post} from 'mattermost-redux/types/posts';
+
+import {makeCreateAriaLabelForPost, makeGetReplyCount} from 'utils/post_utils.jsx';
+
 import {markPostAsUnread} from 'actions/post_actions';
 import {selectPost, selectPostCard} from 'actions/views/rhs';
 
 import {isArchivedChannel} from 'utils/channel_utils';
 import {Preferences} from 'utils/constants';
-import {makeCreateAriaLabelForPost, makeGetReplyCount} from 'utils/post_utils.jsx';
 
-import Post from './post.jsx';
+import PostComponent from './post';
 
 // isFirstReply returns true when the given post a comment that isn't part of the same thread as the previous post.
-export function isFirstReply(post, previousPost) {
+export function isFirstReply(post: Post, previousPost: Post | null): boolean {
     if (post.root_id) {
         if (previousPost) {
             // Returns true as long as the previous post is part of a different thread
@@ -36,12 +44,18 @@ export function isFirstReply(post, previousPost) {
     return false;
 }
 
-function makeMapStateToProps() {
-    const getReplyCount = makeGetReplyCount();
-    const isPostCommentMention = makeIsPostCommentMention();
-    const createAriaLabelForPost = makeCreateAriaLabelForPost();
+type OwnProps = {
+    post?: Post;
+    postId: string
+    previousPostId?: string;
+}
 
-    return (state, ownProps) => {
+function makeMapStateToProps() {
+    const getReplyCount = makeGetReplyCount() as ((sate: GlobalState, post: Post) => number);
+    const isPostCommentMention = makeIsPostCommentMention();
+    const createAriaLabelForPost = makeCreateAriaLabelForPost() as ((sate: GlobalState, post: Post) => (...args: any[]) => any);
+
+    return (state: GlobalState, ownProps: OwnProps) => {
         const post = ownProps.post || getPost(state, ownProps.postId);
         const channel = getChannel(state, post.channel_id);
 
@@ -79,7 +93,7 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             selectPost,
@@ -89,4 +103,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(Post);
+export default connect(makeMapStateToProps, mapDispatchToProps)(PostComponent);

--- a/components/post_view/post/post.test.tsx
+++ b/components/post_view/post/post.test.tsx
@@ -3,6 +3,10 @@
 
 import React from 'react';
 
+import {Post as IPost} from 'mattermost-redux/types/posts';
+
+import {ShallowWrapper} from 'enzyme';
+
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import PostPreHeader from 'components/post_view/post_pre_header';
@@ -11,7 +15,7 @@ import Post from './post';
 
 describe('Post', () => {
     const baseProps = {
-        post: {id: 'post1', is_pinned: false},
+        post: {id: 'post1', is_pinned: false} as IPost,
         createAriaLabel: jest.fn(),
         currentUserId: 'user1',
         center: false,
@@ -63,13 +67,13 @@ describe('Post', () => {
 
     describe('getClassName', () => {
         test('should not show cursor pointer normally', () => {
-            const wrapper = shallowWithIntl(<Post {...baseProps}/>);
+            const wrapper: ShallowWrapper<any, any, any> = shallowWithIntl(<Post {...baseProps}/>);
 
             expect(wrapper.instance().getClassName(baseProps.post, false, false, false, false, false)).not.toContain('cursor--pointer');
         });
 
         test('should show cursor pointer when alt is held', () => {
-            const wrapper = shallowWithIntl(<Post {...baseProps}/>);
+            const wrapper: ShallowWrapper<any, any, any> = shallowWithIntl(<Post {...baseProps}/>);
 
             wrapper.setState({alt: true});
 
@@ -82,7 +86,7 @@ describe('Post', () => {
                 channelIsArchived: true,
             };
 
-            const wrapper = shallowWithIntl(<Post {...props}/>);
+            const wrapper: ShallowWrapper<any, any, any> = shallowWithIntl(<Post {...props}/>);
 
             wrapper.setState({alt: true});
 

--- a/components/post_view/post/post.tsx
+++ b/components/post_view/post/post.tsx
@@ -1,113 +1,122 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
 import React from 'react';
-import {injectIntl} from 'react-intl';
+import {injectIntl, IntlShape} from 'react-intl';
 
 import {Posts} from 'mattermost-redux/constants';
 import {isMeMessage as checkIsMeMessage} from 'mattermost-redux/utils/post_utils';
 
+import {Post as IPost} from 'mattermost-redux/types/posts';
+
 import * as PostUtils from 'utils/post_utils.jsx';
 import Constants, {A11yCustomEventTypes} from 'utils/constants';
-import {intlShape} from 'utils/react_intl';
 import PostProfilePicture from 'components/post_profile_picture';
 import PostBody from 'components/post_view/post_body';
 import PostHeader from 'components/post_view/post_header';
 import PostContext from 'components/post_view/post_context';
 import PostPreHeader from 'components/post_view/post_pre_header';
 
-class Post extends React.PureComponent {
-    static propTypes = {
+type Props = {
 
-        /**
+    /**
          * The post to render
          */
-        post: PropTypes.object.isRequired,
+    post: IPost,
 
-        /**
+    /**
          * The function to create an aria-label
          */
-        createAriaLabel: PropTypes.func.isRequired,
+    createAriaLabel: (int: IntlShape) => string,
 
-        /**
+    /**
          * The logged in user ID
          */
-        currentUserId: PropTypes.string.isRequired,
+    currentUserId: string,
 
-        /**
+    /**
          * Set to center the post
          */
-        center: PropTypes.bool,
+    center?: boolean,
 
-        /**
+    /**
          * Set to render post compactly
          */
-        compactDisplay: PropTypes.bool,
+    compactDisplay?: boolean,
 
-        /**
+    /**
          * Set to render a preview of the parent post above this reply
          */
-        isFirstReply: PropTypes.bool,
+    isFirstReply?: boolean,
 
-        /**
+    /**
          * Set to highlight the background of the post
          */
-        shouldHighlight: PropTypes.bool,
+    shouldHighlight?: boolean,
 
-        /**
+    /**
          * Set to render this post as if it was attached to the previous post
          */
-        consecutivePostByUser: PropTypes.bool,
+    consecutivePostByUser?: boolean,
 
-        /**
+    /**
          * Set if the previous post is a comment
          */
-        previousPostIsComment: PropTypes.bool,
+    previousPostIsComment?: boolean,
 
-        /*
+    /*
          * Function called when the post options dropdown is opened
          */
-        togglePostMenu: PropTypes.func,
+    togglePostMenu: (value: boolean) => void,
 
-        /**
+    /**
          * Set to render this comment as a mention
          */
-        isCommentMention: PropTypes.bool,
+    isCommentMention?: boolean,
 
-        /**
+    /**
          * The number of replies in the same thread as this post
          */
-        replyCount: PropTypes.number,
+    replyCount: number,
 
-        /**
+    /**
          * To Check if the current post is last in the list
          */
-        isLastPost: PropTypes.bool,
+    isLastPost?: boolean,
 
-        /**
+    /**
          * Whether or not the channel that contains this post is archived
          */
-        channelIsArchived: PropTypes.bool.isRequired,
+    channelIsArchived?: boolean,
 
-        intl: intlShape.isRequired,
-        actions: PropTypes.shape({
-            selectPost: PropTypes.func.isRequired,
-            selectPostCard: PropTypes.func.isRequired,
-            markPostAsUnread: PropTypes.func.isRequired,
-        }).isRequired,
+    intl: IntlShape,
+    actions: {
+        selectPost: (post: IPost) => void,
+        selectPostCard: (post: IPost) => void,
+        markPostAsUnread: (post: IPost) => void,
+    },
 
-        /*
+    /*
          * Set to mark the post as flagged
          */
-        isFlagged: PropTypes.bool.isRequired,
-    }
+    isFlagged: boolean,
+}
 
-    static defaultProps = {
-        post: {},
-    };
+type State = {
+    dropdownOpened: boolean,
+    hover: boolean,
+    alt: boolean,
+    a11yActive: boolean,
+    currentAriaLabel: string,
+    ariaHidden: boolean,
+    fadeOutHighlight: boolean,
+}
 
-    constructor(props) {
+class Post extends React.PureComponent<Props, State> {
+    private postRef: React.RefObject<HTMLDivElement>;
+    private highlightTimeout: NodeJS.Timeout | undefined;
+
+    constructor(props: Props) {
         super(props);
 
         this.postRef = React.createRef();
@@ -149,17 +158,19 @@ class Post extends React.PureComponent {
             this.postRef.current.removeEventListener(A11yCustomEventTypes.DEACTIVATE, this.handleA11yDeactivateEvent);
         }
 
-        clearTimeout(this.highlightTimeout);
+        if (this.highlightTimeout) {
+            clearTimeout(this.highlightTimeout);
+        }
     }
 
     componentDidUpdate() {
-        if (this.state.a11yActive) {
+        if (this.state.a11yActive && this.postRef.current) {
             this.postRef.current.dispatchEvent(new Event(A11yCustomEventTypes.UPDATE));
         }
     }
 
-    handleCommentClick = (e) => {
-        e.preventDefault();
+    handleCommentClick = () => {
+        // e.preventDefault();
 
         const post = this.props.post;
         if (!post) {
@@ -168,20 +179,20 @@ class Post extends React.PureComponent {
         this.props.actions.selectPost(post);
     }
 
-    handleCardClick = (post) => {
+    handleCardClick = (post: IPost) => {
         if (!post) {
             return;
         }
         this.props.actions.selectPostCard(post);
     }
 
-    handlePostClick = (e) => {
+    handlePostClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         const post = this.props.post;
         if (!post) {
             return;
         }
 
-        if (this.props.channelIsArchived || post.system_post_ids) {
+        if (this.props.channelIsArchived) {
             return;
         }
 
@@ -190,7 +201,7 @@ class Post extends React.PureComponent {
         }
     }
 
-    handleDropdownOpened = (opened) => {
+    handleDropdownOpened = (opened: boolean) => {
         if (this.props.togglePostMenu) {
             this.props.togglePostMenu(opened);
         }
@@ -200,7 +211,7 @@ class Post extends React.PureComponent {
         });
     }
 
-    hasSameRoot = (props) => {
+    hasSameRoot = (props: Props) => {
         const post = props.post;
 
         if (props.isFirstReply) {
@@ -214,7 +225,7 @@ class Post extends React.PureComponent {
         return false;
     }
 
-    getClassName = (post, isSystemMessage, isMeMessage, fromWebhook, fromAutoResponder, fromBot) => {
+    getClassName = (post: IPost, isSystemMessage: boolean, isMeMessage: boolean, fromWebhook: boolean, fromAutoResponder: boolean, fromBot: boolean) => {
         let className = 'post';
 
         if (post.failed || post.state === Posts.POST_DELETED) {
@@ -283,7 +294,7 @@ class Post extends React.PureComponent {
             className += ' post--pinned-or-flagged';
         }
 
-        if (this.state.alt && !(this.props.channelIsArchived || post.system_post_ids)) {
+        if (this.state.alt && !(this.props.channelIsArchived)) {
             className += ' cursor--pointer';
         }
 
@@ -298,7 +309,7 @@ class Post extends React.PureComponent {
         this.setState({hover: false});
     }
 
-    handleAlt = (e) => {
+    handleAlt = (e: KeyboardEvent) => {
         if (this.state.alt !== e.altKey) {
             this.setState({alt: e.altKey});
         }
@@ -339,9 +350,9 @@ class Post extends React.PureComponent {
         if (!hideProfilePicture) {
             profilePic = (
                 <PostProfilePicture
-                    compactDisplay={this.props.compactDisplay}
-                    post={post}
+                    compactDisplay={Boolean(this.props.compactDisplay)}
                     userId={post.user_id}
+                    post={post}
                 />
             );
 
@@ -360,16 +371,15 @@ class Post extends React.PureComponent {
         }
 
         return (
-            <PostContext.Provider value={{handlePopupOpened: this.handleDropdownOpened}}>
+            <PostContext.Provider value={{handlePopupOpened: this.handleDropdownOpened} as any}>
                 <div
                     ref={this.postRef}
                     id={'post_' + post.id}
                     data-testid='postView'
                     role='listitem'
                     className={`a11y__section ${this.getClassName(post, isSystemMessage, isMeMessage, fromWebhook, fromAutoResponder, fromBot)}`}
-                    tabIndex='0'
+                    tabIndex={0}
                     onFocus={this.handlePostFocus}
-                    onBlur={this.removeFocus}
                     onMouseOver={this.setHover}
                     onMouseLeave={this.unsetHover}
                     onTouchStart={this.setHover}

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -71,7 +71,7 @@ export default class PostBody extends React.PureComponent {
         /**
          * Whether or not the post username can be overridden.
          */
-        enablePostUsernameOverride: PropTypes.bool.isRequired,
+        enablePostUsernameOverride: PropTypes.bool,
 
         /**
          * Set not to allow edits on post

--- a/components/post_view/post_header/post_header.jsx
+++ b/components/post_view/post_header/post_header.jsx
@@ -63,17 +63,17 @@ export default class PostHeader extends React.PureComponent {
         /**
          * Whether or not the post username can be overridden.
          */
-        enablePostUsernameOverride: PropTypes.bool.isRequired,
+        enablePostUsernameOverride: PropTypes.bool,
 
         /**
          * If the user that made the post is a bot.
          */
-        isBot: PropTypes.bool.isRequired,
+        isBot: PropTypes.bool,
 
         /**
          * If the user that made the post is a guest.
          */
-        isGuest: PropTypes.bool.isRequired,
+        isGuest: PropTypes.bool,
 
         /**
          * To Check if the current post is last in the list

--- a/package-lock.json
+++ b/package-lock.json
@@ -12559,11 +12559,15 @@
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
+      "requires": {
+        "icu4c-data": "0.64.2"
+      },
       "dependencies": {
         "icu4c-data": {
           "version": "0.64.2",
           "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-          "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
+          "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+          "dev": true
         }
       }
     },
@@ -13463,12 +13467,6 @@
       "requires": {
         "postcss": "^7.0.14"
       }
-    },
-    "icu4c-data": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",


### PR DESCRIPTION

#### Summary
Migrated  components/post_view/post/ index.js and post.jsx to typescript
also migrated corresponding test

Some notable points:

- Had to use `Any` type here, because could not infer  type from component created with  `injectIntl`

- Modified following compoonents because props that are passed with redux-connect function were marked as Proptype.isRequired and because of this  typescript compiler was throwing errors  

1.  components/post_view/post_body/post_body.jsx
2. components/post_view/post_header/post_header.jsx
3. components/post_profile_picture/post_profile_picture.jsx

All tests passing - No ts errors


#### Ticket Link

Fixes: https://github.com/mattermost/mattermost-server/issues/15464
JIRA:  https://mattermost.atlassian.net/browse/MM-20477

