### PR TITLE
[MM-29496, MM-29497] Update changeCSS() call to CSS variable for away status indicator

### DIFF
--- a/sass/components/_status-icon.scss
+++ b/sass/components/_status-icon.scss
@@ -82,14 +82,6 @@
             position: relative;
             top: 2px;
         }
-
-        &.status--away {
-            color: var(--away-indicator);
-        }
-        
-        &.away--icon {
-            fill: var(--away-indicator);
-        }
     }
 }
 
@@ -214,5 +206,17 @@
     }
     .offline--icon {
         fill: rgba(var(--center-channel-color-rgb), 0.56);
+    }
+}
+
+.app__body {
+    .status {
+        &.status--away {
+            color: var(--away-indicator);
+        }
+        
+        &.away--icon {
+            fill: var(--away-indicator);
+        }
     }
 }

--- a/sass/components/_status-icon.scss
+++ b/sass/components/_status-icon.scss
@@ -82,6 +82,14 @@
             position: relative;
             top: 2px;
         }
+
+        &.status--away {
+            color: var(--away-indicator);
+        }
+        
+        &.away--icon {
+            fill: var(--away-indicator);
+        }
     }
 }
 
@@ -206,16 +214,5 @@
     }
     .offline--icon {
         fill: rgba(var(--center-channel-color-rgb), 0.56);
-    }
-}
-
-.app__body {
-    .status {
-        .status--away {
-            color: var(--away-indicator);
-        }
-        .away--icon {
-            fill: var(--away-indicator);
-        }
     }
 }

--- a/sass/components/_status-icon.scss
+++ b/sass/components/_status-icon.scss
@@ -208,3 +208,14 @@
         fill: rgba(var(--center-channel-color-rgb), 0.56);
     }
 }
+
+.app__body {
+    .status {
+        .status--away {
+            color: var(--away-indicator);
+        }
+        .away--icon {
+            fill: var(--away-indicator);
+        }
+    }
+}

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -574,11 +574,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .status .online--icon', 'fill:' + theme.onlineIndicator);
     }
 
-    if (theme.awayIndicator) {
-        changeCss('.app__body .status.status--away', 'color:' + theme.awayIndicator);
-        changeCss('.app__body .status .away--icon', 'fill:' + theme.awayIndicator);
-    }
-
     let dndIndicator;
     if (theme.dndIndicator) {
         dndIndicator = theme.dndIndicator;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Deletes changeCSS() call in `utils/utils.jsx` in favor of a CSS variable in `_status-icon.scss`.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-29496
- https://mattermost.atlassian.net/browse/MM-29497

#### Github Issue Links
- Fixes https://github.com/mattermost/mattermost-server/issues/15883
- Fixes https://github.com/mattermost/mattermost-server/issues/15884
