### PR TITLE
[GH-15893] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 633

### DIFF
--- a/sass/components/_forms.scss
+++ b/sass/components/_forms.scss
@@ -163,6 +163,7 @@
     .form-control {
         color: v(center-channel-color);
         border-color: v(center-channel-color-16);
+        background: var(--center-channel-bg);
 
         &:focus {
             border-color: v(center-channel-color-40);

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -630,7 +630,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .popover.right>.arrow:after, .app__body .tip-overlay.tip-overlay--sidebar .arrow, .app__body .tip-overlay.tip-overlay--header .arrow', 'border-right-color:' + theme.centerChannelBg);
         changeCss('.app__body .popover.left>.arrow:after', 'border-left-color:' + theme.centerChannelBg);
         changeCss('.app__body .popover.top>.arrow:after, .app__body .tip-overlay.tip-overlay--chat .arrow', 'border-top-color:' + theme.centerChannelBg);
-        changeCss('@media(min-width: 768px){.app__body .form-control', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .attachment__content, .app__body .attachment-actions button', 'background:' + theme.centerChannelBg);
         changeCss('body.app__body', 'scrollbar-face-color:' + theme.centerChannelBg);
         changeCss('body.app__body', 'scrollbar-track-color:' + theme.centerChannelBg);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Replaced JavaScript variable `theme.centerChannelBg` with CSS variable `--center-channel-bg` for `.app__body .form-control`.

#### Ticket Link


Fixes [mattermost/mattermost-server#15893](https://github.com/mattermost/mattermost-server/issues/15893)

#### Related Pull Requests


#### Screenshots
