### PR TITLE
[GH-15890] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 627

### DIFF
--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -277,6 +277,10 @@
     text-transform: uppercase;
     font-weight: 600;
 
+    span {
+        background: v(center-channel-bg);
+    }
+
     &:first-child {
         &:before {
             display: none;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -624,7 +624,6 @@ export function applyTheme(theme) {
         changeCss('#post-list .post-list-holder-by-time, .app__body .post .dropdown-menu a, .app__body .post .Menu .MenuItem', 'background:' + theme.centerChannelBg);
         changeCss('#post-create, .app__body .emoji-picker__preview', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .date-separator .separator__text, .app__body .new-separator .separator__text', 'background:' + theme.centerChannelBg);
-        changeCss('.app__body .search-help-popover .search-autocomplete__divider span', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .dropdown-menu, .app__body .popover, .app__body .tip-overlay', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .popover.bottom>.arrow:after', 'border-bottom-color:' + theme.centerChannelBg);
         changeCss('.app__body .popover.right>.arrow:after, .app__body .tip-overlay.tip-overlay--sidebar .arrow, .app__body .tip-overlay.tip-overlay--header .arrow', 'border-right-color:' + theme.centerChannelBg);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Replaced JavaScript variable `theme.centerChannelBg` with CSS variable `--center-channel-bg` for `.app__body .search-help-popover .search-autocomplete__divider span`.

#### Ticket Link

Fixes [mattermost/mattermost-server#15890](https://github.com/mattermost/mattermost-server/issues/15890)

#### Related Pull Requests


#### Screenshots
