### PR TITLE
[GH-15885] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 613

### DIFF
--- a/sass/layout/_legacy-sidebar-left.scss
+++ b/sass/layout/_legacy-sidebar-left.scss
@@ -181,6 +181,10 @@
             @include transition-delay(0s);
             @include transition-timing-function(ease-in, step-end);
         }
+
+        svg {
+            fill: var(--mention-color);
+        }
     }
 
     .nav-pills__unread-indicator-top {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -610,7 +610,6 @@ export function applyTheme(theme) {
     }
 
     if (theme.mentionColor) {
-        changeCss('.sidebar--left .nav-pills__unread-indicator svg', 'fill:' + theme.mentionColor);
         changeCss('.app__body .sidebar--left .nav-pills__unread-indicator', 'color:' + theme.mentionColor);
         changeCss('.app__body .sidebar--left .badge, .app__body .list-group-item.active > .badge, .nav-pills > .active > a > .badge', 'color:' + theme.mentionColor);
         changeCss('.app__body .multi-teams .team-sidebar .badge, .app__body .list-group-item.active > .badge, .nav-pills > .active > a > .badge', 'color:' + theme.mentionColor);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Remove changeCss() for `.nav-pills__unread-indicator svg`.
This is no longer required as CSS variable `--mention-color` is already used.

https://github.com/mattermost/mattermost-webapp/blob/c3f01ee92ca30d6bedf62aa93b6e117efd37f9a4/sass/layout/_sidebar-left.scss#L421

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/15885
