### PR TITLE
[GH-15898] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 668

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1837,7 +1837,9 @@
     .post-collapse__show-more-button {
         @include single-transition(all, .15s, ease);
         @include border-radius(2px);
-        color: var(--center-channel-bg);
+        &:hover {
+            color: var(--center-channel-bg);
+        }
         border: 1px solid transparent;
         display: inline-block;
         flex-shrink: 0;

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1837,6 +1837,7 @@
     .post-collapse__show-more-button {
         @include single-transition(all, .15s, ease);
         @include border-radius(2px);
+        color: var(--center-channel-bg);
         border: 1px solid transparent;
         display: inline-block;
         flex-shrink: 0;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -618,6 +618,7 @@ export function applyTheme(theme) {
 
     if (theme.centerChannelBg) {
         changeCss('.app__body #channel_view.channel-view', `background: ${theme.centerChannelBg}`);
+        changeCss('@media(max-width: 768px){.app__body .post .MenuWrapper .dropdown-menu button', 'background:' + theme.centerChannelBg);
         changeCss('@media(max-width: 320px){.tutorial-steps__container', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .post-card--info, .app__body .bg--white, .app__body .system-notice, .app__body .channel-header__info .channel-header__description:before, .app__body .app__content, .app__body .markdown__table, .app__body .markdown__table tbody tr, .app__body .modal .modal-footer, .app__body .status-wrapper .status, .app__body .alert.alert-transparent', 'background:' + theme.centerChannelBg);
         changeCss('#post-list .post-list-holder-by-time, .app__body .post .dropdown-menu a, .app__body .post .Menu .MenuItem', 'background:' + theme.centerChannelBg);

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -665,7 +665,6 @@ export function applyTheme(theme) {
             `background-color:${theme.centerChannelBg}`,
         );
 
-        changeCss('.app__body .post-collapse__show-more-button:hover', `color:${theme.centerChannelBg}`);
         changeCss('.app__body .post-collapse__show-more-button', `background:${theme.centerChannelBg}`);
     }
 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -618,7 +618,6 @@ export function applyTheme(theme) {
 
     if (theme.centerChannelBg) {
         changeCss('.app__body #channel_view.channel-view', `background: ${theme.centerChannelBg}`);
-        changeCss('@media(max-width: 768px){.app__body .post .MenuWrapper .dropdown-menu button', 'background:' + theme.centerChannelBg);
         changeCss('@media(max-width: 320px){.tutorial-steps__container', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .post-card--info, .app__body .bg--white, .app__body .system-notice, .app__body .channel-header__info .channel-header__description:before, .app__body .app__content, .app__body .markdown__table, .app__body .markdown__table tbody tr, .app__body .modal .modal-footer, .app__body .status-wrapper .status, .app__body .alert.alert-transparent', 'background:' + theme.centerChannelBg);
         changeCss('#post-list .post-list-holder-by-time, .app__body .post .dropdown-menu a, .app__body .post .Menu .MenuItem', 'background:' + theme.centerChannelBg);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Removes the line: changeCss('.app__body .post-collapse_*show-more-button:hover', 'color:${theme.centerChannelBg}'); from `utils/utils.jsx` and replaces it with a new color variable under the ` .post-collapse__show-more-button` section in `sass/components/_post.scss `

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/15898