### PR TITLE
[GH-15889] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 622

### DIFF
--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -2366,6 +2366,7 @@
     }
 
     .tutorial-steps__container {
+        background: v(center-channel-bg);
         left: 0;
         position: fixed;
         top: 0;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -619,7 +619,6 @@ export function applyTheme(theme) {
     if (theme.centerChannelBg) {
         changeCss('.app__body #channel_view.channel-view', `background: ${theme.centerChannelBg}`);
         changeCss('@media(max-width: 768px){.app__body .post .MenuWrapper .dropdown-menu button', 'background:' + theme.centerChannelBg);
-        changeCss('@media(max-width: 320px){.tutorial-steps__container', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .post-card--info, .app__body .bg--white, .app__body .system-notice, .app__body .channel-header__info .channel-header__description:before, .app__body .app__content, .app__body .markdown__table, .app__body .markdown__table tbody tr, .app__body .modal .modal-footer, .app__body .status-wrapper .status, .app__body .alert.alert-transparent', 'background:' + theme.centerChannelBg);
         changeCss('#post-list .post-list-holder-by-time, .app__body .post .dropdown-menu a, .app__body .post .Menu .MenuItem', 'background:' + theme.centerChannelBg);
         changeCss('#post-create, .app__body .emoji-picker__preview', 'background:' + theme.centerChannelBg);


### PR DESCRIPTION
#### Summary

Replaced the use of the Javascript variable `theme.centerChannelBg` with the CSS variable `--center-channel-bg` for the `.tutorial-steps__container` selector.

#### Ticket Link

Fixes issue mattermost/mattermost-server#15889