### PR TITLE
[GH-15875] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 564

### DIFF
--- a/sass/layout/_navigation.scss
+++ b/sass/layout/_navigation.scss
@@ -90,6 +90,7 @@
             &.navbar-right__icon {
                 @include border-radius(50px);
                 display: flex;
+                background: rgba(var(--sidebar-header-text-color-rgb), 0.2);
                 align-items: center;
                 justify-content: center;
                 height: 32px;
@@ -198,11 +199,5 @@
 
     .badge-notify {
         background: $red;
-    }
-}
-
-.app__body {
-    .navbar-right__icon {
-        background: rgba(var(--sidebar-header-text-color-rgb), 0.2);
     }
 }

--- a/sass/layout/_navigation.scss
+++ b/sass/layout/_navigation.scss
@@ -201,3 +201,5 @@
         background: $red;
     }
 }
+
+

--- a/sass/layout/_navigation.scss
+++ b/sass/layout/_navigation.scss
@@ -201,4 +201,8 @@
     }
 }
 
-
+.app__body {
+    .navbar-right__icon {
+        background: rgba(var(--sidebar-header-text-color-rgb), 0.2);
+    }
+}

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -561,7 +561,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .post-list__timestamp > div, .app__body .multi-teams .team-sidebar .team-wrapper .team-container a:hover .team-btn__content, .app__body .multi-teams .team-sidebar .team-wrapper .team-container.active .team-btn__content', 'border-color:' + changeOpacity(theme.sidebarHeaderTextColor, 0.5));
         changeCss('.app__body .team-btn', 'border-color:' + changeOpacity(theme.sidebarHeaderTextColor, 0.3));
         changeCss('@media(max-width: 768px){.app__body .search-bar__container', 'color:' + theme.sidebarHeaderTextColor);
-        changeCss('.app__body .navbar-right__icon', 'background:' + changeOpacity(theme.sidebarHeaderTextColor, 0.2));
         changeCss('.app__body .navbar-right__icon:hover, .app__body .navbar-right__icon:focus', 'background:' + changeOpacity(theme.sidebarHeaderTextColor, 0.3));
         changeCss('.team-sidebar .fa', 'color:' + theme.sidebarHeaderTextColor);
         changeCss('.emoji-picker .emoji-picker__header, .emoji-picker .emoji-picker__header .emoji-picker__header-close-button', 'color:' + theme.sidebarHeaderTextColor);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Removes the line: 
![image](https://user-images.githubusercontent.com/53306868/95776642-b7013400-0c92-11eb-85cd-1228370918f4.png)

from utils/utils.jsx and replaces it with a new background variable under the app__body section in sass/layout/_navigation.scss

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/15875