### PR TITLE
MM-T702 Edit to invalid URL

### DIFF
--- a/e2e/cypress/integration/integrations/incoming_webhook/edit_to_invalid_url_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/edit_to_invalid_url_spec.js
@@ -18,7 +18,7 @@ describe('Integrations', () => {
     const badUrl = 'testurl.mm';
 
     before(() => {
-        // # Login as test user and visit the newly created test channel
+        // # Login then visit the integrations slash commands add page
         cy.apiInitSetup().then(({team}) => {
             testTeam = team;
             cy.visit(`/${team.name}/integrations/commands/add`);

--- a/e2e/cypress/integration/integrations/incoming_webhook/edit_to_invalid_url_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/edit_to_invalid_url_spec.js
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @integrations
+
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
+describe('Integrations', () => {
+    let testTeam;
+    const httpUrl = 'http://testurl.mm';
+    const httpsUrl = 'https//testurl.mm';
+    const badUrl = 'testurl.mm';
+
+    before(() => {
+        // # Login as test user and visit the newly created test channel
+        cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
+            cy.visit(`/${team.name}/integrations/commands/add`);
+        });
+    });
+
+    it('MM-T702 Edit to invalid URL', () => {
+        // # Setup slash command with HTTP url
+        cy.get('#displayName', {timeout: TIMEOUTS.ONE_MIN}).type('Missing Protocol Test');
+        cy.get('#trigger').type('trigger');
+        cy.get('#url').type(httpUrl);
+        cy.get('#saveCommand').click();
+        cy.get('#formTitle').contains('Setup Successful');
+
+        // # Return to slash command and edit url to exclude HTTP
+        cy.visit(`/${testTeam.name}/integrations/commands/installed`);
+        cy.findByText('Edit', {timeout: TIMEOUTS.ONE_MIN}).click();
+        cy.get('#url').clear().type(badUrl);
+        cy.get('#saveCommand').click();
+
+        // * Warning message appears on clicking Update
+        cy.get('#confirmModalBody').contains('Your changes may break the existing slash command. Are you sure you would like to update it?');
+        cy.get('#confirmModalButton').click();
+
+        // * Error message appears after clicking modal Update button
+        cy.findByText('Invalid URL', {exact: false}).should('be.visible').contains('Invalid URL. Must be a valid URL and start with http:// or https://.');
+
+        // * Error message removed when valid HTTPS URL entered and saved
+        cy.get('#url').clear().type(httpsUrl);
+        cy.get('#saveCommand').click();
+        cy.findByText('Invalid URL', {exact: false}).should('not.be', 'visible');
+
+        // # Return to slash command and edit url to exclude HTTPS
+        cy.visit(`/${testTeam.name}/integrations/commands/installed`);
+        cy.findByText('Edit', {timeout: TIMEOUTS.ONE_MIN}).click();
+        cy.get('#url').clear().type(badUrl);
+        cy.get('#saveCommand').click();
+
+        // * Warning message appears on clicking Update
+        cy.get('#confirmModalBody').contains('Your changes may break the existing slash command. Are you sure you would like to update it?');
+        cy.get('#confirmModalButton').click();
+
+        // * Error message appears after clicking modal Update button
+        cy.findByText('Invalid URL', {exact: false}).should('be.visible').contains('Invalid URL. Must be a valid URL and start with http:// or https://.');
+
+        // * Error message removed when correct URL entered and saved
+        cy.get('#url').clear().type(httpUrl);
+        cy.get('#saveCommand').click();
+        cy.findByText('Invalid URL', {exact: false}).should('not.be', 'visible');
+    });
+});


### PR DESCRIPTION
This PR validates that an error message appears when the user tries to edit a slash command's url and omits the protocol (https or https). This test:

- creates a slash command with an http url
- edits the url field and removes the 'http' transfer protocol
- asserts a modal warning appears on clicking Update
- asserts an error message appears after confirming the modal warning
- adds an https protocol url and saves, removing warning
- edits the url field and removes the 'https' transfer protocol
- asserts a modal warning appears on clicking Update
- asserts an error message appears after confirming the modal warning
- adds an http protocol url and saves, removing warning

[vercel](https://automation-test-cases.vercel.app/test/MM-T702)
TM4J - could not find a test-case

![Screen Shot 2020-10-12 at 3 16 10 PM](https://user-images.githubusercontent.com/586584/95782431-e2d5e700-0c9d-11eb-931f-6d6a0886fba8.png)
