### PR TITLE
[MM-29557] [MM-29590] Update subscription when purchase modal closes

### DIFF
--- a/components/purchase_modal/index.ts
+++ b/components/purchase_modal/index.ts
@@ -7,7 +7,7 @@ import {Stripe} from '@stripe/stripe-js';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {GenericAction, ActionFunc} from 'mattermost-redux/types/actions';
-import {getCloudProducts} from 'mattermost-redux/actions/cloud';
+import {getCloudProducts, getCloudSubscription} from 'mattermost-redux/actions/cloud';
 import {getClientConfig} from 'mattermost-redux/actions/general';
 
 import {GlobalState} from 'types/store';
@@ -47,6 +47,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
                 getCloudProducts,
                 completeStripeAddPaymentMethod,
                 getClientConfig,
+                getCloudSubscription,
             },
             dispatch,
         ),

--- a/components/purchase_modal/index.ts
+++ b/components/purchase_modal/index.ts
@@ -37,6 +37,7 @@ type Actions = {
     getCloudProducts: () => void;
     completeStripeAddPaymentMethod: (stripe: Stripe, billingDetails: BillingDetails, isDevMode: boolean) => Promise<boolean | null>;
     getClientConfig: () => void;
+    getCloudSubscription: () => void;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -43,6 +43,7 @@ type Props = {
         getCloudProducts: () => void;
         completeStripeAddPaymentMethod: (stripe: Stripe, billingDetails: BillingDetails, isDevMode: boolean) => Promise<boolean | null>;
         getClientConfig: () => void;
+        getCloudSubscription: () => void;
     };
 }
 
@@ -250,7 +251,10 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                                             this.props.actions.completeStripeAddPaymentMethod
                                         }
                                         isDevMode={this.props.isDevMode}
-                                        onClose={this.props.actions.closeModal}
+                                        onClose={() => {
+                                            this.props.actions.getCloudSubscription();
+                                            this.props.actions.closeModal();
+                                        }}
                                         onBack={() => {
                                             this.setState({processing: false});
                                         }}


### PR DESCRIPTION
#### Summary
There was a certain case where when you complete the purchase, the app would still show the various modals/banners around upgrading until refresh. This PR grabs the latest information on the subscription whenever the purchase modal closes, which will trigger re-renders of all downstream components depending on it (like the announcement banner, or information around the subscription in the system console)
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29557
https://mattermost.atlassian.net/browse/MM-29590

#### Related Pull Requests
N/A
#### Screenshots
N/A