### PR TITLE
[MM-29615] Fixed subscription page so it doesn't load until subscription info is loaded

### DIFF
--- a/components/admin_console/billing/billing_subscriptions.tsx
+++ b/components/admin_console/billing/billing_subscriptions.tsx
@@ -154,6 +154,10 @@ const BillingSubscriptions: React.FC<Props> = () => {
         </div>
     );
 
+    if (!subscription) {
+        return null;
+    }
+
     return (
         <div className='wrapper--fixed BillingSubscriptions'>
             <FormattedAdminHeader


### PR DESCRIPTION
#### Summary
This PR stops the Subscription page from loading until the subscription info has fully loaded.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29615