### PR TITLE
[MM-29501] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln 621 (#15888)

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -618,7 +618,6 @@ export function applyTheme(theme) {
 
     if (theme.centerChannelBg) {
         changeCss('.app__body #channel_view.channel-view', `background: ${theme.centerChannelBg}`);
-        changeCss('@media(max-width: 768px){.app__body .post .MenuWrapper .dropdown-menu button', 'background:' + theme.centerChannelBg);
         changeCss('@media(max-width: 320px){.tutorial-steps__container', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .post-card--info, .app__body .bg--white, .app__body .system-notice, .app__body .channel-header__info .channel-header__description:before, .app__body .app__content, .app__body .markdown__table, .app__body .markdown__table tbody tr, .app__body .modal .modal-footer, .app__body .status-wrapper .status, .app__body .alert.alert-transparent', 'background:' + theme.centerChannelBg);
         changeCss('#post-list .post-list-holder-by-time, .app__body .post .dropdown-menu a, .app__body .post .Menu .MenuItem', 'background:' + theme.centerChannelBg);


### PR DESCRIPTION
#### Summary

Remove the line as it is already taken into account unconditionally at line 623 thanks to '.app__body .post .Menu .MenuItem' selector
When this was added in commit https://github.com/mattermost/mattermost-webapp/commit/c8ae25a2816656a7791599de765b1e0a84d9c886 cited selector wasn't present

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/15888
JIRA ticket: https://mattermost.atlassian.net/browse/MM-29501