### PR TITLE
[MM-29632] Added extra null checking for company address

### DIFF
--- a/components/admin_console/billing/company_info_display.tsx
+++ b/components/admin_console/billing/company_info_display.tsx
@@ -67,8 +67,8 @@ const CompanyInfoDisplay: React.FC = () => {
     }
 
     let body = noCompanyInfoSection;
-    const address = (companyInfo.company_address && companyInfo.company_address.line1) ? companyInfo.company_address : companyInfo.billing_address;
-    if (address && address.line1) {
+    const address = companyInfo.company_address?.line1 ? companyInfo.company_address : companyInfo.billing_address;
+    if (address?.line1) {
         body = (
             <div className='CompanyInfoDisplay__companyInfo'>
                 <div className='CompanyInfoDisplay__companyInfo-text'>

--- a/components/admin_console/billing/company_info_display.tsx
+++ b/components/admin_console/billing/company_info_display.tsx
@@ -67,8 +67,8 @@ const CompanyInfoDisplay: React.FC = () => {
     }
 
     let body = noCompanyInfoSection;
-    const address = companyInfo.company_address.line1 ? companyInfo.company_address : companyInfo.billing_address;
-    if (address.line1) {
+    const address = (companyInfo.company_address && companyInfo.company_address.line1) ? companyInfo.company_address : companyInfo.billing_address;
+    if (address && address.line1) {
         body = (
             <div className='CompanyInfoDisplay__companyInfo'>
                 <div className='CompanyInfoDisplay__companyInfo-text'>


### PR DESCRIPTION
#### Summary
This PR fixes the case where the `company_address` field is `null` but the `billing_address` is not but still contains no data. A white screen would appear.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29632