### PR TITLE
[MM-29646] Down't show picker error if paid tier

### DIFF
--- a/components/invitation_modal/invitation_modal_members_step/index.ts
+++ b/components/invitation_modal/invitation_modal_members_step/index.ts
@@ -10,6 +10,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getStandardAnalytics} from 'mattermost-redux/actions/admin';
 import {bindActionCreators, Dispatch} from 'redux';
 import {GenericAction} from 'mattermost-redux/types/actions';
+import {getCloudSubscription} from 'mattermost-redux/actions/cloud';
 
 import {GlobalState} from 'types/store';
 
@@ -23,6 +24,7 @@ function mapStateToProps(state: GlobalState) {
         analytics: state.entities.admin.analytics,
         userIsAdmin: isAdmin(getCurrentUser(state).roles),
         isCloud: getLicense(state).Cloud === 'true',
+        subscription: state.entities.cloud.subscription,
     };
 }
 
@@ -31,6 +33,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
         actions: bindActionCreators(
             {
                 getStandardAnalytics,
+                getCloudSubscription,
             },
             dispatch,
         ),

--- a/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.jsx
+++ b/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.jsx
@@ -37,8 +37,10 @@ class InvitationModalMembersStep extends React.PureComponent {
         userIsAdmin: PropTypes.bool.isRequired,
         isCloud: PropTypes.bool.isRequired,
         analytics: PropTypes.object.isRequired,
+        subscription: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             getStandardAnalytics: PropTypes.func.isRequired,
+            getCloudSubscription: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -149,7 +151,14 @@ class InvitationModalMembersStep extends React.PureComponent {
     };
 
     shouldShowPickerError = () => {
-        const {userLimit, analytics, userIsAdmin, isCloud} = this.props;
+        const {userLimit, analytics, userIsAdmin, isCloud, subscription} = this.props;
+
+        if (subscription === null) {
+            return false;
+        }
+        if (subscription.is_paid_tier === 'true') {
+            return false;
+        }
 
         if (userLimit === '0' || !userIsAdmin || !isCloud) {
             return false;
@@ -169,6 +178,9 @@ class InvitationModalMembersStep extends React.PureComponent {
     componentDidMount() {
         if (!this.props.analytics) {
             this.props.actions.getStandardAnalytics();
+        }
+        if (!this.props.subscription) {
+            this.props.actions.getCloudSubscription();
         }
     }
 

--- a/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.test.jsx
+++ b/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.test.jsx
@@ -20,11 +20,15 @@ describe('components/invitation_modal/InvitationModalMembersStep', () => {
         userLimit: '0',
         currentUsers: 4,
         isCloud: false,
+        subscription: {
+            is_paid_tier: 'false',
+        },
         analytics: {
             TOTAL_USERS: 10,
         },
         actions: {
             getStandardAnalytics: () => { },
+            getCloudSubscription: () => { },
         },
     };
 

--- a/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.test.jsx
+++ b/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.test.jsx
@@ -27,8 +27,8 @@ describe('components/invitation_modal/InvitationModalMembersStep', () => {
             TOTAL_USERS: 10,
         },
         actions: {
-            getStandardAnalytics: () => { },
-            getCloudSubscription: () => { },
+            getStandardAnalytics: () => {},
+            getCloudSubscription: () => {},
         },
     };
 

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -133,9 +133,8 @@ class MainMenu extends React.PureComponent {
         if (this.props.subscription?.is_paid_tier === 'true') { // eslint-disable-line camelcase
             return false;
         }
-        return false;
 
-        // return (this.props.currentUsers >= this.props.userLimit) && (this.props.userLimit !== '0') && this.props.userIsAdmin;
+        return (this.props.currentUsers >= this.props.userLimit) && (this.props.userLimit !== '0') && this.props.userIsAdmin;
     }
 
     render() {

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -133,8 +133,9 @@ class MainMenu extends React.PureComponent {
         if (this.props.subscription?.is_paid_tier === 'true') { // eslint-disable-line camelcase
             return false;
         }
+        return false;
 
-        return (this.props.currentUsers >= this.props.userLimit) && (this.props.userLimit !== '0') && this.props.userIsAdmin;
+        // return (this.props.currentUsers >= this.props.userLimit) && (this.props.userLimit !== '0') && this.props.userIsAdmin;
     }
 
     render() {


### PR DESCRIPTION
#### Summary
This check was missed in the initial addition of the is paid field. When a user upgraded their account, they still couldn't invite more than 10 people in the invite members modal. This adds a check that tells the error to not show in the case of a paid tier.
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29646

#### Related Pull Requests
n/a
#### Screenshots
n/a