### PR TITLE
[MM-29635] Don't show panel in subscription section if at user limit

### DIFF
--- a/components/admin_console/billing/billing_subscriptions.tsx
+++ b/components/admin_console/billing/billing_subscriptions.tsx
@@ -87,7 +87,7 @@ const BillingSubscriptions: React.FC<Props> = () => {
             return false;
         }
 
-        if ((userLimit - Number(analytics.TOTAL_USERS)) <= WARNING_THRESHOLD && (userLimit - Number(analytics.TOTAL_USERS) >= 0)) {
+        if ((userLimit - Number(analytics.TOTAL_USERS)) <= WARNING_THRESHOLD && (userLimit - Number(analytics.TOTAL_USERS) > 0)) {
             return true;
         }
 


### PR DESCRIPTION
#### Summary
Small change, if the number of users is equal to the user limit, don't show the panel in the subscription section. IE, it will now only show the panel if between the threshold and 1 user remaining.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29635
#### Related Pull Requests
n/a

#### Screenshots
n/a