### PR TITLE
[MM-29686] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln.…

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -67,6 +67,10 @@
                 top: 3px;
             }
         }
+        
+        .bg-text-200 {
+            background: rgba(var(--center-channel-color-rgb), 0.2);
+        }
     }
 }
 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -670,7 +670,6 @@ export function applyTheme(theme) {
     }
 
     if (theme.centerChannelColor) {
-        changeCss('.app__body .bg-text-200', 'background:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .user-popover__role', 'background:' + changeOpacity(theme.centerChannelColor, 0.3));
         changeCss('.app__body .svg-text-color', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .mentions__name .status.status--group, .app__body .multi-select__note', 'background:' + changeOpacity(theme.centerChannelColor, 0.12));


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds `bg-text-200` class near `.more-modal__gm-icon` (all elements using `bg-text-200` uses `.more-modal__gm-icon`, and replaces `utils/utils.jsx` to use `--center-channel-color` CSS variables.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Github Issue: Fixes https://github.com/mattermost/mattermost-server/issues/15961
JIRA Ticket: https://mattermost.atlassian.net/browse/MM-29686
