### PR TITLE
[MM-29688] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 675

### DIFF
--- a/sass/layout/_channel-icon.scss
+++ b/sass/layout/_channel-icon.scss
@@ -17,3 +17,9 @@
     left: -2px;
     top: 2px;
 }
+
+.app__body {
+    .svg-text-color {
+        fill: var(--center-channel-color);
+    }
+}

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -672,7 +672,6 @@ export function applyTheme(theme) {
     if (theme.centerChannelColor) {
         changeCss('.app__body .bg-text-200', 'background:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .user-popover__role', 'background:' + changeOpacity(theme.centerChannelColor, 0.3));
-        changeCss('.app__body .svg-text-color', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .mentions__name .status.status--group, .app__body .multi-select__note', 'background:' + changeOpacity(theme.centerChannelColor, 0.12));
         changeCss('.app__body .modal-tabs .nav-tabs > li, .app__body .system-notice, .app__body .file-view--single .file__image .image-loaded, .app__body .post .MenuWrapper .dropdown-menu button, .app__body .member-list__popover .more-modal__body, .app__body .alert.alert-transparent, .app__body .table > thead > tr > th, .app__body .table > tbody > tr > td', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.12));
         changeCss('.app__body .post-list__arrows', 'fill:' + changeOpacity(theme.centerChannelColor, 0.3));


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/15963, MM-29688

Fixed  `.app__body .svg-text-color` class to use CSS variables.
It is generally used with channel-icon , so css was added in _channel-icon.scss.

#### Ticket Link
Github Issue: Fixes https://github.com/mattermost/mattermost-server/issues/15963
JIRA Ticket: MM-29688