### PR TITLE
[MM-29723] Update subscription when payment status websocket event is received

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -26,6 +26,7 @@ import {
     markChannelAsRead,
     getChannelMemberCountsByGroup,
 } from 'mattermost-redux/actions/channels';
+import {getCloudSubscription} from 'mattermost-redux/actions/cloud';
 import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {
@@ -471,6 +472,9 @@ export function handleEvent(msg) {
 
     case SocketEvents.SIDEBAR_CATEGORY_ORDER_UPDATED:
         dispatch(handleSidebarCategoryOrderUpdated(msg));
+        break;
+    case SocketEvents.CLOUD_PAYMENT_STATUS_UPDATED:
+        dispatch(handleCloudPaymentStatusUpdated(msg));
         break;
 
     default:
@@ -1324,4 +1328,8 @@ function handleSidebarCategoryDeleted(msg) {
 
 function handleSidebarCategoryOrderUpdated(msg) {
     return receivedCategoryOrder(msg.broadcast.team_id, msg.data.order);
+}
+
+function handleCloudPaymentStatusUpdated() {
+    return (doDispatch) => doDispatch(getCloudSubscription());
 }

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -381,6 +381,7 @@ export const SocketEvents = {
     SIDEBAR_CATEGORY_UPDATED: 'sidebar_category_updated',
     SIDEBAR_CATEGORY_DELETED: 'sidebar_category_deleted',
     SIDEBAR_CATEGORY_ORDER_UPDATED: 'sidebar_category_order_updated',
+    CLOUD_PAYMENT_STATUS_UPDATED: 'cloud_payment_status_updated',
 };
 
 export const TutorialSteps = {


### PR DESCRIPTION
#### Summary
When a sysadmin upgraded the cloud subscription, another sysadmin that was logged in wouldn't see the updated screen until they refreshed. This PR receives a websocket event that will force an update on the subscription.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29723

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/15988)
