### PR TITLE
[MM-29715] Added call to getCloudSubscription on close modal

### DIFF
--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -236,6 +236,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                                 TELEMETRY_CATEGORIES.CLOUD_PURCHASING,
                                 'click_close_purchasing_screen',
                             );
+                            this.props.actions.getCloudSubscription();
                             this.props.actions.closeModal();
                         }}
                         ref={this.modal}


### PR DESCRIPTION
#### Summary
When closing the Purchase Modal after completing a purchase by clicking 'X', the subscription wouldn't update in the background. This PR adds the call to `getCloudSubscription` to make sure the subscription is updated properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29715