### PR TITLE
Add e2e test for /open command

### DIFF
--- a/e2e/cypress/integration/integrations/slash_commands_spec.js
+++ b/e2e/cypress/integration/integrations/slash_commands_spec.js
@@ -67,14 +67,14 @@ describe('Integrations', () => {
         cy.get('#newChannelName').type(privateChannelName);
         cy.get('#submitNewChannel').click();
 
-        // # User with privilege try /open command without tilde
+        // # User, who is a member of the channel, try /open command without tilde
         cy.get('#publicChannelList').findByText('Town Square').click();
         cy.postMessage(`/open ${privateChannelName}`);
 
         // * Private channel should be active
         cy.get('#privateChannelList').get('.active').should('contain', privateChannelName);
 
-        // # User with privilege try /open command with tilde
+        // # User, who is a member of the channel, try /open command without tilde
         cy.get('#publicChannelList').findByText('Town Square').click();
         cy.postMessage(`/open ~${privateChannelName}`);
 
@@ -85,14 +85,14 @@ describe('Integrations', () => {
         cy.apiLogin(user2);
         cy.visit(testChannelUrl1);
 
-        // # User without privilege try /open command without tilde
+        // # User, who is *not* a member of the channel, try /open command without tilde
         cy.get('#publicChannelList').findByText('Town Square').click();
         cy.postMessage(`/open ${privateChannelName}`);
 
         // * Error message should be presented.
         cy.getLastPost().should('contain', 'An error occurred while joining the channel.').and('contain', 'System');
 
-        // # User without privilege try /open command with tilde
+        // # User, who is *not* a member of the channel, try /open command without tilde
         cy.get('#publicChannelList').findByText('Town Square').click();
         cy.postMessage(`/open ~${privateChannelName}`);
 

--- a/e2e/cypress/integration/integrations/slash_commands_spec.js
+++ b/e2e/cypress/integration/integrations/slash_commands_spec.js
@@ -55,6 +55,51 @@ describe('Integrations', () => {
         });
     });
 
+    it('MM-T663 /open command for private channels', () => {
+        const privateChannelName = 'private-channel';
+
+        cy.apiLogin(user1);
+        cy.visit(testChannelUrl1);
+
+        // # User 1 Create a private channel, with ${channelName}
+        cy.get('#createPrivateChannel').click();
+        cy.get('#private').click();
+        cy.get('#newChannelName').type(privateChannelName);
+        cy.get('#submitNewChannel').click();
+
+        // # User with privilege try /open command without tilde
+        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.postMessage(`/open ${privateChannelName}`);
+
+        // * Private channel should be active
+        cy.get('#privateChannelList').get('.active').should('contain', privateChannelName);
+
+        // # User with privilege try /open command with tilde
+        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.postMessage(`/open ~${privateChannelName}`);
+
+        // * Private channel should be active
+        cy.get('#privateChannelList').get('.active').should('contain', privateChannelName);
+
+        // # Login with user without privilege
+        cy.apiLogin(user2);
+        cy.visit(testChannelUrl1);
+
+        // # User without privilege try /open command without tilde
+        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.postMessage(`/open ${privateChannelName}`);
+
+        // * Error message should be presented.
+        cy.getLastPost().should('contain', 'An error occurred while joining the channel.').and('contain', 'System');
+
+        // # User without privilege try /open command with tilde
+        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.postMessage(`/open ~${privateChannelName}`);
+
+        // * Error message should be presented.
+        cy.getLastPost().should('contain', 'An error occurred while joining the channel.').and('contain', 'System');
+    });
+
     it('MM-T687 /msg', () => {
         cy.apiLogin(user1);
         cy.visit(testChannelUrl1);


### PR DESCRIPTION
#### Summary
Adds test case for /open command:

Privileged user try to /open to private channel with channel name

Privileged user try to /open to private channel with tilde(~) + channel name

Unprivileged user try to /open to private channel with channel name

Unprivileged user try to /open to private channel with tilde(~) + channel name

#### Ticket Link
Github Issue: Fixes https://github.com/mattermost/mattermost-server/issues/15699
JIRA Ticket: MM-T663