### PR TITLE
MM-29870 Cypress/E2E: Fix tests of autocomplete with Elasticsearch

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -17,6 +17,7 @@
         "ldapServer": "localhost",
         "ldapPort": 389,
         "runLDAPSync": true,
+        "runWithEELicense": false,
         "resetBeforeTest": false,
         "storybookUrl": "http://localhost:6006/",
         "webhookBaseUrl": "http://localhost:3000"

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
@@ -188,14 +188,14 @@ module.exports = {
                         expect(addResponse.status).to.equal(201);
 
                         // explicitly wait to give some to index before searching
-                        cy.wait(TIMEOUTS.HALF_SEC);
+                        cy.wait(TIMEOUTS.TWO_SEC);
                         return cy.wrap(channel);
                     });
                 });
             }
 
             // explicitly wait to give some to index before searching
-            cy.wait(TIMEOUTS.HALF_SEC);
+            cy.wait(TIMEOUTS.TWO_SEC);
             return cy.wrap(channel);
         });
     },

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/system_console_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/system_console_spec.js
@@ -52,20 +52,11 @@ describe('Elasticsearch system console', () => {
         // # Small wait to ensure new row is added
         cy.wait(TIMEOUTS.HALF_SEC);
 
-        // * First row should now say Pending
+        // # Get the first row
         cy.get('.job-table__table').
             find('tbody > tr').
             eq(0).
-            as('firstRow').
-            find('.status-icon-warning', {timeout: TIMEOUTS.HALF_MIN}).
-            should('be.visible').
-            and('have.text', 'Pending');
-
-        // * First row should update to say In Progress
-        cy.get('@firstRow').
-            find('.status-icon-warning', {timeout: TIMEOUTS.TWO_MIN}).
-            should('be.visible').
-            and('have.text', 'In Progress');
+            as('firstRow');
 
         // * First row update to say Success
         cy.waitUntil(() => {

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -107,6 +107,11 @@ before(() => {
 
         // * Verify that the server database matches with the DB client and config at "cypress.json"
         cy.apiRequireServerDBToMatch();
+
+        if (Cypress.env('runWithEELicense')) {
+            // * Verify that the server is loaded with license when running tests for EE
+            cy.apiRequireLicense();
+        }
     });
 });
 


### PR DESCRIPTION
#### Summary
In CircleCI, we're loading the license directly into the database. For some reason, upon server start, the workers related to Enterprise (including Elasticsearch) didn't start as expected.  So, we're uploading the license via `cy.apiRequireLicense()` on global `before` hook whenever we are running tests for EE.  Bonus: this is also the first step towards running tests for TE and EE.

The additional `CYPRESS_runWithEELicense` is by default set to false at `cypress.json`. Therefore, contributors, especially from the community, is not affected by this change.  Docs to be added at https://developers.mattermost.com/contribute/webapp/end-to-end-tests/#environment-variables

Report - https://mm-cypress-report.s3.amazonaws.com/1139-es-license-master/mochawesome.html

#### Ticket Link
Jira ticket - https://mattermost.atlassian.net/browse/MM-29870
- failing on daily unstable tests
