### PR TITLE
[MM-29855] Migrate string-refs to functional ones: this.refs.content

### DIFF
--- a/components/admin_console/permission_schemes_settings/permission_description.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_description.jsx
@@ -29,6 +29,8 @@ export class PermissionDescription extends React.PureComponent {
         this.state = {
             open: false,
         };
+
+        this.contentRef = React.createRef();
     }
 
     closeTooltip = () => {
@@ -82,7 +84,7 @@ export class PermissionDescription extends React.PureComponent {
                 show={this.state.open}
                 delayShow={Constants.OVERLAY_TIME_DELAY}
                 placement='top'
-                target={this.refs.content}
+                target={this.contentRef.current}
             >
                 <Tooltip id={this.id}>
                     {content}
@@ -96,7 +98,7 @@ export class PermissionDescription extends React.PureComponent {
             <span
                 className='permission-description'
                 onClick={this.parentPermissionClicked}
-                ref='content'
+                ref={this.contentRef}
                 onMouseOver={this.openTooltip}
                 onMouseOut={this.closeTooltip}
             >


### PR DESCRIPTION
#### Summary
Update `this.refs.content` to `this.content` as a react ref function

#### Ticket Link
github issue -> Fixes https://github.com/mattermost/mattermost-server/issues/16038
JIRA ticket -> https://mattermost.atlassian.net/browse/MM-29855

#### Related Pull Requests
n/a

#### Screenshots
n/a