### PR TITLE
[MM-28218] Fix for when both billing address and company address are missing and you can't add company info

### DIFF
--- a/components/admin_console/billing/company_info_edit.tsx
+++ b/components/admin_console/billing/company_info_edit.tsx
@@ -42,7 +42,7 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     const [country, setCountry] = useState(getName(companyInfo?.company_address?.country || 'US'));
     const [state, setState] = useState(companyInfo?.company_address?.state);
 
-    const [sameAsBillingAddress, setSameAsBillingAddress] = useState(!companyInfo?.company_address?.line1 && companyInfo?.billing_address?.line1);
+    const [sameAsBillingAddress, setSameAsBillingAddress] = useState(Boolean(!companyInfo?.company_address?.line1 && companyInfo?.billing_address?.line1));
     const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
     const [isSaving, setIsSaving] = useState(false);
 

--- a/components/admin_console/billing/company_info_edit.tsx
+++ b/components/admin_console/billing/company_info_edit.tsx
@@ -42,7 +42,7 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     const [country, setCountry] = useState(getName(companyInfo?.company_address?.country || 'US'));
     const [state, setState] = useState(companyInfo?.company_address?.state);
 
-    const [sameAsBillingAddress, setSameAsBillingAddress] = useState(!companyInfo?.company_address?.line1);
+    const [sameAsBillingAddress, setSameAsBillingAddress] = useState(!companyInfo?.company_address?.line1 && companyInfo?.billing_address?.line1);
     const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
     const [isSaving, setIsSaving] = useState(false);
 


### PR DESCRIPTION
#### Summary
This PR fixes an issue where if the billing address and company address were both blank, the user was unable to update the company address.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28218