### PR TITLE
MM-28490 Increase the number of new posts received before the events being batched

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -546,7 +546,7 @@ function debouncePostEvent(wait) {
     };
 
     return function fx(msg) {
-        if (timeout && count > 2) {
+        if (timeout && count > 4) {
             // If the timeout is going this is the second or further event so queue them up.
             if (queue.push(msg) > 200) {
                 // Don't run us out of memory, give up if the queue gets insane
@@ -594,6 +594,7 @@ export function handleNewPostEvent(msg) {
 
 export function handleNewPostEvents(queue) {
     return (myDispatch, myGetState) => {
+        // Note that this method doesn't properly update the sidebar state for these posts
         const posts = queue.map((msg) => JSON.parse(msg.data.post));
 
         // Receive the posts as one continuous block since they were received within a short period


### PR DESCRIPTION
Jason reported an issue where some new DMs weren't causing the channel to become visible in the sidebar, and we think this is only happening to him because he's in so many channels, so he's more likely to run into the batched handling of new posts. The batched post handling skips some steps of receiving new posts such as counting mentions and unread messages, and because the DM is not becoming unread, it's not appearing in the sidebar.

We'd obviously like to improve the handling of multiple new posts at once, but for the time being, we're going to see if decreasing the chance that this logic triggers helps to begin with.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28490