### PR TITLE
MM-29918 Cypress/E2E: Add ability to run tests for EE and TE

### DIFF
--- a/e2e/cypress/integration/enterprise/group_mentions/group_mentions_permissions_spec.js
+++ b/e2e/cypress/integration/enterprise/group_mentions/group_mentions_permissions_spec.js
@@ -6,7 +6,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @system_console @group_mentions
+// Group: @enterprise @system_console @group_mentions
 
 import ldapUsers from '../../../fixtures/ldap_users.json';
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/enterprise/group_mentions/group_mentions_posts_spec.js
+++ b/e2e/cypress/integration/enterprise/group_mentions/group_mentions_posts_spec.js
@@ -6,7 +6,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @system_console @group_mentions
+// Group: @enterprise @system_console @group_mentions
 
 import ldapUsers from '../../../fixtures/ldap_users.json';
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/enterprise/group_mentions/group_mentions_system_messages_spec.js
+++ b/e2e/cypress/integration/enterprise/group_mentions/group_mentions_system_messages_spec.js
@@ -6,7 +6,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @system_console @group_mentions
+// Group: @enterprise @system_console @group_mentions
 
 import ldapUsers from '../../../fixtures/ldap_users.json';
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @guest_account
+// Group: @enterprise @guest_account
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @guest_account
+// Group: @enterprise @guest_account
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_invitation_ui_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @guest_account
+// Group: @enterprise @guest_account
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @guest_account
+// Group: @enterprise @guest_account
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @guest_account
+// Group: @enterprise @guest_account
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/enterprise/guest_accounts/system_console_guest_access_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/system_console_guest_access_ui_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @guest_account
+// Group: @enterprise @guest_account
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/enterprise/guest_accounts/system_console_manage_guest_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/system_console_manage_guest_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @guest_account
+// Group: @enterprise @guest_account
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/enterprise/profile_popover/profile_popover_spec.js
+++ b/e2e/cypress/integration/enterprise/profile_popover/profile_popover_spec.js
@@ -7,11 +7,11 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @profile_popover
+// Group: @enterprise @profile_popover
 
-import * as TIMEOUTS from '../../fixtures/timeouts';
-import {createPrivateChannel} from '../enterprise/elasticsearch_autocomplete/helpers';
-import {getAdminAccount} from '../../support/env';
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+import {createPrivateChannel} from '../elasticsearch_autocomplete/helpers';
+import {getAdminAccount} from '../../../support/env';
 
 describe('Profile popover', () => {
     let testTeam;

--- a/e2e/cypress/integration/enterprise/system_console/channel_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_members_spec.js
@@ -7,6 +7,8 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Group: @enterprise
+
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('Channel members test', () => {

--- a/e2e/cypress/integration/enterprise/system_console/team_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/team_members_spec.js
@@ -8,6 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
+// Group: @enterprise
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 

--- a/e2e/cypress/integration/enterprise/visual_regression/helpers.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/helpers.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-const applitoolsConfig = require('../../../applitools.config');
+const applitoolsConfig = require('../../../../applitools.config');
 
 export function getBatchName(suffix) {
     const batchName = Cypress.env('batchName') || applitoolsConfig.batchName;

--- a/e2e/cypress/integration/enterprise/visual_regression/system_console/about_section_spec.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/system_console/about_section_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @enterprise @system_console @visual_regression
 
-import * as TIMEOUTS from '../../../fixtures/timeouts';
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
 
 import {getBatchName} from '../helpers';
 

--- a/e2e/cypress/integration/enterprise/visual_regression/system_console/authentication_section_spec.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/system_console/authentication_section_spec.js
@@ -10,38 +10,65 @@
 // Stage: @prod
 // Group: @enterprise @system_console @visual_regression
 
-import * as TIMEOUTS from '../../../fixtures/timeouts';
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
 
 import {getBatchName} from '../helpers';
 
-describe('System Console - Compliance', () => {
+describe('System Console - Authentication', () => {
     const testCases = [
         {
-            section: 'Compliance',
-            header: 'Data Retention Policy',
-            sidebar: 'Data Retention Policy',
-            url: 'admin_console/compliance/data_retention',
+            section: 'Authentication',
+            header: 'Signup',
+            sidebar: 'Signup',
+            url: 'admin_console/authentication/signup',
         },
         {
-            section: 'Compliance',
-            header: 'Compliance Export (Beta)',
-            sidebar: 'Compliance Export (Beta)',
-            url: 'admin_console/compliance/export',
+            section: 'Authentication',
+            header: 'Email Authentication',
+            sidebar: 'Email',
+            url: 'admin_console/authentication/email',
         },
         {
-            section: 'Compliance',
-            header: 'Compliance Monitoring',
-            sidebar: 'Compliance Monitoring',
-            url: 'admin_console/compliance/monitoring',
-            saveOptions: {
-                layout: [{selector: '.compliance-panel__table'}],
+            section: 'Authentication',
+            header: 'Password',
+            sidebar: 'Password',
+            url: 'admin_console/authentication/password',
+        },
+        {
+            section: 'Authentication',
+            header: 'Multi-factor Authentication',
+            sidebar: 'MFA',
+            url: 'admin_console/authentication/mfa',
+        },
+        {
+            section: 'Authentication',
+            header: 'AD/LDAP',
+            sidebar: 'AD/LDAP',
+            url: 'admin_console/authentication/ldap',
+            openOptions: {
+                browser: {width: 1024, height: 4850, name: 'chrome'},
             },
         },
         {
-            section: 'Compliance',
-            header: 'Custom Terms of Service (Beta)',
-            sidebar: 'Custom Terms of Service (Beta)',
-            url: 'admin_console/compliance/custom_terms_of_service',
+            section: 'Authentication',
+            header: 'SAML 2.0',
+            sidebar: 'SAML 2.0',
+            url: 'admin_console/authentication/saml',
+            openOptions: {
+                browser: {width: 1024, height: 4100, name: 'chrome'},
+            },
+        },
+        {
+            section: 'Authentication',
+            header: 'OAuth 2.0',
+            sidebar: 'OAuth 2.0',
+            url: 'admin_console/authentication/oauth',
+        },
+        {
+            section: 'Authentication',
+            header: 'Guest Access (Beta)',
+            sidebar: 'Guest Access (Beta)',
+            url: 'admin_console/authentication/guest_access',
         },
     ];
 
@@ -64,10 +91,12 @@ describe('System Console - Compliance', () => {
     testCases.forEach((testCase) => {
         it(`${testCase.section} - ${testCase.header}`, () => {
             const browser = [{width: 1024, height: 2100, name: 'chrome'}];
+            const otherOpenOptions = testCase.openOptions ? testCase.openOptions : {};
 
             cy.visualEyesOpen({
-                batchName: getBatchName('System Console - Compliance'),
+                batchName: getBatchName('System Console - Authentication'),
                 browser,
+                ...otherOpenOptions,
             });
 
             // # Click the link on the sidebar
@@ -79,13 +108,9 @@ describe('System Console - Compliance', () => {
             cy.url().should('include', testCase.url);
             cy.get('.admin-console').should('be.visible').within(() => {
                 cy.get('.admin-console__header').should('be.visible').and(testCase.headerContains ? 'contain' : 'have.text', testCase.header);
-                const otherSaveOptions = testCase.saveOptions ? testCase.saveOptions : {};
-                cy.visualSaveSnapshot({
-                    tag: testCase.sidebar,
-                    target: 'window',
-                    fully: true,
-                    ...otherSaveOptions,
-                });
+
+                // # Save snapshot for visual testing
+                cy.visualSaveSnapshot({tag: testCase.sidebar, target: 'window', fully: true});
             });
         });
     });

--- a/e2e/cypress/integration/enterprise/visual_regression/system_console/compliance_section_spec.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/system_console/compliance_section_spec.js
@@ -10,65 +10,38 @@
 // Stage: @prod
 // Group: @enterprise @system_console @visual_regression
 
-import * as TIMEOUTS from '../../../fixtures/timeouts';
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
 
 import {getBatchName} from '../helpers';
 
-describe('System Console - Authentication', () => {
+describe('System Console - Compliance', () => {
     const testCases = [
         {
-            section: 'Authentication',
-            header: 'Signup',
-            sidebar: 'Signup',
-            url: 'admin_console/authentication/signup',
+            section: 'Compliance',
+            header: 'Data Retention Policy',
+            sidebar: 'Data Retention Policy',
+            url: 'admin_console/compliance/data_retention',
         },
         {
-            section: 'Authentication',
-            header: 'Email Authentication',
-            sidebar: 'Email',
-            url: 'admin_console/authentication/email',
+            section: 'Compliance',
+            header: 'Compliance Export (Beta)',
+            sidebar: 'Compliance Export (Beta)',
+            url: 'admin_console/compliance/export',
         },
         {
-            section: 'Authentication',
-            header: 'Password',
-            sidebar: 'Password',
-            url: 'admin_console/authentication/password',
-        },
-        {
-            section: 'Authentication',
-            header: 'Multi-factor Authentication',
-            sidebar: 'MFA',
-            url: 'admin_console/authentication/mfa',
-        },
-        {
-            section: 'Authentication',
-            header: 'AD/LDAP',
-            sidebar: 'AD/LDAP',
-            url: 'admin_console/authentication/ldap',
-            openOptions: {
-                browser: {width: 1024, height: 4850, name: 'chrome'},
+            section: 'Compliance',
+            header: 'Compliance Monitoring',
+            sidebar: 'Compliance Monitoring',
+            url: 'admin_console/compliance/monitoring',
+            saveOptions: {
+                layout: [{selector: '.compliance-panel__table'}],
             },
         },
         {
-            section: 'Authentication',
-            header: 'SAML 2.0',
-            sidebar: 'SAML 2.0',
-            url: 'admin_console/authentication/saml',
-            openOptions: {
-                browser: {width: 1024, height: 4100, name: 'chrome'},
-            },
-        },
-        {
-            section: 'Authentication',
-            header: 'OAuth 2.0',
-            sidebar: 'OAuth 2.0',
-            url: 'admin_console/authentication/oauth',
-        },
-        {
-            section: 'Authentication',
-            header: 'Guest Access (Beta)',
-            sidebar: 'Guest Access (Beta)',
-            url: 'admin_console/authentication/guest_access',
+            section: 'Compliance',
+            header: 'Custom Terms of Service (Beta)',
+            sidebar: 'Custom Terms of Service (Beta)',
+            url: 'admin_console/compliance/custom_terms_of_service',
         },
     ];
 
@@ -91,12 +64,10 @@ describe('System Console - Authentication', () => {
     testCases.forEach((testCase) => {
         it(`${testCase.section} - ${testCase.header}`, () => {
             const browser = [{width: 1024, height: 2100, name: 'chrome'}];
-            const otherOpenOptions = testCase.openOptions ? testCase.openOptions : {};
 
             cy.visualEyesOpen({
-                batchName: getBatchName('System Console - Authentication'),
+                batchName: getBatchName('System Console - Compliance'),
                 browser,
-                ...otherOpenOptions,
             });
 
             // # Click the link on the sidebar
@@ -108,9 +79,13 @@ describe('System Console - Authentication', () => {
             cy.url().should('include', testCase.url);
             cy.get('.admin-console').should('be.visible').within(() => {
                 cy.get('.admin-console__header').should('be.visible').and(testCase.headerContains ? 'contain' : 'have.text', testCase.header);
-
-                // # Save snapshot for visual testing
-                cy.visualSaveSnapshot({tag: testCase.sidebar, target: 'window', fully: true});
+                const otherSaveOptions = testCase.saveOptions ? testCase.saveOptions : {};
+                cy.visualSaveSnapshot({
+                    tag: testCase.sidebar,
+                    target: 'window',
+                    fully: true,
+                    ...otherSaveOptions,
+                });
             });
         });
     });

--- a/e2e/cypress/integration/enterprise/visual_regression/system_console/environment_section_spec.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/system_console/environment_section_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @enterprise @system_console @visual_regression
 
-import * as TIMEOUTS from '../../../fixtures/timeouts';
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
 
 describe('System Console - Enterprise', () => {
     const testCases = [

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -16,6 +16,9 @@
  *   --group=[group]
  *      Selects spec files with matching group. It can be of multiple values separated by comma.
  *      E.g. "--group='@channel,@messaging'" will select files with either @channel or @messaging.
+ *   --exclude-group=[group]
+ *      Exclude spec files with matching group. It can be of multiple values separated by comma.
+ *      E.g. "--exclude-group='@enterprise'" will select files except @enterprise.
  *   --invert
  *      Selected files are those not matching any of the specified stage or group.
  *
@@ -35,6 +38,12 @@
  *      - will run all non-production tests
  * 4. "BROWSER='chrome' HEADLESS='false' node run_tests.js --stage='@prod' --group='@channel,@messaging'"
  *      - will run spec files matching stage and group values in Chrome (headed)
+ * 5. "CYPRESS_runWithEELicense=true node run_tests.js --stage='@prod'"
+ *      - will run all production tests
+ *      - typical test run for Enterprise Edition, given license file can be found in `cypress/fixtures` folder
+ * 6. "node run_tests.js --stage='@prod' --exclude-group'@enterprise'"
+ *      - will run all production tests except @enterprise group
+ *      - typical test run for Team Edition
  */
 
 const os = require('os');
@@ -72,17 +81,11 @@ async function runTests() {
         return;
     }
 
-    const {invert, group, stage} = argv;
-
     let hasFailed = false;
     for (let i = 0; i < finalTestFiles.length; i++) {
-        const testFile = finalTestFiles[i];
-        const testStage = stage ? `Stage: "${stage}" ` : '';
-        const testGroup = group ? `Group: "${group}" ` : '';
+        printMessage(finalTestFiles, i);
 
-        // Log which files were being tested
-        console.log(chalk.magenta.bold(`${invert ? 'All Except --> ' : ''}${testStage}${stage && group ? '| ' : ''}${testGroup}`));
-        console.log(chalk.magenta(`(Testing ${i + 1} of ${finalTestFiles.length})  - `, testFile));
+        const testFile = finalTestFiles[i];
 
         const result = await cypress.run({
             browser,
@@ -144,6 +147,21 @@ async function runTests() {
     }
 
     chai.expect(hasFailed, FAILURE_MESSAGE).to.be.false;
+}
+
+function printMessage(testFiles, index) {
+    const {invert, excludeGroup, group, stage} = argv;
+
+    const testFile = testFiles[index];
+    const testStage = stage ? `Stage: "${stage}" ` : '';
+    const withGroup = group || excludeGroup;
+    const groupMessage = group ? `"${group}"` : 'All';
+    const excludeGroupMessage = excludeGroup ? `except "${excludeGroup}"` : '';
+    const testGroup = withGroup ? `Group: ${groupMessage} ${excludeGroupMessage}` : '';
+
+    // Log which files were being tested
+    console.log(chalk.magenta.bold(`${invert ? 'All Except --> ' : ''}${testStage}${stage && withGroup ? '| ' : ''}${testGroup}`));
+    console.log(chalk.magenta(`(Testing ${index + 1} of ${testFiles.length})  - `, testFile));
 }
 
 runTests();

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -41,7 +41,7 @@
  * 5. "CYPRESS_runWithEELicense=true node run_tests.js --stage='@prod'"
  *      - will run all production tests
  *      - typical test run for Enterprise Edition, given license file can be found in `cypress/fixtures` folder
- * 6. "node run_tests.js --stage='@prod' --exclude-group'@enterprise'"
+ * 6. "node run_tests.js --stage='@prod' --exclude-group='@enterprise'"
  *      - will run all production tests except @enterprise group
  *      - typical test run for Team Edition
  */


### PR DESCRIPTION
#### Summary
This PR adds the ability to run test in CI for EE and TE.
- For EE: `CYPRESS_runWithEELicense=true node run_tests.js --stage='@prod'`, given that a license file can be found at `cypress/fixtures` folder.
- For TE: `node run_tests.js --stage='@prod' --exclude-group='@enterprise'`

Other changes included:
- For tests that require license to run:
  - Moved folder/files into `/enterprise` folder
  - Added each test file with `@enterprise` metadata

Note: ~~Test runs for EE and TE are ongoing. Will share report links once completed~~ See reports:
- EE test report - https://mm-cypress-report.s3.amazonaws.com/1159-ee-prod-master/mochawesome.html
  - failed tests known to master-prod
- TE test report - https://mm-cypress-report.s3.amazonaws.com/1158-te-prod-master/mochawesome.html
  - failed tests known to master-prod
  - other failed tests seemed to require a license. Will address separately to further verify license requirement.

#### Ticket Link
Jira ticket - https://mattermost.atlassian.net/browse/MM-29918
