### PR TITLE
[MM-29844] Fixed email input to allow multiple emails to be typed and trigger validation on more cases

### DIFF
--- a/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
+++ b/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
@@ -103,11 +103,6 @@ export default class InviteMembersStep extends React.PureComponent<Props, State>
             return;
         }
 
-        if (this.state.emails.length >= 10) {
-            this.setState({emailError: Utils.localizeMessage('next_steps_view.invite_members_step.tooManyEmails', 'Invitations are limited to 10 email addresses.')});
-            return;
-        }
-
         if (value.indexOf(' ') !== -1 || value.indexOf(',') !== -1) {
             const emails = value.split(/[\s,]+/).filter((email) => email.length).map((email) => ({label: email, value: email, error: !isEmail(email)}));
             const newEmails = [...this.state.emails, ...emails];
@@ -118,7 +113,7 @@ export default class InviteMembersStep extends React.PureComponent<Props, State>
                 emailError: newEmails.length > 10 ? Utils.localizeMessage('next_steps_view.invite_members_step.tooManyEmails', 'Invitations are limited to 10 email addresses.') : undefined,
             });
         } else {
-            this.setState({emailInput: value, emailError: undefined});
+            this.setState({emailInput: value});
         }
     }
 
@@ -141,7 +136,8 @@ export default class InviteMembersStep extends React.PureComponent<Props, State>
     onBlur = () => {
         if (this.state.emailInput) {
             const emails = this.state.emailInput.split(/[\s,]+/).filter((email) => email.length).map((email) => ({label: email, value: email, error: !isEmail(email)}));
-            this.setState({emails: [...this.state.emails, ...emails], emailInput: '', emailError: undefined});
+            const newEmails = [...this.state.emails, ...emails];
+            this.setState({emails: newEmails, emailInput: '', emailError: newEmails.length > 10 ? Utils.localizeMessage('next_steps_view.invite_members_step.tooManyEmails', 'Invitations are limited to 10 email addresses.') : undefined});
         }
     }
 


### PR DESCRIPTION
#### Summary
When copying and pasting emails over the limit, the control wouldn't allow the email to be added, but would still disable the Send button, requiring the user to delete an email unnecessarily.

This PR allows the users to enter as many emails as they want, but will trigger validation on each addition and on typing to ensure that more than 10 cannot be sent out.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29844