### PR TITLE
Cypress/E2E: Added mouseover trigger to image before clicking modal close

### DIFF
--- a/e2e/cypress/integration/markdown/markdown_image_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_image_spec.js
@@ -92,7 +92,7 @@ describe('Markdown', () => {
             });
 
             // * Verify that the preview modal opens
-            cy.get('div.modal-image__content').should('be.visible');
+            cy.get('div.modal-image__content').should('be.visible').trigger('mouseover');
 
             // # Close the modal
             cy.get('div.modal-close').should('exist').click({force: true});
@@ -115,7 +115,7 @@ describe('Markdown', () => {
             });
 
             // * Verify that the preview modal opens
-            cy.get('div.file-details__container').should('be.visible');
+            cy.get('div.file-details__container').should('be.visible').trigger('mouseover');
 
             // # Close the modal
             cy.get('div.modal-close').should('exist').click({force: true});

--- a/e2e/cypress/integration/messaging/image_attachment_spec.js
+++ b/e2e/cypress/integration/messaging/image_attachment_spec.js
@@ -175,7 +175,7 @@ describe('Image attachment', () => {
             });
 
             // * Verify that the preview modal opens
-            cy.get('div.modal-image__content').should('be.visible');
+            cy.get('div.modal-image__content').should('be.visible').trigger('mouseover');
 
             // # Close the modal
             cy.get('div.modal-close').should('exist').click({force: true});

--- a/e2e/cypress/integration/messaging/long_post_attachments_spec.js
+++ b/e2e/cypress/integration/messaging/long_post_attachments_spec.js
@@ -97,8 +97,11 @@ describe('MM-T105 Long post with mutiple attachments', () => {
                 cy.findByTestId('fileCountFooter').contains(`File ${index} of 4`).should('exist');
             }
 
-            // # click on close the preview
-            cy.get('.modal-close').should('be.visible').click();
+            // * Verify that the preview modal opens
+            cy.get('div.modal-image__content').should('be.visible').trigger('mouseover');
+
+            // # Close the modal
+            cy.get('div.modal-close').should('exist').click({force: true});
         });
     });
 });


### PR DESCRIPTION
#### Summary
- Added mouseover trigger to image before clicking modal close

#### Ticket Link
NA

![Screen Shot 2020-10-22 at 10 52 27 AM](https://user-images.githubusercontent.com/487991/96910938-0561c000-1455-11eb-96b1-6e353580f269.png)
![Screen Shot 2020-10-22 at 11 31 06 AM](https://user-images.githubusercontent.com/487991/96914642-195bf080-145a-11eb-83ca-b6ee4155f575.png)
![Screen Shot 2020-10-22 at 11 38 16 AM](https://user-images.githubusercontent.com/487991/96915510-2cbb8b80-145b-11eb-825b-34be413ebe03.png)
