### PR TITLE
[MM-29914] Fixed the initial value of the country on company info edit

### DIFF
--- a/components/admin_console/billing/company_info_edit.tsx
+++ b/components/admin_console/billing/company_info_edit.tsx
@@ -39,7 +39,7 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     const [address2, setAddress2] = useState(companyInfo?.company_address?.line2);
     const [city, setCity] = useState(companyInfo?.company_address?.city);
     const [postalCode, setPostalCode] = useState(companyInfo?.company_address?.postal_code);
-    const [country, setCountry] = useState(getName(companyInfo?.company_address?.country || 'US'));
+    const [country, setCountry] = useState(companyInfo?.company_address?.country || getName('US'));
     const [state, setState] = useState(companyInfo?.company_address?.state);
 
     const [sameAsBillingAddress, setSameAsBillingAddress] = useState(Boolean(!companyInfo?.company_address?.line1 && companyInfo?.billing_address?.line1));


### PR DESCRIPTION
#### Summary
When editing company information where an existing company address was present, the country field wasn't being populated. This required the user to have to select the country a second time before validation allowed the Save button to be enabled.

This PR fixes the initial value of the country so that the Save button is enabled immediately when opening the screen, such that editing other non-required fields (ie. number of employees) to function without issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29914