### PR TITLE
[MM-28312] Hide email invitations on invite members step if they're disabled

### DIFF
--- a/components/next_steps_view/steps/invite_members_step/index.ts
+++ b/components/next_steps_view/steps/invite_members_step/index.ts
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
 
 import {sendEmailInvitesToTeamGracefully, regenerateTeamInviteId} from 'mattermost-redux/actions/teams';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {GenericAction, ActionFunc} from 'mattermost-redux/types/actions';
 import {ServerError} from 'mattermost-redux/types/errors';
@@ -15,8 +16,11 @@ import {GlobalState} from 'types/store';
 import InviteMembersStep from './invite_members_step';
 
 function mapStateToProps(state: GlobalState) {
+    const config = getConfig(state);
+
     return {
         team: getCurrentTeam(state),
+        isEmailInvitesEnabled: config.EnableEmailInvitations === 'true',
     };
 }
 

--- a/components/next_steps_view/steps/invite_members_step/invite_members_step.test.tsx
+++ b/components/next_steps_view/steps/invite_members_step/invite_members_step.test.tsx
@@ -17,6 +17,7 @@ describe('components/next_steps_view/steps/invite_members_step', () => {
         currentUser: TestHelper.getUserMock(),
         expanded: true,
         isAdmin: true,
+        isEmailInvitesEnabled: true,
         actions: {
             sendEmailInvitesToTeamGracefully: jest.fn(),
             regenerateTeamInviteId: jest.fn(),

--- a/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
+++ b/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
@@ -23,6 +23,7 @@ import './invite_members_step.scss';
 
 type Props = StepComponentProps & {
     team: Team;
+    isEmailInvitesEnabled: boolean;
     actions: {
         sendEmailInvitesToTeamGracefully: (teamId: string, emails: string[]) => Promise<{ data: TeamInviteWithError[]; error: ServerError }>;
         regenerateTeamInviteId: (teamId: string) => void;
@@ -217,67 +218,77 @@ export default class InviteMembersStep extends React.PureComponent<Props, State>
         return (
             <div className='NextStepsView__stepWrapper'>
                 <div className='InviteMembersStep'>
-                    <div className='InviteMembersStep__emailInvitations'>
-                        <h3>
-                            <FormattedMessage
-                                id='next_steps_view.invite_members_step.sendInvitationsViaEmail'
-                                defaultMessage='Send invitations via email'
-                            />
-                        </h3>
-                        <FormattedMessage
-                            id='next_steps_view.invite_members_step.youCanInviteUpTo'
-                            defaultMessage='You can invite up to 10 team members using a space or comma between addresses'
-                        />
-                        <MultiInput
-                            onBlur={this.onBlur}
-                            onInputChange={this.onInputChange}
-                            onChange={this.onChange}
-                            value={this.state.emails}
-                            inputValue={this.state.emailInput}
-                            legend={Utils.localizeMessage('next_steps_view.invite_members_step.emailAddresses', 'Email addresses')}
-                            placeholder={Utils.localizeMessage('next_steps_view.invite_members_step.enterEmailAddresses', 'Enter email addresses')}
-                            styles={styles}
-                            name='InviteMembersStep__membersListInput'
-                        />
-                        <div className='InviteMembersStep__send'>
-                            <button
-                                data-testid='InviteMembersStep__sendButton'
-                                className={classNames('NextStepsView__button InviteMembersStep__sendButton secondary', {disabled: !this.state.emails.length || Boolean(this.state.emailsSent) || this.state.emailError})}
-                                disabled={!this.state.emails.length || Boolean(this.state.emailsSent) || Boolean(this.state.emailError)}
-                                onClick={this.sendEmailInvites}
-                            >
-                                <i className='icon icon-send'/>
+                    {this.props.isEmailInvitesEnabled &&
+                        <div className='InviteMembersStep__emailInvitations'>
+                            <h3>
                                 <FormattedMessage
-                                    id='next_steps_view.invite_members_step.send'
-                                    defaultMessage='Send'
+                                    id='next_steps_view.invite_members_step.sendInvitationsViaEmail'
+                                    defaultMessage='Send invitations via email'
                                 />
-                            </button>
-                            <div className={classNames('InviteMembersStep__invitationResults', {error: this.state.emailError})}>
-                                {this.state.emailsSent &&
-                                    <>
-                                        <i className='icon icon-check'/>
-                                        <FormattedMarkdownMessage
-                                            id='next_steps_view.invite_members_step.invitationsSent'
-                                            defaultMessage='{num} invitations sent'
-                                            values={{num: this.state.emailsSent}}
-                                        />
-                                    </>
-                                }
-                                {this.state.emailError &&
-                                    <>
-                                        <i className='icon icon-alert-outline'/>
-                                        <span>{this.state.emailError}</span>
-                                    </>
-                                }
+                            </h3>
+                            <FormattedMessage
+                                id='next_steps_view.invite_members_step.youCanInviteUpTo'
+                                defaultMessage='You can invite up to 10 team members using a space or comma between addresses'
+                            />
+                            <MultiInput
+                                onBlur={this.onBlur}
+                                onInputChange={this.onInputChange}
+                                onChange={this.onChange}
+                                value={this.state.emails}
+                                inputValue={this.state.emailInput}
+                                legend={Utils.localizeMessage('next_steps_view.invite_members_step.emailAddresses', 'Email addresses')}
+                                placeholder={Utils.localizeMessage('next_steps_view.invite_members_step.enterEmailAddresses', 'Enter email addresses')}
+                                styles={styles}
+                                name='InviteMembersStep__membersListInput'
+                            />
+                            <div className='InviteMembersStep__send'>
+                                <button
+                                    data-testid='InviteMembersStep__sendButton'
+                                    className={classNames('NextStepsView__button InviteMembersStep__sendButton secondary', {disabled: !this.state.emails.length || Boolean(this.state.emailsSent) || this.state.emailError})}
+                                    disabled={!this.state.emails.length || Boolean(this.state.emailsSent) || Boolean(this.state.emailError)}
+                                    onClick={this.sendEmailInvites}
+                                >
+                                    <i className='icon icon-send'/>
+                                    <FormattedMessage
+                                        id='next_steps_view.invite_members_step.send'
+                                        defaultMessage='Send'
+                                    />
+                                </button>
+                                <div className={classNames('InviteMembersStep__invitationResults', {error: this.state.emailError})}>
+                                    {this.state.emailsSent &&
+                                        <>
+                                            <i className='icon icon-check'/>
+                                            <FormattedMarkdownMessage
+                                                id='next_steps_view.invite_members_step.invitationsSent'
+                                                defaultMessage='{num} invitations sent'
+                                                values={{num: this.state.emailsSent}}
+                                            />
+                                        </>
+                                    }
+                                    {this.state.emailError &&
+                                        <>
+                                            <i className='icon icon-alert-outline'/>
+                                            <span>{this.state.emailError}</span>
+                                        </>
+                                    }
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    }
                     <div className='InviteMembersStep__shareInviteLink'>
                         <h3>
-                            <FormattedMessage
-                                id='next_steps_view.invite_members_step.orShareThisLink'
-                                defaultMessage='Or share this link to invite members'
-                            />
+                            {this.props.isEmailInvitesEnabled &&
+                                <FormattedMessage
+                                    id='next_steps_view.invite_members_step.orShareThisLink'
+                                    defaultMessage='Or share this link to invite members'
+                                />
+                            }
+                            {!this.props.isEmailInvitesEnabled &&
+                                <FormattedMessage
+                                    id='next_steps_view.invite_members_step.shareThisLink'
+                                    defaultMessage='Share this link to invite members'
+                                />
+                            }
                         </h3>
                         <div className='InviteMembersStep__shareLinkBlock'>
                             <input

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3278,6 +3278,7 @@
   "next_steps_view.invite_members_step.orShareThisLink": "Or share this link to invite members",
   "next_steps_view.invite_members_step.send": "Send",
   "next_steps_view.invite_members_step.sendInvitationsViaEmail": "Send invitations via email",
+  "next_steps_view.invite_members_step.shareThisLink": "Share this link to invite members",
   "next_steps_view.invite_members_step.tooManyEmails": "Invitations are limited to 10 email addresses.",
   "next_steps_view.invite_members_step.youCanInviteUpTo": "You can invite up to 10 team members using a space or comma between addresses",
   "next_steps_view.mobile_tips_message": "To configure your workspace, continue on a desktop computer.",


### PR DESCRIPTION
#### Summary
When email invites are disabled on the server, and you try to send invites via the Onboarding flow as a sysadmin, there will be a generic error message.

This PR just disables the email invite prompt if email invites are disabled. It shouldn't make a difference for Cloud customers, since email invites should be enabled by default for Cloud.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28312
