### PR TITLE
(WIP) Fixes MM-13497 : Migrate 'components/admin_console/license_settings' module and associated tests to TypeScript

### DIFF
--- a/components/admin_console/license_settings/index.ts
+++ b/components/admin_console/license_settings/index.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
+import {bindActionCreators, Dispatch} from 'redux';
 import {getLicenseConfig} from 'mattermost-redux/actions/general';
 import {uploadLicense, removeLicense} from 'mattermost-redux/actions/admin';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -11,15 +11,18 @@ import {requestTrialLicense, upgradeToE0Status, upgradeToE0, restartServer, ping
 
 import LicenseSettings from './license_settings.jsx';
 
-function mapStateToProps(state) {
+import {GlobalState} from 'types/store'
+
+function mapStateToProps(state : GlobalState) {
     const config = getConfig(state);
     return {
         stats: state.entities.admin.analytics,
         upgradedFromTE: config.UpgradedFromTE === 'true',
+        // Todo this requires changes in Mattermost redux
     };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch : Dispatch) {
     return {
         actions: bindActionCreators({
             getLicenseConfig,

--- a/components/admin_console/license_settings/license_settings.tsx
+++ b/components/admin_console/license_settings/license_settings.tsx
@@ -16,25 +16,47 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx'
 import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
 
-export default class LicenseSettings extends React.PureComponent {
-    static propTypes = {
-        license: PropTypes.object.isRequired,
-        enterpriseReady: PropTypes.bool.isRequired,
-        upgradedFromTE: PropTypes.bool.isRequired,
-        stats: PropTypes.object,
-        config: PropTypes.object,
-        isDisabled: PropTypes.bool,
-        actions: PropTypes.shape({
-            getLicenseConfig: PropTypes.func.isRequired,
-            uploadLicense: PropTypes.func.isRequired,
-            removeLicense: PropTypes.func.isRequired,
-            upgradeToE0: PropTypes.func.isRequired,
-            restartServer: PropTypes.func.isRequired,
-            ping: PropTypes.func.isRequired,
-            upgradeToE0Status: PropTypes.func.isRequired,
-            requestTrialLicense: PropTypes.func.isRequired,
-        }).isRequired,
+import {ActionResult, ActionFunc} from 'mattermost-redux/types/actions'
+import {StatusOK} from 'mattermost-redux/types/client4'
+
+type Props = {
+    licence : Object, // change later
+    enterpriseReady: boolean,
+    upgradedFromTE : boolean,
+    stats ?: Object, // change later
+    config ?: Object, // change later
+    isDisabled?: boolean,
+    actions : {
+        getLicenseConfig(): ActionResult,
+        uploadLicense(File): ActionFunc,
+        removeLicense(): ActionFunc ,
+        upgradeToE0(): Promise<StatusOK> ,
+        // restartServer: ,
+        // ping: ,
+        // upgradeToE0Status: ,
+        // requestTrialLicense: ,
     }
+}
+
+export default class LicenseSettings extends React.PureComponent<Props> {
+    // static propTypes = {
+    //     license: PropTypes.object.isRequired,
+    //     enterpriseReady: PropTypes.bool.isRequired,
+    //     upgradedFromTE: PropTypes.bool.isRequired,
+    //     stats: PropTypes.object,
+    //     config: PropTypes.object,
+    //     isDisabled: PropTypes.bool,
+    //     actions: PropTypes.shape({
+    //         getLicenseConfig: PropTypes.func.isRequired,``
+    //         uploadLicense: PropTypes.func.isRequired,
+    //         removeLicense: PropTypes.func.isRequired,
+    //         upgradeToE0: PropTypes.func.isRequired,
+    //         restartServer: PropTypes.func.isRequired,
+    //         ping: PropTypes.func.isRequired,
+    //         upgradeToE0Status: PropTypes.func.isRequired,
+    //         requestTrialLicense: PropTypes.func.isRequired,
+    //     }).isRequired,
+    // }
 
     constructor(props) {
         super(props);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
WIP 🚧 : Attempt to migrate files under `components/admin_console` to typescript.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
GH : Fixes https://github.com/mattermost/mattermost-server/issues/13497
JIRA: https://mattermost.atlassian.net/browse/MM-20575

#### Related Pull Requests
none

#### Screenshots
none