### PR TITLE
Update channel-header heading color

### DIFF
--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -162,6 +162,7 @@
         font-weight: 600;
         overflow: hidden;
         text-overflow: ellipsis;
+        color: var(--center-channel-color);
     }
 
     .caret {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -684,7 +684,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .shadow--2', '-moz-box-shadow: 0  20px 30px 0 ' + changeOpacity(theme.centerChannelColor, 0.1) + ', 0 14px 20px 0 ' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .shadow--2', '-webkit-box-shadow: 0  20px 30px 0 ' + changeOpacity(theme.centerChannelColor, 0.1) + ', 0 14px 20px 0 ' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .shortcut-key, .app__body .post__body hr, .app__body .loading-screen .loading__content .round, .app__body .tutorial__circles .circle', 'background:' + theme.centerChannelColor);
-        changeCss('.app__body .channel-header .heading', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .markdown__table tbody tr:nth-child(2n)', 'background:' + changeOpacity(theme.centerChannelColor, 0.07));
         changeCss('.app__body .channel-header__info .header-dropdown__icon', 'color:' + changeOpacity(theme.centerChannelColor, 0.8));
         changeCss('.app__body .post-create__container .post-create-body .send-button.disabled i', 'color:' + changeOpacity(theme.centerChannelColor, 0.4));


### PR DESCRIPTION
#### Summary
Removes changeCss() for the channel header heading (`.app__body .channel-header .heading`).
Sets the color of `.app__body .channel-header .heading` to `--center-channel-color` from scss file.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16025

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![image](https://user-images.githubusercontent.com/14865943/97110940-e42ff680-1716-11eb-9dbf-a8df74a4dd1b.png)
![image](https://user-images.githubusercontent.com/14865943/97110944-ed20c800-1716-11eb-804d-829690bc6290.png)
![image](https://user-images.githubusercontent.com/14865943/97110953-f742c680-1716-11eb-9881-064df4ce0ff9.png)

