### PR TITLE
[MM-29836] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 693

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -684,7 +684,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .post .post__link', 'color:' + changeOpacity(theme.centerChannelColor, 0.65));
         changeCss('.app__body #archive-link-home, .video-div .video-thumbnail__error', 'background:' + changeOpacity(theme.centerChannelColor, 0.15));
         changeCss('.app__body #post-create', 'color:' + theme.centerChannelColor);
-        changeCss('.app__body .shadow--2', 'box-shadow: 0 20px 30px 0' + changeOpacity(theme.centerChannelColor, 0.1) + ', 0 14px 20px 0 ' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .shadow--2', '-moz-box-shadow: 0  20px 30px 0 ' + changeOpacity(theme.centerChannelColor, 0.1) + ', 0 14px 20px 0 ' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .shadow--2', '-webkit-box-shadow: 0  20px 30px 0 ' + changeOpacity(theme.centerChannelColor, 0.1) + ', 0 14px 20px 0 ' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .shortcut-key, .app__body .post__body hr, .app__body .loading-screen .loading__content .round, .app__body .tutorial__circles .circle', 'background:' + theme.centerChannelColor);


### PR DESCRIPTION
#### Summary
Removes ChangeCSS() for `.app__body .shadow--2',` selectors with `'box-shadow: 0 20px 30px 0' <ins> changeOpacity(theme.centerChannelColor, 0.1) </ins> ', 0 14px 20px 0 ' <ins> changeOpacity(theme.centerChannelColor, 0.1)` properties

I am assuming `.shadow--2` does not affect any elements on the app so I am just deleting the line if that is right

#### Ticket Link
  Github Issue: Fixes https://github.com/mattermost/mattermost-server/issues/16022
  JIRA Ticket: Fixes https://mattermost.atlassian.net/browse/MM-29836