### PR TITLE
MM-2998 Add telemetry for product notices

### DIFF
--- a/components/product_notices_modal/__snapshots__/product_notices.test.tsx.snap
+++ b/components/product_notices_modal/__snapshots__/product_notices.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`ProductNoticesModal Match snapshot for user notice 1`] = `
     className="GenericModal__button actionButton"
     href="http://download.com/path"
     id="actionButton"
+    onClick={[Function]}
     rel="noopener noreferrer"
     target="_blank"
   >
@@ -150,6 +151,7 @@ exports[`ProductNoticesModal Should match snapshot for system admin notice 1`] =
     className="GenericModal__button actionButton"
     href="http://download.com/path"
     id="actionButton"
+    onClick={[Function]}
     rel="noopener noreferrer"
     target="_blank"
   >

--- a/components/product_notices_modal/product_notices.test.tsx
+++ b/components/product_notices_modal/product_notices.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {trackEvent} from 'actions/diagnostics_actions.jsx';
+import {trackEvent} from 'actions/telemetry_actions.jsx';
 
 import GenericModal from 'components/generic_modal';
 import {isDesktopApp, getDesktopVersion} from 'utils/user_agent';
@@ -12,8 +12,8 @@ import {isDesktopApp, getDesktopVersion} from 'utils/user_agent';
 import ProductNoticesModal from './product_notices_modal';
 
 jest.mock('utils/user_agent');
-jest.mock('actions/diagnostics_actions.jsx', () => {
-    const original = jest.requireActual('actions/diagnostics_actions.jsx');
+jest.mock('actions/telemetry_actions.jsx', () => {
+    const original = jest.requireActual('actions/telemetry_actions.jsx');
     return {
         ...original,
         trackEvent: jest.fn(),

--- a/components/product_notices_modal/product_notices.test.tsx
+++ b/components/product_notices_modal/product_notices.test.tsx
@@ -6,10 +6,18 @@ import {shallow} from 'enzyme';
 
 import GenericModal from 'components/generic_modal';
 import {isDesktopApp, getDesktopVersion} from 'utils/user_agent';
+import {trackEvent} from 'actions/diagnostics_actions.jsx';
 
 import ProductNoticesModal from './product_notices_modal';
 
 jest.mock('utils/user_agent');
+jest.mock('actions/diagnostics_actions.jsx', () => {
+    const original = jest.requireActual('actions/diagnostics_actions.jsx');
+    return {
+        ...original,
+        trackEvent: jest.fn(),
+    };
+});
 
 describe('ProductNoticesModal', () => {
     const noticesData = [{
@@ -99,6 +107,7 @@ describe('ProductNoticesModal', () => {
         await baseProps.actions.getInProductNotices();
         wrapper.setState({noticesData: [noticesData[1]]});
         wrapper.find(GenericModal).prop('handleConfirm')?.();
+        expect(trackEvent).toHaveBeenCalledWith('ui', 'notice_click_123');
         expect(window.open).toHaveBeenCalledWith(noticesData[1].actionParam, '_blank');
     });
 
@@ -172,5 +181,12 @@ describe('ProductNoticesModal', () => {
         });
 
         expect(baseProps.actions.getInProductNotices).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should call for trackEvent on click of action button', async () => {
+        const wrapper = shallow(<ProductNoticesModal {...baseProps}/>);
+        await baseProps.actions.getInProductNotices();
+        wrapper.find('.actionButton').simulate('click');
+        expect(trackEvent).toHaveBeenCalledWith('ui', 'notice_click_124');
     });
 });

--- a/components/product_notices_modal/product_notices.test.tsx
+++ b/components/product_notices_modal/product_notices.test.tsx
@@ -4,9 +4,10 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
+import {trackEvent} from 'actions/diagnostics_actions.jsx';
+
 import GenericModal from 'components/generic_modal';
 import {isDesktopApp, getDesktopVersion} from 'utils/user_agent';
-import {trackEvent} from 'actions/diagnostics_actions.jsx';
 
 import ProductNoticesModal from './product_notices_modal';
 

--- a/components/product_notices_modal/product_notices_modal.tsx
+++ b/components/product_notices_modal/product_notices_modal.tsx
@@ -6,6 +6,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {ProductNotices, ProductNotice} from 'mattermost-redux/types/product_notices';
 import {WebsocketStatus} from 'mattermost-redux/types/websocket';
+
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 
 import Markdown from 'components/markdown';

--- a/components/product_notices_modal/product_notices_modal.tsx
+++ b/components/product_notices_modal/product_notices_modal.tsx
@@ -6,7 +6,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {ProductNotices, ProductNotice} from 'mattermost-redux/types/product_notices';
 import {WebsocketStatus} from 'mattermost-redux/types/websocket';
-import {trackEvent} from 'actions/diagnostics_actions.jsx';
+import {trackEvent} from 'actions/telemetry_actions.jsx';
 
 import Markdown from 'components/markdown';
 import GenericModal from 'components/generic_modal';

--- a/components/product_notices_modal/product_notices_modal.tsx
+++ b/components/product_notices_modal/product_notices_modal.tsx
@@ -6,6 +6,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {ProductNotices, ProductNotice} from 'mattermost-redux/types/product_notices';
 import {WebsocketStatus} from 'mattermost-redux/types/websocket';
+import {trackEvent} from 'actions/diagnostics_actions.jsx';
 
 import Markdown from 'components/markdown';
 import GenericModal from 'components/generic_modal';
@@ -186,6 +187,11 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
         return null;
     }
 
+    private trackClickEvent = () => {
+        const presentNoticeInfo = this.state.noticesData[this.state.presentNoticeIndex];
+        trackEvent('ui', `notice_click_${presentNoticeInfo.id}`);
+    }
+
     private renderActionButton(presentNoticeInfo: ProductNotice) {
         const noOfNotices = this.state.noticesData.length;
 
@@ -197,6 +203,7 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
                     rel='noopener noreferrer'
                     className='GenericModal__button actionButton'
                     href={presentNoticeInfo.actionParam}
+                    onClick={this.trackClickEvent}
                 >
                     {presentNoticeInfo.actionText}
                 </a>
@@ -209,6 +216,7 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
         const presentNoticeInfo = this.state.noticesData[this.state.presentNoticeIndex];
         const noOfNotices = this.state.noticesData.length;
         if (noOfNotices === 1 && presentNoticeInfo.actionText) {
+            this.trackClickEvent();
             window.open(presentNoticeInfo.actionParam, '_blank');
         } else if (this.state.presentNoticeIndex + 1 < noOfNotices) {
             const nextNoticeInfo = this.state.noticesData[this.state.presentNoticeIndex + 1];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17897,8 +17897,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#2e73d31ab7b7d9ae3907995f462e3768dacf3410",
-      "from": "github:mattermost/mattermost-redux#2e73d31ab7b7d9ae3907995f462e3768dacf3410",
+      "version": "github:mattermost/mattermost-redux#8572f82fef2ea4abed563f0698961e22962b13b0",
+      "from": "github:mattermost/mattermost-redux#8572f82fef2ea4abed563f0698961e22962b13b0",
       "requires": {
         "core-js": "3.6.5",
         "form-data": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17897,8 +17897,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#8572f82fef2ea4abed563f0698961e22962b13b0",
-      "from": "github:mattermost/mattermost-redux#8572f82fef2ea4abed563f0698961e22962b13b0",
+      "version": "github:mattermost/mattermost-redux#fdf8fa87579f6457d55f8999301fe52068ac67d6",
+      "from": "github:mattermost/mattermost-redux#fdf8fa87579f6457d55f8999301fe52068ac67d6",
       "requires": {
         "core-js": "3.6.5",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "localforage-observable": "2.0.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#87769262aa02e1784570f61f4f962050e07cc335",
-    "mattermost-redux": "github:mattermost/mattermost-redux#8572f82fef2ea4abed563f0698961e22962b13b0",
+    "mattermost-redux": "github:mattermost/mattermost-redux#fdf8fa87579f6457d55f8999301fe52068ac67d6",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "localforage-observable": "2.0.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#87769262aa02e1784570f61f4f962050e07cc335",
-    "mattermost-redux": "github:mattermost/mattermost-redux#2e73d31ab7b7d9ae3907995f462e3768dacf3410",
+    "mattermost-redux": "github:mattermost/mattermost-redux#8572f82fef2ea4abed563f0698961e22962b13b0",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",


### PR DESCRIPTION
#### Summary
   * Add  track event when user clicks on action button of notice

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29998

#### Related Pull Requests
https://github.com/mattermost/mattermost-redux/pull/1277