### PR TITLE
Apply Theme center-channel-color to .shadow--2

### DIFF
--- a/components/system_notice/__snapshots__/system_notice.test.jsx.snap
+++ b/components/system_notice/__snapshots__/system_notice.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`components/SystemNotice should match snapshot for admin, admin notice 1`] = `
 <div
-  className="system-notice bg--white shadow--2"
+  className="system-notice bg--white"
 >
   <div
     className="system-notice__header"
@@ -69,7 +69,7 @@ exports[`components/SystemNotice should match snapshot for admin, admin notice 1
 
 exports[`components/SystemNotice should match snapshot for admin, regular notice 1`] = `
 <div
-  className="system-notice bg--white shadow--2"
+  className="system-notice bg--white"
 >
   <div
     className="system-notice__header"
@@ -119,7 +119,7 @@ exports[`components/SystemNotice should match snapshot for admin, regular notice
 
 exports[`components/SystemNotice should match snapshot for regular user, admin and regular notice 1`] = `
 <div
-  className="system-notice bg--white shadow--2"
+  className="system-notice bg--white"
 >
   <div
     className="system-notice__header"
@@ -177,7 +177,7 @@ exports[`components/SystemNotice should match snapshot for regular user, no noti
 
 exports[`components/SystemNotice should match snapshot for regular user, regular notice 1`] = `
 <div
-  className="system-notice bg--white shadow--2"
+  className="system-notice bg--white"
 >
   <div
     className="system-notice__header"
@@ -229,7 +229,7 @@ exports[`components/SystemNotice should match snapshot for show function returni
 
 exports[`components/SystemNotice should match snapshot for show function returning true 1`] = `
 <div
-  className="system-notice bg--white shadow--2"
+  className="system-notice bg--white"
 >
   <div
     className="system-notice__header"
@@ -279,7 +279,7 @@ exports[`components/SystemNotice should match snapshot for show function returni
 
 exports[`components/SystemNotice should match snapshot for with allowForget equal false 1`] = `
 <div
-  className="system-notice bg--white shadow--2"
+  className="system-notice bg--white"
 >
   <div
     className="system-notice__header"

--- a/components/system_notice/system_notice.jsx
+++ b/components/system_notice/system_notice.jsx
@@ -116,7 +116,7 @@ export default class SystemNotice extends React.PureComponent {
 
         return (
             <div
-                className='system-notice bg--white shadow--2'
+                className='system-notice bg--white'
             >
                 <div className='system-notice__header'>
                     <div className='system-notice__logo'>

--- a/sass/components/_system-notice.scss
+++ b/sass/components/_system-notice.scss
@@ -1,7 +1,7 @@
 @charset 'UTF-8';
 
 .system-notice {
-    @include box-shadow(0 20px 30px alpha-color($black, .07), 0 14px 20px alpha-color($black, .07));
+    @include box-shadow(0 20px 30px rgba(var(--center-channel-color-rgb), 0.1), 0 14px 20px rgba(var(--center-channel-color-rgb), 0.1));
     @include border-radius(4px);
     background-color: $white;
     border: 1px solid alpha-color($black, .15);

--- a/sass/components/_system-notice.scss
+++ b/sass/components/_system-notice.scss
@@ -11,11 +11,6 @@
     right: 12px;
     width: 280px;
     z-index: 9999;
-
-    .shadow--2 {
-        -moz-box-shadow: 0 20px 30px 0 rgba(var(--center-channel-color-rgb), 0.1), 0 14px 20px 0 rgba(var(--center-channel-color-rgb), 0.1);
-        -webkit-box-shadow: 0 20px 30px 0 rgba(var(--center-channel-color-rgb), 0.1), 0 14px 20px 0 rgba(var(--center-channel-color-rgb), 0.1);
-    }
 }
 
 .system-notice__header {

--- a/sass/components/_system-notice.scss
+++ b/sass/components/_system-notice.scss
@@ -11,6 +11,11 @@
     right: 12px;
     width: 280px;
     z-index: 9999;
+
+    .shadow--2 {
+        -moz-box-shadow: 0 20px 30px 0 rgba(var(--center-channel-color-rgb), 0.1), 0 14px 20px 0 rgba(var(--center-channel-color-rgb), 0.1);
+        -webkit-box-shadow: 0 20px 30px 0 rgba(var(--center-channel-color-rgb), 0.1), 0 14px 20px 0 rgba(var(--center-channel-color-rgb), 0.1);
+    }
 }
 
 .system-notice__header {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -681,8 +681,6 @@ export function applyTheme(theme) {
         changeCss('.app__body #archive-link-home, .video-div .video-thumbnail__error', 'background:' + changeOpacity(theme.centerChannelColor, 0.15));
         changeCss('.app__body #post-create', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .shadow--2', 'box-shadow: 0 20px 30px 0' + changeOpacity(theme.centerChannelColor, 0.1) + ', 0 14px 20px 0 ' + changeOpacity(theme.centerChannelColor, 0.1));
-        changeCss('.app__body .shadow--2', '-moz-box-shadow: 0  20px 30px 0 ' + changeOpacity(theme.centerChannelColor, 0.1) + ', 0 14px 20px 0 ' + changeOpacity(theme.centerChannelColor, 0.1));
-        changeCss('.app__body .shadow--2', '-webkit-box-shadow: 0  20px 30px 0 ' + changeOpacity(theme.centerChannelColor, 0.1) + ', 0 14px 20px 0 ' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .shortcut-key, .app__body .post__body hr, .app__body .loading-screen .loading__content .round, .app__body .tutorial__circles .circle', 'background:' + theme.centerChannelColor);
         changeCss('.app__body .channel-header .heading', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .markdown__table tbody tr:nth-child(2n)', 'background:' + changeOpacity(theme.centerChannelColor, 0.07));


### PR DESCRIPTION
#### Summary
Removes `changeCss()` for `.shadow--2` `-moz-box-shadow` and `-webkit-box-shadow` (currently only used in .app__body .system-notice.shadow--2)
Removes `.shadow--2` class for `SystemNotice` component
No additions were made to SCSS files because `SystemNotice` already has `@include box-shadow(0 20px 30px alpha-color($black, .07), 0 14px 20px alpha-color($black, .07));` set in `sass/components/_system-notice.scss` 

#### Ticket Link
Fixes [mattermost/mattermost-server#16023](https://github.com/mattermost/mattermost-server/issues/16023)
Fixes [mattermost/mattermost-server#16024](https://github.com/mattermost/mattermost-server/issues/16024)

#### Related Pull Requests
Seems like the non `-moz` and non -`webkit` version of this similar change was tackled in https://github.com/mattermost/mattermost-webapp/pull/6933

#### Screenshots
Currently retains its previous look as shown below:
![image](https://user-images.githubusercontent.com/14865943/97321635-0efe8400-18aa-11eb-8d13-579965c38e3e.png)
