### PR TITLE
MM-29986 Don't show archived channels with unread filter enabled

### DIFF
--- a/selectors/views/channel_sidebar.ts
+++ b/selectors/views/channel_sidebar.ts
@@ -84,9 +84,11 @@ export const getUnreadChannels = (() => {
         (state: GlobalState) => getUnreadChannelIds(state),
         getCurrentChannelId,
         (allChannels, unreadChannelIds, currentChannelId) => {
-            const unreadChannels = unreadChannelIds.map((channelId) => allChannels[channelId]);
+            const unreadChannels = unreadChannelIds.
+                map((channelId) => allChannels[channelId]).
+                filter((channel) => channel.delete_at === 0);
 
-            if (unreadChannelIds.indexOf(currentChannelId) === -1) {
+            if (unreadChannels.findIndex((channel) => channel.id === currentChannelId) === -1) {
                 unreadChannels.push(allChannels[currentChannelId]);
             }
 

--- a/selectors/views/channel_sidebar.ts
+++ b/selectors/views/channel_sidebar.ts
@@ -84,9 +84,17 @@ export const getUnreadChannels = (() => {
         (state: GlobalState) => getUnreadChannelIds(state),
         getCurrentChannelId,
         (allChannels, unreadChannelIds, currentChannelId) => {
-            const unreadChannels = unreadChannelIds.
-                map((channelId) => allChannels[channelId]).
-                filter((channel) => channel.delete_at === 0);
+            const unreadChannels = [];
+            for (const channelId of unreadChannelIds) {
+                const channel = allChannels[channelId];
+
+                // Only include an archived channel if it's the current channel
+                if (channel.delete_at > 0 && channel.id !== currentChannelId) {
+                    continue;
+                }
+
+                unreadChannels.push(channel);
+            }
 
             if (unreadChannels.findIndex((channel) => channel.id === currentChannelId) === -1) {
                 unreadChannels.push(allChannels[currentChannelId]);


### PR DESCRIPTION
This is coming in a bit late, but with the new unread filter enabled, we forgot to filter out archived channels when the user isn't looking at them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29986