### PR TITLE
MM-20413: Migrate 'components/channel_header_mobile/collapse_rhs_button' module to TypeScript

### DIFF
--- a/components/channel_header_mobile/collapse_rhs_button/collapse_rhs_button.tsx
+++ b/components/channel_header_mobile/collapse_rhs_button/collapse_rhs_button.tsx
@@ -2,31 +2,28 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import MenuIcon from 'components/widgets/icons/menu_icon';
 
-const CollapseRhsButton = ({
-    actions: {
-        toggleRhsMenu,
-    },
-}) => (
+type Actions = {
+    toggleRhsMenu: (e?:React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+}
+
+type Props = {
+    actions: Actions
+}
+
+const CollapseRhsButton: React.FunctionComponent<Props> = (props: Props) => (
     <button
         key='navbar-toggle-menu'
         type='button'
         className='navbar-toggle navbar-right__icon menu-toggle pull-right'
         data-toggle='collapse'
         data-target='#sidebar-nav'
-        onClick={toggleRhsMenu}
+        onClick={props.actions.toggleRhsMenu}
     >
         <MenuIcon/>
     </button>
 );
-
-CollapseRhsButton.propTypes = {
-    actions: PropTypes.shape({
-        toggleRhsMenu: PropTypes.func.isRequired,
-    }).isRequired,
-};
 
 export default CollapseRhsButton;

--- a/components/channel_header_mobile/collapse_rhs_button/index.ts
+++ b/components/channel_header_mobile/collapse_rhs_button/index.ts
@@ -1,14 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {bindActionCreators} from 'redux';
+import {bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
+
+import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {toggleMenu as toggleRhsMenu} from 'actions/views/rhs';
 
 import CollapseRhsButton from './collapse_rhs_button';
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = (dispatch:Dispatch<GenericAction>) => ({
     actions: bindActionCreators({
         toggleRhsMenu,
     }, dispatch),


### PR DESCRIPTION
#### Summary
Migrating 'components/channel_header_mobile/collapse_rhs_button' module to TypeScript

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16160
JIRA: https://mattermost.atlassian.net/browse/MM-20413
