### PR TITLE
MM-30177: Migrate changeCSS() to CSS variable '.app__body .input-grou…

### DIFF
--- a/sass/routes/_settings.scss
+++ b/sass/routes/_settings.scss
@@ -678,3 +678,9 @@
     text-overflow: ellipsis;
     white-space: pre;
 }
+
+.app__body {
+    .input-group-addon {
+        border-color: rgba(var(--center-channel-color-rgb), 0.1)
+    }
+} 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -696,7 +696,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .popover.top>.arrow', 'border-top-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .popover .popover__row', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('body.app__body, .app__body .custom-textarea', 'color:' + theme.centerChannelColor);
-        changeCss('.app__body .input-group-addon', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('@media(min-width: 768px){.app__body .post-list__table .post-list__content .dropdown-menu a:hover, .dropdown-menu > li > button:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .MenuWrapper .MenuItem > button:hover, .app__body .Menu .MenuItem > button:hover, .app__body .MenuWrapper .MenuItem > button:focus, .app__body .MenuWrapper .MenuItem > a:hover, .app__body .dropdown-menu div > a:focus, .app__body .dropdown-menu div > a:hover, .dropdown-menu li > a:focus, .app__body .dropdown-menu li > a:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .attachment .attachment__content, .app__body .attachment-actions button', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.3));


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Migrate changeCSS() to CSS variable in utils/utils.jsx
`changeCss('.app__body .input-group-addon', 'border-color:' changeOpacity(theme.centerChannelColor, 0.1));`

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/16181
Jira: https://mattermost.atlassian.net/browse/MM-30177
