### PR TITLE
Campaign/applytheme center channel color

### DIFF
--- a/sass/responsive/_desktop.scss
+++ b/sass/responsive/_desktop.scss
@@ -55,6 +55,12 @@
                     }
                 }
             }
+
+            .date-separator {
+                .separator_text {
+                    color: var(--center-channel-color)
+                }
+            }
         }
     }
 }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -703,7 +703,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .attachment-actions button:focus, .app__body .attachment-actions button:hover', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.5));
         changeCss('.app__body .attachment-actions button:focus, .app__body .attachment-actions button:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.03));
         changeCss('.app__body .input-group-addon, .app__body .channel-intro .channel-intro__content, .app__body .webhooks__container', 'background:' + changeOpacity(theme.centerChannelColor, 0.05));
-        changeCss('.app__body .date-separator .separator__text', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .date-separator .separator__hr, .app__body .modal-footer, .app__body .modal .custom-textarea', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .search-item-container', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .modal .custom-textarea:focus', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.3));


### PR DESCRIPTION
Summary
Migrate `changeCss('.app__body .date-separator .separator__text', 'color:' theme.centerChannelColor)` in line 706 to CSS variables. Css applied in sass/responsive/_desktop.scss.

Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16182

Jira: https://mattermost.atlassian.net/browse/MM-30178.

If I have to make changes in the PR, please do tell me. Thanks