### PR TITLE
[MM-30175] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 709

### DIFF
--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -71,7 +71,7 @@
 
     &.top {
         > .arrow {
-            border-top-color: rgba(var(--center-channel-color), 0.25);
+            border-top-color: rgba(var(--center-channel-color-rgb), 0.25);
         }
     }
 

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -18,10 +18,6 @@
         box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
         border-color: v(center-channel-color-16);
     }
-
-    .popover.top > .arrow {
-        border-top-color: rgba(var(--center-channel-color), 0.25);
-    }
 }
 
 .popover {
@@ -72,7 +68,13 @@
 
     &.bottom,
     &.right,
-    &.top,
+
+    &.top {
+        > .arrow {
+            border-top-color: rgba(var(--center-channel-color), 0.25);
+        }
+    }
+
     &.left {
         > .arrow {
             display: none;

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -18,6 +18,10 @@
         box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
         border-color: v(center-channel-color-16);
     }
+
+    .popover.top > .arrow {
+        border-top-color: rgba(var(--center-channel-color), 0.25);
+    }
 }
 
 .popover {

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -68,13 +68,7 @@
 
     &.bottom,
     &.right,
-
-    &.top {
-        > .arrow {
-            border-top-color: rgba(var(--center-channel-color-rgb), 0.25);
-        }
-    }
-
+    &.top,
     &.left {
         > .arrow {
             display: none;
@@ -87,6 +81,12 @@
 
     &.bottom {
         margin-top: 10px;
+    }
+
+    &.top {
+        > .arrow {
+            border-top-color: rgba(var(--center-channel-color-rgb), 0.25);
+        }
     }
 
     ul + p,

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -693,7 +693,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .btn.btn-transparent', 'color:' + changeOpacity(theme.centerChannelColor, 0.7));
         changeCss('.app__body .popover.right>.arrow', 'border-right-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .popover.left>.arrow', 'border-left-color:' + changeOpacity(theme.centerChannelColor, 0.25));
-        changeCss('.app__body .popover.top>.arrow', 'border-top-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .popover .popover__row', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('body.app__body, .app__body .custom-textarea', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .input-group-addon', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.1));


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Migrate a CSS variable for popover from `utils/utils.jsx` into `sass/components/_popover.scss`
<!--
A description of what this pull request does.
-->

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16179
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
