### PR TITLE
[MM-30173] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 707

### DIFF
--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -70,7 +70,7 @@
 
     &.right {
         > .arrow {
-            border-right-color: rgba(var(--center-channel-color), 0.25);
+            border-right-color: rgba(var(--center-channel-color-rgb), 0.25);
         }
     }
     &.top,

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -67,12 +67,7 @@
     }
 
     &.bottom,
-
-    &.right {
-        > .arrow {
-            border-right-color: rgba(var(--center-channel-color-rgb), 0.25);
-        }
-    }
+    &.right,
     &.top,
     &.left {
         > .arrow {
@@ -86,6 +81,12 @@
 
     &.bottom {
         margin-top: 10px;
+    }
+
+    &.right {
+        > .arrow {
+            border-right-color: rgba(var(--center-channel-color-rgb), 0.25);
+        }
     }
 
     ul + p,

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -67,7 +67,12 @@
     }
 
     &.bottom,
-    &.right,
+
+    &.right {
+        > .arrow {
+            border-right-color: rgba(var(--center-channel-color), 0.25);
+        }
+    }
     &.top,
     &.left {
         > .arrow {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -691,7 +691,6 @@ export function applyTheme(theme) {
         changeCss('.emoji-picker .emoji-picker__header', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .popover.bottom>.arrow', 'border-bottom-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .btn.btn-transparent', 'color:' + changeOpacity(theme.centerChannelColor, 0.7));
-        changeCss('.app__body .popover.right>.arrow', 'border-right-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .popover.left>.arrow', 'border-left-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .popover.top>.arrow', 'border-top-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .popover .popover__row', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Migrate a CSS variable for popover from `utils/utils.jsx` into `sass/components/_popover.scss`
<!--
A description of what this pull request does.
-->

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16177
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
