### PR TITLE
MM-30095/MM-30195 Re-add missing elements to RHS

### DIFF
--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -9,6 +9,7 @@ import {trackEvent} from 'actions/telemetry_actions.jsx';
 import Constants from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
 
+import FileUploadOverlay from 'components/file_upload_overlay';
 import RhsThread from 'components/rhs_thread';
 import RhsCard from 'components/rhs_card';
 import Search from 'components/search/index.tsx';
@@ -162,26 +163,25 @@ export default class SidebarRight extends React.PureComponent {
             isExpanded,
         } = this.props;
 
-        let content = null;
         const isSidebarRightExpanded = (postRightVisible || postCardVisible || isPluginView || searchVisible) && isExpanded;
 
-        switch (true) {
-        case postRightVisible:
+        let content = null;
+        if (postRightVisible) {
             content = (
-                <RhsThread
-                    previousRhsState={previousRhsState}
-                    currentUserId={currentUserId}
-                    toggleSize={this.toggleSize}
-                    shrink={this.onShrink}
-                />
+                <>
+                    <FileUploadOverlay overlayType='right'/>
+                    <RhsThread
+                        previousRhsState={previousRhsState}
+                        currentUserId={currentUserId}
+                        toggleSize={this.toggleSize}
+                        shrink={this.onShrink}
+                    />
+                </>
             );
-            break;
-        case postCardVisible:
+        } else if (postCardVisible) {
             content = <RhsCard previousRhsState={previousRhsState}/>;
-            break;
-        case isPluginView:
+        } else if (isPluginView) {
             content = <RhsPlugin/>;
-            break;
         }
 
         return (

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -184,6 +184,14 @@ export default class SidebarRight extends React.PureComponent {
             content = <RhsPlugin/>;
         }
 
+        if (content) {
+            content = (
+                <div className='post-right__container'>
+                    {content}
+                </div>
+            );
+        }
+
         return (
             <div
                 className={classNames('sidebar--right', {'sidebar--right--expanded': isSidebarRightExpanded}, {'move--left': isOpen})}


### PR DESCRIPTION
Some recent RHS changes accidentally removed some stuff in the RHS that was actually important. There's still an outstanding issue with the search not working any more, but Nevy is looking into that.

One small thing to note, but there's a slight difference in the DOM from before the RHS refactoring since the `.sidebar-right-container` div now wraps the `.post-right__container` one. Before, I think we'd have only one of those at once. I don't think this causes any different behaviour, but I thought I'd note it since the CSS in the RHS is complicated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30095
https://mattermost.atlassian.net/browse/MM-30195