### PR TITLE
[MM-20196] Use UTC timezone for formattedDate so it doesn't change the date

### DIFF
--- a/components/admin_console/billing/billing_history.tsx
+++ b/components/admin_console/billing/billing_history.tsx
@@ -194,7 +194,7 @@ const BillingHistory: React.FC<Props> = () => {
                         >
                             <td>
                                 <FormattedDate
-                                    value={new Date(invoice.period_start).toUTCString()}
+                                    value={new Date(invoice.period_start)}
                                     month='2-digit'
                                     day='2-digit'
                                     year='numeric'

--- a/components/admin_console/billing/billing_history.tsx
+++ b/components/admin_console/billing/billing_history.tsx
@@ -198,6 +198,7 @@ const BillingHistory: React.FC<Props> = () => {
                                     month='2-digit'
                                     day='2-digit'
                                     year='numeric'
+                                    timeZone='utc'
                                 />
                             </td>
                             <td>

--- a/components/admin_console/billing/billing_history.tsx
+++ b/components/admin_console/billing/billing_history.tsx
@@ -194,11 +194,11 @@ const BillingHistory: React.FC<Props> = () => {
                         >
                             <td>
                                 <FormattedDate
-                                    value={new Date(invoice.period_start)}
+                                    value={new Date(invoice.period_start).toUTCString()}
                                     month='2-digit'
                                     day='2-digit'
                                     year='numeric'
-                                    timeZone='utc'
+                                    timeZone='UTC'
                                 />
                             </td>
                             <td>

--- a/components/admin_console/billing/billing_summary.tsx
+++ b/components/admin_console/billing/billing_summary.tsx
@@ -120,6 +120,7 @@ const BillingSummary: React.FC = () => {
                         month='short'
                         year='numeric'
                         day='numeric'
+                        timeZone='UTC'
                     />
                 </div>
                 <div className='BillingSummary__lastInvoice-productName'>


### PR DESCRIPTION
#### Summary
FormattedDate converts the time to the local timezone. Setting the timeZone prop to UTC will keep it as the proper date, since that date is UTC.
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30196

#### Related Pull Requests
N/A
#### Screenshots
N/A