### PR TITLE
[MM-30127] Make invoice.tax a boolean so a rogue 0 isn't rendered

### DIFF
--- a/components/admin_console/billing/billing_summary.tsx
+++ b/components/admin_console/billing/billing_summary.tsx
@@ -210,7 +210,7 @@ const BillingSummary: React.FC = () => {
                         </div>
                     </div>
                 ))}
-                {invoice.tax &&
+                {Boolean(invoice.tax) &&
                     <div className='BillingSummary__lastInvoice-charge'>
                         <div className='BillingSummary__lastInvoice-chargeDescription'>
                             <FormattedMessage


### PR DESCRIPTION
#### Summary
See here: https://stackoverflow.com/a/53048160

Because this was a number, the condition wouldn't return the latter, so it return invoice.tax, and print just "0" in the dom. This will ensure its not rendered in the case its false.
#### Ticket Link
https://stackoverflow.com/a/53048160

#### Related Pull Requests
n/a
#### Screenshots
n/a