### PR TITLE
Cypress/E2E: Move cluster spec to enterprise

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/cluster_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/cluster_spec.js
@@ -7,7 +7,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @system_console
+// Group: @enterprise @system_console
 
 describe('Cluster', () => {
     before(() => {

--- a/e2e/cypress/integration/enterprise/system_console/cluster_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/cluster_spec.js
@@ -11,24 +11,34 @@
 
 describe('Cluster', () => {
     before(() => {
-        // # Visit customization system console page
+        // * Check if server has license
+        cy.apiRequireLicense();
+
+        // # Reset Experimental Gossip Encryption
+        cy.apiUpdateConfig({ClusterSettings: {
+            Enable: null,
+            UseExperimentalGossip: null,
+            EnableExperimentalGossipEncryption: null,
+        }});
+
+        // # Visit high availability system console page
         cy.visit('/admin_console/environment/high_availability');
     });
 
     it('SC25050 - Can change Experimental Gossip Encryption', () => {
         cy.findByTestId('EnableExperimentalGossipEncryption').scrollIntoView().should('be.visible').within(() => {
-            // Verify that setting is visible and matches text content
+            // * Verify that setting is visible and matches text content
             cy.get('.control-label').should('be.visible').and('have.text', 'Enable Experimental Gossip encryption:');
 
-            // Verify that the help setting is visible and matches text content
+            // * Verify that the help setting is visible and matches text content
             const contents = 'When true, all communication through the gossip protocol will be encrypted.';
             cy.get('.help-text').should('be.visible').and('have.text', contents);
 
-            // Verify that the default value is false.
+            // * Verify that Experimental Gossip Encryption is set to false by default
             cy.get('#EnableExperimentalGossipEncryptionfalse').should('have.attr', 'checked');
         });
 
-        // Now change the config
+        // # Enable Experimental Gossip Encryption
         cy.apiUpdateConfig({ClusterSettings: {
             Enable: true,
             UseExperimentalGossip: true,
@@ -37,7 +47,7 @@ describe('Cluster', () => {
         cy.reload();
 
         cy.findByTestId('EnableExperimentalGossipEncryption').scrollIntoView().should('be.visible').within(() => {
-            // Verify that the setting has now changed..
+            // * Verify that Experimental Gossip Encryption is set to true
             cy.get('#EnableExperimentalGossipEncryptiontrue').should('have.attr', 'checked');
         });
     });


### PR DESCRIPTION
#### Summary
- Moved spec to enterprise as it requires license
- Added feature reset so that verification for default state passes

#### Ticket Link
NA