### PR TITLE
[MM-30190] Show spinner when loading invoices instead of 'no invoices found'

### DIFF
--- a/components/admin_console/billing/billing_history.scss
+++ b/components/admin_console/billing/billing_history.scss
@@ -99,6 +99,11 @@
     text-align: right;
 }
 
+.BillingHistory__spinner {
+    margin: auto;
+    text-align: center;
+}
+
 .BillingHistory__paymentStatus {
     color: var(--sys-online-indicator);
 

--- a/components/admin_console/billing/billing_history.tsx
+++ b/components/admin_console/billing/billing_history.tsx
@@ -10,6 +10,8 @@ import {Client4} from 'mattermost-redux/client';
 import {Invoice} from 'mattermost-redux/types/cloud';
 import {GlobalState} from 'mattermost-redux/types/store';
 
+import LoadingSpinner from 'components/widgets/loading/loading_spinner';
+
 import {pageVisited, trackEvent} from 'actions/telemetry_actions';
 import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
@@ -112,7 +114,6 @@ const BillingHistory: React.FC<Props> = () => {
 
         // TODO: When server paging, check if there are more invoices
     };
-
     useEffect(() => {
         dispatch(getCloudProducts());
         dispatch(getCloudSubscription());
@@ -267,8 +268,20 @@ const BillingHistory: React.FC<Props> = () => {
                                 </div>
                             </div>
                         </div>
+
                         <div className='BillingHistory__cardBody'>
-                            {billingHistory ? billingHistoryTable : noBillingHistorySection}
+                            {invoices != null && (
+                                <>
+                                    {billingHistory ?
+                                        billingHistoryTable :
+                                        noBillingHistorySection}
+                                </>
+                            )}
+                            {invoices == null && (
+                                <div className='BillingHistory__spinner'>
+                                    <LoadingSpinner/>
+                                </div>
+                            )}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
#### Summary
The billing history screen would flash "No invoices found" (or something similar) until the invoices endpoint returned something (regardless of if it was going to return something or not. 

invoices starts out null, and then is defined when the endpoint returns, even if the endpoint returns nothing. So we just need to know whether its null or not, before handing over the render to the rest of the logic.

I also added a spinner because I thought it looked good. Spoke with Matt, and he agrees.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30190

#### Related Pull Requests
n/a

#### Screenshots
![2020-11-03 13 47 44](https://user-images.githubusercontent.com/12176405/98028422-15c25500-1ddc-11eb-9ae7-06503e95b8bb.gif)
