### PR TITLE
MM-29929 Fix for unread messages toast on marking channel as unread

### DIFF
--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -98,15 +98,17 @@ class ToastWrapper extends React.PureComponent {
                 showMessageHistoryToast = props.initScrollOffsetFromBottom > THRESHOLD_FROM_BOTTOM || !props.atLatestPost;
             }
 
-            // show unread toast when a channel is marked as unread
-            if (props.channelMarkedAsUnread && !prevState.channelMarkedAsUnread && !prevState.showUnreadToast) {
-                showUnreadToast = props.initScrollOffsetFromBottom > THRESHOLD_FROM_BOTTOM;
-            }
+            if (!props.atBottom) {
+                // show unread toast when a channel is marked as unread
+                if (props.channelMarkedAsUnread && !prevState.channelMarkedAsUnread && !prevState.showUnreadToast) {
+                    showUnreadToast = true;
+                }
 
-            // show unread toast when a channel is remarked as unread using the change in lastViewedAt
-            // lastViewedAt changes only if a channel is remarked as unread in channelMarkedAsUnread state
-            if (props.channelMarkedAsUnread && props.lastViewedAt !== prevState.lastViewedAt) {
-                showUnreadToast = props.initScrollOffsetFromBottom > THRESHOLD_FROM_BOTTOM;
+                // show unread toast when a channel is remarked as unread using the change in lastViewedAt
+                // lastViewedAt changes only if a channel is remarked as unread in channelMarkedAsUnread state
+                if (props.channelMarkedAsUnread && props.lastViewedAt !== prevState.lastViewedAt) {
+                    showUnreadToast = true;
+                }
             }
         }
 

--- a/components/toast_wrapper/toast_wrapper.test.jsx
+++ b/components/toast_wrapper/toast_wrapper.test.jsx
@@ -145,7 +145,7 @@ describe('components/ToastWrapper', () => {
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
             expect(wrapper.state('showUnreadToast')).toBe(false);
             wrapper.setProps({channelMarkedAsUnread: true, atBottom: false});
-            expect(wrapper.state('showUnreadToast')).toBe(false);
+            expect(wrapper.state('showUnreadToast')).toBe(true);
         });
 
         test('Should have unread toast channel is marked as unread again', () => {
@@ -170,12 +170,12 @@ describe('components/ToastWrapper', () => {
                 ],
             });
 
-            expect(wrapper.state('showUnreadToast')).toBe(false);
+            expect(wrapper.state('showUnreadToast')).toBe(true);
             wrapper.setProps({atBottom: true});
             expect(wrapper.state('showUnreadToast')).toBe(false);
             wrapper.setProps({atBottom: false});
             wrapper.setProps({lastViewedAt: 12342});
-            expect(wrapper.state('showUnreadToast')).toBe(false);
+            expect(wrapper.state('showUnreadToast')).toBe(true);
         });
 
         test('Should have archive toast if channel is not atLatestPost and focusedPostId exists', () => {


### PR DESCRIPTION
#### Summary
This was a regression caused here https://github.com/mattermost/mattermost-webapp/pull/5828.

   * The initOffset we use for displaying toast should be only used mount as that is not a scroll position that is updated after mount. It. can only be used for determining the offset when mounting like unread toast but not after. scrolling a bit and marking channel as unread. We are not tracking the real-time scroll offsets to do this atm.

   * Changing this to show unread toast on all occasions of marking the channel as
     unread other than channel at the bottom

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29929