### PR TITLE
[MM-30226][MM-39255] Allow a post to be sent when you do CMD + ENTER on Mac with 'Allow all messages' to be sent via CMD + ENTER

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -297,7 +297,7 @@ class EditPostModal extends React.PureComponent {
 
     handleKeyDown = (e) => {
         const {ctrlSend, codeBlockOnCtrlEnter} = this.props;
-        
+
         const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
         const ctrlKeyCombo = ctrlOrMetaKeyPressed && !e.altKey && !e.shiftKey;
         const ctrlEnterKeyCombo = (ctrlSend || codeBlockOnCtrlEnter) && Utils.isKeyPressed(e, KeyCodes.ENTER) && ctrlOrMetaKeyPressed;

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -296,14 +296,18 @@ class EditPostModal extends React.PureComponent {
     }
 
     handleKeyDown = (e) => {
-        const ctrlKeyCombo = (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey;
+        const {ctrlSend, codeBlockOnCtrlEnter} = this.props;
+        
+        const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
+        const ctrlKeyCombo = ctrlOrMetaKeyPressed && !e.altKey && !e.shiftKey;
+        const ctrlEnterKeyCombo = (ctrlSend || codeBlockOnCtrlEnter) && Utils.isKeyPressed(e, KeyCodes.ENTER) && ctrlOrMetaKeyPressed;
         const markdownHotkey = Utils.isKeyPressed(e, KeyCodes.B) || Utils.isKeyPressed(e, KeyCodes.I);
 
         // listen for line break key combo and insert new line character
         if (Utils.isUnhandledLineBreakKeyCombo(e)) {
             e.stopPropagation(); // perhaps this should happen in all of these cases? or perhaps Modal should not be listening?
             this.setState({editText: Utils.insertLineBreakFromKeyEvent(e)});
-        } else if (this.props.ctrlSend && Utils.isKeyPressed(e, KeyCodes.ENTER) && e.ctrlKey === true) {
+        } else if (ctrlEnterKeyCombo) {
             this.handleEdit();
         } else if (Utils.isKeyPressed(e, KeyCodes.ESCAPE) && !this.state.showEmojiPicker) {
             this.handleHide();

--- a/components/edit_post_modal/edit_post_modal.test.jsx
+++ b/components/edit_post_modal/edit_post_modal.test.jsx
@@ -407,21 +407,49 @@ describe('components/EditPostModal', () => {
         var wrapper = shallowWithIntl(createEditPost({ctrlSend: true}), {context: options.get()});
         var instance = wrapper.instance();
         instance.handleEdit = jest.fn();
-        instance.handleKeyDown({keyCode: 1, ctrlKey: true, ...eventMethods});
+
+        // Test with Control Key (Windows)
+        instance.handleKeyDown({keyCode: 1, ctrlKey: true, metaKey: false, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
-        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, ...eventMethods});
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: false, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
-        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true, ...eventMethods});
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true, metaKey: false, ...eventMethods});
+        expect(instance.handleEdit).toBeCalled();
+
+        wrapper = shallowWithIntl(createEditPost({ctrlSend: true}));
+        instance = wrapper.instance();
+        instance.handleEdit = jest.fn();
+        
+        // Test with Command Key (Mac)
+        instance.handleKeyDown({keyCode: 1, ctrlKey: false, metaKey: true, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: false, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: true, ...eventMethods});
         expect(instance.handleEdit).toBeCalled();
 
         wrapper = shallowWithIntl(createEditPost({ctrlSend: false}));
         instance = wrapper.instance();
         instance.handleEdit = jest.fn();
-        instance.handleKeyDown({keyCode: 1, ctrlKey: true, ...eventMethods});
+
+        // Test with Control Key (Windows)
+        instance.handleKeyDown({keyCode: 1, ctrlKey: true, metaKey: false, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
-        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, ...eventMethods});
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: false, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
-        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true, ...eventMethods});
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true, metaKey: false, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+
+        wrapper = shallowWithIntl(createEditPost({ctrlSend: false}));
+        instance = wrapper.instance();
+        instance.handleEdit = jest.fn();
+        
+        // Test with Command Key (Mac)
+        instance.handleKeyDown({keyCode: 1, ctrlKey: false, metaKey: true, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: false, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: true, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
     });
 

--- a/components/edit_post_modal/edit_post_modal.test.jsx
+++ b/components/edit_post_modal/edit_post_modal.test.jsx
@@ -419,7 +419,7 @@ describe('components/EditPostModal', () => {
         wrapper = shallowWithIntl(createEditPost({ctrlSend: true}));
         instance = wrapper.instance();
         instance.handleEdit = jest.fn();
-        
+
         // Test with Command Key (Mac)
         instance.handleKeyDown({keyCode: 1, ctrlKey: false, metaKey: true, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
@@ -443,7 +443,7 @@ describe('components/EditPostModal', () => {
         wrapper = shallowWithIntl(createEditPost({ctrlSend: false}));
         instance = wrapper.instance();
         instance.handleEdit = jest.fn();
-        
+
         // Test with Command Key (Mac)
         instance.handleKeyDown({keyCode: 1, ctrlKey: false, metaKey: true, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
This PR fixes when trying to edit a post and using `CMD + ENTER` on mac for all messages to send the message. Previously, it did nothing. Now, it sends the message. This matches the behaviour of when creating a post.

Also addresses the problem where if you are within a code block when editing a post and setting is set to send messages only for code blocks, if you hit enter it should move the text to a new line and not submit. If you type `CMD + ENTER` then it will edit the post.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30226
https://mattermost.atlassian.net/browse/MM-30255