### PR TITLE
MM-27941: Sends the root post create_at time to the API when replying.

### DIFF
--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -64,7 +64,7 @@ export function makeOnMoveHistoryIndex(rootId, direction) {
     };
 }
 
-export function submitPost(channelId, rootId, draft) {
+export function submitPost(channelId, rootId, draft, rootCreateAt) {
     return async (dispatch, getState) => {
         const state = getState();
 
@@ -78,6 +78,7 @@ export function submitPost(channelId, rootId, draft) {
             channel_id: channelId,
             root_id: rootId,
             parent_id: rootId,
+            root_create_at: rootCreateAt,
             pending_post_id: `${userId}:${time}`,
             user_id: userId,
             create_at: time,
@@ -145,7 +146,7 @@ export function submitCommand(channelId, rootId, draft) {
     };
 }
 
-export function makeOnSubmit(channelId, rootId, latestPostId) {
+export function makeOnSubmit(channelId, rootId, latestPostId, rootCreateAt) {
     return (options = {}) => async (dispatch, getState) => {
         const draft = getPostDraft(getState(), StoragePrefixes.COMMENT_DRAFT, rootId);
         const {message} = draft;
@@ -164,7 +165,7 @@ export function makeOnSubmit(channelId, rootId, latestPostId) {
         } else if (message.indexOf('/') === 0 && !options.ignoreSlash) {
             await dispatch(submitCommand(channelId, rootId, draft));
         } else {
-            dispatch(submitPost(channelId, rootId, draft));
+            dispatch(submitPost(channelId, rootId, draft, rootCreateAt));
         }
     };
 }

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -59,6 +59,11 @@ class CreateComment extends React.PureComponent {
         rootId: PropTypes.string.isRequired,
 
         /**
+         * The create at date of the parent post
+         */
+        rootCreateAt: PropTypes.string,
+
+        /**
          * True if the root message was deleted
          */
         rootDeleted: PropTypes.bool.isRequired,

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -135,7 +135,7 @@ function makeMapDispatchToProps() {
         }
 
         if (rootId !== ownProps.rootId || channelId !== ownProps.channelId || latestPostId !== ownProps.latestPostId) {
-            onSubmit = makeOnSubmit(ownProps.channelId, ownProps.rootId, ownProps.latestPostId);
+            onSubmit = makeOnSubmit(ownProps.channelId, ownProps.rootId, ownProps.latestPostId, ownProps.rootCreateAt);
         }
 
         rootId = ownProps.rootId;

--- a/components/rhs_thread/__snapshots__/rhs_thread.test.tsx.snap
+++ b/components/rhs_thread/__snapshots__/rhs_thread.test.tsx.snap
@@ -121,6 +121,7 @@ exports[`components/RhsThread should match snapshot 1`] = `
     <Connect(injectIntl(CreateComment))
       channelId="channel_id"
       latestPostId="id"
+      rootCreateAt={1502715365009}
       rootDeleted={false}
       rootId="id"
     />

--- a/components/rhs_thread/rhs_thread.tsx
+++ b/components/rhs_thread/rhs_thread.tsx
@@ -383,6 +383,7 @@ export default class RhsThread extends React.Component<Props, State> {
                         <CreateComment
                             channelId={selected.channel_id}
                             rootId={selected.id}
+                            rootCreateAt={createAt}
                             rootDeleted={(selected as Post).state === Posts.POST_DELETED}
                             latestPostId={postsLength > 0 ? postsArray[postsLength - 1].id : selected.id}
                         />

--- a/selectors/rhs.ts
+++ b/selectors/rhs.ts
@@ -71,6 +71,7 @@ export const getSelectedPost = createSelector(
             message: localizeMessage('rhs_thread.rootPostDeletedMessage.body', 'Part of this thread has been deleted due to a data retention policy. You can no longer reply to this thread.'),
             channel_id: selectedPostChannelId,
             user_id: currentUserId,
+            create_at: 0
         };
     },
 );

--- a/selectors/rhs.ts
+++ b/selectors/rhs.ts
@@ -71,7 +71,7 @@ export const getSelectedPost = createSelector(
             message: localizeMessage('rhs_thread.rootPostDeletedMessage.body', 'Part of this thread has been deleted due to a data retention policy. You can no longer reply to this thread.'),
             channel_id: selectedPostChannelId,
             user_id: currentUserId,
-            create_at: 0
+            create_at: 0,
         };
     },
 );

--- a/types/store/rhs.ts
+++ b/types/store/rhs.ts
@@ -14,6 +14,7 @@ export type FakePost = {
     message: string;
     channel_id: $ID<Channel>;
     user_id: $ID<UserProfile>;
+    create_at: number;
 };
 
 export type PostDraft = {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- https://github.com/mattermost/mattermost-server/pull/16219
- https://github.com/mattermost/mattermost-redux/pull/1288

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->