### PR TITLE
MM-T2833 Use a slash command that accepts an optional argument

### DIFF
--- a/e2e/cypress/integration/integrations/slash_command_accepts_argument_spec.js
+++ b/e2e/cypress/integration/integrations/slash_command_accepts_argument_spec.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @integrations
+
+describe('Integrations', () => {
+    let testTeam;
+    let testChannel;
+
+    before(() => {
+        // # Login as test user and visit the newly created test channel
+        cy.apiInitSetup().then(({team, user, channel}) => {
+            testTeam = team;
+            testChannel = channel;
+
+            // # Set up and enable Agenda plugin required for test
+            cy.apiInstallPluginFromUrl('https://github.com/mattermost/mattermost-plugin-agenda/releases/download/v0.2.1/com.mattermost.agenda-0.2.1.tar.gz', true);
+            cy.apiEnablePluginById('com.mattermost.agenda');
+
+            // # Login as regular user and visit test channel
+            cy.apiLogin(user);
+            cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+        });
+    });
+
+    after(() => {
+    // # Clean up - remove Agenda plugin
+        cy.apiAdminLogin();
+        cy.apiRemovePluginById('com.mattermost.agenda');
+    });
+
+    it('MM-T2833 Use a slash command that accepts an optional argument', () => {
+        const nextWeek = Cypress.moment().add(7, 'days').format('MMMDD');
+        const testText = 'meeting agenda items';
+
+        // # Post a message with the plugin for a meeting in one week
+        cy.findByTestId('post_textbox').type(`/agenda queue next-week ${testText}{enter}`);
+        cy.uiWaitUntilMessagePostedIncludes(`${testText}`).then(() => {
+            cy.getLastPostId().then((postId) => {
+                cy.get(`#postMessageText_${postId}`).within(() => {
+                    // * Assert that the agenda message is posted with date one week away with test text
+                    cy.contains(`${testChannel.name}-${nextWeek} 1) ${testText}`);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
**_Summary_**

This PR validates that a plugin that accepts an optional argument (agenda plugin) works as expected.

**_Steps_**

- the agenda plugin is installed
- an entry is posted with an argument to schedule the meeting time to 1 week away
- the created entry is asserted to have been posted correctly
- the agenda plugin is removed

<img width="578" alt="Screen Shot 2020-11-11 at 8 52 52 PM" src="https://user-images.githubusercontent.com/586584/98886078-49971d80-2461-11eb-9a25-de2556d74bdf.png">

**_Links_**

[vercel](https://automation-test-cases.vercel.app/test/MM-T2833)
[TM4J](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T2833)
