### PR TITLE
[MM-29621] Only load the stripe library when cloud components are actually rendered

### DIFF
--- a/components/admin_console/billing/payment_info_edit.tsx
+++ b/components/admin_console/billing/payment_info_edit.tsx
@@ -5,6 +5,7 @@ import React, {useEffect, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
+import {Stripe} from '@stripe/stripe-js';
 import {loadStripe} from '@stripe/stripe-js/pure'; // https://github.com/stripe/stripe-js#importing-loadstripe-without-side-effects
 import {Elements} from '@stripe/react-stripe-js';
 
@@ -25,7 +26,7 @@ import {browserHistory} from 'utils/browser_history';
 import './payment_info_edit.scss';
 import AlertBanner from 'components/alert_banner';
 
-let stripePromise: any;
+let stripePromise: Promise<Stripe | null>;
 
 const PaymentInfoEdit: React.FC = () => {
     const dispatch = useDispatch();

--- a/components/admin_console/billing/payment_info_edit.tsx
+++ b/components/admin_console/billing/payment_info_edit.tsx
@@ -5,7 +5,7 @@ import React, {useEffect, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
-import {loadStripe} from '@stripe/stripe-js';
+import {loadStripe} from '@stripe/stripe-js/pure'; // https://github.com/stripe/stripe-js#importing-loadstripe-without-side-effects
 import {Elements} from '@stripe/react-stripe-js';
 
 import {getCloudCustomer} from 'mattermost-redux/actions/cloud';
@@ -25,7 +25,7 @@ import {browserHistory} from 'utils/browser_history';
 import './payment_info_edit.scss';
 import AlertBanner from 'components/alert_banner';
 
-const stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
+let stripePromise: any;
 
 const PaymentInfoEdit: React.FC = () => {
     const dispatch = useDispatch();
@@ -70,6 +70,10 @@ const PaymentInfoEdit: React.FC = () => {
 
         setIsSaving(false);
     };
+
+    if (!stripePromise) {
+        stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
+    }
 
     return (
         <div className='wrapper--fixed PaymentInfoEdit'>

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -81,7 +81,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
         return {...state, productPrice};
     }
 
-    async componentDidMount() {
+    componentDidMount() {
         pageVisited(TELEMETRY_CATEGORIES.CLOUD_PURCHASING, 'pageview_purchase');
         this.props.actions.getCloudProducts();
 

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -31,7 +31,7 @@ import ProcessPaymentSetup from './process_payment_setup';
 import './purchase.scss';
 import 'components/payment_form/payment_form.scss';
 
-let stripePromise: any;
+let stripePromise: Promise<Stripe | null>;
 
 type Props = {
     show: boolean;

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -3,7 +3,8 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {Stripe, loadStripe} from '@stripe/stripe-js';
+import {Stripe} from '@stripe/stripe-js';
+import {loadStripe} from '@stripe/stripe-js/pure'; // https://github.com/stripe/stripe-js#importing-loadstripe-without-side-effects
 import {Elements} from '@stripe/react-stripe-js';
 
 import {Product} from 'mattermost-redux/types/cloud';
@@ -30,7 +31,7 @@ import ProcessPaymentSetup from './process_payment_setup';
 import './purchase.scss';
 import 'components/payment_form/payment_form.scss';
 
-const stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
+let stripePromise: any;
 
 type Props = {
     show: boolean;
@@ -80,7 +81,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
         return {...state, productPrice};
     }
 
-    componentDidMount() {
+    async componentDidMount() {
         pageVisited(TELEMETRY_CATEGORIES.CLOUD_PURCHASING, 'pageview_purchase');
         this.props.actions.getCloudProducts();
 
@@ -223,6 +224,9 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
     }
 
     render() {
+        if (!stripePromise) {
+            stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
+        }
         return (
             <Elements
                 options={{fonts: [{cssSrc: STRIPE_CSS_SRC}]}}


### PR DESCRIPTION
#### Summary
As soon as a component that uses stripe was imported into any file in the webapp, the stripe library would be loaded regardless of whether it was a cloud instance or not. This PR moves the stripe lib loading to wait for the component to render before attempting to load. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29621

#### Related Pull Requests
N/A
#### Screenshots
N/A