### PR TITLE
[MM-29515] Hide imports tab when in cloud installation

### DIFF
--- a/components/team_settings_modal/index.ts
+++ b/components/team_settings_modal/index.ts
@@ -3,6 +3,8 @@
 
 import {connect} from 'react-redux';
 
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
+
 import {ModalIdentifiers} from 'utils/constants';
 import {isModalOpen} from 'selectors/views/modals';
 
@@ -14,6 +16,7 @@ function mapStateToProps(state: GlobalState) {
     const modalId = ModalIdentifiers.TEAM_SETTINGS;
     return {
         show: isModalOpen(state, modalId),
+        isCloud: getLicense(state).Cloud === 'true',
     };
 }
 

--- a/components/team_settings_modal/team_settings_modal.test.tsx
+++ b/components/team_settings_modal/team_settings_modal.test.tsx
@@ -9,7 +9,12 @@ import TeamSettingsModal from 'components/team_settings_modal/team_settings_moda
 
 describe('components/team_settings_modal', () => {
     test('should match snapshot', () => {
-        const wrapper = shallow(<TeamSettingsModal onHide={jest.fn()}/>);
+        const wrapper = shallow(
+            <TeamSettingsModal
+                isCloud={false}
+                onHide={jest.fn()}
+            />,
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -18,6 +23,7 @@ describe('components/team_settings_modal', () => {
 
         const wrapper = shallow(
             <TeamSettingsModal
+                isCloud={false}
                 onHide={onHide}
             />,
         );

--- a/components/team_settings_modal/team_settings_modal.tsx
+++ b/components/team_settings_modal/team_settings_modal.tsx
@@ -14,7 +14,7 @@ import TeamSettings from 'components/team_settings';
 
 type Props = {
     onHide: () => void,
-    isCloud: boolean,
+    isCloud?: boolean,
 }
 
 export type State = {

--- a/components/team_settings_modal/team_settings_modal.tsx
+++ b/components/team_settings_modal/team_settings_modal.tsx
@@ -13,7 +13,8 @@ const SettingsSidebar = React.lazy(() => import('components/settings_sidebar'));
 import TeamSettings from 'components/team_settings';
 
 type Props = {
-    onHide: () => void
+    onHide: () => void,
+    isCloud: boolean,
 }
 
 export type State = {
@@ -74,7 +75,9 @@ export default class TeamSettingsModal extends React.PureComponent<Props, State>
     render() {
         const tabs = [];
         tabs.push({name: 'general', uiName: Utils.localizeMessage('team_settings_modal.generalTab', 'General'), icon: 'icon fa fa-cog', iconTitle: Utils.localizeMessage('generic_icons.settings', 'Settings Icon')});
-        tabs.push({name: 'import', uiName: Utils.localizeMessage('team_settings_modal.importTab', 'Import'), icon: 'icon fa fa-upload', iconTitle: Utils.localizeMessage('generic_icons.upload', 'Upload Icon')});
+        if (!this.props.isCloud) {
+            tabs.push({name: 'import', uiName: Utils.localizeMessage('team_settings_modal.importTab', 'Import'), icon: 'icon fa fa-upload', iconTitle: Utils.localizeMessage('generic_icons.upload', 'Upload Icon')});
+        }
 
         return (
             <Modal

--- a/package-lock.json
+++ b/package-lock.json
@@ -6995,7 +6995,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -9511,14 +9511,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -12583,7 +12583,7 @@
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
       "requires": {
-        "icu4c-data": "0.63.2"
+        "icu4c-data": "0.64.2"
       }
     },
     "function-bind": {
@@ -14107,7 +14107,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -19588,7 +19588,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -6995,7 +6995,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -9511,14 +9511,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -12583,7 +12583,7 @@
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
       "requires": {
-        "icu4c-data": "0.64.2"
+        "icu4c-data": "0.63.2"
       }
     },
     "function-bind": {
@@ -14107,7 +14107,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -19588,7 +19588,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true


### PR DESCRIPTION
#### Summary
We don't want to show the old slack import tool in cloud installations. This PR will hide it from the menu if the instance is a cloud one.
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29515
#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/16271

#### Screenshots
N/A