### PR TITLE
Cypress/E2E: Fix toast appears unread spec

### DIFF
--- a/e2e/cypress/integration/mark_as_unread/toast_appears_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/toast_appears_unread_spec.js
@@ -52,7 +52,7 @@ describe('Verify unread toast appears after repeated manual marking post as unre
                             Cypress._.times(30, (index) => {
                                 cy.postMessageAs({
                                     sender: otherUser,
-                                    message: index.toString(),
+                                    message: `${index.toString()}\nsecond line\nthird line\nfourth line`,
                                     channelId: townSquareChannel.id,
                                 });
                             });


### PR DESCRIPTION
#### Summary
- Per this [comment](https://mattermost.atlassian.net/browse/MM-30534?focusedCommentId=101466), we just need to increase the content size to trigger the div toast
- Specifically testing for 1000 pixels might be finicky when they change later so I opted to just increase the content

@saturninoabril I didn't add v5.29 milestone since today is release day but feel free to add if you think we should

#### Ticket Link
NA

![Screen Shot 2020-11-16 at 10 27 40 AM](https://user-images.githubusercontent.com/487991/99292655-61222d80-27f6-11eb-83c8-6cf3202caaac.png)
