### PR TITLE
[MM-29821] Prefer TypeScript files over JavaScript in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -249,7 +249,7 @@ var config = {
             jquery: 'jquery/src/jquery',
             superagent: 'node_modules/superagent/lib/client',
         },
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
     },
     performance: {
         hints: 'warning',


### PR DESCRIPTION
#### Summary
In some cases, `.js/.jsx` files can be leftover from a TypeScript migration, and our webpack configuration was compiling in the JS over the TS file. This PR ensures that webpack in the webapp will prefer TS over JS.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29821