### PR TITLE
MM-30477 Fix for autocomplete not closing

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -190,14 +190,13 @@ export function autocompleteUsersInChannel(prefix, channelId) {
 
         const respose = await dispatch(autocompleteUsers(prefix, currentTeamId, channelId));
         const data = respose.data;
-
         if (data) {
             return {
                 ...respose,
                 data: {
                     ...data,
-                    users: addLastViewAtToProfiles(state, data.users),
-                    out_of_channel: addLastViewAtToProfiles(state, data.out_of_channel),
+                    users: addLastViewAtToProfiles(state, data.users || []),
+                    out_of_channel: addLastViewAtToProfiles(state, data.out_of_channel || []),
                 },
             };
         }

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -6,6 +6,7 @@ import thunk from 'redux-thunk';
 
 import {General, Posts, RequestStatus} from 'mattermost-redux/constants';
 import {leaveChannel, markChannelAsRead} from 'mattermost-redux/actions/channels';
+import * as UserActions from 'mattermost-redux/actions/users';
 import * as PostActions from 'mattermost-redux/actions/posts';
 
 import {browserHistory} from 'utils/browser_history';
@@ -34,6 +35,8 @@ jest.mock('actions/channel_actions.jsx', () => ({
     openDirectChannelToUserId: jest.fn(() => ({type: ''})),
 }));
 
+jest.mock('mattermost-redux/actions/users');
+
 jest.mock('mattermost-redux/actions/channels', () => ({
     ...jest.requireActual('mattermost-redux/actions/channels'),
     markChannelAsRead: jest.fn(() => ({type: ''})),
@@ -44,6 +47,10 @@ jest.mock('mattermost-redux/actions/posts');
 
 jest.mock('selectors/local_storage', () => ({
     getLastViewedChannelName: () => 'channel1',
+}));
+
+jest.mock('mattermost-redux/selectors/entities/utils', () => ({
+    makeAddLastViewAtToProfiles: () => jest.fn().mockReturnValue([]),
 }));
 
 describe('channel view actions', () => {
@@ -758,6 +765,14 @@ describe('channel view actions', () => {
             jest.runOnlyPendingTimers();
             await Promise.resolve();
             expect(PostActions.getPostsUnread).toHaveBeenCalledWith('channelid1');
+        });
+    });
+
+    describe('autocompleteUsersInChannel', () => {
+        test('should return empty arrays if the key is missing in reponse', async () => {
+            UserActions.autocompleteUsers.mockReturnValue(() => ({data: {}}));
+            const response = await store.dispatch(Actions.autocompleteUsersInChannel('test', 'channelid1'));
+            expect(response).toStrictEqual({data: {out_of_channel: [], users: []}});
         });
     });
 });


### PR DESCRIPTION
#### Summary
  * makeAddLastViewAtToProfiles selector expects profiles to be
    arrays always causing this to error out incase of no results
  * Changing this pass in array incase of no key in data

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30477
https://mattermost.atlassian.net/browse/MM-30739
