### PR TITLE
[MM-27260] Added transform to channel collapsing

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -759,6 +759,8 @@
         list-style-type: none;
         /* border: solid 2px transparent; */
         color: rgba(var(--sidebar-text-rgb), 0.6);
+        transform: scaleY(100%);
+        transform-origin: top;
 
         &:hover {
             .btn-close {
@@ -817,7 +819,7 @@
 
 
     .SidebarChannel.animating {
-        transition-property: height, padding, color;
+        transition-property: height, padding, color, transform;
         transition-duration: 0.15s; /* collapse animation speed */
         transition-timing-function: ease-out;
     }
@@ -827,6 +829,7 @@
     }
 
     .SidebarChannel.collapsed {
+        transform: scaleY(0);
         height: 0 !important;
         padding-top: 0;
         padding-bottom: 0;


### PR DESCRIPTION
#### Summary
When a category is collapsed, all the channels are rendered in the same location to start since the parent `div` of the channel has a `height: 0`. But since the inner divs can overflow, they all end up overlapping which can show up in some cases.

This PR adds a `transform` to the collapsing style such that the channel truly has no visible height and the channels will unfold gracefully.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27260