### PR TITLE
If card year is 0 return false for isExpired

### DIFF
--- a/components/admin_console/billing/payment_info.tsx
+++ b/components/admin_console/billing/payment_info.tsx
@@ -32,6 +32,11 @@ const PaymentInfo: React.FC<Props> = () => {
 
         const expiryYear = customer.payment_method.exp_year;
 
+        // If not expiry year, or its 0, it's not expired (because it probably isn't set)
+        if (!expiryYear) {
+            return false;
+        }
+
         // This works because we store the expiry month as the actual 1-12 base month, but Date uses a 0-11 base month
         // But credit cards expire at the end of their expiry month, so we can just use that number.
         const lastExpiryDate = new Date(expiryYear, customer.payment_method.exp_month, 1);

--- a/utils/cloud_utils.ts
+++ b/utils/cloud_utils.ts
@@ -10,6 +10,11 @@ export function isCustomerCardExpired(customer?: CloudCustomer): boolean {
 
     const expiryYear = customer.payment_method.exp_year;
 
+    // If not expiry year, or its 0, it's not expired (because it probably isn't set)
+    if (!expiryYear) {
+        return false;
+    }
+
     // This works because we store the expiry month as the actual 1-12 base month, but Date uses a 0-11 base month
     // But credit cards expire at the end of their expiry month, so we can just use that number.
     const lastExpiryDate = new Date(expiryYear, customer.payment_method.exp_month, 1);


### PR DESCRIPTION
#### Summary
Not sure how I missed this, but stripe sends the exp_year as 0 when it's not set (rather than null or something) so it would always be a date in the past. If it's 0, just return false.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30104
#### Related Pull Requests
N/A
#### Screenshots
N/A