### PR TITLE
MM-30285: Add online status to the profile popover

### DIFF
--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -24,6 +24,7 @@ import LocalizedIcon from 'components/localized_icon';
 import ToggleModalButtonRedux from 'components/toggle_modal_button_redux';
 import Avatar from 'components/widgets/users/avatar';
 import Popover from 'components/widgets/popover';
+import StatusIcon from 'components/status_icon';
 
 /**
  * The profile popover, or hovercard, that appears with user information when clicking
@@ -293,6 +294,7 @@ class ProfilePopover extends React.PureComponent {
                         className='overflow--ellipsis text-nowrap'
                     >
                         <strong>{fullname}</strong>
+                        <StatusIcon status={this.props.status}/>
                     </div>
                 </OverlayTrigger>,
             );
@@ -347,6 +349,7 @@ class ProfilePopover extends React.PureComponent {
                         className='text-nowrap text-lowercase user-popover__email pb-1'
                     >
                         {email}
+                        {fullname ? null : <StatusIcon status={this.props.status}/>}
                     </a>
                 </div>,
             );


### PR DESCRIPTION
#### Summary
This pull request adds a status indicator on the profile popover. It will display the StatusIcon component after fullname, but if fullname is not set the StatusIcon will appear after the e-mail adress in the popover.

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/16248

#### Screenshots
![mm-1](https://user-images.githubusercontent.com/14109085/99908317-377b7180-2ce2-11eb-9f17-7b0858a98eb0.png) ![mm-2](https://user-images.githubusercontent.com/14109085/99908319-38140800-2ce2-11eb-9868-8530c5c7cf56.png)