### PR TITLE
[MM-20400] Migrate 'components/plugin_marketplace/marketplace_item' module and associated tests to TypeScript

### DIFF
--- a/components/plugin_marketplace/marketplace_item/__snapshots__/marketplace_item.test.tsx.snap
+++ b/components/plugin_marketplace/marketplace_item/__snapshots__/marketplace_item.test.tsx.snap
@@ -162,88 +162,6 @@ exports[`components/MarketplaceItem MarketplaceItem should render installed plug
 </Fragment>
 `;
 
-exports[`components/MarketplaceItem MarketplaceItem should render when not from the marketplace 1`] = `
-<Fragment>
-  <div
-    className="more-modal__row more-modal__row--link"
-    id="marketplace-plugin-id"
-    key="id"
-  >
-    <div
-      className="icon__plugin icon__plugin--background"
-    >
-      <img
-        src="icon"
-      />
-    </div>
-    <div
-      className="more-modal__details"
-    >
-      <a
-        aria-label="name"
-        className="style--none more-modal__row--link"
-        href="http://example.com"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        name
-        <span
-          className="light subtitle"
-        >
-          (1.0.0)
-        </span>
-      </a>
-      <a
-        aria-label="test plugin"
-        className="style--none more-modal__row--link"
-        href="http://example.com"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        <p
-          className="more-modal__description"
-        >
-          test plugin
-        </p>
-      </a>
-      <UpdateDetails
-        installedVersion=""
-        isInstalling={false}
-        onUpdate={[Function]}
-        version="1.0.0"
-      />
-    </div>
-    <div
-      className="more-modal__actions"
-    >
-      <button
-        className="btn btn-primary"
-        disabled={false}
-        onClick={[Function]}
-      >
-        <LoadingWrapper
-          loading={false}
-          text="Installing..."
-        >
-          <FormattedMessage
-            defaultMessage="Install"
-            id="marketplace_modal.list.Install"
-          />
-        </LoadingWrapper>
-      </button>
-    </div>
-    <UpdateConfirmationModal
-      installedVersion=""
-      name="name"
-      onCancel={[Function]}
-      onUpdate={[Function]}
-      show={false}
-      version="1.0.0"
-    />
-  </div>
-</Fragment>
-`;
-
 exports[`components/MarketplaceItem MarketplaceItem should render with empty list of labels 1`] = `
 <Fragment>
   <div
@@ -1080,7 +998,6 @@ exports[`components/MarketplaceItem UpdateConfirmationModal should render withou
 exports[`components/MarketplaceItem UpdateDetails should render with release notes url 1`] = `
 <UpdateDetails
   installedVersion="0.0.1"
-  isDefaultMarketplace={true}
   isInstalling={false}
   onUpdate={[Function]}
   releaseNotesUrl="http://example.com/release"
@@ -1132,7 +1049,6 @@ exports[`components/MarketplaceItem UpdateDetails should render with release not
 exports[`components/MarketplaceItem UpdateDetails should render without release notes url 1`] = `
 <UpdateDetails
   installedVersion="0.0.1"
-  isDefaultMarketplace={true}
   isInstalling={false}
   onUpdate={[Function]}
   releaseNotesUrl=""
@@ -1154,7 +1070,9 @@ exports[`components/MarketplaceItem UpdateDetails should render without release 
       releaseNotesUrl=""
       version="0.0.2"
     >
-      0.0.2
+      <span>
+        0.0.2
+      </span>
     </UpdateVersion>
      - 
     <b>

--- a/components/plugin_marketplace/marketplace_item/index.ts
+++ b/components/plugin_marketplace/marketplace_item/index.ts
@@ -15,7 +15,7 @@ import {trackEvent} from 'actions/telemetry_actions.jsx';
 
 import MarketplaceItem, {MarketplaceItemProps} from './marketplace_item';
 
-function mapStateToProps(state:GlobalState, props: MarketplaceItemProps) {
+function mapStateToProps(state: GlobalState, props: MarketplaceItemProps) {
     const installing = getInstalling(state, props.id);
     const error = getError(state, props.id);
     const isDefaultMarketplace = getConfig(state).IsDefaultMarketplace === 'true';

--- a/components/plugin_marketplace/marketplace_item/index.ts
+++ b/components/plugin_marketplace/marketplace_item/index.ts
@@ -2,8 +2,10 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
+import {bindActionCreators, Dispatch} from 'redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {GlobalState} from 'mattermost-redux/types/store';
+import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {installPlugin} from 'actions/marketplace';
 import {closeModal} from 'actions/views/modals';
@@ -11,9 +13,9 @@ import {ModalIdentifiers} from 'utils/constants';
 import {getInstalling, getError} from 'selectors/views/marketplace';
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 
-import MarketplaceItem from './marketplace_item';
+import MarketplaceItem, {MarketplaceItemProps} from './marketplace_item';
 
-function mapStateToProps(state, props) {
+function mapStateToProps(state:GlobalState, props: MarketplaceItemProps) {
     const installing = getInstalling(state, props.id);
     const error = getError(state, props.id);
     const isDefaultMarketplace = getConfig(state).IsDefaultMarketplace === 'true';
@@ -26,7 +28,7 @@ function mapStateToProps(state, props) {
     };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             installPlugin,

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.test.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.test.tsx
@@ -7,16 +7,15 @@ import {shallow} from 'enzyme';
 import ConfirmModal from 'components/confirm_modal';
 import {mountWithIntl as mount} from 'tests/helpers/intl-test-helper';
 
-import MarketplaceItem, {UpdateDetails, UpdateConfirmationModal} from './marketplace_item';
+import MarketplaceItem, {UpdateDetails, UpdateDetailsProps, UpdateConfirmationModal, UpdateConfirmationModalProps, MarketplaceItemProps} from './marketplace_item';
 
 describe('components/MarketplaceItem', () => {
     describe('UpdateDetails', () => {
-        const baseProps = {
+        const baseProps:UpdateDetailsProps = {
             version: '0.0.2',
             releaseNotesUrl: 'http://example.com/release',
             installedVersion: '0.0.1',
             isInstalling: false,
-            isDefaultMarketplace: true,
             onUpdate: () => {},
         };
 
@@ -36,7 +35,7 @@ describe('components/MarketplaceItem', () => {
             it('when installed version matches available version', () => {
                 const props = {
                     ...baseProps,
-                    installedVersion: baseProps.availableVersion,
+                    installedVersion: baseProps.installedVersion,
                 };
                 const wrapper = mount(
                     <UpdateDetails {...props}/>,
@@ -93,7 +92,7 @@ describe('components/MarketplaceItem', () => {
     });
 
     describe('UpdateConfirmationModal', () => {
-        const baseProps = {
+        const baseProps:UpdateConfirmationModalProps = {
             show: true,
             name: 'pluginName',
             version: '0.0.2',
@@ -195,16 +194,13 @@ describe('components/MarketplaceItem', () => {
     });
 
     describe('MarketplaceItem', () => {
-        const baseProps = {
+        const baseProps:MarketplaceItemProps = {
             id: 'id',
             name: 'name',
             description: 'test plugin',
             version: '1.0.0',
-            downloadUrl: 'http://example.com/download',
-            signatureUrl: 'http://example.com/signature',
             homepageUrl: 'http://example.com',
             installedVersion: '',
-            iconUrl: '',
             iconData: 'icon',
             installing: false,
             isDefaultMarketplace: true,
@@ -353,19 +349,6 @@ describe('components/MarketplaceItem', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
-        test('should render when not from the marketplace', () => {
-            const props = {
-                ...baseProps,
-                downloadUrl: '',
-            };
-
-            const wrapper = shallow(
-                <MarketplaceItem {...props}/>,
-            );
-
-            expect(wrapper).toMatchSnapshot();
-        });
-
         describe('should track detailed event with default marketplace', () => {
             test('on install', () => {
                 const props = {
@@ -377,7 +360,7 @@ describe('components/MarketplaceItem', () => {
                     <MarketplaceItem {...props}/>,
                 );
 
-                wrapper.instance().onInstall();
+                (wrapper.instance() as MarketplaceItem).onInstall();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_download', {
                     plugin_id: 'id',
                     version: '1.0.0',
@@ -397,7 +380,7 @@ describe('components/MarketplaceItem', () => {
                     <MarketplaceItem {...props}/>,
                 );
 
-                wrapper.instance().onUpdate();
+                (wrapper.instance() as MarketplaceItem).onUpdate();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_download_update', {
                     plugin_id: 'id',
                     version: '2.0.0',
@@ -417,7 +400,7 @@ describe('components/MarketplaceItem', () => {
                     <MarketplaceItem {...props}/>,
                 );
 
-                wrapper.instance().onConfigure();
+                (wrapper.instance() as MarketplaceItem).onConfigure();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_configure');
             });
         });
@@ -433,7 +416,7 @@ describe('components/MarketplaceItem', () => {
                     <MarketplaceItem {...props}/>,
                 );
 
-                wrapper.instance().onInstall();
+                (wrapper.instance() as MarketplaceItem).onInstall();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_download');
             });
 
@@ -449,7 +432,7 @@ describe('components/MarketplaceItem', () => {
                     <MarketplaceItem {...props}/>,
                 );
 
-                wrapper.instance().onUpdate();
+                (wrapper.instance() as MarketplaceItem).onUpdate();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_download_update');
             });
 
@@ -465,7 +448,7 @@ describe('components/MarketplaceItem', () => {
                     <MarketplaceItem {...props}/>,
                 );
 
-                wrapper.instance().onConfigure();
+                (wrapper.instance() as MarketplaceItem).onConfigure();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_configure');
             });
         });

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.test.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.test.tsx
@@ -11,7 +11,7 @@ import MarketplaceItem, {UpdateDetails, UpdateDetailsProps, UpdateConfirmationMo
 
 describe('components/MarketplaceItem', () => {
     describe('UpdateDetails', () => {
-        const baseProps:UpdateDetailsProps = {
+        const baseProps: UpdateDetailsProps = {
             version: '0.0.2',
             releaseNotesUrl: 'http://example.com/release',
             installedVersion: '0.0.1',
@@ -92,7 +92,7 @@ describe('components/MarketplaceItem', () => {
     });
 
     describe('UpdateConfirmationModal', () => {
-        const baseProps:UpdateConfirmationModalProps = {
+        const baseProps: UpdateConfirmationModalProps = {
             show: true,
             name: 'pluginName',
             version: '0.0.2',
@@ -194,7 +194,7 @@ describe('components/MarketplaceItem', () => {
     });
 
     describe('MarketplaceItem', () => {
-        const baseProps:MarketplaceItemProps = {
+        const baseProps: MarketplaceItemProps = {
             id: 'id',
             name: 'name',
             description: 'test plugin',
@@ -212,7 +212,7 @@ describe('components/MarketplaceItem', () => {
         };
 
         test('should render', () => {
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...baseProps}/>,
             );
 
@@ -223,7 +223,7 @@ describe('components/MarketplaceItem', () => {
             const props = {...baseProps};
             delete props.iconData;
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -234,7 +234,7 @@ describe('components/MarketplaceItem', () => {
             const props = {...baseProps};
             delete props.homepageUrl;
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -247,7 +247,7 @@ describe('components/MarketplaceItem', () => {
                 error: 'An error occurred.',
             };
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -260,7 +260,7 @@ describe('components/MarketplaceItem', () => {
                 installedVersion: '1.0.0',
             };
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -273,7 +273,7 @@ describe('components/MarketplaceItem', () => {
                 installedVersion: '0.9.9',
             };
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -287,7 +287,7 @@ describe('components/MarketplaceItem', () => {
                 releaseNotesUrl: 'http://example.com/release',
             };
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -300,7 +300,7 @@ describe('components/MarketplaceItem', () => {
                 labels: [],
             };
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -319,7 +319,7 @@ describe('components/MarketplaceItem', () => {
                 ],
             };
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -342,7 +342,7 @@ describe('components/MarketplaceItem', () => {
                 ],
             };
 
-            const wrapper = shallow(
+            const wrapper = shallow<MarketplaceItem>(
                 <MarketplaceItem {...props}/>,
             );
 
@@ -356,11 +356,11 @@ describe('components/MarketplaceItem', () => {
                     isDefaultMarketplace: true,
                 };
 
-                const wrapper = shallow(
+                const wrapper = shallow<MarketplaceItem>(
                     <MarketplaceItem {...props}/>,
                 );
 
-                (wrapper.instance() as MarketplaceItem).onInstall();
+                wrapper.instance().onInstall();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_download', {
                     plugin_id: 'id',
                     version: '1.0.0',
@@ -376,11 +376,11 @@ describe('components/MarketplaceItem', () => {
                     isDefaultMarketplace: true,
                 };
 
-                const wrapper = shallow(
+                const wrapper = shallow<MarketplaceItem>(
                     <MarketplaceItem {...props}/>,
                 );
 
-                (wrapper.instance() as MarketplaceItem).onUpdate();
+                wrapper.instance().onUpdate();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_download_update', {
                     plugin_id: 'id',
                     version: '2.0.0',
@@ -396,11 +396,11 @@ describe('components/MarketplaceItem', () => {
                     isDefaultMarketplace: true,
                 };
 
-                const wrapper = shallow(
+                const wrapper = shallow<MarketplaceItem>(
                     <MarketplaceItem {...props}/>,
                 );
 
-                (wrapper.instance() as MarketplaceItem).onConfigure();
+                wrapper.instance().onConfigure();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_configure');
             });
         });
@@ -412,11 +412,11 @@ describe('components/MarketplaceItem', () => {
                     isDefaultMarketplace: false,
                 };
 
-                const wrapper = shallow(
+                const wrapper = shallow<MarketplaceItem>(
                     <MarketplaceItem {...props}/>,
                 );
 
-                (wrapper.instance() as MarketplaceItem).onInstall();
+                wrapper.instance().onInstall();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_download');
             });
 
@@ -428,11 +428,11 @@ describe('components/MarketplaceItem', () => {
                     isDefaultMarketplace: false,
                 };
 
-                const wrapper = shallow(
+                const wrapper = shallow<MarketplaceItem>(
                     <MarketplaceItem {...props}/>,
                 );
 
-                (wrapper.instance() as MarketplaceItem).onUpdate();
+                wrapper.instance().onUpdate();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_download_update');
             });
 
@@ -444,11 +444,11 @@ describe('components/MarketplaceItem', () => {
                     isDefaultMarketplace: false,
                 };
 
-                const wrapper = shallow(
+                const wrapper = shallow<MarketplaceItem>(
                     <MarketplaceItem {...props}/>,
                 );
 
-                (wrapper.instance() as MarketplaceItem).onConfigure();
+                wrapper.instance().onConfigure();
                 expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_configure');
             });
         });

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.test.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.test.tsx
@@ -35,7 +35,7 @@ describe('components/MarketplaceItem', () => {
             it('when installed version matches available version', () => {
                 const props = {
                     ...baseProps,
-                    installedVersion: baseProps.installedVersion,
+                    installedVersion: baseProps.version,
                 };
                 const wrapper = mount(
                     <UpdateDetails {...props}/>,

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
@@ -47,7 +47,6 @@ export const UpdateVersion = ({version, releaseNotesUrl}: UpdateVersionProps): J
     );
 };
 
-
 // Label renders a tag showing a name and a description in a tooltip.
 // If a URL is provided, clicking on the tag will open the URL in a new tab.
 export const Label = ({name, description, url, color}: MarketplaceLabel): JSX.Element => {

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
@@ -271,7 +271,7 @@ export type MarketplaceItemProps = {
     releaseNotesUrl?: string,
     labels?: MarketplaceLabel[],
     iconData?: string,
-    installedVersion: string,
+    installedVersion?: string,
     installing: boolean,
     error?: string
     isDefaultMarketplace: boolean,

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
@@ -10,6 +10,8 @@ import {FormattedMessage} from 'react-intl';
 
 import {Link} from 'react-router-dom';
 
+import {MarketplaceLabel} from 'mattermost-redux/types/plugins';
+
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import ConfirmModal from 'components/confirm_modal';
 import OverlayTrigger from 'components/overlay_trigger';
@@ -45,16 +47,10 @@ export const UpdateVersion = ({version, releaseNotesUrl}: UpdateVersionProps): J
     );
 };
 
-type Label = {
-    name: string,
-    description?: string,
-    url?: string,
-    color?: string,
-}
 
 // Label renders a tag showing a name and a description in a tooltip.
 // If a URL is provided, clicking on the tag will open the URL in a new tab.
-export const Label = ({name, description, url, color} : Label): JSX.Element => {
+export const Label = ({name, description, url, color}: MarketplaceLabel): JSX.Element => {
     const tag = (
         <span
             className='tag'
@@ -274,7 +270,7 @@ export type MarketplaceItemProps = {
     version: string,
     homepageUrl?: string,
     releaseNotesUrl?: string,
-    labels?: Label[],
+    labels?: MarketplaceLabel[],
     iconData?: string,
     installedVersion: string,
     installing: boolean,

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
@@ -22,9 +22,9 @@ import {localizeMessage} from 'utils/utils';
 import {Constants} from 'utils/constants';
 
 type UpdateVersionProps = {
-    version: string,
-    releaseNotesUrl?: string,
-}
+    version: string;
+    releaseNotesUrl?: string;
+};
 
 // UpdateVersion renders the version text in the update details, linking out to release notes if available.
 export const UpdateVersion = ({version, releaseNotesUrl}: UpdateVersionProps): JSX.Element => {
@@ -96,12 +96,12 @@ export const Label = ({name, description, url, color}: MarketplaceLabel): JSX.El
 };
 
 export type UpdateDetailsProps = {
-    version: string,
-    releaseNotesUrl?: string,
-    installedVersion?: string,
-    isInstalling: boolean,
-    onUpdate: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void,
-}
+    version: string;
+    releaseNotesUrl?: string;
+    installedVersion?: string;
+    isInstalling: boolean;
+    onUpdate: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+};
 
 // UpdateDetails renders an inline update prompt for plugins, when available.
 export const UpdateDetails = ({version, releaseNotesUrl, installedVersion, isInstalling, onUpdate}: UpdateDetailsProps): JSX.Element | null => {
@@ -145,14 +145,14 @@ export const UpdateDetails = ({version, releaseNotesUrl, installedVersion, isIns
 };
 
 export type UpdateConfirmationModalProps = {
-    show: boolean,
-    name: string,
-    version: string,
-    releaseNotesUrl?: string,
-    installedVersion?: string,
-    onUpdate: (checked: boolean) => void,
-    onCancel: (checked: boolean) => void,
-}
+    show: boolean;
+    name: string;
+    version: string;
+    releaseNotesUrl?: string;
+    installedVersion?: string;
+    onUpdate: (checked: boolean) => void;
+    onCancel: (checked: boolean) => void;
+};
 
 // UpdateConfirmationModal prompts before allowing upgrade, specially handling major version changes.
 export const UpdateConfirmationModal = ({show, name, version, installedVersion, releaseNotesUrl, onUpdate, onCancel}: UpdateConfirmationModalProps): JSX.Element | null => {
@@ -263,25 +263,25 @@ export const UpdateConfirmationModal = ({show, name, version, installedVersion, 
 };
 
 export type MarketplaceItemProps = {
-    id: string,
-    name: string,
-    description: string,
-    version: string,
-    homepageUrl?: string,
-    releaseNotesUrl?: string,
-    labels?: MarketplaceLabel[],
-    iconData?: string,
-    installedVersion?: string,
-    installing: boolean,
-    error?: string
-    isDefaultMarketplace: boolean,
-    trackEvent: (category: string, event: string, props?: any) => void
+    id: string;
+    name: string;
+    description: string;
+    version: string;
+    homepageUrl?: string;
+    releaseNotesUrl?: string;
+    labels?: MarketplaceLabel[];
+    iconData?: string;
+    installedVersion?: string;
+    installing: boolean;
+    error?: string;
+    isDefaultMarketplace: boolean;
+    trackEvent: (category: string, event: string, props?: any) => void;
 
     actions: {
-        installPlugin: (category: string, event: string) => void,
-        closeMarketplaceModal: () => void,
-    },
-}
+        installPlugin: (category: string, event: string) => void;
+        closeMarketplaceModal: () => void;
+    };
+};
 
 type MarketplaceItemState = {
     showUpdateConfirmationModal: boolean;
@@ -296,7 +296,7 @@ export default class MarketplaceItem extends React.PureComponent <MarketplaceIte
         };
     }
 
-    trackEvent = (eventName:string, allowDetail = true):void => {
+    trackEvent = (eventName: string, allowDetail = true): void => {
         if (this.props.isDefaultMarketplace && allowDetail) {
             this.props.trackEvent('plugins', eventName, {
                 plugin_id: this.props.id,
@@ -308,33 +308,33 @@ export default class MarketplaceItem extends React.PureComponent <MarketplaceIte
         }
     }
 
-    onInstall = ():void => {
+    onInstall = (): void => {
         this.trackEvent('ui_marketplace_download');
         this.props.actions.installPlugin(this.props.id, this.props.version);
     }
 
-    showUpdateConfirmationModal = ():void => {
+    showUpdateConfirmationModal = (): void => {
         this.setState({showUpdateConfirmationModal: true});
     }
 
-    hideUpdateConfirmationModal = ():void => {
+    hideUpdateConfirmationModal = (): void => {
         this.setState({showUpdateConfirmationModal: false});
     }
 
-    onUpdate = ():void => {
+    onUpdate = (): void => {
         this.trackEvent('ui_marketplace_download_update');
 
         this.hideUpdateConfirmationModal();
         this.props.actions.installPlugin(this.props.id, this.props.version);
     }
 
-    onConfigure = ():void => {
+    onConfigure = (): void => {
         this.trackEvent('ui_marketplace_configure', false);
 
         this.props.actions.closeMarketplaceModal();
     }
 
-    getItemButton():JSX.Element {
+    getItemButton(): JSX.Element {
         let actionButton = (
             <FormattedMessage
                 id='marketplace_modal.list.Install'
@@ -387,7 +387,7 @@ export default class MarketplaceItem extends React.PureComponent <MarketplaceIte
         return button;
     }
 
-    render():JSX.Element {
+    render(): JSX.Element {
         let versionLabel = `(${this.props.version})`;
         if (this.props.installedVersion !== '') {
             versionLabel = `(${this.props.installedVersion})`;

--- a/components/plugin_marketplace/marketplace_list/__snapshots__/marketplace_list.test.jsx.snap
+++ b/components/plugin_marketplace/marketplace_list/__snapshots__/marketplace_list.test.jsx.snap
@@ -6,7 +6,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
 >
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -17,7 +16,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -28,7 +26,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -39,7 +36,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -50,7 +46,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -61,7 +56,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -72,7 +66,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -83,7 +76,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -94,7 +86,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -105,7 +96,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -116,7 +106,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -127,7 +116,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -138,7 +126,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -149,7 +136,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""
@@ -160,7 +146,6 @@ exports[`components/marketplace/marketplace_list should render with multiple plu
   />
   <Connect(MarketplaceItem)
     description="This plugin sends quarterly user satisfaction surveys to gather feedback and help improve Mattermost"
-    downloadUrl="https://github.com/mattermost/mattermost-plugin-nps/releases/download/v1.0.3/com.mattermost.nps-1.0.3.tar.gz"
     homepageUrl="https://github.com/mattermost/mattermost-plugin-nps"
     id="com.mattermost.nps"
     installedVersion=""

--- a/components/plugin_marketplace/marketplace_list/marketplace_list.jsx
+++ b/components/plugin_marketplace/marketplace_list/marketplace_list.jsx
@@ -58,7 +58,6 @@ export default class MarketplaceList extends React.PureComponent {
                         description={p.manifest.description}
                         version={p.manifest.version}
                         isPrepackaged={false}
-                        downloadUrl={p.download_url}
                         homepageUrl={p.homepage_url}
                         releaseNotesUrl={p.release_notes_url}
                         labels={p.labels}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5014,6 +5014,11 @@
         "redux": "^4.0.5"
       }
     },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
+    },
     "@types/sizzle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
@@ -6995,7 +7000,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -9511,14 +9516,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -12581,10 +12586,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "0.64.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -13483,12 +13485,6 @@
         "postcss": "^7.0.14"
       }
     },
-    "icu4c-data": {
-      "version": "0.63.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.63.2.tgz",
-      "integrity": "sha512-vT6/47CcBzDemlhRzkL7dZLoNvuUWjjiuKZHMt5T4dbkKAqLBh7ZQ33GU13ecC/aIcMlIdBOqtF4uIYTgWML4Q==",
-      "dev": true
-    },
     "identity-obj-proxy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
@@ -14107,7 +14103,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -19588,7 +19584,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -6615,9 +6615,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "regenerator-runtime": {
           "version": "0.11.1",
@@ -17895,8 +17895,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#40368bb807b8b5a3dc0f4ce4a5a76eabc5c9de54",
-      "from": "github:mattermost/mattermost-redux#40368bb807b8b5a3dc0f4ce4a5a76eabc5c9de54",
+      "version": "github:mattermost/mattermost-redux#eecb8979562187cd1e443ab21f9cc5119b6aa0ea",
+      "from": "github:mattermost/mattermost-redux#eecb8979562187cd1e443ab21f9cc5119b6aa0ea",
       "requires": {
         "core-js": "3.6.5",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@stripe/react-stripe-js": "1.1.2",
     "@stripe/stripe-js": "1.9.0",
     "@types/country-list": "2.1.0",
+    "@types/semver": "7.3.4",
     "bootstrap": "3.4.1",
     "chart.js": "2.9.3",
     "compass-mixins": "0.12.10",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "localforage-observable": "2.0.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#87769262aa02e1784570f61f4f962050e07cc335",
-    "mattermost-redux": "github:mattermost/mattermost-redux#40368bb807b8b5a3dc0f4ce4a5a76eabc5c9de54",
+    "mattermost-redux": "github:mattermost/mattermost-redux#eecb8979562187cd1e443ab21f9cc5119b6aa0ea",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",


### PR DESCRIPTION
#### Summary
In preparation of the upcoming re-design of the Marketplace the whole Marketplace should get a migrated to typescript.

Most of the migration was straight forward. Please see my comments below on the questionable or tricky parts.

Please also note that this PR will go into the Marketplace feature branch.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20400

#### Related Pull Requests
- Has redux changes https://github.com/mattermost/mattermost-redux/pull/1304

