### PR TITLE
MM-30992 Add the capability to run part by part for Cypress parallel testing (part 1)

### DIFF
--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -171,6 +171,10 @@ function getTestFilesIdentifier(numberOfTestFiles) {
     const {part, of} = argv;
     const PART = parseInt(part, 10) || 1;
     const OF = parseInt(of, 10) || 1;
+    if (PART > OF) {
+        throw new Error(`"--part=${PART}" should not be greater than "--of=${OF}"`);
+    }
+
     const multiplier = Math.ceil(numberOfTestFiles / OF);
     const start = (PART - 1) * multiplier;
     let end = start + multiplier;

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -169,8 +169,10 @@ function printMessage(testFiles, overallIndex, currentIndex, lastIndex) {
 
 function getTestFilesIdentifier(numberOfTestFiles) {
     const {part, of} = argv;
-    const multiplier = Math.round(numberOfTestFiles / of);
-    const start = (part - 1) * multiplier;
+    const PART = parseInt(part, 10) || 1;
+    const OF = parseInt(of, 10) || 1;
+    const multiplier = Math.ceil(numberOfTestFiles / OF);
+    const start = (PART - 1) * multiplier;
     let end = start + multiplier;
     end = end < numberOfTestFiles ? end : numberOfTestFiles;
 

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -23,11 +23,12 @@
  *      Selected files are those not matching any of the specified stage or group.
  *
  * Environment:
- *   BROWSER=[browser]      : Chrome by default. Set to run test on other browser such as chrome, edge, electron and firefox.
- *                            The environment should have the specified browser to successfully run.
- *   HEADLESS=[boolean]     : Headless by default (true) or false to run on headed mode.
- *   BRANCH=[branch]        : Branch identifier from CI
- *   BUILD_ID=[build_id]    : Build identifier from CI
+ *   BROWSER=[browser]          : Chrome by default. Set to run test on other browser such as chrome, edge, electron and firefox.
+ *                                The environment should have the specified browser to successfully run.
+ *   HEADLESS=[boolean]         : Headless by default (true) or false to run on headed mode.
+ *   BRANCH=[branch]            : Branch identifier from CI
+ *   BUILD_ID=[build_id]        : Build identifier from CI
+ *   CI_BASE_URL=[ci_base_url]  : Test server base URL in CI
  *
  * Example:
  * 1. "node run_tests.js"
@@ -38,16 +39,15 @@
  *      - will run all non-production tests
  * 4. "BROWSER='chrome' HEADLESS='false' node run_tests.js --stage='@prod' --group='@channel,@messaging'"
  *      - will run spec files matching stage and group values in Chrome (headed)
- * 5. "CYPRESS_runWithEELicense=true node run_tests.js --stage='@prod'"
- *      - will run all production tests
- *      - typical test run for Enterprise Edition, given license file can be found in `cypress/fixtures` folder
- * 6. "node run_tests.js --stage='@prod' --exclude-group='@enterprise'"
+ * 5. "node run_tests.js --stage='@prod' --exclude-group='@enterprise'"
  *      - will run all production tests except @enterprise group
  *      - typical test run for Team Edition
+ * 6. "node run_tests.js --stage='@prod' --part=1 --of=2"
+ *      - will run the first half (1 of 2) of all production tests
+ *      - will be used for parallel testing where each part could run separately against its own test server
  */
 
 const os = require('os');
-const chai = require('chai');
 const chalk = require('chalk');
 const cypress = require('cypress');
 const argv = require('yargs').argv;
@@ -67,7 +67,6 @@ async function runTests() {
         ENABLE_VISUAL_TEST,
         APPLITOOLS_API_KEY,
         APPLITOOLS_BATCH_NAME,
-        FAILURE_MESSAGE,
     } = process.env;
 
     const browser = BROWSER || 'chrome';
@@ -75,15 +74,22 @@ async function runTests() {
     const platform = os.platform();
     const initialTestFiles = getTestFiles().sort((a, b) => a.localeCompare(b));
     const {finalTestFiles} = getSkippedFiles(initialTestFiles, platform, browser, headless);
+    const numberOfTestFiles = finalTestFiles.length;
 
-    if (!finalTestFiles.length) {
+    if (!numberOfTestFiles) {
         console.log(chalk.red('Nothing to test!'));
         return;
     }
 
-    let hasFailed = false;
-    for (let i = 0; i < finalTestFiles.length; i++) {
-        printMessage(finalTestFiles, i);
+    const {
+        start,
+        end,
+        lastIndex,
+        multiplier,
+    } = getTestFilesIdentifier(numberOfTestFiles);
+
+    for (let i = start; i < end; i++) {
+        printMessage(finalTestFiles, i, (i % multiplier) + 1, lastIndex);
 
         const testFile = finalTestFiles[i];
 
@@ -140,19 +146,13 @@ async function runTests() {
 
             writeJsonToFile(environment, 'environment.json', RESULTS_DIR);
         }
-
-        if (!hasFailed && result.totalFailed > 0) {
-            hasFailed = true;
-        }
     }
-
-    chai.expect(hasFailed, FAILURE_MESSAGE).to.be.false;
 }
 
-function printMessage(testFiles, index) {
+function printMessage(testFiles, overallIndex, currentIndex, lastIndex) {
     const {invert, excludeGroup, group, stage} = argv;
 
-    const testFile = testFiles[index];
+    const testFile = testFiles[overallIndex];
     const testStage = stage ? `Stage: "${stage}" ` : '';
     const withGroup = group || excludeGroup;
     const groupMessage = group ? `"${group}"` : 'All';
@@ -161,7 +161,22 @@ function printMessage(testFiles, index) {
 
     // Log which files were being tested
     console.log(chalk.magenta.bold(`${invert ? 'All Except --> ' : ''}${testStage}${stage && withGroup ? '| ' : ''}${testGroup}`));
-    console.log(chalk.magenta(`(Testing ${index + 1} of ${testFiles.length})  - `, testFile));
+    console.log(chalk.magenta(`(Testing ${overallIndex + 1} of ${testFiles.length})  - `, testFile));
+    if (process.env.CI_BASE_URL) {
+        console.log(chalk.magenta(`Testing ${currentIndex}/${lastIndex} in "${process.env.CI_BASE_URL}" server`));
+    }
+}
+
+function getTestFilesIdentifier(numberOfTestFiles) {
+    const {part, of} = argv;
+    const multiplier = Math.round(numberOfTestFiles / of);
+    const start = (part - 1) * multiplier;
+    let end = start + multiplier;
+    end = end < numberOfTestFiles ? end : numberOfTestFiles;
+
+    const lastIndex = end < numberOfTestFiles ? multiplier : numberOfTestFiles - start;
+
+    return {start, end, lastIndex, multiplier};
 }
 
 runTests();

--- a/e2e/save_report.js
+++ b/e2e/save_report.js
@@ -25,6 +25,7 @@
  *      - TYPE=[type], e.g. "MASTER", "PR", "RELEASE"
  */
 
+const chai = require('chai');
 const {merge} = require('mochawesome-merge');
 const generator = require('mochawesome-report-generator');
 
@@ -40,7 +41,7 @@ const {
 const {saveArtifacts} = require('./utils/artifacts');
 const {MOCHAWESOME_REPORT_DIR, RESULTS_DIR} = require('./utils/constants');
 const {saveDashboard} = require('./utils/dashboard');
-const {saveTestCases} = require('./utils/test_cases');
+const {createTestCycle, createTestExecutions} = require('./utils/test_cases');
 
 require('dotenv').config();
 
@@ -53,6 +54,7 @@ const saveReport = async () => {
         DIAGNOSTIC_WEBHOOK_URL,
         DIAGNOSTIC_USER_ID,
         DIAGNOSTIC_TEAM_ID,
+        FAILURE_MESSAGE,
         TM4J_ENABLE,
         TYPE,
         WEBHOOK_URL,
@@ -83,10 +85,17 @@ const saveReport = async () => {
         console.log('Successfully uploaded artifacts to S3:', result.reportLink);
     }
 
+    // Create test cycle to Test Management
+    let testCycle;
+    if (TM4J_ENABLE === 'true') {
+        const {start, end} = jsonReport.stats;
+        testCycle = await createTestCycle(start, end);
+    }
+
     // Send test report to "QA: UI Test Automation" channel via webhook
     if (TYPE && TYPE !== 'NONE' && WEBHOOK_URL) {
         const environment = readJsonFromFile(`${RESULTS_DIR}/environment.json`);
-        const data = generateTestReport(summary, result && result.success, result && result.reportLink, environment);
+        const data = generateTestReport(summary, result && result.success, result && result.reportLink, environment, testCycle.key);
         await sendReport('summary report to Community channel', WEBHOOK_URL, data);
     }
 
@@ -104,8 +113,10 @@ const saveReport = async () => {
 
     // Save test cases to Test Management
     if (TM4J_ENABLE === 'true') {
-        await saveTestCases(jsonReport);
+        await createTestExecutions(jsonReport, testCycle);
     }
+
+    chai.expect(Boolean(jsonReport.stats.failures), FAILURE_MESSAGE).to.be.false;
 };
 
 saveReport();

--- a/e2e/utils/test_cases.js
+++ b/e2e/utils/test_cases.js
@@ -192,5 +192,7 @@ async function saveTestExecution(testExecution, index) {
 }
 
 module.exports = {
+    createTestCycle,
     saveTestCases,
+    createTestExecutions,
 };


### PR DESCRIPTION
#### Summary
Add the capability to run part by part for Cypress parallel testing.

Each part can execute by:
- `node run_tests.js --stage='@prod' --part=1 --of=2` 
- `node run_tests.js --stage='@prod' --part=2 --of=2`

See https://community-release.mattermost.com/core/pl/u96tyu4e9i8xir8gy17ckxgqge for generated test report which will include field for "Test Execution" -- link to Zephyr recorded test execution.

#### Ticket Link
Jira ticket: https://mattermost.atlassian.net/browse/MM-30992

#### Screenshots
Typical job, like in CircleCI:
- Each E2E test part or job will run until complete. Then, each test artifacts will persist to workspace for next job processing which is consolidating and publishing all reports. The last job determines whether E2E failed or succeed.
![Screen Shot 2020-12-01 at 8 42 56 PM](https://user-images.githubusercontent.com/5334504/100742560-eec86480-3415-11eb-98ce-f474f6a7b52d.png)
