### PR TITLE
MM-30972 Add proper padding to code preview line numbers

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -398,6 +398,10 @@
             .post-code {
                 background: transparent;
 
+                .post-code__line-numbers {
+                    padding: 5px 0;
+                }
+
                 code {
                     margin: 0;
                     padding: 5px 0;


### PR DESCRIPTION
The lack of padding caused the line numbers to not be aligned with the corresponding lines. Here's how it looks now:
<img width="217" alt="Screen Shot 2020-12-02 at 3 36 11 PM" src="https://user-images.githubusercontent.com/3277310/100928675-82e90900-34b4-11eb-87d7-e8c39a9111c5.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30972