### PR TITLE
MM-30810 Remove special props from /me post

### DIFF
--- a/components/post_markdown/system_message_helpers.jsx
+++ b/components/post_markdown/system_message_helpers.jsx
@@ -350,7 +350,10 @@ function renderChannelUnarchivedMessage(post) {
 }
 
 function renderMeMessage(post) {
-    return renderFormattedText((post.props && post.props.message) ? post.props.message : post.message);
+    // Trim off the leading and trailing asterisk added to /me messages
+    const message = post.message.replace(/^\*|\*$/g, '');
+
+    return renderFormattedText(message);
 }
 
 const systemMessageRenderers = {


### PR DESCRIPTION
Originally, /me posts were just styled by adding asterisks to force them to become italic, but we wanted to change how they were formatted, so we stored the non-formatted message in props to allow the client to do its formatting. We still needed the `Post.Message` to be wrapped in asterisks for compatibility with mobile and other clients.

That ended up causing problems because editing the post would only change the `Post.Message` without changing the copy in the props, so instead of trying to manage two copies of the post, we're just going to have the web app remove the asterisks from the message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30810

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/16456