### PR TITLE
MM-23267 Fixed autocomplete bug

### DIFF
--- a/components/suggestion/search_channel_provider.jsx
+++ b/components/suggestion/search_channel_provider.jsx
@@ -34,7 +34,7 @@ export default class SearchChannelProvider extends Provider {
     }
 
     handlePretextChanged(pretext, resultsCallback) {
-        const captured = (/\b(?:in|channel):\s*(\S*)$/i).exec(pretext.toLowerCase());
+        const captured = (/\b(?:in|channel):([\s\S]*)$/i).exec(pretext.toLowerCase());
         if (captured) {
             let channelPrefix = captured[1];
             const isAtSearch = channelPrefix.startsWith('@');


### PR DESCRIPTION
fixed the bug that autocomplete would disappear if there are spaces between the channel name

The problem is caused by the regex because the previous version did not consider the situation when there are spaces between the channel name.
ex: 
before: when typing "IN: Town Squ" at the search box, the autocomplete would disappear
Now:  when typing "IN: Town Squ" at the search box, the autocomplete would still be there


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23267
Fixes https://github.com/mattermost/mattermost-server/issues/16242

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->