### PR TITLE
[MM-31403] Ensure other permissions except billing getting deleted

### DIFF
--- a/components/admin_console/system_roles/system_role/system_role_permissions.tsx
+++ b/components/admin_console/system_roles/system_role/system_role_permissions.tsx
@@ -164,7 +164,9 @@ export default class SystemRolePermissions extends React.PureComponent<Props, St
         if (!isLicensedForCloud) {
             // Remove the billing section if it's not licensed for cloud
             const billingSectionIndex = sectionsList.findIndex((section) => section.name === 'billing');
-            sectionsList.splice(billingSectionIndex, 1);
+            if (billingSectionIndex > -1) {
+                sectionsList.splice(billingSectionIndex, 1);
+            }
         }
 
         return getSectionsListForRole(sectionsList, this.props.role.name, editedSectionsByRole).map((section: SystemSection) => {


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
If the billing section is not found a -1 is returned but we still delete that which deletes the last permission section in the list. We need to check it's greater than -1 to make sure we aren't deleting other permissions

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-31403