### PR TITLE
MM-31466 Performance investigation part two

### DIFF
--- a/actions/views/channel_sidebar.ts
+++ b/actions/views/channel_sidebar.ts
@@ -4,14 +4,13 @@
 import {createCategory as createCategoryRedux, moveChannelsToCategory} from 'mattermost-redux/actions/channel_categories';
 import {General} from 'mattermost-redux/constants';
 import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
-import {getCategory, makeGetCategoriesForTeam, makeGetChannelsForCategory} from 'mattermost-redux/selectors/entities/channel_categories';
+import {getCategory, makeGetChannelsForCategory} from 'mattermost-redux/selectors/entities/channel_categories';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import {insertMultipleWithoutDuplicates} from 'mattermost-redux/utils/array_utils';
 
 import {setItem} from 'actions/storage';
-import {getChannelsInCategoryOrder, getDisplayedChannels} from 'selectors/views/channel_sidebar';
+import {getCategoriesForCurrentTeam, getChannelsInCategoryOrder, getDisplayedChannels} from 'selectors/views/channel_sidebar';
 import {DraggingState, GlobalState} from 'types/store';
 import {ActionTypes, StoragePrefixes} from 'utils/constants';
 
@@ -86,9 +85,7 @@ export function moveChannelsInSidebar(categoryId: string, targetIndex: number, d
 
         // Multi channel case
         if (multiSelectedChannelIds.length && multiSelectedChannelIds.indexOf(draggableChannelId) !== -1) {
-            const getCategoriesForTeam = makeGetCategoriesForTeam();
-            const currentTeam = getCurrentTeam(state);
-            const categories = getCategoriesForTeam(state, currentTeam.id);
+            const categories = getCategoriesForCurrentTeam(state);
             const displayedChannels = getDisplayedChannels(state);
 
             let channelsToMove = [draggableChannelId];

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -297,6 +297,12 @@ class CreateComment extends React.PureComponent {
         this.props.resetCreatePostRequest();
         document.removeEventListener('paste', this.pasteHandler);
         document.removeEventListener('keydown', this.focusTextboxIfNecessary);
+
+        if (this.saveDraftFrame) {
+            cancelAnimationFrame(this.saveDraftFrame);
+
+            this.props.onUpdateCommentDraft(this.state.draft);
+        }
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -697,7 +703,12 @@ class CreateComment extends React.PureComponent {
 
         const {draft} = this.state;
         const updatedDraft = {...draft, message};
-        this.props.onUpdateCommentDraft(updatedDraft);
+
+        cancelAnimationFrame(this.saveDraftFrame);
+        this.saveDraftFrame = requestAnimationFrame(() => {
+            this.props.onUpdateCommentDraft(updatedDraft);
+        });
+
         this.setState({draft: updatedDraft, serverError}, () => {
             this.scrollToBottom();
         });

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/index.ts
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/index.ts
@@ -8,19 +8,21 @@ import {favoriteChannel, unfavoriteChannel, markChannelAsRead} from 'mattermost-
 import Permissions from 'mattermost-redux/constants/permissions';
 import {isFavoriteChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getMyChannelMemberships, getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
-import {makeGetCategoriesForTeam, getCategoryInTeamWithChannel} from 'mattermost-redux/selectors/entities/channel_categories';
+import {getCategoryInTeamWithChannel} from 'mattermost-redux/selectors/entities/channel_categories';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {Action} from 'mattermost-redux/types/actions';
 import {Channel} from 'mattermost-redux/types/channels';
 import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
-import {memoizeResult} from 'mattermost-redux/utils/helpers';
 
 import {unmuteChannel, muteChannel} from 'actions/channel_actions';
 import {addChannelsInSidebar} from 'actions/views/channel_sidebar';
 import {openModal} from 'actions/views/modals';
-import {getDisplayedChannels} from 'selectors/views/channel_sidebar';
+
+import {getCategoriesForCurrentTeam, getDisplayedChannels} from 'selectors/views/channel_sidebar';
+
 import {GlobalState} from 'types/store';
+
 import {getSiteURL} from 'utils/url';
 
 import SidebarChannelMenu from './sidebar_channel_menu';
@@ -30,15 +32,6 @@ type OwnProps = {
     channelLink: string;
     isUnread: boolean;
 }
-
-const getCategoriesForCurrentTeam = (() => {
-    const getCategoriesForTeam = makeGetCategoriesForTeam();
-
-    return memoizeResult((state: GlobalState) => {
-        const currentTeamId = getCurrentTeam(state).id;
-        return getCategoriesForTeam(state, currentTeamId);
-    });
-})();
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const member = getMyChannelMemberships(state)[ownProps.channel.id];

--- a/components/sidebar/sidebar_channel_list/index.ts
+++ b/components/sidebar/sidebar_channel_list/index.ts
@@ -6,7 +6,6 @@ import {bindActionCreators, Dispatch} from 'redux';
 
 import {moveCategory} from 'mattermost-redux/actions/channel_categories';
 import {getCurrentChannelId, getUnreadChannelIds} from 'mattermost-redux/selectors/entities/channels';
-import {makeGetCategoriesForTeam} from 'mattermost-redux/selectors/entities/channel_categories';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
@@ -20,28 +19,29 @@ import {
     multiSelectChannelAdd,
 } from 'actions/views/channel_sidebar';
 import {close} from 'actions/views/lhs';
-import {isUnreadFilterEnabled, getDraggingState, getDisplayedChannels} from 'selectors/views/channel_sidebar';
+import {
+    getDisplayedChannels,
+    getDraggingState,
+    getCategoriesForCurrentTeam,
+    isUnreadFilterEnabled,
+} from 'selectors/views/channel_sidebar';
 import {GlobalState} from 'types/store';
 
 import SidebarChannelList from './sidebar_channel_list';
 
-function makeMapStateToProps() {
-    const getCategoriesForTeam = makeGetCategoriesForTeam();
+function mapStateToProps(state: GlobalState) {
+    const currentTeam = getCurrentTeam(state);
 
-    return (state: GlobalState) => {
-        const currentTeam = getCurrentTeam(state);
-
-        return {
-            currentTeam,
-            currentChannelId: getCurrentChannelId(state),
-            categories: getCategoriesForTeam(state, currentTeam.id),
-            isUnreadFilterEnabled: isUnreadFilterEnabled(state),
-            unreadChannelIds: getUnreadChannelIds(state),
-            displayedChannels: getDisplayedChannels(state),
-            draggingState: getDraggingState(state),
-            newCategoryIds: state.views.channelSidebar.newCategoryIds,
-            multiSelectedChannelIds: state.views.channelSidebar.multiSelectedChannelIds,
-        };
+    return {
+        currentTeam,
+        currentChannelId: getCurrentChannelId(state),
+        categories: getCategoriesForCurrentTeam(state),
+        isUnreadFilterEnabled: isUnreadFilterEnabled(state),
+        unreadChannelIds: getUnreadChannelIds(state),
+        displayedChannels: getDisplayedChannels(state),
+        draggingState: getDraggingState(state),
+        newCategoryIds: state.views.channelSidebar.newCategoryIds,
+        multiSelectedChannelIds: state.views.channelSidebar.multiSelectedChannelIds,
     };
 }
 
@@ -61,4 +61,4 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     };
 }
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(SidebarChannelList);
+export default connect(mapStateToProps, mapDispatchToProps)(SidebarChannelList);

--- a/components/textbox/index.ts
+++ b/components/textbox/index.ts
@@ -31,6 +31,8 @@ type Props = {
 
 /* eslint-disable camelcase */
 
+const getProfilesInChannelOptions = {active: true};
+
 const makeMapStateToProps = () => {
     const getProfilesInChannel = makeGetProfilesInChannel();
     const addLastViewAtToProfiles = makeAddLastViewAtToProfiles();
@@ -44,7 +46,7 @@ const makeMapStateToProps = () => {
             permission: Permissions.USE_GROUP_MENTIONS,
         });
         const autocompleteGroups = useGroupMentions ? getAssociatedGroupsForReference(state, teamId, ownProps.channelId) : null;
-        const profilesInChannel = getProfilesInChannel(state, ownProps.channelId, {active: true});
+        const profilesInChannel = getProfilesInChannel(state, ownProps.channelId, getProfilesInChannelOptions);
         const profilesWithLastViewAtInChannel = addLastViewAtToProfiles(state, profilesInChannel);
 
         return {

--- a/selectors/views/channel_sidebar.ts
+++ b/selectors/views/channel_sidebar.ts
@@ -18,7 +18,7 @@ import {Channel} from 'mattermost-redux/types/channels';
 import {ChannelCategory} from 'mattermost-redux/types/channel_categories';
 import {RelationOneToOne} from 'mattermost-redux/types/utilities';
 import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
-import {memoizeResult} from 'mattermost-redux/utils/helpers';
+import {createIdsSelector, memoizeResult} from 'mattermost-redux/utils/helpers';
 
 import {getItemFromStorage} from 'selectors/storage';
 import {GlobalState} from 'types/store';
@@ -58,7 +58,7 @@ export const getChannelsByCategoryForCurrentTeam: (state: GlobalState) => Relati
 // getChannelsInCategoryOrder returns an array of channels on the current team that are currently visible in the sidebar.
 // Channels are returned in the same order as in the sidebar.
 export const getChannelsInCategoryOrder = (() => {
-    const getCollapsedStateForAllCategories = createSelector(
+    const getCollapsedStateForAllCategories = createIdsSelector(
         getPrefix,
         getCategoriesForCurrentTeam,
         (state: GlobalState) => state.storage.storage,

--- a/selectors/views/channel_sidebar.ts
+++ b/selectors/views/channel_sidebar.ts
@@ -16,7 +16,9 @@ import {getLastPostPerChannel} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {Channel} from 'mattermost-redux/types/channels';
 import {ChannelCategory} from 'mattermost-redux/types/channel_categories';
+import {RelationOneToOne} from 'mattermost-redux/types/utilities';
 import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
+import {memoizeResult} from 'mattermost-redux/utils/helpers';
 
 import {getItemFromStorage} from 'selectors/storage';
 import {GlobalState} from 'types/store';
@@ -35,18 +37,32 @@ export function isUnreadFilterEnabled(state: GlobalState) {
     return state.views.channelSidebar.unreadFilterEnabled;
 }
 
+export const getCategoriesForCurrentTeam: (state: GlobalState) => ChannelCategory[] = (() => {
+    const getCategoriesForTeam = makeGetCategoriesForTeam();
+
+    return memoizeResult((state: GlobalState) => {
+        const currentTeamId = getCurrentTeamId(state);
+        return getCategoriesForTeam(state, currentTeamId);
+    });
+})();
+
+export const getChannelsByCategoryForCurrentTeam: (state: GlobalState) => RelationOneToOne<ChannelCategory, Channel[]> = (() => {
+    const getChannelsByCategory = makeGetChannelsByCategory();
+
+    return memoizeResult((state: GlobalState) => {
+        const currentTeamId = getCurrentTeamId(state);
+        return getChannelsByCategory(state, currentTeamId);
+    });
+})();
+
 // getChannelsInCategoryOrder returns an array of channels on the current team that are currently visible in the sidebar.
 // Channels are returned in the same order as in the sidebar.
 export const getChannelsInCategoryOrder = (() => {
-    const getCategoriesForTeam = makeGetCategoriesForTeam();
-    const getChannelsByCategory = makeGetChannelsByCategory();
-
     const getCollapsedStateForAllCategories = createSelector(
         getPrefix,
-        (state: GlobalState) => getCategoriesForTeam(state, getCurrentTeamId(state)),
+        getCategoriesForCurrentTeam,
         (state: GlobalState) => state.storage.storage,
         (prefix, categories, storage) => {
-            // return categories.map((category: ChannelCategory) => isCategoryCollapsedFromStorage(prefix, storage, category.id));
             return categories.reduce((map: Record<string, boolean>, category: ChannelCategory) => {
                 map[category.id] = isCategoryCollapsedFromStorage(prefix, storage, category.id);
                 return map;
@@ -56,8 +72,8 @@ export const getChannelsInCategoryOrder = (() => {
 
     return createSelector(
         getCollapsedStateForAllCategories,
-        (state: GlobalState) => getCategoriesForTeam(state, getCurrentTeamId(state)),
-        (state: GlobalState) => getChannelsByCategory(state, getCurrentTeamId(state)),
+        getCategoriesForCurrentTeam,
+        getChannelsByCategoryForCurrentTeam,
         getCurrentChannelId,
         (state: GlobalState) => getUnreadChannelIds(state),
         (collapsedState, categories, channelsByCategory, currentChannelId, unreadChannelIds) => {


### PR DESCRIPTION
Round two of the performance improvements including in order from most important to least:
1. We throttled updates to the comment draft when typing in the RHS a la https://github.com/mattermost/mattermost-webapp/pull/4692 which provides a huge improvement when typing rapidly in the RHS. (https://github.com/mattermost/mattermost-webapp/commit/b5b0a3ffa728506b9c021083e14167757c356214)
2. We reduced lag with the new sidebar by adding some slight tweaks when we read the collapsed state of categories from `state.storage.storage`. That part of state changes whenever the draft is updated, and it made some of the heavier sidebar selectors recalculate very often. It's much cheaper for us to do a quick shallow check on a map of categories to their collapsed state than it is to recalculate `getChannelsInCategoryOrder` every time a post draft changes (https://github.com/mattermost/mattermost-webapp/commit/f3ba0a3edf4e1df2cc6d3fd7de5e36f76b4b3f0f).
3. We added a `getCategoriesForCurrentTeam` selector that can be reused for every `SidebarChannel` so that each one isn't calculating and memoizing that list of categories separately. (https://github.com/mattermost/mattermost-webapp/commit/602d697549fcdd0382af99595d163e5b56ad61fc and https://github.com/mattermost/mattermost-webapp/commit/76a8d0ee76eed3d525b4737582b9e1a4691bfa43)
4. We now pass a constant options object into the Textbox's `addLastViewAtToProfiles` to avoid it recalculating unnecessarily (https://github.com/mattermost/mattermost-webapp/commit/d758665696feb27fb39ffceda3e7def170db0ac9)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31466

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/4692
https://github.com/mattermost/mattermost-webapp/pull/7207