### PR TITLE
Cypress/E2E: Ignore uncaught exception by cypress

### DIFF
--- a/e2e/cypress/integration/messaging/at_mentions_spec.js
+++ b/e2e/cypress/integration/messaging/at_mentions_spec.js
@@ -11,7 +11,7 @@
 // Group: @messaging
 
 import {getAdminAccount} from '../../support/env';
-import {ignoreUncaughtException, spyNotificationAs} from '../../support/notification';
+import {spyNotificationAs} from '../../support/notification';
 
 function setNotificationSettings(desiredSettings = {first: true, username: true, shouts: true, custom: true, customText: '@'}, channel) {
     // Navigate to settings modal
@@ -109,8 +109,6 @@ describe('at-mention', () => {
     });
 
     it('N14571 still triggers notification if username is not listed in words that trigger mentions', () => {
-        ignoreUncaughtException();
-
         // # Set Notification settings
         setNotificationSettings({first: false, username: true, shouts: true, custom: true}, otherChannel);
 
@@ -160,8 +158,6 @@ describe('at-mention', () => {
     });
 
     it('N14570 does not trigger notifications with "Your non case-sensitive username" unchecked', () => {
-        ignoreUncaughtException();
-
         // # Set Notification settings
         setNotificationSettings({first: false, username: false, shouts: true, custom: true}, otherChannel);
 
@@ -200,8 +196,6 @@ describe('at-mention', () => {
     });
 
     it('N14572 does not trigger notifications with "channel-wide mentions" unchecked', () => {
-        ignoreUncaughtException();
-
         // # Set Notification settings
         setNotificationSettings({first: false, username: false, shouts: false, custom: true}, otherChannel);
 
@@ -243,8 +237,6 @@ describe('at-mention', () => {
     });
 
     it('MM-T184 Words that trigger mentions support Chinese', () => {
-        ignoreUncaughtException();
-
         var customText = '番茄';
 
         // # Set Notification settings

--- a/e2e/cypress/integration/messaging/message_permalink_spec.js
+++ b/e2e/cypress/integration/messaging/message_permalink_spec.js
@@ -13,14 +13,6 @@
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('Message permalink', () => {
-    function ignoreUncaughtException() {
-        cy.on('uncaught:exception', (err) => {
-            expect(err.message).to.include('Cannot clear timer: timer created');
-
-            return false;
-        });
-    }
-
     let testTeam;
     let testChannel;
     let testUser;
@@ -75,8 +67,6 @@ describe('Message permalink', () => {
     });
 
     it('Permalink highlight should fade after timeout and change to channel url', () => {
-        ignoreUncaughtException();
-
         // # Post message to use
         const message = 'Hello' + Date.now();
         cy.postMessage(message);

--- a/e2e/cypress/integration/notifications/desktop_notifications_spec.js
+++ b/e2e/cypress/integration/notifications/desktop_notifications_spec.js
@@ -13,7 +13,7 @@
 import * as MESSAGES from '../../fixtures/messages';
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {getEmailUrl} from '../../utils';
-import {spyNotificationAs, ignoreUncaughtException} from '../../support/notification';
+import {spyNotificationAs} from '../../support/notification';
 
 describe('Desktop notifications', () => {
     let testTeam;
@@ -272,8 +272,6 @@ describe('Desktop notifications', () => {
     });
 
     it('MM-T488 Desktop Notifications - Teammate name display set to username', () => {
-        ignoreUncaughtException();
-
         cy.apiCreateUser({}).then(({user}) => {
             cy.apiAddUserToTeam(testTeam.id, user.id);
             cy.apiLogin(user);
@@ -307,8 +305,6 @@ describe('Desktop notifications', () => {
 
     describe('MM-T489 Desktop Notifications - Teammate name display set to nickname', () => {
         it('displays teammates nickname when nickname exists', () => {
-            ignoreUncaughtException();
-
             const nickname = 'the rock';
 
             // # Ensure user has a nickname set up
@@ -348,8 +344,6 @@ describe('Desktop notifications', () => {
         });
 
         it('displays teammates first and last name when nickname does not exists', () => {
-            ignoreUncaughtException();
-
             // # Ensure user has a nickname set up
             cy.apiPatchUser(testUser.id, {nickname: ''});
 
@@ -386,8 +380,6 @@ describe('Desktop notifications', () => {
     });
 
     it('MM-T490 Desktop Notifications - Teammate name display set to first and last name', () => {
-        ignoreUncaughtException();
-
         cy.apiCreateUser({}).then(({user}) => {
             cy.apiAddUserToTeam(testTeam.id, user.id);
             cy.apiLogin(user);
@@ -475,7 +467,6 @@ describe('Desktop notifications', () => {
                 // # Have another user post a direct message
                 cy.apiCreateDirectChannel([user.id, testUser.id]).then(({channel: dmChannel}) => {
                     cy.postMessageAs({sender: testUser, message: 'hi', channelId: dmChannel.id});
-                    ignoreUncaughtException();
 
                     // * DM notification is received
                     cy.get('@withNotification').should('have.been.called');
@@ -508,7 +499,6 @@ describe('Desktop notifications', () => {
                 // # Have another user post a direct message
                 cy.apiCreateDirectChannel([user.id, testUser.id]).then(({channel: dmChannel}) => {
                     cy.postMessageAs({sender: testUser, message: 'hi', channelId: dmChannel.id});
-                    ignoreUncaughtException();
 
                     // * DM notification is not received
                     cy.get('@withNotification').should('not.have.been.called');
@@ -521,7 +511,6 @@ describe('Desktop notifications', () => {
         cy.apiCreateUser().then(({user}) => {
             cy.apiAddUserToTeam(testTeam.id, user.id);
             cy.apiLogin(user);
-            ignoreUncaughtException();
 
             // # Visit town-square.
             cy.visit(`/${testTeam.name}/channels/town-square`);

--- a/e2e/cypress/integration/team_settings/teams_spec.js
+++ b/e2e/cypress/integration/team_settings/teams_spec.js
@@ -11,7 +11,6 @@
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {getAdminAccount} from '../../support/env';
-import {ignoreUncaughtException} from '../../support/notification';
 
 function removeTeamMember(teamName, username) {
     cy.apiAdminLogin();
@@ -316,7 +315,6 @@ describe('Teams Suite', () => {
 
         // # Select test team name
         cy.findByText(testTeam.display_name, {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').click();
-        ignoreUncaughtException();
 
         // # Verify Town square is visible
         cy.url().should('include', `/${testTeam.name}/channels/town-square`);

--- a/e2e/cypress/support/api/system.js
+++ b/e2e/cypress/support/api/system.js
@@ -142,10 +142,8 @@ const expectConfigToBeUpdatable = (currentConfig, newConfig) => {
 };
 
 Cypress.Commands.add('apiUpdateConfig', (newConfig = {}) => {
-    // # Get current settings
-    return cy.request('/api/v4/config').then((response) => {
-        const currentConfig = response.body;
-
+    // # Get current config
+    return cy.apiGetConfig().then(({config: currentConfig}) => {
         // * Check if config can be updated
         expectConfigToBeUpdatable(currentConfig, newConfig);
 

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -90,6 +90,11 @@ Cypress.on('test:after:run', (test, runnable) => {
     }
 });
 
+// Turn off all uncaught exception handling
+Cypress.on('uncaught:exception', () => {
+    return false;
+});
+
 before(() => {
     // # Try to login using existing sysadmin account
     cy.apiAdminLogin({failOnStatusCode: false}).then((response) => {

--- a/e2e/cypress/support/notification.js
+++ b/e2e/cypress/support/notification.js
@@ -19,11 +19,3 @@ export function spyNotificationAs(name, permission) {
 
     cy.window().should('have.property', 'Notification');
 }
-
-// Ignore an uncaught exception
-export function ignoreUncaughtException() {
-    cy.on('uncaught:exception', (err) => {
-        expect(err.message).to.include('.close is not a function');
-        return false;
-    });
-}


### PR DESCRIPTION
#### Summary
Ignore/turn off all uncaught exception by Cypress.
There are several varieties of error and none could easily determined whether it's from the application itself or Cypress. Note that those uncaught exceptions were not observed while checking manually; only during test automation with Cypress.

#### Ticket Link
Failing on daily Cypress test.

#### Screenshots
On local:
![Screen Shot 2021-01-04 at 6 36 21 PM](https://user-images.githubusercontent.com/5334504/103529075-fde07d80-4ebf-11eb-8d61-a79882dbe4d8.png)

On CI:
<img width="1108" alt="Screen Shot 2021-01-04 at 7 09 39 PM" src="https://user-images.githubusercontent.com/5334504/103529346-75aea800-4ec0-11eb-959e-0abbb1bff0d7.png">
