### PR TITLE
Cypress/E2E: Add explicit wait with cy.postMessage

### DIFF
--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -107,6 +107,10 @@ Cypress.Commands.add('uiPostMessageQuickly', (message) => {
 });
 
 function postMessageAndWait(textboxSelector, message) {
+    // Add explicit wait to let the page load freely since `cy.get` seemed to block
+    // some operation which caused to prolong complete page loading.
+    cy.wait(TIMEOUTS.THREE_SEC);
+
     cy.get(textboxSelector, {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`${message}{enter}`).wait(TIMEOUTS.HALF_SEC);
     cy.waitUntil(() => {
         return cy.get(textboxSelector).then((el) => {


### PR DESCRIPTION
#### Summary
On local dev, specifically when running with `npm run cypress:open`, `cy.postMessage` randomly failed waiting for `#post_textbox` to be visible. Not sure if you're seeing it too. As I observed, the channel page took so long to load on Cypress than normal (manual). It seemed that some webapp operation is blocked by Cypress while trying to wait for an element with `cy.get(textboxSelector, {timeout: TIMEOUTS.HALF_MIN})`.
I'm not a fan of explicit wait but I find it reasonable in this case. Please try on your local setup and let me know if something improves.  TIA.

#### Ticket Link
none
