### PR TITLE
[MM-31580] Fix call to getChannel to use new parameter format

### DIFF
--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -48,7 +48,7 @@ export function sendDesktopNotification(post, msgProps) {
         }
         const teamId = msgProps.team_id;
 
-        let channel = makeGetChannel()(state, post.channel_id);
+        let channel = makeGetChannel()(state, {id: post.channel_id});
         const user = getCurrentUser(state);
         const userStatus = getStatusForUserId(state, user.id);
         const member = getMyChannelMember(state, post.channel_id);


### PR DESCRIPTION
#### Summary
`makeGetChannel` was changed to take an object including an `id`, but this call to it wasn't updated, causing a bug in notifications. This PR fixes that call.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31580