### PR TITLE
MM-31616 - fix js errors shown for switch channel&incident plugin suggestion m…

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -658,8 +658,9 @@ export default class SuggestionBox extends React.PureComponent {
 
             if (handled) {
                 if (this.state.suggestionBoxAlgn.pixelsToMoveX === undefined &&
-                    this.state.suggestionBoxAlgn.pixelsToMoveY === undefined) {
-                    const char = provider.triggerCharacter || '@';
+                    this.state.suggestionBoxAlgn.pixelsToMoveY === undefined &&
+                    provider.triggerCharacter && ['@', ':', '~'].indexOf(provider.triggerCharacter) !== -1) {
+                    const char = provider.triggerCharacter;
                     const pxToSubstract = Utils.getPxToSubstract(char);
 
                     // get the alignment for the box and set it in the component state

--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -225,7 +225,8 @@ export default class SuggestionList extends React.PureComponent {
 
         const contentStyle = {maxHeight};
         const {pixelsToMoveX, pixelsToMoveY} = this.props.suggestionBoxAlgn;
-        const boxAlignment = {transform: `translate(${pixelsToMoveX}px, ${pixelsToMoveY}px)`};
+        const boxAlignment = pixelsToMoveX !== undefined && pixelsToMoveY !== undefined ?
+            {transform: `translate(${pixelsToMoveX}px, ${pixelsToMoveY}px)`} : {};
 
         return (<div className={mainClass}>
             <div


### PR DESCRIPTION
#### Summary
Fixes the issue reported when opening the switch channels modal and when adding a new incident via the incident plugin.

This commit makes sure that the logic applied to the suggestion_box to align the caret with the avatar/icon added in original [PR7082](https://github.com/mattermost/mattermost-webapp/pull/7082) will only and only apply to the Mention, Channel or Emoji provider. Also, checks for the two alignment values to not be undefined.

#### Ticket Link:
[MM-31616](https://mattermost.atlassian.net/browse/MM-31616)
