### PR TITLE
MM-31716: Remove the word experimental from gossip setting

### DIFF
--- a/components/admin_console/__snapshots__/cluster_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/cluster_settings.test.jsx.snap
@@ -145,7 +145,7 @@ exports[`components/ClusterSettings should match snapshot, encryption disabled 1
         id="UseExperimentalGossip"
         label={
           <FormattedMessage
-            defaultMessage="Use Experimental Gossip:"
+            defaultMessage="Use Gossip:"
             id="admin.cluster.UseExperimentalGossip"
           />
         }
@@ -418,7 +418,7 @@ exports[`components/ClusterSettings should match snapshot, encryption enabled 1`
         id="UseExperimentalGossip"
         label={
           <FormattedMessage
-            defaultMessage="Use Experimental Gossip:"
+            defaultMessage="Use Gossip:"
             id="admin.cluster.UseExperimentalGossip"
           />
         }

--- a/components/admin_console/cluster_settings.jsx
+++ b/components/admin_console/cluster_settings.jsx
@@ -204,7 +204,7 @@ export default class ClusterSettings extends AdminSettings {
                     label={
                         <FormattedMessage
                             id='admin.cluster.UseExperimentalGossip'
-                            defaultMessage='Use Experimental Gossip:'
+                            defaultMessage='Use Gossip:'
                         />
                     }
                     helpText={

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -440,7 +440,7 @@
   "admin.cluster.StreamingPortDesc": "The port used for streaming data between servers.",
   "admin.cluster.StreamingPortEx": "E.g.: \"8075\"",
   "admin.cluster.unknown": "unknown",
-  "admin.cluster.UseExperimentalGossip": "Use Experimental Gossip:",
+  "admin.cluster.UseExperimentalGossip": "Use Gossip:",
   "admin.cluster.UseExperimentalGossipDesc": "When true, the server will attempt to communicate via the gossip protocol over the gossip port.  When false the server will attempt to communicate over the streaming port. When false the gossip port and protocol are still used to determine cluster health.",
   "admin.cluster.UseIpAddress": "Use IP Address:",
   "admin.cluster.UseIpAddressDesc": "When true, the cluster will attempt to communicate via IP Address vs using the hostname.",


### PR DESCRIPTION
This PR just makes a small UI adjustment which removes the word experimental
from the system console. Any other things like variable names and id names
haven't been touched because the entire thing is going to be removed
after 3 months when the feature becomes default.

Test snapshots have been updated, and verified that there are no Cypress tests
matching this string.

https://mattermost.atlassian.net/browse/MM-31716

```release-notes
Removed the word "experimental" from gossip setting in the admin console
```
