### PR TITLE
[MM-30806] Account Settings - Setting to limit number of DMs/GMs shown in new sidebar

### DIFF
--- a/components/user_settings/sidebar/limit_visible_gms_dms/index.ts
+++ b/components/user_settings/sidebar/limit_visible_gms_dms/index.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {Preferences} from 'mattermost-redux/constants';
+import {getInt} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import {GlobalState} from 'types/store';
+
+import LimitVisibleGMsDMs from './limit_visible_gms_dms';
+
+function mapStateToProps(state: GlobalState) {
+    return {
+        currentUserId: getCurrentUserId(state),
+        dmGmLimit: getInt(state, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.LIMIT_VISIBLE_DMS_GMS, 20),
+    };
+}
+
+const mapDispatchToProps = {
+    savePreferences,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LimitVisibleGMsDMs);

--- a/components/user_settings/sidebar/limit_visible_gms_dms/limit_visible_gms_dms.tsx
+++ b/components/user_settings/sidebar/limit_visible_gms_dms/limit_visible_gms_dms.tsx
@@ -134,6 +134,8 @@ export default class LimitVisibleGMsDMs extends React.PureComponent<Props, State
                             onChange={this.handleChange}
                             value={this.state.limit}
                             isSearchable={false}
+                            menuPortalTarget={document.body}
+                            styles={reactStyles}
                         />
                         <div className='mt-5'>
                             <FormattedMessage
@@ -150,3 +152,10 @@ export default class LimitVisibleGMsDMs extends React.PureComponent<Props, State
         );
     }
 }
+
+const reactStyles = {
+    menuPortal: (provided: React.CSSProperties) => ({
+        ...provided,
+        zIndex: 9999,
+    }),
+};

--- a/components/user_settings/sidebar/limit_visible_gms_dms/limit_visible_gms_dms.tsx
+++ b/components/user_settings/sidebar/limit_visible_gms_dms/limit_visible_gms_dms.tsx
@@ -10,6 +10,7 @@ import {PreferenceType} from 'mattermost-redux/types/preferences';
 
 import SettingItemMax from 'components/setting_item_max';
 import SettingItemMin from 'components/setting_item_min';
+import {localizeMessage} from 'utils/utils';
 
 type Limit = {
     value: number;
@@ -31,6 +32,7 @@ type State = {
 }
 
 const limits: Limit[] = [
+    {value: 10000, label: localizeMessage('user.settings.sidebar.limitVisibleGMsDMs.allDirectMessages', 'All Direct Messages')},
     {value: 10, label: '10'},
     {value: 15, label: '15'},
     {value: 20, label: '20'},
@@ -52,13 +54,17 @@ export default class LimitVisibleGMsDMs extends React.PureComponent<Props, State
         if (props.active !== state.active) {
             if (props.active && !state.active) {
                 return {
-                    limit: {value: props.dmGmLimit, label: String(props.dmGmLimit)},
+                    limit: limits.find((l) => l.value === props.dmGmLimit),
                     active: props.active,
                 };
             }
 
             return {
                 active: props.active,
+            };
+        } else if (!props.active) {
+            return {
+                limit: limits.find((l) => l.value === props.dmGmLimit),
             };
         }
 
@@ -88,7 +94,7 @@ export default class LimitVisibleGMsDMs extends React.PureComponent<Props, State
 
     renderDescription = () => {
         return (
-            <span>{this.props.dmGmLimit}</span>
+            <span>{this.state.limit.label}</span>
         );
     }
 

--- a/components/user_settings/sidebar/limit_visible_gms_dms/limit_visible_gms_dms.tsx
+++ b/components/user_settings/sidebar/limit_visible_gms_dms/limit_visible_gms_dms.tsx
@@ -1,0 +1,146 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import ReactSelect, {ValueType} from 'react-select';
+import {FormattedMessage} from 'react-intl';
+
+import {Preferences} from 'mattermost-redux/constants';
+import {PreferenceType} from 'mattermost-redux/types/preferences';
+
+import SettingItemMax from 'components/setting_item_max';
+import SettingItemMin from 'components/setting_item_min';
+
+type Limit = {
+    value: number;
+    label: string;
+};
+
+type Props = {
+    active: boolean;
+    currentUserId: string;
+    savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<{data: boolean}>;
+    dmGmLimit: number;
+    updateSection: (section: string) => void;
+}
+
+type State = {
+    active: boolean;
+    limit: Limit;
+    isSaving: boolean;
+}
+
+const limits: Limit[] = [
+    {value: 10, label: '10'},
+    {value: 15, label: '15'},
+    {value: 20, label: '20'},
+    {value: 40, label: '40'},
+];
+
+export default class LimitVisibleGMsDMs extends React.PureComponent<Props, State> {
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            active: false,
+            limit: {value: 20, label: '20'},
+            isSaving: false,
+        };
+    }
+
+    static getDerivedStateFromProps(props: Props, state: State) {
+        if (props.active !== state.active) {
+            if (props.active && !state.active) {
+                return {
+                    limit: {value: props.dmGmLimit, label: String(props.dmGmLimit)},
+                    active: props.active,
+                };
+            }
+
+            return {
+                active: props.active,
+            };
+        }
+
+        return null;
+    }
+
+    handleChange = (selected: ValueType<Limit>) => {
+        if (selected && 'value' in selected) {
+            this.setState({limit: selected});
+        }
+    }
+
+    handleSubmit = async () => {
+        this.setState({isSaving: true});
+
+        await this.props.savePreferences(this.props.currentUserId, [{
+            user_id: this.props.currentUserId,
+            category: Preferences.CATEGORY_SIDEBAR_SETTINGS,
+            name: Preferences.LIMIT_VISIBLE_DMS_GMS,
+            value: this.state.limit.value.toString(),
+        }]);
+
+        this.setState({isSaving: false});
+
+        this.props.updateSection('');
+    }
+
+    renderDescription = () => {
+        return (
+            <span>{this.props.dmGmLimit}</span>
+        );
+    }
+
+    render() {
+        const title = (
+            <FormattedMessage
+                id='user.settings.sidebar.limitVisibleGMsDMsTitle'
+                defaultMessage='Number of direct messages to show'
+            />
+        );
+
+        if (!this.props.active) {
+            return (
+                <SettingItemMin
+                    title={title}
+                    describe={this.renderDescription()}
+                    section='limitVisibleGMsDMs'
+                    updateSection={this.props.updateSection}
+                />
+            );
+        }
+
+        return (
+            <SettingItemMax
+                title={title}
+                inputs={
+                    <fieldset>
+                        <legend className='form-legend hidden-label'>
+                            {title}
+                        </legend>
+                        <ReactSelect
+                            className='react-select'
+                            classNamePrefix='react-select'
+                            id='limitVisibleGMsDMs'
+                            options={limits}
+                            clearable={false}
+                            onChange={this.handleChange}
+                            value={this.state.limit}
+                            isSearchable={false}
+                        />
+                        <div className='mt-5'>
+                            <FormattedMessage
+                                id='user.settings.sidebar.limitVisibleGMsDMsDesc'
+                                defaultMessage='You can also change these settings in the direct messages sidebar menu.'
+                            />
+                        </div>
+                    </fieldset>
+                }
+                submit={this.handleSubmit}
+                saving={this.state.isSaving}
+                updateSection={this.props.updateSection}
+            />
+        );
+    }
+}

--- a/components/user_settings/sidebar/user_settings_sidebar.tsx
+++ b/components/user_settings/sidebar/user_settings_sidebar.tsx
@@ -22,6 +22,7 @@ import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min';
 
 import ShowUnreadsCategory from './show_unreads_category';
+import LimitVisibleGMsDMs from './limit_visible_gms_dms';
 
 export interface UserSettingsSidebarProps {
     actions: {
@@ -754,6 +755,23 @@ export default class UserSettingsSidebar extends React.PureComponent<UserSetting
         );
     };
 
+    renderLimitVisibleGMsDMsSection = () => {
+        if (this.props.enableLegacySidebar) {
+            // Only render this section when the new sidebar is enabled
+            return null;
+        }
+
+        return (
+            <>
+                <div className='divider-dark'/>
+                <LimitVisibleGMsDMs
+                    active={this.props.activeSection === 'limitVisibleGMsDMs'}
+                    updateSection={this.updateSection}
+                />
+            </>
+        );
+    };
+
     render(): JSX.Element {
         const {showUnusedOption, showChannelOrganization, enableLegacySidebar} = this.props;
 
@@ -804,6 +822,7 @@ export default class UserSettingsSidebar extends React.PureComponent<UserSetting
                     {channelOrganizationSection}
                     {channelSwitcherSection}
                     {this.renderShowUnreadsCategorySection()}
+                    {this.renderLimitVisibleGMsDMsSection()}
                     {showUnusedOption ? <div className='divider-light'/> : <div className='divider-dark'/>}
                     {autoCloseDMSection}
                 </div>

--- a/components/user_settings/sidebar/user_settings_sidebar.tsx
+++ b/components/user_settings/sidebar/user_settings_sidebar.tsx
@@ -776,7 +776,7 @@ export default class UserSettingsSidebar extends React.PureComponent<UserSetting
         const {showUnusedOption, showChannelOrganization, enableLegacySidebar} = this.props;
 
         const channelOrganizationSection = (showChannelOrganization && enableLegacySidebar) ? this.renderChannelOrganizationSection() : null;
-        const autoCloseDMSection = showUnusedOption ? this.renderAutoCloseDMSection() : null;
+        const autoCloseDMSection = (showUnusedOption && enableLegacySidebar) ? this.renderAutoCloseDMSection() : null;
         const channelSwitcherSection = enableLegacySidebar ? this.renderChannelSwitcherSection() : null;
 
         return (

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4343,6 +4343,7 @@
   "user.settings.sidebar.groupChannelsTitle": "Channel grouping",
   "user.settings.sidebar.groupDesc": "Group channels by type, or combine all types into a list.",
   "user.settings.sidebar.icon": "Sidebar Settings Icon",
+  "user.settings.sidebar.limitVisibleGMsDMs.allDirectMessages": "All Direct Messages",
   "user.settings.sidebar.limitVisibleGMsDMsDesc": "You can also change these settings in the direct messages sidebar menu.",
   "user.settings.sidebar.limitVisibleGMsDMsTitle": "Number of direct messages to show",
   "user.settings.sidebar.never": "Never",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4343,6 +4343,8 @@
   "user.settings.sidebar.groupChannelsTitle": "Channel grouping",
   "user.settings.sidebar.groupDesc": "Group channels by type, or combine all types into a list.",
   "user.settings.sidebar.icon": "Sidebar Settings Icon",
+  "user.settings.sidebar.limitVisibleGMsDMsDesc": "You can also change these settings in the direct messages sidebar menu.",
+  "user.settings.sidebar.limitVisibleGMsDMsTitle": "Number of direct messages to show",
   "user.settings.sidebar.never": "Never",
   "user.settings.sidebar.off": "Off",
   "user.settings.sidebar.on": "On",


### PR DESCRIPTION
#### Summary
The Account Settings section that allows the user to set the limit on DMs/GMs in the new sidebar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30806