### PR TITLE
Promoting tests to prod from unstable - part I

### DIFF
--- a/e2e/cypress/integration/account_settings/display/account_settings_position_spec.js
+++ b/e2e/cypress/integration/account_settings/display/account_settings_position_spec.js
@@ -7,7 +7,9 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
+
 describe('Account Settings > General > Position', () => {
     let testTeam;
     let testUser;

--- a/e2e/cypress/integration/account_settings/display/theme/save_theme_spec.js
+++ b/e2e/cypress/integration/account_settings/display/theme/save_theme_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import * as TIMEOUTS from '../../../../fixtures/timeouts';

--- a/e2e/cypress/integration/account_settings/general/fullname_truncate_spec.js
+++ b/e2e/cypress/integration/account_settings/general/fullname_truncate_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/account_settings/general/profile_picture_spec.js
+++ b/e2e/cypress/integration/account_settings/general/profile_picture_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/account_settings/general/username_spec.js
+++ b/e2e/cypress/integration/account_settings/general/username_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/archived_channel/archive_channel_addReaction_spec.js
+++ b/e2e/cypress/integration/archived_channel/archive_channel_addReaction_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel
 
 describe('Archived channels', () => {

--- a/e2e/cypress/integration/archived_channel/archive_channel_operations_spec.js
+++ b/e2e/cypress/integration/archived_channel/archive_channel_operations_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel
 
 import {getAdminAccount} from '../../support/env';

--- a/e2e/cypress/integration/bot_accounts/bot_api_not_cloud_spec.js
+++ b/e2e/cypress/integration/bot_accounts/bot_api_not_cloud_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @not_cloud @bot_accounts
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/bot_accounts/bot_channel_intro_spec.js
+++ b/e2e/cypress/integration/bot_accounts/bot_channel_intro_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @bot_accounts
 
 import {createBotPatch} from '../../support/api/bots';

--- a/e2e/cypress/integration/bot_accounts/display_name_spec.js
+++ b/e2e/cypress/integration/bot_accounts/display_name_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @bot_accounts
 
 describe('Bot display name', () => {

--- a/e2e/cypress/integration/bot_accounts/edit_bot_username_spec.js
+++ b/e2e/cypress/integration/bot_accounts/edit_bot_username_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @bot_accounts
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/bot_accounts/in_teams_and_channels_spec.js
+++ b/e2e/cypress/integration/bot_accounts/in_teams_and_channels_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @bot_accounts
 
 import {createBotPatch} from '../../support/api/bots';

--- a/e2e/cypress/integration/bot_accounts/post_message_spec.js
+++ b/e2e/cypress/integration/bot_accounts/post_message_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @bot_accounts
 
 describe('Bot post message', () => {

--- a/e2e/cypress/integration/bot_accounts/promote_demote_spec.js
+++ b/e2e/cypress/integration/bot_accounts/promote_demote_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @bot_accounts
 
 import {createBotPatch} from '../../support/api/bots';

--- a/e2e/cypress/integration/bot_accounts/tags_spec.js
+++ b/e2e/cypress/integration/bot_accounts/tags_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @bot_accounts
 
 import {createBotPatch} from '../../support/api/bots';

--- a/e2e/cypress/integration/bot_accounts/token_spec.js
+++ b/e2e/cypress/integration/bot_accounts/token_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // ******************************************************************
-// !!! THIS IS A DUPLICATE IMPLIMENTATION OF THE TEST IN bot_api_spec.js.
+// !!! THIS IS A DUPLICATE IMPLEMENTATION OF THE TEST IN bot_api_spec.js.
 // HOWEVER, PROMOTING THIS TO PROD UNTIL THE OTHER FILE IS STABLE
 // ENOUGH, SO THAT MANUAL TESTING ON THIS TEST CASE CAN BE ELIMINATED.
 // ONCE THAT FILE IS STABLE, THIS ONE SHOULD BE DELETED. !!!

--- a/e2e/cypress/integration/bot_accounts/token_spec.js
+++ b/e2e/cypress/integration/bot_accounts/token_spec.js
@@ -7,6 +7,14 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// ******************************************************************
+// !!! THIS IS A DUPLICATE IMPLIMENTATION OF THE TEST IN bot_api_spec.js.
+// HOWEVER, PROMOTING THIS TO PROD UNTIL THE OTHER FILE IS STABLE
+// ENOUGH, SO THAT MANUAL TESTING ON THIS TEST CASE CAN BE ELIMINATED.
+// ONCE THAT FILE IS STABLE, THIS ONE SHOULD BE DELETED. !!!
+// ******************************************************************
+
+// Stage: @prod
 // Group: @bot_accounts
 
 describe('Bot Tokens', () => {

--- a/e2e/cypress/integration/channel/add_users_to_channel_spec.js
+++ b/e2e/cypress/integration/channel/add_users_to_channel_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel @channel_settings @smoke
 
 function verifyMentionedUserAndProfilePopover(postId) {

--- a/e2e/cypress/integration/channel/channel_routing_spec.js
+++ b/e2e/cypress/integration/channel/channel_routing_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel
 
 describe('Channel routing', () => {

--- a/e2e/cypress/integration/channel_sidebar/dm_gm_behaviour_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/dm_gm_behaviour_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @dm_category
 
 import {getAdminAccount} from '../../support/env';

--- a/e2e/cypress/integration/channel_sidebar/sidebar_category_menu_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/sidebar_category_menu_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel_sidebar
 
 describe('Sidebar category menu', () => {

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_invitation_ui_more_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_invitation_ui_more_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @guest_account
 
 /**

--- a/e2e/cypress/integration/enterprise/ldap/ldap_group_sync_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_group_sync_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @ldap
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/enterprise/ldap/ldap_setting_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_setting_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @ldap
 
 // assumes the CYPRESS_* variables are set

--- a/e2e/cypress/integration/enterprise/ldap_group/channel_modes_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/channel_modes_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @ldap_group
 
 describe('Test channel public/private toggle', () => {

--- a/e2e/cypress/integration/enterprise/system_console/archived_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/archived_channels_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';


### PR DESCRIPTION
Promoting some tests that have been consistently passing in the last five runs to prod from unstable.
There are more tests that need to be looked into more in detail, thus doing it in parts for this week.
Also, note that I have added a comment in `token_spec` for MM-T1880 since there was a duplicate implementation of that test case; we'd want to keep the test from `bot_api_spec` but that file is not stable enough for prod, thus promoting this one for now so that it eliminates the need to run the test manually and has been passing consistently.