### PR TITLE
[MM-32193][MM-32178] Move transform for team sidebar button to anchor

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -865,7 +865,7 @@
         opacity: 1;
         visibility: visible;
         align-items: center;
-        overflow-y: hidden;
+        overflow: hidden;
 
         &:hover {
             .btn-close {
@@ -991,7 +991,7 @@
         color: rgba(var(--sidebar-text-rgb), 0.6);
         align-items: center;
         margin-right: 0;
-        width: 100%;
+        width: 240px;
         border-top: 0;
         border-bottom: 0;
         height: 32px;

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -940,6 +940,10 @@
                 color: var(--center-channel-bg);
             }
         }
+
+        > span {
+            flex-grow: 1;
+        }
     }
 
     .SidebarChannel:hover {

--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -53,12 +53,6 @@
             justify-content: center;
             align-items: center;
             text-align: center;
-            transition: transform 0.1s;
-            transform-origin: center center;
-
-            &:active {
-                transform: translate(0, 2px);
-            }
 
             &.unread {
                 .unread-badge {
@@ -68,32 +62,23 @@
                     border-radius: 100%;
                     width: 8px;
                     height: 8px;
-                    box-shadow: 0 0 0 3px var(--sidebar-header-bg);
+                    box-shadow:
+                        0 0 0 3px rgba(0, 0, 0, 0.2),
+                        0 0 0 3px var(--sidebar-header-bg);
                     background: white;
                     z-index: 1;
-                }
-
-                &:before {
-                    content: "";
-                    position: absolute;
-                    width: 14px;
-                    height: 14px;
-                    border: 3px solid rgba(0, 0, 0, 0.2);
-                    border-radius: 100%;
-                    top: -5px;
-                    right: 6px;
-                    z-index: 2;
                 }
             }
 
             a {
                 display: block;
                 text-decoration: none;
-            }
+                transition: transform 0.1s;
+                transform: translate(0, 0);
+                transform-origin: center center;
 
-            &.active {
-                .TeamIcon__content {
-                    @include opacity(1);
+                &:active {
+                    transform: translate(0, 2px);
                 }
             }
 

--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -82,6 +82,12 @@
                 }
             }
 
+            &.active {
+                .TeamIcon__content {
+                    @include opacity(1);
+                }
+            }
+
             button {
                 border: none;
                 padding: 0;

--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -54,7 +54,6 @@
             align-items: center;
             text-align: center;
             transition: transform 0.1s;
-            transform: translate(0, 0);
             transform-origin: center center;
 
             &:active {


### PR DESCRIPTION
#### Summary
A CSS statement transforming the base team sidebar button container (`transform: translate(0, 0)`) was causing the desktop `Copy Link` context menu to not be rendered correctly.

Moving the transform to the `a` element inside the `team-container` stops it from affecting the context menu.

EDIT: Also noticed the extra transform statement was causing a horizontal scrollbar to appear. Seems to fix that as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32193
https://mattermost.atlassian.net/browse/MM-32178