### PR TITLE
Fix for accessibility buttons and dropdown tests

### DIFF
--- a/e2e/cypress/integration/accessibility/accessibility_buttons_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_buttons_spec.js
@@ -56,10 +56,10 @@ describe('Verify Accessibility Support in different Buttons', () => {
         cy.get('#toggleFavorite').focus().tab({shift: true}).tab();
 
         // # Press tab until the focus is on the Pinned posts button
-        cy.focused().tab().tab().tab().tab();
+        cy.focused().tab().tab();
 
         // * Verify accessibility support in Pinned Posts button
-        cy.get('#channelHeaderPinButton').should('have.attr', 'aria-label', 'Pinned posts').and('have.class', 'a11y--active a11y--focused').tab();
+        cy.get('#channelHeaderPinButton').should('have.attr', 'aria-label', 'Pinned posts').and('have.class', 'a11y--active a11y--focused').tab().tab();
 
         // * Verify accessibility support in Search input
         cy.get('#searchBox').should('have.attr', 'aria-label', 'Search').and('have.class', 'a11y--active a11y--focused').tab();

--- a/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
@@ -47,7 +47,7 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
 
     it('MM-T1464 Accessibility Support in Channel Menu Dropdown', () => {
         // # Press tab from the Channel Favorite button
-        cy.get('#toggleFavorite').focus().wait(TIMEOUTS.HALF_SEC).tab({shift: true}).tab().tab();
+        cy.get('#toggleFavorite').focus().wait(TIMEOUTS.HALF_SEC).tab({shift: true}).tab().tab({shift:true});
 
         // * Verify the aria-label in channel menu button
         cy.get('#channelHeaderDropdownButton button').should('have.attr', 'aria-label', 'channel menu').and('have.class', 'a11y--active a11y--focused').click();


### PR DESCRIPTION
This PR includes possible fixes for failures in prod tests in accessibility buttons and dropdown menu because of channel header redesign. The tests with the changes are passing on my local server:
![Screen Shot 2021-01-20 at 7 14 54 PM](https://user-images.githubusercontent.com/691331/105275881-0fc74f00-5b55-11eb-8941-5ecc275a6632.png)
![Screen Shot 2021-01-20 at 7 13 45 PM](https://user-images.githubusercontent.com/691331/105275888-13f36c80-5b55-11eb-968c-079ba5d2fbd5.png)
