### PR TITLE
[MM-32138] - Fix margin of history arrows without unread filter button

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -245,12 +245,12 @@
             border-right: 1px solid rgba(255, 255, 255, 0.16);
             height: 28px;
             margin-left: 8px;
+            margin-right: 8px;
         }
 
         .SidebarChannelNavigator_backButton {
             border-radius: 4px;
             padding: 0;
-            margin-left: 8px;
             background: transparent;
         }
 


### PR DESCRIPTION
#### Summary
Fix the alignment of the history arrows on desktop app when the unread category is enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32138

V.5.32