### PR TITLE
MM-32197 Use other timestamps when autohiding DMs/GMs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18394,8 +18394,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#402096d99aae75e0c5e6e0741582ff0bb229b51c",
-      "from": "github:mattermost/mattermost-redux#402096d99aae75e0c5e6e0741582ff0bb229b51c",
+      "version": "github:mattermost/mattermost-redux#dcb0a60885453f13e78cbb1c4dab629250734009",
+      "from": "github:mattermost/mattermost-redux#dcb0a60885453f13e78cbb1c4dab629250734009",
       "requires": {
         "core-js": "3.6.5",
         "form-data": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18394,8 +18394,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#dcb0a60885453f13e78cbb1c4dab629250734009",
-      "from": "github:mattermost/mattermost-redux#dcb0a60885453f13e78cbb1c4dab629250734009",
+      "version": "github:mattermost/mattermost-redux#1ae950bc24f3385b58887b76dc2c7232aa7d05f2",
+      "from": "github:mattermost/mattermost-redux#1ae950bc24f3385b58887b76dc2c7232aa7d05f2",
       "requires": {
         "core-js": "3.6.5",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "localforage-observable": "2.0.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#87769262aa02e1784570f61f4f962050e07cc335",
-    "mattermost-redux": "github:mattermost/mattermost-redux#dcb0a60885453f13e78cbb1c4dab629250734009",
+    "mattermost-redux": "github:mattermost/mattermost-redux#1ae950bc24f3385b58887b76dc2c7232aa7d05f2",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "localforage-observable": "2.0.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#87769262aa02e1784570f61f4f962050e07cc335",
-    "mattermost-redux": "github:mattermost/mattermost-redux#402096d99aae75e0c5e6e0741582ff0bb229b51c",
+    "mattermost-redux": "github:mattermost/mattermost-redux#dcb0a60885453f13e78cbb1c4dab629250734009",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",


### PR DESCRIPTION
The last_viewed_at timestamp for channel members is only ever updated on the server to the time of the most recent post in the channel, so when the user refreshes, the priority for showing DM channels might change.

The old autohiding solved that by using some other timestamps which I'd like to remove eventually if we can make last_viewed_at work better, but in the mean time, we can still make use of them to get a better idea of when the user actually last viewed the channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32197

#### Related Pull Requests
https://github.com/mattermost/mattermost-redux/pull/1339