### PR TITLE
Cypress/E2E: Fix time out error on initial Cypress run against remote server

### DIFF
--- a/components/admin_console/system_roles/system_role/add_users_to_role_modal/__snapshots__/add_users_to_role_modal.test.tsx.snap
+++ b/components/admin_console/system_roles/system_role/add_users_to_role_modal/__snapshots__/add_users_to_role_modal.test.tsx.snap
@@ -182,8 +182,10 @@ exports[`admin_console/add_users_to_role_modal should match snapshot 1`] = `
       }
       perPage={50}
       placeholderText="Search and add members"
+      saveButtonPosition="top"
       saving={false}
       valueRenderer={[Function]}
+      valueWithImage={false}
       values={Array []}
     />
   </ModalBody>

--- a/e2e/cypress/support/api/system.js
+++ b/e2e/cypress/support/api/system.js
@@ -100,7 +100,7 @@ Cypress.Commands.add('apiDeleteLicense', () => {
     });
 });
 
-const getDefaultConfig = () => {
+export const getDefaultConfig = () => {
     const cypressEnv = Cypress.env();
 
     const fromCypressEnv = {

--- a/e2e/cypress/support/api/user.js
+++ b/e2e/cypress/support/api/user.js
@@ -188,7 +188,7 @@ Cypress.Commands.add('apiCreateAdmin', () => {
     return cy.request(options).then((res) => {
         expect(res.status).to.equal(201);
 
-        return cy.wrap({sysadmin: res.body});
+        return cy.wrap({sysadmin: {...res.body, password}});
     });
 });
 

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -32,6 +32,8 @@ import './ui';
 import './ui_commands'; // soon to deprecate
 import './visual_commands';
 
+import {getDefaultConfig} from './api/system';
+
 Cypress.on('test:after:run', (test, runnable) => {
     // Only if the test is failed do we want to add
     // the additional context of the screenshot.
@@ -106,6 +108,9 @@ before(() => {
         } else {
             // # Create and login a newly created user as sysadmin
             cy.apiCreateAdmin().then(({sysadmin}) => {
+                // Sends dummy call to update the config after creating an admin user.
+                // Without this, first call to `cy.apiUpdateConfig()` consistently getting time out error in CI against remote server.
+                cy.externalRequest({user: sysadmin, method: 'put', path: 'config', data: getDefaultConfig(), failOnStatusCode: false});
                 cy.apiAdminLogin().then(() => sysadminSetup(sysadmin));
             });
         }

--- a/e2e/cypress/support/task_commands.d.ts
+++ b/e2e/cypress/support/task_commands.d.ts
@@ -18,6 +18,27 @@ declare namespace Cypress {
     interface Chainable<Subject = any> {
 
         /**
+         * externalRequest is a task which is wrapped as command with post-verification
+         * that the external request is successfully completed
+         * @param {Object} options
+         * @param {<UserProfile, 'username' | 'password'>} options.user - a user initiating external request
+         * @param {String} options.method - an HTTP method (e.g. get, post, etc)
+         * @param {String} options.path - API path that is relative to Cypress.config().baseUrl
+         * @param {Object} options.data - payload
+         * @param {Boolean} options.failOnStatusCode - whether to fail on status code, default is true
+         *
+         * @example
+         *    cy.externalRequest({user: sysadmin, method: 'POST', path: 'config', data});
+         */
+        externalRequest(options?: {
+            user: Pick<UserProfile, 'username' | 'password'>;
+            method: string;
+            path: string;
+            data?: Record<string, any>;
+            failOnStatusCode?: boolean;
+        }): Chainable<Response>;
+
+        /**
          * Adds a given reaction to a specific post from a user
          * @param {Object} reactToMessageObject - Information on person and post to which a reaction needs to be added
          * @param {Object} reactToMessageObject.sender - a user object who will post a message

--- a/e2e/cypress/support/task_commands.js
+++ b/e2e/cypress/support/task_commands.js
@@ -66,20 +66,12 @@ Cypress.Commands.add('postIncomingWebhook', ({url, data, waitFor}) => {
     }));
 });
 
-/**
-* externalRequest is a task which is wrapped as command with post-verification
-* that the external request is successfully completed
-* @param {Object} user - a user initiating external request
-* @param {String} method - an HTTP method (e.g. get, post, etc)
-* @param {String} path - API path that is relative to Cypress.config().baseUrl
-* @param {Object} data - payload
-*/
-Cypress.Commands.add('externalRequest', ({user, method, path, data}) => {
+Cypress.Commands.add('externalRequest', ({user, method, path, data, failOnStatusCode = true}) => {
     const baseUrl = Cypress.config('baseUrl');
 
     return cy.task('externalRequest', {baseUrl, user, method, path, data}).then((response) => {
         // Temporarily ignore error related to Cloud
-        if (response.data.id !== 'ent.cloud.request_error') {
+        if (response.data && response.data.id !== 'ent.cloud.request_error' && failOnStatusCode) {
             expect(response.status).to.be.oneOf([200, 201, 204]);
         }
 


### PR DESCRIPTION
#### Summary
Fix time out error on initial Cypress run against remote server. Note that the time out error is not related to product changes but most likely related to initial access by newly created admin user against newly created remote server in CI. It might be something to do with DNS propagation but will investigate further. For the meantime, the solution here works 100% of the time.

#### Ticket Link
none, failing on daily Cypress run
