### PR TITLE
[MM-32167] Alphabetical and recency sorted categories will now have the same drop behaviour as DMs (#7348)

### DIFF
--- a/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
+++ b/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`components/sidebar/sidebar_category should match snapshot 1`] = `
 <div
-  className="SidebarChannelGroup a11y__section"
+  className="SidebarChannelGroup a11y__section autoSortedCategory"
 >
   <Connect(Droppable)
     direction="vertical"
@@ -63,9 +63,9 @@ exports[`components/sidebar/sidebar_category should match snapshot 2`] = `
         channelId="channel_id"
         channelIndex={0}
         getChannelRef={[MockFunction]}
+        isAutoSortedCategory={true}
         isCategoryCollapsed={false}
         isCategoryDragged={false}
-        isDMCategory={false}
         isDropDisabled={false}
         key="channel_id"
         setChannelRef={[MockFunction]}
@@ -77,7 +77,7 @@ exports[`components/sidebar/sidebar_category should match snapshot 2`] = `
 
 exports[`components/sidebar/sidebar_category should match snapshot when collapsed 1`] = `
 <div
-  className="SidebarChannelGroup a11y__section"
+  className="SidebarChannelGroup a11y__section autoSortedCategory isCollapsed"
 >
   <Connect(Droppable)
     direction="vertical"
@@ -138,9 +138,9 @@ exports[`components/sidebar/sidebar_category should match snapshot when collapse
         channelId="channel_id"
         channelIndex={0}
         getChannelRef={[MockFunction]}
+        isAutoSortedCategory={true}
         isCategoryCollapsed={true}
         isCategoryDragged={false}
-        isDMCategory={false}
         isDropDisabled={false}
         key="channel_id"
         setChannelRef={[MockFunction]}
@@ -152,7 +152,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when collapse
 
 exports[`components/sidebar/sidebar_category should match snapshot when isNewCategory 1`] = `
 <div
-  className="SidebarChannelGroup a11y__section"
+  className="SidebarChannelGroup a11y__section autoSortedCategory"
 >
   <Connect(Droppable)
     direction="vertical"
@@ -245,7 +245,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when isNewCat
 
 exports[`components/sidebar/sidebar_category should match snapshot when sorting is set to by recency 1`] = `
 <div
-  className="SidebarChannelGroup a11y__section dmCategory"
+  className="SidebarChannelGroup a11y__section autoSortedCategory"
 >
   <Connect(Droppable)
     direction="vertical"
@@ -339,9 +339,9 @@ exports[`components/sidebar/sidebar_category should match snapshot when sorting 
         channelId="channel_id"
         channelIndex={0}
         getChannelRef={[MockFunction]}
+        isAutoSortedCategory={true}
         isCategoryCollapsed={false}
         isCategoryDragged={false}
-        isDMCategory={true}
         isDropDisabled={false}
         key="channel_id"
         setChannelRef={[MockFunction]}
@@ -353,7 +353,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when sorting 
 
 exports[`components/sidebar/sidebar_category should match snapshot when the category is DM and there are no DMs to display 1`] = `
 <div
-  className="SidebarChannelGroup a11y__section dmCategory"
+  className="SidebarChannelGroup a11y__section autoSortedCategory"
 >
   <Connect(Droppable)
     direction="vertical"

--- a/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -116,7 +116,7 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                 isCategoryCollapsed={isCollapsed}
                 isCategoryDragged={draggingState.type === DraggingStateTypes.CATEGORY && draggingState.id === category.id}
                 isDropDisabled={this.isDropDisabled()}
-                isDMCategory={category.type === CategoryTypes.DIRECT_MESSAGES}
+                isAutoSortedCategory={category.sorting === CategorySorting.Alphabetical || category.sorting === CategorySorting.Recency}
             />
         );
     }
@@ -216,6 +216,23 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                 </div>
             </React.Fragment>
         );
+    }
+
+    showPlaceholder = () => {
+        const {channels, draggingState, category, isNewCategory} = this.props;
+
+        if (category.sorting === CategorySorting.Alphabetical ||
+            category.sorting === CategorySorting.Recency ||
+            isNewCategory) {
+            // Always show the placeholder if the channel being dragged is from the current category
+            if (channels.find((channel) => channel.id === draggingState.id)) {
+                return true;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     render() {
@@ -323,10 +340,11 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                     return (
                         <div
                             className={classNames('SidebarChannelGroup a11y__section', {
-                                dmCategory: category.type === CategoryTypes.DIRECT_MESSAGES,
+                                autoSortedCategory: category.sorting === CategorySorting.Alphabetical || category.sorting === CategorySorting.Recency,
                                 dropDisabled: this.isDropDisabled(),
                                 menuIsOpen: this.state.isMenuOpen,
                                 capture: this.props.draggingState.state === DraggingStates.CAPTURE,
+                                isCollapsed,
                             })}
                             ref={provided.innerRef}
                             {...provided.draggableProps}
@@ -367,7 +385,7 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                                                 >
                                                     {this.renderNewDropBox(droppableSnapshot.isDraggingOver)}
                                                     {renderedChannels}
-                                                    {(category.type === CategoryTypes.DIRECT_MESSAGES || isNewCategory) ? null : droppableProvided.placeholder}
+                                                    {this.showPlaceholder() ? droppableProvided.placeholder : null}
                                                 </ul>
                                             </div>
                                         </div>

--- a/components/sidebar/sidebar_channel/index.ts
+++ b/components/sidebar/sidebar_channel/index.ts
@@ -7,7 +7,7 @@ import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/commo
 import {getCurrentChannelId, makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
-import {getDraggingState, isChannelSelected} from 'selectors/views/channel_sidebar';
+import {getAutoSortedCategoryIds, getDraggingState, isChannelSelected} from 'selectors/views/channel_sidebar';
 import {GlobalState} from 'types/store';
 import {NotificationLevels} from 'utils/constants';
 
@@ -53,6 +53,7 @@ function makeMapStateToProps() {
             draggingState: getDraggingState(state),
             isChannelSelected: isChannelSelected(state, ownProps.channelId),
             multiSelectedChannelIds: state.views.channelSidebar.multiSelectedChannelIds,
+            autoSortedCategoryIds: getAutoSortedCategoryIds(state),
         };
     };
 }

--- a/components/sidebar/sidebar_channel/sidebar_channel.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.test.tsx
@@ -37,11 +37,12 @@ describe('components/sidebar/sidebar_channel', () => {
         setChannelRef: jest.fn(),
         isCategoryCollapsed: false,
         isCurrentChannel: false,
-        isDMCategory: false,
+        isAutoSortedCategory: false,
         isCategoryDragged: false,
         isDropDisabled: false,
         draggingState: {},
         multiSelectedChannelIds: [],
+        autoSortedCategoryIds: new Set<string>(),
         isChannelSelected: false,
     };
 

--- a/components/sidebar/sidebar_channel/sidebar_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.tsx
@@ -69,7 +69,7 @@ type Props = {
      */
     isCurrentChannel: boolean;
 
-    isDMCategory: boolean;
+    isAutoSortedCategory: boolean;
 
     isDraggable: boolean;
 
@@ -82,6 +82,8 @@ type Props = {
     isChannelSelected: boolean;
 
     multiSelectedChannelIds: string[];
+
+    autoSortedCategoryIds: Set<string>;
 };
 
 type State = {
@@ -135,10 +137,11 @@ export default class SidebarChannel extends React.PureComponent<Props, State> {
             currentTeamName,
             isCurrentChannel,
             isDraggable,
-            isDMCategory,
+            isAutoSortedCategory,
             isChannelSelected,
             draggingState,
             multiSelectedChannelIds,
+            autoSortedCategoryIds,
         } = this.props;
 
         let ChannelComponent: React.ComponentType<{channel: Channel; currentTeamName: string; isCollapsed: boolean}> = SidebarBaseChannel;
@@ -188,8 +191,8 @@ export default class SidebarChannel extends React.PureComponent<Props, State> {
                                     active: isCurrentChannel,
                                     dragging: snapshot.isDragging,
                                     selectedDragging: isChannelSelected && draggingState.state && draggingState.id !== channel.id,
-                                    fadeDMs: snapshot.isDropAnimating && snapshot.draggingOver?.includes('direct_messages'),
-                                    noFloat: isDMCategory && !snapshot.isDragging,
+                                    fadeOnDrop: snapshot.isDropAnimating && snapshot.draggingOver && autoSortedCategoryIds.has(snapshot.draggingOver),
+                                    noFloat: isAutoSortedCategory && !snapshot.isDragging,
                                 })}
                                 onTransitionEnd={this.removeAnimation}
                                 {...provided.draggableProps}

--- a/components/sidebar/unread_channels/unread_channels.tsx
+++ b/components/sidebar/unread_channels/unread_channels.tsx
@@ -42,7 +42,7 @@ export default function UnreadChannels(props: Props) {
                                 isCategoryDragged={false}
                                 isDraggable={false}
                                 isDropDisabled={true}
-                                isDMCategory={false}
+                                isAutoSortedCategory={true}
                             />
                         );
                     })}

--- a/e2e/cypress/integration/bot_accounts/in_lists_spec.js
+++ b/e2e/cypress/integration/bot_accounts/in_lists_spec.js
@@ -130,7 +130,7 @@ describe('Bots in lists', () => {
     it('MM-T1836_1 Bot accounts display (Legacy Sidebar)', () => {
         cy.apiUpdateConfig({
             ServiceSettings: {
-                ExperimentalChannelSidebarOrganization: 'disabled',
+                EnableLegacySidebar: true,
             },
         });
 
@@ -149,13 +149,13 @@ describe('Bots in lists', () => {
     it('MM-T1836_2 Bot accounts display (New Sidebar)', () => {
         cy.apiUpdateConfig({
             ServiceSettings: {
-                ExperimentalChannelSidebarOrganization: 'always_on',
+                EnableLegacySidebar: false,
             },
         });
 
         cy.visit(`/${team.name}/messages/@${bots[0].username}`);
 
-        cy.get('.dmCategory .SidebarChannel.active > .SidebarLink').then(($link) => {
+        cy.get('.SidebarChannelGroup:contains(DIRECT MESSAGES) .SidebarChannel.active > .SidebarLink').then(($link) => {
             // * Verify DM label
             cy.wrap($link).find('.SidebarChannelLinkLabel').should('have.text', bots[0].username);
 
@@ -171,7 +171,7 @@ describe('Bots in lists', () => {
         cy.postMessage('Hello, regular user');
 
         // * Verify Bots and Regular users as siblings in DMs
-        cy.get('.dmCategory .SidebarChannel.active').siblings('.SidebarChannel').then(($siblings) => {
+        cy.get('.SidebarChannelGroup:contains(DIRECT MESSAGES) .SidebarChannel.active').siblings('.SidebarChannel').then(($siblings) => {
             cy.wrap($siblings).contains('.SidebarChannelLinkLabel', bots[0].username);
         });
     });

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -624,7 +624,7 @@
         }
     }
 
-    .SidebarChannelGroup:not(.dmCategory) .draggingOver .SidebarChannelGroupHeader:hover {
+    .SidebarChannelGroup:not(.autoSortedCategory) .draggingOver .SidebarChannelGroupHeader:hover {
         box-shadow: inset -1px 0 0 rgba(var(--sidebar-text-rgb), 0.60), inset 0 -1px 0 rgba(var(--sidebar-text-rgb), 0.6), inset 1px 0 0 rgba(var(--sidebar-text-rgb), 0.6), inset 0 1px 0 rgba(var(--sidebar-text-rgb), 0.6);
         border-radius: 4px;
 
@@ -746,20 +746,26 @@
     .SidebarChannelGroup .SidebarChannelGroupHeader > i {
         font-size: 12px;
     }
-    .SidebarChannelGroup__is-collapsed {
-        animation-name: menuAnimation;
-        animation-duration: 0.25s;
-        animation-timing-function: linear;
-    }
 
-    .SidebarChannelGroup.dmCategory .draggingOver {
+    .SidebarChannelGroup.autoSortedCategory .draggingOver {
         box-shadow: inset -1px 0 0 rgba(var(--sidebar-text-rgb), 0.6), inset 0 -1px 0 rgba(var(--sidebar-text-rgb), 0.6), inset 1px 0 0 rgba(var(--sidebar-text-rgb), 0.6), inset 0 1px 0 rgba(var(--sidebar-text-rgb), 0.6);
         border-radius: 4px;
 
-        .SidebarChannelGroupHeader_groupButton {
-            background-color: inherit;
+        .SidebarChannelGroupHeader {
+            background-color: var(--sidebar-bg);
+
+            .SidebarChannelGroupHeader_groupButton {
+                border-radius: 4px 4px 0 0;
+                box-shadow: inset -1px 0 0 rgba(var(--sidebar-text-rgb), 0.6), inset 1px 0 0 rgba(var(--sidebar-text-rgb), 0.6), inset 0 1px 0 rgba(var(--sidebar-text-rgb), 0.6);
+            }
         }
     }
+
+    // .SidebarChannelGroup.autoSortedCategory.isCollapsed .draggingOver {
+    //     .SidebarChannelGroupHeader {
+    //         background-color: transparent;
+    //     }
+    // }
 
     .SidebarChannelGroup.capture .SidebarChannelGroup_content {
         margin-bottom: 0;
@@ -819,6 +825,7 @@
     /* Content */
     .SidebarChannelGroup_content {
         margin-bottom: 14px;
+        min-height: 2px;
     }
 
     .SidebarChannelGroup.a11y--active .SidebarChannelGroup_content {
@@ -865,7 +872,7 @@
             }
         }
 
-        &.fadeDMs {
+        &.fadeOnDrop {
             opacity: 0;
             transition: 'all cubic-bezier(.2,1,.1,1) 0.33s';
         }

--- a/selectors/views/channel_sidebar.ts
+++ b/selectors/views/channel_sidebar.ts
@@ -16,7 +16,7 @@ import {getLastPostPerChannel} from 'mattermost-redux/selectors/entities/posts';
 import {shouldShowUnreadsCategory} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {Channel} from 'mattermost-redux/types/channels';
-import {ChannelCategory} from 'mattermost-redux/types/channel_categories';
+import {CategorySorting, ChannelCategory} from 'mattermost-redux/types/channel_categories';
 import {RelationOneToOne} from 'mattermost-redux/types/utilities';
 import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
 import {createIdsSelector, memoizeResult} from 'mattermost-redux/utils/helpers';
@@ -46,6 +46,15 @@ export const getCategoriesForCurrentTeam: (state: GlobalState) => ChannelCategor
         return getCategoriesForTeam(state, currentTeamId);
     });
 })();
+
+export const getAutoSortedCategoryIds: (state: GlobalState) => Set<string> = (() => createSelector(
+    (state: GlobalState) => getCategoriesForCurrentTeam(state),
+    (categories) => {
+        return new Set(categories.filter((category) =>
+            category.sorting === CategorySorting.Alphabetical ||
+            category.sorting === CategorySorting.Recency).map((category) => category.id));
+    },
+))();
 
 export const getChannelsByCategoryForCurrentTeam: (state: GlobalState) => RelationOneToOne<ChannelCategory, Channel[]> = (() => {
     const getChannelsByCategory = makeGetChannelsByCategory();


### PR DESCRIPTION
#### Summary
Cherry-pick of #7348 to `cloud`