### PR TITLE
Cypress/E2E: Separate TM4J keys for team and enterprise of site statistics

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/reporting/site_statistics_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/reporting/site_statistics_spec.js
@@ -31,7 +31,7 @@ describe('System Console > Site Statistics', () => {
         cy.apiPatchMe({locale: 'en'});
     });
 
-    it('MM-T904_1 Site Statistics displays expected content categories', () => {
+    it('MM-T904 Site Statistics displays expected content categories', () => {
         // # Visit site statistics page.
         cy.visitAndWait('/admin_console/reporting/system_analytics');
 

--- a/e2e/cypress/integration/system_console/reporting/site_statistics_te_spec.js
+++ b/e2e/cypress/integration/system_console/reporting/site_statistics_te_spec.js
@@ -16,7 +16,7 @@ describe('System Console > Site Statistics', () => {
         cy.shouldRunOnTeamEdition();
     });
 
-    it('MM-T904_2 Site Statistics displays expected content categories', () => {
+    it('MM-T3804 Site Statistics displays expected content categories', () => {
         // # Visit site statistics page.
         cy.visitAndWait('/admin_console/reporting/system_analytics');
 


### PR DESCRIPTION
#### Summary
Separate TM4J keys for team and enterprise of site statistics
- remain MM-T904 for enterprise, and
- add MM-T3804 for team edition