### PR TITLE
Cypress/E2E: Fix for more channels and auth specs

### DIFF
--- a/e2e/cypress/integration/channel/more_public_channels_spec.js
+++ b/e2e/cypress/integration/channel/more_public_channels_spec.js
@@ -10,8 +10,6 @@
 // Stage: @prod
 // Group: @channel
 
-import * as TIMEOUTS from '../../fixtures/timeouts';
-
 function verifyNoChannelToJoinMessage(isVisible) {
     cy.findByText('No more channels to join').should(isVisible ? 'be.visible' : 'not.exist');
     cy.findByText('Click \'Create New Channel\' to make a new one').should(isVisible ? 'be.visible' : 'not.exist');
@@ -52,14 +50,11 @@ describe('more public channels', () => {
         cy.visitAndWait(`/${testTeam.name}/channels/town-square`);
 
         // # Go to LHS and click "More..." under Public Channels group
-        cy.get('#publicChannelList').should('be.visible').within(() => {
-            cy.findByText('More...').scrollIntoView().should('be.visible').click();
-        });
+        cy.findByRole('list', {name: 'public channels'}).
+            findByText('More...').scrollIntoView().should('be.visible').click();
 
         // * Assert that the moreChannelsModel is visible
-        cy.get('#moreChannelsModal').should('be.visible').within(() => {
-            cy.wait(TIMEOUTS.HALF_MIN);
-
+        cy.findByRole('dialog', {name: 'More Channels'}).should('be.visible').within(() => {
             // * Assert that the moreChannelsList is visible and the number of channels is 31
             cy.get('#moreChannelsList').should('be.visible').children().should('have.length', 31);
 
@@ -89,14 +84,11 @@ describe('more public channels', () => {
         cy.visitAndWait(`/${testTeam.name}/channels/town-square`);
 
         // # Go to LHS and click "More..." under Public Channels group
-        cy.get('#publicChannelList').should('be.visible').within(() => {
-            cy.findByText('More...').scrollIntoView().should('be.visible').click();
-        });
+        cy.findByRole('list', {name: 'public channels'}).
+            findByText('More...').scrollIntoView().should('be.visible').click();
 
         // * Assert the moreChannelsModel is visible
-        cy.get('#moreChannelsModal').should('be.visible').within(() => {
-            cy.wait(TIMEOUTS.HALF_MIN);
-
+        cy.findByRole('dialog', {name: 'More Channels'}).should('be.visible').within(() => {
             // * Assert the moreChannelsList does have one child
             cy.get('#moreChannelsList').should('be.visible').children().should('have.length', 1);
 

--- a/e2e/cypress/integration/enterprise/system_console/authentication/authentication2_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/authentication/authentication2_spec.js
@@ -47,29 +47,29 @@ describe('Authentication Part 2', () => {
                 EnableUserCreation: true,
                 EnableOpenServer: true,
             },
+        }).then(() => {
+            cy.apiLogout();
+
+            // # Go to front page
+            cy.visitAndWait('/login');
+
+            // * Assert that create account button is visible
+            cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+            // # Go to sign up with email page
+            cy.visitAndWait('/signup_email');
+
+            cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`Hossein2Cool4School${getRandomId()}@mattermost.com`);
+
+            cy.get('#password').type('Test123456!');
+
+            cy.get('#name').clear().type(`HosseinIs2Cool${getRandomId()}`);
+
+            cy.findByText('Create Account').click();
+
+            // * Make sure account was created successfully and we are at the select team page
+            cy.findByText('Teams you can join:', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
         });
-
-        cy.apiLogout();
-
-        // # Go to front page
-        cy.visitAndWait('/login');
-
-        // * Assert that create account button is visible
-        cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-
-        // # Go to sign up with email page
-        cy.visitAndWait('/signup_email');
-
-        cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`Hossein2Cool4School${getRandomId()}@mattermost.com`);
-
-        cy.get('#password').type('Test123456!');
-
-        cy.get('#name').clear().type(`HosseinIs2Cool${getRandomId()}`);
-
-        cy.findByText('Create Account').click();
-
-        // * Make sure account was created successfully and we are at the select team page
-        cy.findByText('Teams you can join:', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
     });
 
     it('MM-T1757 - Restrict Domains - Multiple - fail', () => {
@@ -80,34 +80,34 @@ describe('Authentication Part 2', () => {
                 EnableUserCreation: true,
                 EnableOpenServer: true,
             },
+        }).then(() => {
+            cy.apiLogin(testUserAlreadyInTeam);
+
+            cy.visitAndWait('/');
+
+            // * Verify the side bar is visible
+            cy.get('#sidebarHeaderDropdownButton', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+            // # Click on the side bar
+            cy.get('#sidebarHeaderDropdownButton').click();
+
+            // * Verify Account Settings button is visible and exist and then click on it
+            cy.findByText('Account Settings', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('exist').click();
+
+            // # Click "Edit" to the right of "Email"
+            cy.get('#emailEdit').should('be.visible').click();
+
+            // # Type new email
+            cy.get('#primaryEmail').should('be.visible').type('user-123123@example.com');
+            cy.get('#confirmEmail').should('be.visible').type('user-123123@example.com');
+            cy.get('#currentPassword').should('be.visible').type(testUser.password);
+
+            // # Save the settings
+            cy.get('#saveSetting').click().wait(TIMEOUTS.HALF_SEC);
+
+            // * Assert an error exist and is what is expected
+            cy.findByText('The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email.').should('be.visible');
         });
-
-        cy.apiLogin(testUserAlreadyInTeam);
-
-        cy.visitAndWait('/');
-
-        // * Verify the side bar is visible
-        cy.get('#sidebarHeaderDropdownButton', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-
-        // # Click on the side bar
-        cy.get('#sidebarHeaderDropdownButton').click();
-
-        // * Verify Account Settings button is visible and exist and then click on it
-        cy.findByText('Account Settings', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('exist').click();
-
-        // # Click "Edit" to the right of "Email"
-        cy.get('#emailEdit').should('be.visible').click();
-
-        // # Type new email
-        cy.get('#primaryEmail').should('be.visible').type('user-123123@example.com');
-        cy.get('#confirmEmail').should('be.visible').type('user-123123@example.com');
-        cy.get('#currentPassword').should('be.visible').type(testUser.password);
-
-        // # Save the settings
-        cy.get('#saveSetting').click().wait(TIMEOUTS.HALF_SEC);
-
-        // * Assert an error exist and is what is expected
-        cy.findByText('The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email.').should('be.visible');
     });
 
     it('MM-T1758 - Restrict Domains - Team invite closed team', () => {
@@ -118,22 +118,22 @@ describe('Authentication Part 2', () => {
                 EnableUserCreation: true,
                 EnableOpenServer: true,
             },
+        }).then(() => {
+            cy.apiLogout();
+
+            cy.visitAndWait(`/signup_email/?id=${testTeam.invite_id}`);
+
+            cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`Hossein_Is_The_Best_PROGRAMMER${getRandomId()}@BestInTheWorld.com`);
+
+            cy.get('#password').type('Test123456!');
+
+            cy.get('#name').clear().type(`HosseinIs2Cool${getRandomId()}`);
+
+            cy.findByText('Create Account').click();
+
+            // * Make sure account was not created successfully
+            cy.findByText('The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email.').should('be.visible').and('exist');
         });
-
-        cy.apiLogout();
-
-        cy.visitAndWait(`/signup_email/?id=${testTeam.invite_id}`);
-
-        cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`Hossein_Is_The_Best_PROGRAMMER${getRandomId()}@BestInTheWorld.com`);
-
-        cy.get('#password').type('Test123456!');
-
-        cy.get('#name').clear().type(`HosseinIs2Cool${getRandomId()}`);
-
-        cy.findByText('Create Account').click();
-
-        // * Make sure account was not created successfully
-        cy.findByText('The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email.').should('be.visible').and('exist');
     });
 
     it('MM-T1759 - Restrict Domains - Team invite open team', () => {
@@ -144,32 +144,32 @@ describe('Authentication Part 2', () => {
                 EnableUserCreation: true,
                 EnableOpenServer: true,
             },
+        }).then(() => {
+            cy.visitAndWait(`/admin_console/user_management/teams/${testTeam.id}`);
+
+            cy.findByTestId('allowAllToggleSwitch', {timeout: TIMEOUTS.ONE_MIN}).click();
+
+            // # Click "Save"
+            cy.findByText('Save').scrollIntoView().click();
+
+            // # Wait until we are at the Mattermost Teams page
+            cy.findByText('Mattermost Teams', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+            cy.apiLogout();
+
+            cy.visitAndWait(`/signup_email/?id=${testTeam.invite_id}`);
+
+            cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`Hossein_Is_The_Best_PROGRAMMER${getRandomId()}@BestInTheWorld.com`);
+
+            cy.get('#password').type('Test123456!');
+
+            cy.get('#name').clear().type(`HosseinIs2Cool${getRandomId()}`);
+
+            cy.findByText('Create Account').click();
+
+            // * Make sure account was not created successfully
+            cy.findByText('The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email.').should('be.visible').and('exist');
         });
-
-        cy.visitAndWait(`/admin_console/user_management/teams/${testTeam.id}`);
-
-        cy.findByTestId('allowAllToggleSwitch', {timeout: TIMEOUTS.ONE_MIN}).click();
-
-        // # Click "Save"
-        cy.findByText('Save').scrollIntoView().click();
-
-        // # Wait until we are at the Mattermost Teams page
-        cy.findByText('Mattermost Teams', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-
-        cy.apiLogout();
-
-        cy.visitAndWait(`/signup_email/?id=${testTeam.invite_id}`);
-
-        cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`Hossein_Is_The_Best_PROGRAMMER${getRandomId()}@BestInTheWorld.com`);
-
-        cy.get('#password').type('Test123456!');
-
-        cy.get('#name').clear().type(`HosseinIs2Cool${getRandomId()}`);
-
-        cy.findByText('Create Account').click();
-
-        // * Make sure account was not created successfully
-        cy.findByText('The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email.').should('be.visible').and('exist');
     });
 
     it('MM-T1760 - Enable Open Server false: Create account link is hidden', () => {
@@ -178,14 +178,13 @@ describe('Authentication Part 2', () => {
             TeamSettings: {
                 EnableOpenServer: false,
             },
+        }).then(() => {
+            cy.apiLogout();
+            cy.visitAndWait('/');
+
+            // * Assert that create account button is not visible
+            cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('not.be.visible');
         });
-
-        cy.apiLogout();
-
-        cy.visitAndWait('/');
-
-        // * Assert that create account button is not visible
-        cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('not.be.visible');
     });
 
     it('MM-T1761 - Enable Open Server - Create link appears if email account creation is false and other signin methods are true', () => {
@@ -200,14 +199,13 @@ describe('Authentication Part 2', () => {
             LdapSettings: {
                 Enable: true,
             },
+        }).then(() => {
+            cy.apiLogout();
+            cy.visitAndWait('/');
+
+            // * Assert that create account button is visible
+            cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
         });
-
-        cy.apiLogout();
-
-        cy.visitAndWait('/');
-
-        // * Assert that create account button is visible
-        cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
     });
 
     it('MM-T1762 - Invite Salt', () => {
@@ -229,37 +227,37 @@ describe('Authentication Part 2', () => {
                 EnableUserCreation: true,
                 EnableOpenServer: true,
             },
-        });
+        }).then(() => {
+            cy.apiLogout();
 
-        cy.apiLogout();
+            // # Go to front page
+            cy.visitAndWait('/login');
 
-        // # Go to front page
-        cy.visitAndWait('/login');
+            // * Assert that create account button is visible
+            cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
-        // * Assert that create account button is visible
-        cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+            // # Go to sign up with email page
+            cy.visitAndWait('/signup_email');
 
-        // # Go to sign up with email page
-        cy.visitAndWait('/signup_email');
+            const username = `Hossein${getRandomId()}`;
 
-        const username = `Hossein${getRandomId()}`;
+            cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`${username}@example.com`);
 
-        cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`${username}@example.com`);
+            cy.get('#password').type('Test123456!');
 
-        cy.get('#password').type('Test123456!');
+            cy.get('#name').clear().type(`${username}`);
 
-        cy.get('#name').clear().type(`${username}`);
+            cy.findByText('Create Account').click();
 
-        cy.findByText('Create Account').click();
+            // * Make sure account was created successfully and we are on the team joining page
+            cy.findByText('Teams you can join:', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
-        // * Make sure account was created successfully and we are on the team joining page
-        cy.findByText('Teams you can join:', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+            const mailUrl = getEmailUrl(Cypress.config('baseUrl'));
 
-        const mailUrl = getEmailUrl(Cypress.config('baseUrl'));
-
-        cy.task('getRecentEmail', {username, mailUrl}).then((response) => {
-            // * Verify the subject
-            expect(response.data.subject).to.include('[Mattermost] You joined');
+            cy.task('getRecentEmail', {username, mailUrl}).then((response) => {
+                // * Verify the subject
+                expect(response.data.subject).to.include('[Mattermost] You joined');
+            });
         });
     });
 
@@ -279,16 +277,16 @@ describe('Authentication Part 2', () => {
                 TokenEndpoint: '',
                 UserApiEndpoint: '',
             },
+        }).then(() => {
+            cy.apiLogout();
+
+            cy.visitAndWait(`/signup_user_complete/?id=${testTeam.invite_id}`);
+
+            cy.findByText('GitLab Single Sign-On', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+            // * Email and Password option does not exist
+            cy.findByText('Email and Password').should('not.exist').and('not.be.visible');
         });
-
-        cy.apiLogout();
-
-        cy.visitAndWait(`/signup_user_complete/?id=${testTeam.invite_id}`);
-
-        cy.findByText('GitLab Single Sign-On', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-
-        // * Email and Password option does not exist
-        cy.findByText('Email and Password').should('not.exist').and('not.be.visible');
     });
 
     it('MM-T1766 - Authentication - Email - Creation with email = true', () => {
@@ -301,13 +299,13 @@ describe('Authentication Part 2', () => {
                 EnableUserCreation: true,
                 EnableOpenServer: true,
             },
+        }).then(() => {
+            cy.apiLogout();
+
+            cy.visitAndWait(`/signup_user_complete/?id=${testTeam.invite_id}`);
+
+            // * Email and Password option exist
+            cy.findByText('Email and Password', {timeout: TIMEOUTS.ONE_MIN}).should('exist').and('be.visible');
         });
-
-        cy.apiLogout();
-
-        cy.visitAndWait(`/signup_user_complete/?id=${testTeam.invite_id}`);
-
-        // * Email and Password option exist
-        cy.findByText('Email and Password', {timeout: TIMEOUTS.ONE_MIN}).should('exist').and('be.visible');
     });
 });

--- a/e2e/cypress/integration/enterprise/system_console/cluster_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/cluster_spec.js
@@ -7,7 +7,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @system_console
+// Group: @enterprise @system_console @high_availability
 
 describe('Cluster', () => {
     before(() => {


### PR DESCRIPTION
#### Summary
Fix for more channels and auth specs.

For authentication specs, it's not easily reproducible in local but that's likely related to the race condition after updating a config and checking UI related to it. Fixed by moving UI check inside the `.then` of `apiUpdateConfig`.

#### Ticket Link
none, failing in daily Cypress run