### PR TITLE
Cypress/E2E: Fix tests for archived channels

### DIFF
--- a/e2e/cypress/integration/channel/archived_channels_1_spec.js
+++ b/e2e/cypress/integration/channel/archived_channels_1_spec.js
@@ -10,12 +10,10 @@
 // Group: @channel
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
-import {getAdminAccount} from '../../support/env';
 import {getRandomId} from '../../utils';
 
 describe('Leave an archived channel', () => {
     let testTeam;
-    let testUser;
 
     before(() => {
         cy.apiUpdateConfig({
@@ -28,9 +26,8 @@ describe('Leave an archived channel', () => {
         });
 
         // # Login as test user and visit town-square
-        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             testTeam = team;
-            testUser = user;
 
             cy.visitAndWait(`/${team.name}/channels/town-square`);
 
@@ -80,80 +77,6 @@ describe('Leave an archived channel', () => {
             // * Verify that the thread is visible and marked as archived
             cy.get(`#rhsPost_${archivedPostId}`).should('be.visible');
             cy.get('#rhsContainer .channel-archived-warning').should('be.visible');
-        });
-    });
-
-    it('MM-T1687 App does not crash when another user archives a channel', () => {
-        cy.makeClient({user: getAdminAccount()}).then((client) => {
-            // # Have another user create a private channel
-            const channelName = `channel${getRandomId()}`;
-            cy.wrap(client.createChannel({
-                display_name: channelName,
-                name: channelName,
-                team_id: testTeam.id,
-                type: 'P',
-            })).then((channel) => {
-                // # Then invite us to it
-                cy.wrap(client.addToChannel(testUser.id, channel.id));
-
-                // * Verify that the newly created channel is in the sidebar
-                cy.get(`#sidebarItem_${channel.name}`).should('be.visible');
-
-                // # Then archive the channel
-                cy.wrap(client.deleteChannel(channel.id));
-
-                // * Verify that the channel is no longer in the sidebar and that the app hasn't crashed
-                cy.get(`#sidebarItem_${channel.name}`).should('not.be.visible');
-            });
-        });
-    });
-
-    it('MM-T1688 archived channels only appear in search results as long as the user does not leave them', () => {
-        // # Create a new channel
-        cy.uiCreateChannel({isNewSidebar: true}).as('channel');
-
-        // # Make a post
-        const archivedPostText = `archived${getRandomId()}`;
-        cy.postMessage(archivedPostText);
-        cy.getLastPostId().as('archivedPostId');
-
-        // # Archive the newly created channel
-        cy.uiArchiveChannel();
-
-        // # Switch away from the archived channel
-        cy.get('#sidebarItem_town-square').click();
-
-        // * Verify that the channel is no longer in the sidebar
-        cy.get('@channel').then((channel) => {
-            cy.get(`#sidebarItem_${channel.name}`).should('not.be.visible');
-        });
-
-        // # Search for the post
-        cy.uiSearchPosts(archivedPostText);
-
-        cy.get('@archivedPostId').then((archivedPostId) => {
-            // * Verify that the post is shown in the search results
-            cy.get(`#searchResult_${archivedPostId}`).should('be.visible');
-
-            // # Switch back to the archived channel through the permalink
-            cy.uiJumpToSearchResult(archivedPostId);
-        });
-
-        // * Wait for the permalink URL to disappear
-        cy.get('@channel').then((channel) => {
-            cy.url().should('include', `/${testTeam.name}/channels/${channel.name}`);
-        });
-
-        // # Leave the channel
-        cy.uiLeaveChannel();
-
-        // # Search for the post again
-        cy.uiSearchPosts(archivedPostText);
-
-        cy.get('@archivedPostId').then((archivedPostId) => {
-            // * Verify that the post is no longer shown in the search results
-            cy.get(`#searchResult_${archivedPostId}`).should('not.exist');
-            cy.get('#search-items-container .no-results__wrapper').should('be.visible');
         });
     });
 

--- a/e2e/cypress/integration/channel/archived_channels_2_spec.js
+++ b/e2e/cypress/integration/channel/archived_channels_2_spec.js
@@ -1,0 +1,119 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @channel
+
+import {getAdminAccount} from '../../support/env';
+import {getRandomId} from '../../utils';
+
+describe('Leave an archived channel', () => {
+    let testTeam;
+    let testUser;
+
+    before(() => {
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableLegacySidebar: false,
+            },
+            TeamSettings: {
+                ExperimentalViewArchivedChannels: true,
+            },
+        });
+
+        // # Login as test user and visit town-square
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as test user and visit town-square
+        cy.apiLogin(testUser);
+        cy.visitAndWait(`/${testTeam.name}/channels/town-square`);
+    });
+
+    it('MM-T1687 App does not crash when another user archives a channel', () => {
+        cy.makeClient({user: getAdminAccount()}).then((client) => {
+            // # Have another user create a private channel
+            const channelName = `channel${getRandomId()}`;
+            cy.wrap(client.createChannel({
+                display_name: channelName,
+                name: channelName,
+                team_id: testTeam.id,
+                type: 'P',
+            })).then(async (channel) => {
+                // # Then invite us to it
+                await client.addToChannel(testUser.id, channel.id);
+
+                cy.wrap(channel);
+            }).then((channel) => {
+                // * Verify that the newly created channel is in the sidebar
+                cy.get(`#sidebarItem_${channel.name}`).should('be.visible');
+
+                cy.wrap(channel);
+            }).then(async (channel) => {
+                // # Then archive the channel
+                await client.deleteChannel(channel.id);
+
+                // * Verify that the channel is no longer in the sidebar and that the app hasn't crashed
+                cy.get(`#sidebarItem_${channel.name}`).should('not.be.visible');
+            });
+        });
+    });
+
+    it('MM-T1688 archived channels only appear in search results as long as the user does not leave them', () => {
+        // # Create a new channel
+        cy.uiCreateChannel({isNewSidebar: true}).as('channel');
+
+        // # Make a post
+        const archivedPostText = `archived${getRandomId()}`;
+        cy.postMessage(archivedPostText);
+        cy.getLastPostId().as('archivedPostId');
+
+        // # Archive the newly created channel
+        cy.uiArchiveChannel();
+
+        // # Switch away from the archived channel
+        cy.get('#sidebarItem_town-square').click();
+
+        // * Verify that the channel is no longer in the sidebar
+        cy.get('@channel').then((channel) => {
+            cy.get(`#sidebarItem_${channel.name}`).should('not.be.visible');
+        });
+
+        // # Search for the post
+        cy.uiSearchPosts(archivedPostText);
+
+        cy.get('@archivedPostId').then((archivedPostId) => {
+            // * Verify that the post is shown in the search results
+            cy.get(`#searchResult_${archivedPostId}`).should('be.visible');
+
+            // # Switch back to the archived channel through the permalink
+            cy.uiJumpToSearchResult(archivedPostId);
+        });
+
+        // * Wait for the permalink URL to disappear
+        cy.get('@channel').then((channel) => {
+            cy.url().should('include', `/${testTeam.name}/channels/${channel.name}`);
+        });
+
+        // # Leave the channel
+        cy.uiLeaveChannel();
+
+        // # Search for the post again
+        cy.uiSearchPosts(archivedPostText);
+
+        cy.get('@archivedPostId').then((archivedPostId) => {
+            // * Verify that the post is no longer shown in the search results
+            cy.get(`#searchResult_${archivedPostId}`).should('not.exist');
+            cy.get('#search-items-container .no-results__wrapper').should('be.visible');
+        });
+    });
+});

--- a/e2e/cypress/integration/channel/archived_channels_2_spec.js
+++ b/e2e/cypress/integration/channel/archived_channels_2_spec.js
@@ -36,7 +36,7 @@ describe('Leave an archived channel', () => {
     beforeEach(() => {
         // # Login as test user and visit town-square
         cy.apiLogin(testUser);
-        cy.visitAndWait(`/${testTeam.name}/channels/town-square`);
+        cy.visit(`/${testTeam.name}/channels/town-square`);
     });
 
     it('MM-T1687 App does not crash when another user archives a channel', () => {


### PR DESCRIPTION
#### Summary
Fix tests for archived channels.

`archived_channels_1_spec.js`
- moved all 7 stable tests here. 

`archived_channels_2_spec.js`
- moved 2 failing tests here
- MM-T1687 - fixed by correctly executing the sequence by reorganizing the use of `.then`, `cy.wrap` and `async`. so that a channel is not gets deleted first as expected.
- MM-T1688 - fixed by explicit log in of test user in the `beforeEach` hook

#### Ticket Link
none, failing on daily Cypress run