### PR TITLE
Cypress/E2E: Fix and reorganize tests for authentication

### DIFF
--- a/e2e/cypress/integration/auth_sso/authentication_1_spec.js
+++ b/e2e/cypress/integration/auth_sso/authentication_1_spec.js
@@ -10,18 +10,16 @@
 // Stage: @prod
 // Group: @system_console @authentication
 
-import * as TIMEOUTS from '../../../../fixtures/timeouts';
+import * as TIMEOUTS from '../../fixtures/timeouts';
 
-import {getEmailUrl, getRandomId} from '../../../../utils';
+import {getEmailUrl, getRandomId} from '../../utils';
 
-describe('Authentication Part 2', () => {
+describe('Authentication', () => {
     let testUser;
     let testUserAlreadyInTeam;
     let testTeam;
 
     before(() => {
-        cy.apiRequireLicense();
-
         // # Do email test if setup properly
         cy.apiEmailTest();
 
@@ -136,78 +134,6 @@ describe('Authentication Part 2', () => {
         });
     });
 
-    it('MM-T1759 - Restrict Domains - Team invite open team', () => {
-        // # Enable open server and turn on user account creation and set restricted domain
-        cy.apiUpdateConfig({
-            TeamSettings: {
-                RestrictCreationToDomains: 'mattermost.com, test.com',
-                EnableUserCreation: true,
-                EnableOpenServer: true,
-            },
-        }).then(() => {
-            cy.visit(`/admin_console/user_management/teams/${testTeam.id}`);
-
-            cy.findByTestId('allowAllToggleSwitch', {timeout: TIMEOUTS.ONE_MIN}).click();
-
-            // # Click "Save"
-            cy.findByText('Save').scrollIntoView().click();
-
-            // # Wait until we are at the Mattermost Teams page
-            cy.findByText('Mattermost Teams', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-
-            cy.apiLogout();
-
-            cy.visit(`/signup_email/?id=${testTeam.invite_id}`);
-
-            cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`Hossein_Is_The_Best_PROGRAMMER${getRandomId()}@BestInTheWorld.com`);
-
-            cy.get('#password').type('Test123456!');
-
-            cy.get('#name').clear().type(`HosseinIs2Cool${getRandomId()}`);
-
-            cy.findByText('Create Account').click();
-
-            // * Make sure account was not created successfully
-            cy.findByText('The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email.').should('be.visible').and('exist');
-        });
-    });
-
-    it('MM-T1760 - Enable Open Server false: Create account link is hidden', () => {
-        // # Enable open server and turn on user account creation and set restricted domain
-        cy.apiUpdateConfig({
-            TeamSettings: {
-                EnableOpenServer: false,
-            },
-        }).then(() => {
-            cy.apiLogout();
-            cy.visit('/');
-
-            // * Assert that create account button is not visible
-            cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('not.be.visible');
-        });
-    });
-
-    it('MM-T1761 - Enable Open Server - Create link appears if email account creation is false and other signin methods are true', () => {
-        // # Enable open server and turn on user account creation and set restricted domain
-        cy.apiUpdateConfig({
-            EmailSettings: {
-                EnableSignUpWithEmail: false,
-            },
-            TeamSettings: {
-                EnableOpenServer: true,
-            },
-            LdapSettings: {
-                Enable: true,
-            },
-        }).then(() => {
-            cy.apiLogout();
-            cy.visit('/');
-
-            // * Assert that create account button is visible
-            cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-        });
-    });
-
     it('MM-T1762 - Invite Salt', () => {
         cy.visit('/admin_console/site_config/public_links');
 
@@ -286,26 +212,6 @@ describe('Authentication Part 2', () => {
 
             // * Email and Password option does not exist
             cy.findByText('Email and Password').should('not.exist').and('not.be.visible');
-        });
-    });
-
-    it('MM-T1766 - Authentication - Email - Creation with email = true', () => {
-        // # Enable open server and turn on user account creation and set restricted domain
-        cy.apiUpdateConfig({
-            EmailSettings: {
-                EnableSignUpWithEmail: true,
-            },
-            TeamSettings: {
-                EnableUserCreation: true,
-                EnableOpenServer: true,
-            },
-        }).then(() => {
-            cy.apiLogout();
-
-            cy.visit(`/signup_user_complete/?id=${testTeam.invite_id}`);
-
-            // * Email and Password option exist
-            cy.findByText('Email and Password', {timeout: TIMEOUTS.ONE_MIN}).should('exist').and('be.visible');
         });
     });
 });

--- a/e2e/cypress/integration/auth_sso/authentication_3_spec.js
+++ b/e2e/cypress/integration/auth_sso/authentication_3_spec.js
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @system_console @authentication
+
+describe('Authentication', () => {
+    beforeEach(() => {
+        // # Log in as a admin.
+        cy.apiAdminLogin();
+    });
+
+    after(() => {
+        cy.apiAdminLogin({failOnStatusCode: false});
+        cy.apiUpdateConfig();
+    });
+
+    const testCases = [
+        {
+            title: 'MM-T1767 - Email signin false Username signin true',
+            signinWithEmail: false,
+            signinWithUsername: true,
+        },
+        {
+            title: 'MM-T1768 - Email signin true Username signin true',
+            signinWithEmail: true,
+            signinWithUsername: true,
+        },
+        {
+            title: 'MM-T1769 - Email signin true Username signin false',
+            signinWithEmail: true,
+            signinWithUsername: false,
+        },
+    ];
+
+    testCases.forEach(({title, signinWithEmail, signinWithUsername}) => {
+        it(title, () => {
+            cy.apiUpdateConfig({
+                EmailSettings: {
+                    EnableSignInWithEmail: signinWithEmail,
+                    EnableSignInWithUsername: signinWithUsername,
+                },
+                LdapSettings: {
+                    Enable: false,
+                },
+            });
+
+            cy.apiLogout();
+
+            // # Go to front page
+            cy.visit('/login');
+
+            let expectedPlaceholderText;
+            if (signinWithEmail && signinWithUsername) {
+                expectedPlaceholderText = 'Email or Username';
+            } else if (signinWithEmail) {
+                expectedPlaceholderText = 'Email';
+            } else {
+                expectedPlaceholderText = 'Username';
+            }
+
+            // * Make sure the username field has expected placeholder text
+            cy.findByPlaceholderText(expectedPlaceholderText).should('exist').and('be.visible');
+        });
+    });
+});

--- a/e2e/cypress/integration/auth_sso/hide_create_account_spec.js
+++ b/e2e/cypress/integration/auth_sso/hide_create_account_spec.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @system_console @authentication
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('Authentication', () => {
+    before(() => {
+        // # Enable open server
+        cy.apiUpdateConfig({
+            TeamSettings: {
+                EnableOpenServer: false,
+            },
+        });
+
+        // # Logout and visit default page
+        cy.apiLogout();
+        cy.visit('/');
+    });
+
+    it('MM-T1760 - Enable Open Server false: Create account link is hidden', () => {
+        // * Assert that create account button is not visible
+        cy.findByText('Create one now.', {timeout: TIMEOUTS.TEN_SEC}).should('not.exist');
+    });
+});

--- a/e2e/cypress/integration/enterprise/auth_sso/authentication_spec.js
+++ b/e2e/cypress/integration/enterprise/auth_sso/authentication_spec.js
@@ -1,0 +1,110 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @enterprise @system_console @authentication
+
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
+import {getRandomId} from '../../../utils';
+
+describe('Authentication', () => {
+    let testTeam;
+
+    before(() => {
+        cy.apiRequireLicense();
+
+        cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
+        });
+    });
+
+    beforeEach(() => {
+        // # Log in as a admin.
+        cy.apiAdminLogin();
+    });
+
+    it('MM-T1759 - Restrict Domains - Team invite open team', () => {
+        // # Enable open server and turn on user account creation and set restricted domain
+        cy.apiUpdateConfig({
+            TeamSettings: {
+                RestrictCreationToDomains: 'mattermost.com, test.com',
+                EnableUserCreation: true,
+                EnableOpenServer: true,
+            },
+        }).then(() => {
+            cy.visit(`/admin_console/user_management/teams/${testTeam.id}`);
+
+            cy.findByTestId('allowAllToggleSwitch', {timeout: TIMEOUTS.ONE_MIN}).click();
+
+            // # Click "Save"
+            cy.findByText('Save').scrollIntoView().click();
+
+            // # Wait until we are at the Mattermost Teams page
+            cy.findByText('Mattermost Teams', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+            cy.apiLogout();
+
+            cy.visit(`/signup_email/?id=${testTeam.invite_id}`);
+
+            cy.get('#email', {timeout: TIMEOUTS.ONE_MIN}).type(`Hossein_Is_The_Best_PROGRAMMER${getRandomId()}@BestInTheWorld.com`);
+
+            cy.get('#password').type('Test123456!');
+
+            cy.get('#name').clear().type(`HosseinIs2Cool${getRandomId()}`);
+
+            cy.findByText('Create Account').click();
+
+            // * Make sure account was not created successfully
+            cy.findByText('The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email.').should('be.visible').and('exist');
+        });
+    });
+
+    it('MM-T1761 - Enable Open Server - Create link appears if email account creation is false and other signin methods are true', () => {
+        // # Enable open server and turn on user account creation and set restricted domain
+        cy.apiUpdateConfig({
+            EmailSettings: {
+                EnableSignUpWithEmail: false,
+            },
+            TeamSettings: {
+                EnableOpenServer: true,
+            },
+            LdapSettings: {
+                Enable: true,
+            },
+        }).then(() => {
+            cy.apiLogout();
+            cy.visit('/');
+
+            // * Assert that create account button is visible
+            cy.findByText('Create one now.', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+        });
+    });
+
+    it('MM-T1766 - Authentication - Email - Creation with email = true', () => {
+        // # Enable open server and turn on user account creation and set restricted domain
+        cy.apiUpdateConfig({
+            EmailSettings: {
+                EnableSignUpWithEmail: true,
+            },
+            TeamSettings: {
+                RestrictCreationToDomains: 'mattermost.com, test.com',
+                EnableUserCreation: true,
+                EnableOpenServer: true,
+            },
+        }).then(() => {
+            cy.apiLogout();
+
+            cy.visit(`/signup_user_complete/?id=${testTeam.invite_id}`);
+
+            // * Email and Password option exist
+            cy.findByText('Email and Password', {timeout: TIMEOUTS.ONE_MIN}).should('exist').and('be.visible');
+        });
+    });
+});

--- a/e2e/cypress/integration/enterprise/auth_sso/mfa_authentication_spec.js
+++ b/e2e/cypress/integration/enterprise/auth_sso/mfa_authentication_spec.js
@@ -7,9 +7,9 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @enterprise @system_console @authentication
+// Group: @enterprise @system_console @authentication @mfa
 
-import * as TIMEOUTS from '../../../../fixtures/timeouts';
+import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 const authenticator = require('authenticator');
 

--- a/e2e/cypress/integration/enterprise/system_console/authentication_method_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/authentication_method_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @enterpise @system_console @mfa
+// Group: @enterprise @system_console @mfa
 
 import ldapUsers from '../../../fixtures/ldap_users.json';
 import * as TIMEOUTS from '../../../fixtures/timeouts';


### PR DESCRIPTION
#### Summary
Fix and reorganize tests for authentication.

This should've been a follow up fix for MM-T1760 only where the first attempt seemed to not work (https://github.com/mattermost/mattermost-webapp/pull/7416). However, in a process of doing so, I ended up reorganizing the old `/authentication` folder with the following changes:
- moved into a new `/auth_sso` folder to match with the TM4J
- separated specific tests that requires enterprise license and moved to a new `/enterprise/auth_sso`
- moved MM-T1760 into its new `hide_create_account_spec.js` file as seemed to work consistently when config changes were made in the `before` hook. Also added `after` hook to reset config changes as it may problem on admin login.

#### Ticket Link
none, failed on daily Cypress run
