### PR TITLE
[MM-32121] Fix neverending load on one-paged search results

### DIFF
--- a/components/search_results/search_results.tsx
+++ b/components/search_results/search_results.tsx
@@ -69,6 +69,15 @@ const SearchResults: React.FC<Props> = (props: Props): JSX.Element => {
         scrollbars.current?.scrollToTop();
     }, [props.searchTerms]);
 
+    useEffect(() => {
+        // after the first page of search results, there is no way to
+        // know if the search has more results to return, so we search
+        // for the second page and stop if it yields no results
+        if (props.searchPage === 0) {
+            props.getMorePostsForSearch();
+        }
+    }, [props.searchPage]);
+
     const handleScroll = (): void => {
         if (!props.isFlaggedPosts && !props.isPinnedPosts && !props.isSearchingTerm && !props.isSearchGettingMore) {
             const scrollHeight = scrollbars.current?.getScrollHeight() || 0;


### PR DESCRIPTION
#### Summary
This PR adds a second page search right after the first one, to be able to ensure that there are no more results, or enable the load more scrolling if there are. It fixes the infinite loading indicator on one-paged searches that we were experiencing in community.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32121