### PR TITLE
[MM-32499] Fix console warning

### DIFF
--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -290,7 +290,7 @@ class ProfilePopover extends React.PureComponent {
                     key='user-popover-fullname'
                 >
                     <div
-                        data-testId={`popover-fullname-${this.props.user.username}`}
+                        data-testid={`popover-fullname-${this.props.user.username}`}
                         className='overflow--ellipsis text-nowrap'
                     >
                         <strong>{fullname}</strong>


### PR DESCRIPTION
Changes casing of attr to match elsewhere, fixing react dev tools warning `React does not recognize the `data-testId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `data-testid` instead. `

#### Ticket Link
- Fixes https://mattermost.atlassian.net/browse/MM-32499
