### PR TITLE
[MM-32401][MM-32450] Some style fixes for the sidebar

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -306,7 +306,6 @@
     }
 
     .SidebarMenu {
-        height: 30px;
         opacity: 1;
 
         .dropdown-menu {

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -862,6 +862,9 @@
             border-radius: 4px;
             box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.12);
 
+            /* MM-32401: Needed to ensure that the channel selected count is displayed correctly */
+            overflow: visible;
+
             .SidebarLink {
                 background: rgba(255, 255, 255, 0.08);
                 border-radius: 4px;

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -1605,6 +1605,7 @@
                     .SidebarLink {
                         height: 45px;
                         align-items: center;
+                        width: 290px;
 
                         &::before {
                             height: 45px;


### PR DESCRIPTION
#### Summary
3 fixes are included in this PR:
- On mobile view, the width of the channels was not set on mobile view correctly. Have now been set to `290px`
- On desktop mobile view, the height of the channel menu element was too high. I've removed the specific height of the menu button element which should no longer be required now that we've switched the parent over to flexbox
- When dragging multiple channels, the count of channels was cutoff due to adding `overflow: hidden`. I've added `overflow: visible` to the dragging state of the channel so that it will show correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32401
https://mattermost.atlassian.net/browse/MM-32450
