### PR TITLE
MM-32558: changed SidebarHeader class to span full-width

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -642,7 +642,7 @@
         color: rgba(var(--sidebar-text-rgb), 0.6);
         background-color: var(--sidebar-bg);
         top: 0;
-        box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0.33);
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.33);
         transition: box-shadow 0.25s ease-in-out;
         z-index: 1;
         display: flex;
@@ -659,11 +659,12 @@
             overflow: hidden;
             text-overflow: ellipsis;
             width: 100%;
+            padding-left: 16px;
         }
 
         &.dragging {
             border-radius: 4px;
-            box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.12);
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.12);
             color: var(--sidebar-text);
         }
 
@@ -673,11 +674,15 @@
             &.hide-arrow {
                 visibility: hidden;
             }
+
+            + .SidebarChannelGroupHeader_text {
+                padding-left: 0;
+            }
         }
     }
 
     .SidebarChannelGroupHeader--static {
-        padding-left: 16px;
+        padding-left: 0;
     }
 
     button.SidebarChannelGroupHeader_groupButton > div {

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 
 #TeamSidebar {
     display: flex;
@@ -677,7 +677,7 @@
     }
 
     .SidebarChannelGroupHeader--static {
-        margin-left: 16px;
+        padding-left: 16px;
     }
 
     button.SidebarChannelGroupHeader_groupButton > div {
@@ -870,7 +870,7 @@
 
         &.fadeOnDrop {
             opacity: 0;
-            transition: 'all cubic-bezier(.2,1,.1,1) 0.33s';
+            transition: all cubic-bezier(.2,1,.1,1) 0.33s;
         }
 
         &.noFloat {
@@ -879,7 +879,7 @@
 
         &.selectedDragging {
             opacity: 0.25;
-            transition: 'all cubic-bezier(.2,1,.1,1) 0.33s';
+            transition: all cubic-bezier(.2,1,.1,1) 0.33s;
         }
 
         .btn-close {

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -190,7 +190,7 @@
             width: 100%;
             text-align: left;
             border-radius: 4px;
-            font-family: 'Open Sans';
+            font-family: 'Open Sans', sans-serif;
             font-size: 12px;
             display: flex;
             align-items: center;
@@ -586,7 +586,7 @@
         border: none;
         color: rgba(var(--sidebar-text-rgb), 0.6);
         top: 0;
-        box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0.33);
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.33);
         transition: box-shadow 0.25s ease-in-out;
         z-index: 1;
         display: flex;
@@ -840,7 +840,7 @@
     }
 
     .SidebarChannelGroup .SidebarChannel.newChannelSpacer {
-        height: 0px;
+        height: 0;
     }
 
     /* Channels */
@@ -865,7 +865,7 @@
         &.dragging {
             background-color: var(--sidebar-bg);
             border-radius: 4px;
-            box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.12);
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.12);
 
             .SidebarLink {
                 background: rgba(255, 255, 255, 0.08);
@@ -916,7 +916,7 @@
             right: -8px;
             height: 25px;
             background: var(--center-channel-color);
-            box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.12);
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.12);
             border-radius: 20px;
             padding: 2px 9px 7px 9px;
 


### PR DESCRIPTION
#### Summary

* changed `margin-left` to `padding-left` on `.SidebarChannelGroupHeader--static` class
* added double-quotes for UTF-8 charset setting
* fixed transition property (from string value to actual property values)

#### Ticket Link
Fixes [MM-32558](https://mattermost.atlassian.net/browse/MM-32558)

#### Screenshots
<img width="314" alt="Screenshot 2021-02-03 at 11 10 19" src="https://user-images.githubusercontent.com/32863416/106731984-6f6f3100-6610-11eb-98e9-dd8197de5bb0.png">

