### PR TITLE
Cypress/E2E: Fix dm indicator in title spec

### DIFF
--- a/e2e/cypress/integration/notifications/direct_messages_do_not_add_indicator_spec.js
+++ b/e2e/cypress/integration/notifications/direct_messages_do_not_add_indicator_spec.js
@@ -19,6 +19,12 @@ describe('Notifications', () => {
     let siteName;
 
     before(() => {
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableLegacySidebar: false,
+            },
+        });
+
         cy.apiInitSetup().then(({team, user}) => {
             team1 = team;
             user1 = user;
@@ -42,7 +48,8 @@ describe('Notifications', () => {
             // # Remove mention notification (for initial channel).
             cy.apiLogin(user1);
             cy.visit(testTeam1TownSquareUrl);
-            cy.get('#publicChannelList').get('.unread-title').click();
+            cy.findByText('CHANNELS').get('.unread-title').click();
+            cy.findByText('CHANNELS').get('.unread-title').should('not.be.visible');
             cy.apiLogout();
         });
     });


### PR DESCRIPTION
#### Summary
- Used new sidebar and verified unread channel is visited before logout.

#### Ticket Link
NA