### PR TITLE
added `channel.name` to the concatenated searchString

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -249,7 +249,7 @@ function makeChannelSearchFilter(channelPrefix) {
     const userSearchStrings = {};
 
     return (channel) => {
-        let searchString = channel.display_name;
+        let searchString = `${channel.display_name}${channel.name}`;
         if (channel.type === Constants.GM_CHANNEL || channel.type === Constants.DM_CHANNEL) {
             const usersInChannel = usersInChannels[channel.id] || new Set([]);
 


### PR DESCRIPTION
#### Summary
added `channel.name` to the concatenated searchString to make searching for the channel name (as written in the URL) possible as well.

Screenshot shows how searching for `town-square` is correctly showing `Town Square` as an option

#### Ticket Link
Fixes [MM-25609](https://mattermost.atlassian.net/browse/MM-25609)

#### Screenshots
before|after
--|--
<img width="628" alt="Screenshot 2021-02-04 at 16 03 51" src="https://user-images.githubusercontent.com/32863416/106912128-04eaed80-6703-11eb-8234-0c0194b26f93.png">|<img width="632" alt="Screenshot 2021-02-04 at 14 21 11" src="https://user-images.githubusercontent.com/32863416/106910792-dddfec00-6701-11eb-8b13-b0a5039f538d.png">
