### PR TITLE
Cypress/E2E: Fix search box focus related failures

### DIFF
--- a/e2e/cypress/integration/archived_channel/archive_channel_search_spec.js
+++ b/e2e/cypress/integration/archived_channel/archive_channel_search_spec.js
@@ -59,8 +59,7 @@ describe('archive tests while preventing viewing archived channels', () => {
                 cy.contains('#channelHeaderTitle', 'Off-Topic');
 
                 // # Search for the post from step 1')
-                cy.get('#searchBox').focus().clear();
-                cy.get('#searchBox').should('be.visible').type(`${messageText}{enter}`);
+                cy.get('#searchBox').click().clear().type(`${messageText}{enter}`);
 
                 // * Post is returned by search, since it's not archived anymore
                 cy.get('#searchContainer').should('be.visible');
@@ -94,8 +93,7 @@ describe('archive tests while preventing viewing archived channels', () => {
         cy.uiArchiveChannel();
 
         // # Archive dialogue message reads "This will archive the channel from the team and make its contents inaccessible for all users" (Mobile dialogue makes no mention of the data will be accessible)
-        cy.get('#searchBox').focus().clear();
-        cy.get('#searchBox').focus().type(`${testArchivedMessage}{enter}`);
+        cy.get('#searchBox').click().clear().type(`${testArchivedMessage}{enter}`);
 
         // * Post is not returned by search
         cy.get('#searchContainer').should('be.visible');
@@ -110,8 +108,7 @@ describe('archive tests while preventing viewing archived channels', () => {
             cy.postMessage(messageText);
 
             // # Search for the string of text from step 1
-            cy.get('#searchBox').focus().clear();
-            cy.get('#searchBox').focus().type(`${messageText}{enter}`);
+            cy.get('#searchBox').click().clear().type(`${messageText}{enter}`);
 
             // * Post is returned by search, since it's not archived anymore
             cy.get('#searchContainer').should('be.visible');
@@ -128,12 +125,8 @@ describe('archive tests while preventing viewing archived channels', () => {
 
     it('MM-T1710 archived channels are not listed on the "in:" autocomplete', () => {
         // # Archive a channel and make a mental note of the channel name
-
-        // # Place the focus in the search box
-        cy.get('#searchBox').focus().clear();
-
         // # Type "in:" and note the list of channels that appear
-        cy.get('#searchBox').focus().type(`in:${testChannel.name}`);
+        cy.get('#searchBox').click().clear().type(`in:${testChannel.name}`);
         cy.findByTestId(testChannel.name).should('not.exist');
     });
 });

--- a/e2e/cypress/integration/archived_channel/archived_leave_channel_spec.js
+++ b/e2e/cypress/integration/archived_channel/archived_leave_channel_spec.js
@@ -128,9 +128,7 @@ describe('Leave an archived channel', () => {
             cy.get('#channelInfoModalLabel span.icon__archive').should('not.be.visible');
 
             // # Search for a post in an archived channel
-            cy.get('#searchBox').focus().clear();
-
-            cy.get('#searchBox').should('be.visible').type(`${testArchivedMessage}{enter}`);
+            cy.get('#searchBox').click().clear().type(`${testArchivedMessage}{enter}`);
 
             // # Open the archived channel by selecting Jump from search results and then selecting the link to move to the most recent posts in the channel
             cy.get('#searchContainer').should('be.visible');
@@ -176,7 +174,7 @@ describe('Leave an archived channel', () => {
             cy.visit(`/${testTeam.name}/channels/off-topic`);
 
             // # Search for content from an archived channel
-            cy.get('#searchBox').should('be.visible').clear().type(`${testArchivedMessage}{enter}`);
+            cy.get('#searchBox').click().clear().type(`${testArchivedMessage}{enter}`);
 
             // # Open the channel from search results
             cy.get('#searchContainer').should('be.visible');
@@ -189,7 +187,7 @@ describe('Leave an archived channel', () => {
             });
 
             // # Search for content from a different archived channel
-            cy.get('#searchBox').should('be.visible').clear().type(`${messageText}{enter}`);
+            cy.get('#searchBox').click().clear().type(`${messageText}{enter}`);
 
             // # Open that channel from search results
             cy.get('#searchContainer').should('be.visible');
@@ -302,8 +300,7 @@ describe('Leave an archived channel', () => {
         const messageList = Array.from({length: 40}, (_, i) => `${i}. ${MESSAGES.SMALL} - ${getRandomId()}`);
         createArchivedChannel({prefix: 'archived-search-for'}, messageList).then(({channelName}) => {
             // # Locate the post in a search
-            cy.get('#searchBox').focus().clear();
-            cy.get('#searchBox').should('be.visible').type(`${messageList[1]}{enter}`);
+            cy.get('#searchBox').click().clear().type(`${messageList[1]}{enter}`);
 
             // # Click jump to open an archive post in permalink view
             cy.get('#searchContainer').should('be.visible');

--- a/e2e/cypress/integration/keyboard_shortcuts/keyboard_shortcuts_one_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/keyboard_shortcuts_one_spec.js
@@ -400,7 +400,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1248 - CTRL/CMD+SHIFT+L - Set focus to center channel message box', () => {
         // # Open search box to change focus
-        cy.get('#searchBox').focus().should('be.focused').then(() => {
+        cy.get('#searchBox').click().should('be.focused').then(() => {
             // # Type CTRL/CMD+SHIFT+L
             cy.get('body').cmdOrCtrlShortcut('{shift}L');
             cy.get('#post_textbox').should('be.focused');

--- a/e2e/cypress/integration/search_filter/edit_spec.js
+++ b/e2e/cypress/integration/search_filter/edit_spec.js
@@ -54,7 +54,7 @@ describe('SF15699 Search Date Filter - edit', () => {
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Type on: into search field
-        cy.get('#searchBox').clear().type('on:');
+        cy.get('#searchBox').click().clear().type('on:');
 
         // * Day picker should appear
         cy.get('.DayPicker').
@@ -68,7 +68,7 @@ describe('SF15699 Search Date Filter - edit', () => {
         // * Search field should populate with the correct date, then send rest of query
         cy.get('#searchBox').
             should('have.value', 'on:2019-01-15 ').
-            focus().
+            click().
             type(`${targetMessage}{enter}`).
             should('be.empty');
 
@@ -85,7 +85,7 @@ describe('SF15699 Search Date Filter - edit', () => {
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Back space right after the date to bring up date picker again
-        cy.get('#searchBox').focus().clear().
+        cy.get('#searchBox').click().clear().
             type(`on:2019-01-15 ${targetMessage}`).
             type('{leftarrow}'.repeat(targetMessage.length + 1)).
             type('{backspace}');
@@ -101,6 +101,7 @@ describe('SF15699 Search Date Filter - edit', () => {
         // # Add message to search for, and hit enter
         cy.get('#searchBox').
             should('have.value', `on:2019-01-16  ${targetMessage}`).
+            click().
             type('{enter}').
             should('be.empty');
 

--- a/e2e/cypress/integration/signin_authentication/authentication_spec.js
+++ b/e2e/cypress/integration/signin_authentication/authentication_spec.js
@@ -205,7 +205,7 @@ describe('Authentication', () => {
         cy.url().should('include', `/${testTeam2.name}/channels/town-square`);
     });
 
-    it.only('MM-T419 Desktop session expires when the focus is on the tab', () => {
+    it('MM-T419 Desktop session expires when the focus is on the tab', () => {
         // # Stub notifications API
         spyNotificationAs('withNotification', 'granted');
 

--- a/e2e/cypress/integration/signin_authentication/authentication_spec.js
+++ b/e2e/cypress/integration/signin_authentication/authentication_spec.js
@@ -185,7 +185,7 @@ describe('Authentication', () => {
 
         // # Logout
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#logout').should('be.visible').click();
+        cy.get('#logout').scrollIntoView().should('be.visible').click();
 
         // # Login as user A again, observe you're viewing the team/channel you switched to in step 1
         cy.visit('/login');
@@ -195,7 +195,7 @@ describe('Authentication', () => {
 
         // # Logout
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#logout').scrollIntoView().should('be.visible').click();
+        cy.get('#logout').should('be.visible').click();
 
         // # Login as user B again, observe you're viewing the team/channel you switched to in step 2
         cy.visit('/login');

--- a/e2e/cypress/integration/signin_authentication/authentication_spec.js
+++ b/e2e/cypress/integration/signin_authentication/authentication_spec.js
@@ -195,7 +195,7 @@ describe('Authentication', () => {
 
         // # Logout
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#logout').should('be.visible').click();
+        cy.get('#logout').scrollIntoView().should('be.visible').click();
 
         // # Login as user B again, observe you're viewing the team/channel you switched to in step 2
         cy.visit('/login');

--- a/e2e/cypress/integration/signin_authentication/authentication_spec.js
+++ b/e2e/cypress/integration/signin_authentication/authentication_spec.js
@@ -206,8 +206,19 @@ describe('Authentication', () => {
     });
 
     it('MM-T419 Desktop session expires when the focus is on the tab', () => {
-        // # Stub notifications API
-        spyNotificationAs('withNotification', 'granted');
+        Cypress.on('window:before:load', (win) => {
+            function Notification(title, opts) {
+                this.title = title;
+                this.opts = opts;
+            }
+
+            Notification.requestPermission = () => 'granted';
+            Notification.close = () => true;
+
+            win.Notification = Notification;
+
+            cy.stub(win, 'Notification').as('withNotification');
+        });
 
         cy.visit('/login');
         fillCredentialsForUser(testUser);

--- a/e2e/cypress/integration/signin_authentication/authentication_spec.js
+++ b/e2e/cypress/integration/signin_authentication/authentication_spec.js
@@ -4,6 +4,7 @@
 import {getEmailUrl} from '../../utils';
 import {getAdminAccount} from '../../support/env';
 import timeouts from '../../fixtures/timeouts';
+import {spyNotificationAs} from '../../support/notification';
 
 const authenticator = require('authenticator');
 
@@ -175,7 +176,7 @@ describe('Authentication', () => {
 
         // # Logout
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#logout').scrollIntoView().should('be.visible').click();
+        cy.get('#logout').should('be.visible').click();
 
         // # Login as user B and switch to a different team and channel
         cy.visit('/login');
@@ -204,20 +205,9 @@ describe('Authentication', () => {
         cy.url().should('include', `/${testTeam2.name}/channels/town-square`);
     });
 
-    it('MM-T419 Desktop session expires when the focus is on the tab', () => {
-        Cypress.on('window:before:load', (win) => {
-            function Notification(title, opts) {
-                this.title = title;
-                this.opts = opts;
-            }
-
-            Notification.requestPermission = () => 'granted';
-            Notification.close = () => true;
-
-            win.Notification = Notification;
-
-            cy.stub(win, 'Notification').as('withNotification');
-        });
+    it.only('MM-T419 Desktop session expires when the focus is on the tab', () => {
+        // # Stub notifications API
+        spyNotificationAs('withNotification', 'granted');
 
         cy.visit('/login');
         fillCredentialsForUser(testUser);

--- a/e2e/cypress/integration/signin_authentication/authentication_spec.js
+++ b/e2e/cypress/integration/signin_authentication/authentication_spec.js
@@ -4,7 +4,6 @@
 import {getEmailUrl} from '../../utils';
 import {getAdminAccount} from '../../support/env';
 import timeouts from '../../fixtures/timeouts';
-import {spyNotificationAs} from '../../support/notification';
 
 const authenticator = require('authenticator');
 
@@ -176,7 +175,7 @@ describe('Authentication', () => {
 
         // # Logout
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#logout').should('be.visible').click();
+        cy.get('#logout').scrollIntoView().should('be.visible').click();
 
         // # Login as user B and switch to a different team and channel
         cy.visit('/login');
@@ -186,7 +185,7 @@ describe('Authentication', () => {
 
         // # Logout
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#logout').scrollIntoView().should('be.visible').click();
+        cy.get('#logout').should('be.visible').click();
 
         // # Login as user A again, observe you're viewing the team/channel you switched to in step 1
         cy.visit('/login');

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -111,7 +111,13 @@ function postMessageAndWait(textboxSelector, message) {
     // some operation which caused to prolong complete page loading.
     cy.wait(TIMEOUTS.THREE_SEC);
 
-    cy.get(textboxSelector, {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`${message}{enter}`).wait(TIMEOUTS.HALF_SEC);
+    cy.get(textboxSelector, {timeout: TIMEOUTS.HALF_MIN}).as('textboxSelector');
+    cy.get('@textboxSelector').should('be.visible').clear().type(`${message}{enter}`).wait(TIMEOUTS.HALF_SEC);
+    cy.get('@textboxSelector').invoke('val').then((value) => {
+        if (value.length > 0) {
+            cy.get('@textboxSelector').type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        }
+    });
     cy.waitUntil(() => {
         return cy.get(textboxSelector).then((el) => {
             return el[0].textContent === '';


### PR DESCRIPTION
#### Summary
- Fix search box focus related failures; modified to use click instead of focus
- From `archived_leave_channel_spec.js`, there are 2 expected failures related to [MM-32606](https://mattermost.atlassian.net/browse/MM-32606)
    - MM-T1672_1 and MM-T1673

#### Ticket Link
NA