### PR TITLE
MM-31961: fixed color in search field for dark-theme

### DIFF
--- a/components/search_bar/search_bar.tsx
+++ b/components/search_bar/search_bar.tsx
@@ -115,7 +115,7 @@ const SearchBar: React.FunctionComponent<Props> = (props: Props): JSX.Element =>
                     ref={getSearch}
                     id={props.isSideBarRight ? 'sbrSearchBox' : 'searchBox'}
                     tabIndex='0'
-                    className='search-bar a11y__region'
+                    className='search-bar form-control'
                     containerClass='w-full'
                     data-a11y-sort-order='9'
                     aria-describedby={props.isSideBarRight ? 'sbr-searchbar-help-popup' : 'searchbar-help-popup'}

--- a/components/search_bar/search_bar.tsx
+++ b/components/search_bar/search_bar.tsx
@@ -115,7 +115,7 @@ const SearchBar: React.FunctionComponent<Props> = (props: Props): JSX.Element =>
                     ref={getSearch}
                     id={props.isSideBarRight ? 'sbrSearchBox' : 'searchBox'}
                     tabIndex='0'
-                    className='search-bar form-control'
+                    className='search-bar form-control a11y__region'
                     containerClass='w-full'
                     data-a11y-sort-order='9'
                     aria-describedby={props.isSideBarRight ? 'sbr-searchbar-help-popup' : 'searchbar-help-popup'}

--- a/sass/components/_search.scss
+++ b/sass/components/_search.scss
@@ -112,10 +112,6 @@
             border: 2px solid v(button-bg);
             padding: 0;
 
-            .search-bar {
-                padding-left: 2.9rem;
-            }
-
             .search__icon {
                 top: 6px;
                 left: 8px;

--- a/sass/components/_search.scss
+++ b/sass/components/_search.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 
 .search-bar__container {
     .channel-header__links {
@@ -222,7 +222,7 @@
         .post-pre-header__icons-container {
             padding-right: 10px; // If the padding of post__img changes, this needs to be adjusted accordingly
             width: 53px; // If the width of post__img changes, this needs to be adjusted accordingly
-            margin-left: 0px; // if left margin of post__content changes, this needs to be adjusted accordingly
+            margin-left: 0; // if left margin of post__content changes, this needs to be adjusted accordingly
         }
     }
 }

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 
 @media screen and (max-width: 768px) {
     #navbar_wrapper {
@@ -1379,7 +1379,6 @@
         padding: 0;
 
         .search-form__container {
-            color: $black;
             padding: 0 20px 0 0;
         }
 
@@ -1395,13 +1394,13 @@
             &--focused,
             &--focused:hover {
                 border-color: transparent;
+                border-width: 1px;
             }
 
             .form-control {
                 @include border-radius(3px);
                 background: var(--center-channel-bg);
                 border: none;
-                color: $dark-gray;
                 padding: 0 31px;
             }
         }

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -36,7 +36,7 @@
                 .post-pre-header__icons-container {
                     padding-right: 12px; // If the padding of post__img changes, this needs to be adjusted accordingly
                     width: 60px; // If the width of post__img changes, this needs to be adjusted accordingly
-                    margin-left: 0px; // if left margin of post__content changes, this needs to be adjusted accordingly
+                    margin-left: 0; // if left margin of post__content changes, this needs to be adjusted accordingly
                 }
             }
         }
@@ -193,8 +193,8 @@
                 margin-bottom: 0;
                 max-height: inherit;
                 max-width: inherit;
-                border: 0px;
-                padding-top: 0px;
+                border: 0;
+                padding-top: 0;
                 box-shadow: none;
                 color: inherit;
 
@@ -260,7 +260,7 @@
         .post, .SidebarMenu, .AddChannelDropdown {
             .Menu {
                 @include border-radius(0);
-                border: 0px;
+                border: 0;
                 height: 100%;
                 left: 0;
                 position: fixed;
@@ -299,7 +299,7 @@
                     background: var(--center-channel-bg);
 
                     &:last-child button {
-                        border-bottom: 0px;
+                        border-bottom: 0;
                     }
                 }
             }
@@ -679,7 +679,7 @@
             .post-pre-header__icons-container {
                 padding-right: 8px; // If the padding of post__img changes, this needs to be adjusted accordingly
                 width: 40px; // If the width of post__img changes, this needs to be adjusted accordingly
-                margin-left: 0px;
+                margin-left: 0;
 
                 .icon--post-pre-header {
                     &:nth-of-type(even) {
@@ -1331,7 +1331,7 @@
             }
 
             .status {
-                margin: 0 8px 0 0px;
+                margin: 0 8px 0 0;
                 top: 2px;
                 width: 16px;
 
@@ -1516,7 +1516,7 @@
                 }
 
                 h4 {
-                    margin: 1.5 0 1em;
+                    margin: 1.5em 0 1em;
                 }
 
                 >a {
@@ -1637,7 +1637,7 @@
                 }
 
                 h4 {
-                    margin: 1.5 0 1em;
+                    margin: 1.5em 0 1em;
                 }
 
                 >a {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
1. Fixed color in the mobile search-field for the dark-theme. It was black, but shoudl have been getting the color from the parents `form-control` class.
2. Fixed some warnings and errors in the SCSS files along the way

#### Ticket Link
Fixes [MM-31961](https://mattermost.atlassian.net/browse/MM-31961)

#### Screenshots

focused|un-focused
--|--
<img width="791" alt="Screenshot 2021-02-08 at 11 13 04" src="https://user-images.githubusercontent.com/32863416/107205959-bdb07580-69fe-11eb-8dc2-0c96f089ac85.png">|<img width="791" alt="Screenshot 2021-02-08 at 11 13 18" src="https://user-images.githubusercontent.com/32863416/107205976-c3a65680-69fe-11eb-94b0-9a81ae7f006d.png">
