### PR TITLE
MM-32354 - do not show renew now text in announcement bar tooltip

### DIFF
--- a/components/announcement_bar/configuration_bar/__snapshots__/configuration_bar.test.tsx.snap
+++ b/components/announcement_bar/configuration_bar/__snapshots__/configuration_bar.test.tsx.snap
@@ -4,14 +4,16 @@ exports[`components/ConfigurationBar should match snapshot, expired 1`] = `
 <Connect(AnnouncementBar)
   message={
     <React.Fragment>
-      <img
-        className="advisor-icon"
-        src={null}
-      />
-      <FormattedMessage
-        defaultMessage="Enterprise license is expired and some features may be disabled."
-        id="announcement_bar.error.license_expired"
-      />
+      <React.Fragment>
+        <img
+          className="advisor-icon"
+          src={null}
+        />
+        <FormattedMessage
+          defaultMessage="Enterprise license is expired and some features may be disabled."
+          id="announcement_bar.error.license_expired"
+        />
+      </React.Fragment>
       <Memo(Connect(RenewalLink))
         telemetryInfo={
           Object {
@@ -19,6 +21,18 @@ exports[`components/ConfigurationBar should match snapshot, expired 1`] = `
             "success": "renew_license_banner_success",
           }
         }
+      />
+    </React.Fragment>
+  }
+  tooltipMsg={
+    <React.Fragment>
+      <img
+        className="advisor-icon"
+        src={null}
+      />
+      <FormattedMessage
+        defaultMessage="Enterprise license is expired and some features may be disabled."
+        id="announcement_bar.error.license_expired"
       />
     </React.Fragment>
   }
@@ -30,14 +44,16 @@ exports[`components/ConfigurationBar should match snapshot, expired, in grace pe
 <Connect(AnnouncementBar)
   message={
     <React.Fragment>
-      <img
-        className="advisor-icon"
-        src={null}
-      />
-      <FormattedMessage
-        defaultMessage="Enterprise license is expired and some features may be disabled."
-        id="announcement_bar.error.license_expired"
-      />
+      <React.Fragment>
+        <img
+          className="advisor-icon"
+          src={null}
+        />
+        <FormattedMessage
+          defaultMessage="Enterprise license is expired and some features may be disabled."
+          id="announcement_bar.error.license_expired"
+        />
+      </React.Fragment>
       <Memo(Connect(RenewalLink))
         telemetryInfo={
           Object {
@@ -45,6 +61,18 @@ exports[`components/ConfigurationBar should match snapshot, expired, in grace pe
             "success": "renew_license_banner_success",
           }
         }
+      />
+    </React.Fragment>
+  }
+  tooltipMsg={
+    <React.Fragment>
+      <img
+        className="advisor-icon"
+        src={null}
+      />
+      <FormattedMessage
+        defaultMessage="Enterprise license is expired and some features may be disabled."
+        id="announcement_bar.error.license_expired"
       />
     </React.Fragment>
   }

--- a/components/announcement_bar/configuration_bar/configuration_bar.tsx
+++ b/components/announcement_bar/configuration_bar/configuration_bar.tsx
@@ -164,48 +164,69 @@ const ConfigurationAnnouncementBar: React.FC<Props> = (props: Props) => {
     // System administrators
     if (props.canViewSystemErrors) {
         if (isLicensePastGracePeriod(props.license)) {
+            const message = (<>
+                <img
+                    className='advisor-icon'
+                    src={warningIcon}
+                />
+                <FormattedMessage
+                    id='announcement_bar.error.license_expired'
+                    defaultMessage='Enterprise license is expired and some features may be disabled.'
+                />
+            </>);
             return (
                 <AnnouncementBar
                     type={AnnouncementBarTypes.CRITICAL}
                     message={
                         <>
-                            <img
-                                className='advisor-icon'
-                                src={warningIcon}
-                            />
-                            <FormattedMessage
-                                id='announcement_bar.error.license_expired'
-                                defaultMessage='Enterprise license is expired and some features may be disabled.'
-                            />
+                            {message}
                             <RenewalLink telemetryInfo={renewLinkTelemetry}/>
                         </>
                     }
+                    tooltipMsg={message}
                 />
             );
         }
 
         if (isLicenseExpired(props.license)) {
+            const message = (<>
+                <img
+                    className='advisor-icon'
+                    src={warningIcon}
+                />
+                <FormattedMessage
+                    id='announcement_bar.error.license_expired'
+                    defaultMessage='Enterprise license is expired and some features may be disabled.'
+                />
+            </>);
             return (
                 <AnnouncementBar
                     type={AnnouncementBarTypes.CRITICAL}
                     message={
                         <>
-                            <img
-                                className='advisor-icon'
-                                src={warningIcon}
-                            />
-                            <FormattedMessage
-                                id='announcement_bar.error.license_expired'
-                                defaultMessage='Enterprise license is expired and some features may be disabled.'
-                            />
+                            {message}
                             <RenewalLink telemetryInfo={renewLinkTelemetry}/>
                         </>
                     }
+                    tooltipMsg={message}
                 />
             );
         }
 
         if (isLicenseExpiring(props.license) && !props.dismissedExpiringLicense) {
+            const message = (<>
+                <img
+                    className='advisor-icon'
+                    src={alertIcon}
+                />
+                <FormattedMessage
+                    id='announcement_bar.error.license_expiring'
+                    defaultMessage='Enterprise license expires on {date, date, long}.'
+                    values={{
+                        date: new Date(parseInt(props.license?.ExpiresAt, 10)),
+                    }}
+                />
+            </>);
             return (
                 <AnnouncementBar
                     showCloseButton={true}
@@ -213,20 +234,11 @@ const ConfigurationAnnouncementBar: React.FC<Props> = (props: Props) => {
                     type={AnnouncementBarTypes.ANNOUNCEMENT}
                     message={
                         <>
-                            <img
-                                className='advisor-icon'
-                                src={alertIcon}
-                            />
-                            <FormattedMessage
-                                id='announcement_bar.error.license_expiring'
-                                defaultMessage='Enterprise license expires on {date, date, long}.'
-                                values={{
-                                    date: new Date(parseInt(props.license?.ExpiresAt, 10)),
-                                }}
-                            />
+                            {message}
                             <RenewalLink telemetryInfo={renewLinkTelemetry}/>
                         </>
                     }
+                    tooltipMsg={message}
                 />
             );
         }

--- a/components/announcement_bar/default_announcement_bar/announcement_bar.tsx
+++ b/components/announcement_bar/default_announcement_bar/announcement_bar.tsx
@@ -26,6 +26,7 @@ type Props = {
     textColor: string;
     type: string;
     message: React.ReactNode;
+    tooltipMsg?: React.ReactNode;
     handleClose?: (e?: any) => void;
     showModal?: boolean;
     announcementBarCount?: number;
@@ -115,7 +116,7 @@ export default class AnnouncementBar extends React.PureComponent<Props> {
         }
         const announcementTooltip = (
             <Tooltip id='announcement-bar__tooltip'>
-                {message}
+                {this.props.tooltipMsg ? this.props.tooltipMsg : message}
             </Tooltip>
         );
 

--- a/sass/components/_announcement-bar.scss
+++ b/sass/components/_announcement-bar.scss
@@ -92,30 +92,6 @@
     }
 }
 
-#announcement-bar__tooltip {
-    button {
-        &:hover {
-            background-color: rgba(255, 255, 255, 0.08)
-        }
-        display: inline-block;
-        margin-bottom: 8px;
-        margin-left: 4px;
-        background-color:var(--sidebar-text-active-border);
-        font-family: Open Sans;
-        font-style: normal;
-        font-weight: 600;
-        font-size: 12px;
-        line-height: 16px;
-        padding: 4px 8px;
-        border: none;
-        outline: none;
-        height: 24px;
-        box-sizing: border-box;
-        border-radius: 4px;
-        background-color: inherit
-    }
-}
-
 .announcement-bar-critical {
     background-color: #F74343;
 }


### PR DESCRIPTION
#### Summary
Prevents to show the renew now button text from the announcement bar when hovering and showing the tooltip.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32354

#### Related Pull Requests
No related PRs

#### Screenshots
Before:
<img width="1744" alt="Captura de pantalla 2021-01-20 a las 20 28 20" src="https://user-images.githubusercontent.com/10082627/105226995-03e18a00-5b61-11eb-97a4-9ece1c9084ff.png">

After:
<img width="1753" alt="Captura de pantalla 2021-02-08 a las 11 15 36" src="https://user-images.githubusercontent.com/10082627/107206671-a2923580-69ff-11eb-8bd3-5d2727b94042.png">
