### PR TITLE
MM-26497: markdown table word breaking

### DIFF
--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -175,7 +175,7 @@ h6 {
         font-size: 13px;
         display: block;
         position: relative;
-        padding: 0px;
+        padding: 0;
         text-align: left;
     }
 
@@ -304,7 +304,7 @@ blockquote {
         @include opacity(.6);
         content: '\f10d';
         display: inline-block;
-        font-family: FontAwesome;
+        font-family: FontAwesome, sans-serif;
         font-size: 20px;
         font-style: normal;
         font-weight: normal;

--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -259,7 +259,10 @@ h6 {
     td {
         border: 1px solid #ddd;
         padding: 6px 13px;
-        white-space: nowrap;
+    }
+
+    a {
+        word-break: initial;
     }
 
     tbody tr {

--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 
 h1 {
     font-size: 28px;
@@ -263,6 +263,7 @@ h6 {
 
     a {
         word-break: initial;
+        white-space: nowrap;
     }
 
     tbody tr {


### PR DESCRIPTION
#### Summary
fixed multiple word breaking in markdown tables without affecting links

#### Ticket Link
Fixes [MM-26497](https://mattermost.atlassian.net/browse/MM-26497)

#### Screenshots
<img width="1880" alt="Screenshot 2021-02-09 at 13 14 21" src="https://user-images.githubusercontent.com/32863416/107362204-beb5d580-6ad8-11eb-9c49-6155bc1e39ff.png">
