### PR TITLE
Cypress/E2E: Fix for test that requires untrusted internal connection

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -10,6 +10,7 @@
     "env": {
         "adminUsername": "sysadmin",
         "adminPassword": "Sys@dmin-sample1",
+        "allowedUntrustedInternalConnections": "localhost",
         "dbClient": "postgres",
         "dbConnection": "postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable\u0026connect_timeout=10",
         "adminEmail": "sysadmin@sample.mattermost.com",

--- a/e2e/cypress/support/api/system.js
+++ b/e2e/cypress/support/api/system.js
@@ -109,7 +109,7 @@ export const getDefaultConfig = () => {
             LdapPort: cypressEnv.ldapPort,
         },
         ServiceSettings: {
-            AllowedUntrustedInternalConnections: 'localhost',
+            AllowedUntrustedInternalConnections: cypressEnv.allowedUntrustedInternalConnections,
             SiteURL: Cypress.config('baseUrl'),
         },
     };


### PR DESCRIPTION
#### Summary
This makes it easier to configure a remote test server to allow untrusted internal connections. 
