### PR TITLE
Revert "Allow uploading 10 files per post (#7160)"

### DIFF
--- a/components/file_upload/file_upload.test.jsx
+++ b/components/file_upload/file_upload.test.jsx
@@ -157,7 +157,7 @@ describe('components/FileUpload', () => {
 
         // not allow file upload, max limit has been reached
         wrapper.setState({menuOpen: true});
-        wrapper.setProps({fileCount: 10});
+        wrapper.setProps({fileCount: 5});
         wrapper.instance().handleLocalFileUploaded(evt);
         expect(baseProps.onClick).toHaveBeenCalledTimes(1);
         expect(wrapper.instance().handleMaxUploadReached).toHaveBeenCalledTimes(1);
@@ -270,7 +270,7 @@ describe('components/FileUpload', () => {
     });
 
     test('should error max upload files', () => {
-        const fileCount = 10;
+        const fileCount = 5;
         const props = {...baseProps, fileCount};
         const files = [{name: 'file1.pdf'}, {name: 'file2.jpg'}];
 
@@ -289,7 +289,7 @@ describe('components/FileUpload', () => {
     });
 
     test('should error max upload files', () => {
-        const fileCount = 10;
+        const fileCount = 5;
         const props = {...baseProps, fileCount};
         const files = [{name: 'file1.pdf'}, {name: 'file2.jpg'}];
 

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -966,7 +966,7 @@ export const Constants = {
         other: 'generic',
         image: 'image',
     },
-    MAX_UPLOAD_FILES: 10,
+    MAX_UPLOAD_FILES: 5,
     MAX_FILENAME_LENGTH: 35,
     THUMBNAIL_WIDTH: 128,
     THUMBNAIL_HEIGHT: 100,


### PR DESCRIPTION
This reverts commit 4718281b7600650ef5d87b4d9633907c22a51955.

As mentioned in the related PR, we found issues with the database migration taking a really long time on certain versions of MySQL, so this has to be reverted while we figure out how to do that better.


#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/16907