### PR TITLE
MM-32825 - suggestion box hidden by rhs

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -370,7 +370,7 @@
 .post-create__container {
     @include flex(0 0 auto);
     width: 100%;
-    z-index: 10;
+    z-index: 12;
 
     label {
         font-weight: normal;


### PR DESCRIPTION
#### Summary
This PR increases by 2 the z-index of the post box getting into z-index value of 12, that way it will overlap the z-index of the RHS that is a z-index value of 11.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32825

#### Screenshots
Before:
<img width="1524" alt="Captura de pantalla 2021-02-13 a las 14 35 15" src="https://user-images.githubusercontent.com/10082627/107851288-1e79ec80-6e09-11eb-8d02-1d99fa2c0417.png">

After
<img width="1575" alt="Captura de pantalla 2021-02-13 a las 14 34 47" src="https://user-images.githubusercontent.com/10082627/107851285-1b7efc00-6e09-11eb-9c6d-87938c37416c.png">

