### PR TITLE
Updating font size for add people to channel modal

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -799,7 +799,6 @@
         align-self: center;
         flex-grow: 1;
         flex-shrink: 1;
-        font-size: .9em;
         overflow: hidden;
         padding-left: 10px;
         text-overflow: ellipsis;


### PR DESCRIPTION
#### Summary
**Updating font size for add people to channel modal**
The PR removes the 0.9em font size as that was reducing the font size in the modals.
The more DM modal etc is also affected by this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32811

#### Screenshots
<img width="686" alt="Screenshot 2021-02-15 at 3 37 41 PM" src="https://user-images.githubusercontent.com/11034289/107935874-c75c4f00-6fa3-11eb-86c2-cfaafed98761.png">
