### PR TITLE
MM-27400: tooltip for long channel names

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
@@ -208,7 +208,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     >
       <div>
         <span
-          className="SidebarChannelLinkLabel"
+          className="SidebarChannelLinkLabel truncated"
         >
           channel_label
         </span>

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -95,14 +95,10 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         }
     }
 
-    // TODO: Is there a better way to do this?
     enableToolTipIfNeeded = (): void => {
         const element = this.gmItemRef.current || this.labelRef.current;
-        if (element && element.offsetWidth < element.scrollWidth) {
-            this.setState({showTooltip: true});
-        } else {
-            this.setState({showTooltip: false});
-        }
+        const showTooltip = element && element.offsetWidth < element.scrollWidth;
+        this.setState({showTooltip: Boolean(showTooltip)});
     }
 
     getAriaLabel = (): string => {
@@ -138,11 +134,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
     }
 
     handleSelectChannel = (event: React.MouseEvent<HTMLAnchorElement>): void => {
-        if (event.defaultPrevented) {
-            return;
-        }
-
-        if (event.button !== 0) {
+        if (event.defaultPrevented || event.button !== 0) {
             return;
         }
 
@@ -157,17 +149,13 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         }
     }
 
-    handleMenuToggle = (isMenuOpen: boolean): void => {
-        this.setState({isMenuOpen});
-    }
+    handleMenuToggle = (isMenuOpen: boolean): void => this.setState({isMenuOpen});
 
     /**
      * Show as unread if you have unread mentions
      * OR if you have unread messages and the channel can be marked unread by preferences
      */
-    showChannelAsUnread = (): boolean => {
-        return this.props.unreadMentions > 0 || (this.props.unreadMsgs > 0 && this.props.showUnreadForMsgs);
-    };
+    showChannelAsUnread = (): boolean => this.props.unreadMentions > 0 || (this.props.unreadMsgs > 0 && this.props.showUnreadForMsgs);
 
     render(): JSX.Element {
         const {link, label, channel, unreadMentions, icon, isMuted, isChannelSelected} = this.props;
@@ -205,7 +193,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         }
 
         const content = (
-            <React.Fragment>
+            <>
                 <SidebarChannelIcon
                     channel={channel}
                     icon={icon}
@@ -229,7 +217,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                     isMenuOpen={this.state.isMenuOpen}
                     onToggleMenu={this.handleMenuToggle}
                 />
-            </React.Fragment>
+            </>
         );
 
         // NOTE: class added to temporarily support the desktop app's at-mention DOM scraping of the old sidebar

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -85,18 +85,18 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.enableToolTipIfNeeded();
     }
 
-    componentDidUpdate(prevProps: Props) {
+    componentDidUpdate(prevProps: Props): void {
         if (prevProps.label !== this.props.label) {
             this.enableToolTipIfNeeded();
         }
     }
 
     // TODO: Is there a better way to do this?
-    enableToolTipIfNeeded = () => {
+    enableToolTipIfNeeded = (): void => {
         const element = this.gmItemRef.current || this.labelRef.current;
         if (element && element.offsetWidth < element.scrollWidth) {
             this.setState({showTooltip: true});
@@ -105,7 +105,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         }
     }
 
-    getAriaLabel = () => {
+    getAriaLabel = (): string => {
         const {label, ariaLabelPrefix, unreadMentions} = this.props;
 
         let ariaLabel = label;
@@ -130,14 +130,14 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
     // Bootstrap adds the attr dynamically, removing it to prevent a11y readout
     removeTooltipLink = (): void => this.gmItemRef.current?.removeAttribute?.('aria-describedby');
 
-    handleChannelClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    handleChannelClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         mark('SidebarLink#click');
         trackEvent('ui', 'ui_channel_selected_v2');
 
         this.handleSelectChannel(event);
     }
 
-    handleSelectChannel = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    handleSelectChannel = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         if (event.defaultPrevented) {
             return;
         }
@@ -157,7 +157,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         }
     }
 
-    handleMenuToggle = (isMenuOpen: boolean) => {
+    handleMenuToggle = (isMenuOpen: boolean): void => {
         this.setState({isMenuOpen});
     }
 
@@ -165,11 +165,11 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
      * Show as unread if you have unread mentions
      * OR if you have unread messages and the channel can be marked unread by preferences
      */
-    showChannelAsUnread = () => {
+    showChannelAsUnread = (): boolean => {
         return this.props.unreadMentions > 0 || (this.props.unreadMsgs > 0 && this.props.showUnreadForMsgs);
     };
 
-    render() {
+    render(): JSX.Element {
         const {link, label, channel, unreadMentions, icon, isMuted, isChannelSelected} = this.props;
 
         let labelElement: JSX.Element = (

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -127,12 +127,8 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         return ariaLabel.toLowerCase();
     }
 
-    removeTooltipLink = () => {
-        // Bootstrap adds the attr dynamically, removing it to prevent a11y readout
-        if (this.gmItemRef.current) {
-            this.gmItemRef.current.removeAttribute('aria-describedby');
-        }
-    }
+    // Bootstrap adds the attr dynamically, removing it to prevent a11y readout
+    removeTooltipLink = (): void => this.gmItemRef.current?.removeAttribute?.('aria-describedby');
 
     handleChannelClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         mark('SidebarLink#click');
@@ -178,7 +174,12 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
 
         let labelElement: JSX.Element = (
             <span
-                className={'SidebarChannelLinkLabel'}
+                className={classNames(
+                    'SidebarChannelLinkLabel',
+                    {
+                        truncated: this.state.showTooltip,
+                    },
+                )}
             >
                 {wrapEmojis(label)}
             </span>

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1074,23 +1074,26 @@
         display: flex;
     }
 
-    .SidebarChannel span.SidebarChannelLinkLabel {
-        width: 100%;
-        white-space: nowrap;
-        line-height: 18px;
-        text-align: justify;
-        height: 18px;
+    .SidebarChannel {
+        & span.SidebarChannelLinkLabel {
+            width: 100%;
+            white-space: nowrap;
+            line-height: 18px;
+            text-align: justify;
+            height: 18px;
+
+            &.truncated {
+                text-overflow: ellipsis;
+                overflow: hidden;
+            }
+        }
     }
 
-    .SidebarChannelLinkLabel_wrapper {
+    .SidebarChannelLinkLabel_wrapper,
+    .SidebarChannelLinkLabel_wrapper > div {
         overflow: hidden;
         display: flex;
         flex-grow: 1;
-
-        > span {
-            text-overflow: ellipsis;
-            overflow: hidden;
-        }
     }
 
     /* .SidebarChannel__absolute {


### PR DESCRIPTION
#### Summary
enables tooltips for long channel names (those that will be truncated) in the sidebar

#### Ticket Link
Fixes [MM-27400](https://mattermost.atlassian.net/browse/MM-27400)

#### Screenshots
<img width="784" alt="Screenshot 2021-02-15 at 16 25 29" src="https://user-images.githubusercontent.com/32863416/107965140-700dad00-6faa-11eb-8dfc-f7d1ae654590.png">
