### PR TITLE
MM-32928 Remove custom-protocol-detection

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -319,39 +319,6 @@ SOFTWARE.
 
 ---
 
-## custom-protocol-detection
-
-This product contains 'custom-protocol-detection' by Ismail Habib Muhammad.
-
-Detect whether a custom protocol is available in browser (FF, Chrome, IE8, IE9, IE10, IE11, and Edge)
-
-* HOMEPAGE:
-  * https://github.com/ismailhabib/custom-protocol-detection
-
-* LICENSE: The MIT License (MIT)
-
-Copyright (c) 2015 Ismail Habib Muhammad
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
----
-
 ## dynamic-virtualized-list
 
 This product contains 'dynamic-virtualized-list' by Mattermost.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12215,10 +12215,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "custom-protocol-detection": {
-      "version": "github:ismailhabib/custom-protocol-detection#dfd5d33f98dd1ebab92c48db49bf4b666ffd6b42",
-      "from": "github:ismailhabib/custom-protocol-detection"
-    },
     "cwebp-bin": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "country-list": "2.2.0",
     "crypto-browserify": "3.12.0",
     "css-vars-ponyfill": "2.4.3",
-    "custom-protocol-detection": "github:ismailhabib/custom-protocol-detection",
     "dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#119db968c96643c7106d4d2c965f05b2e251bc83",
     "emoji-regex": "9.2.1",
     "exif2css": "1.3.0",

--- a/types/external/custom-protocol-detection.d.ts
+++ b/types/external/custom-protocol-detection.d.ts
@@ -1,4 +1,0 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-
-declare module 'custom-protocol-detection';


### PR DESCRIPTION
This library hasn't been used since https://github.com/mattermost/mattermost-webapp/pull/4688, so it's safe to remove without worrying about anything changing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32928