### PR TITLE
MM-30852 Add ellipses to text overflow in system console users list

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -836,6 +836,12 @@
         font-weight: 600;
         white-space: nowrap;
 
+        a {
+            overflow: hidden;
+            min-width: 0;
+            text-overflow: ellipsis;
+        }
+
         span {
             overflow: hidden;
             max-width: 90%;
@@ -900,6 +906,7 @@
         display: flex;
         flex-direction: column;
         width: 100%;
+        min-width: 0;
 
         .control-label {
             font-weight: normal;


### PR DESCRIPTION
#### Summary
Excessively long first and last names push member link nearly off right side of user list. This PR horizontal scroll and adds ellipses to text.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30852

#### Screenshots
<img width="943" alt="Screenshot 2021-02-17 at 12 04 57" src="https://user-images.githubusercontent.com/3680799/108165502-aec17580-7118-11eb-8ebe-a5ca158c3e93.png">
<img width="930" alt="Screenshot 2021-02-17 at 12 04 18" src="https://user-images.githubusercontent.com/3680799/108165514-b4b75680-7118-11eb-9729-31cdc98bf62d.png">
