### PR TITLE
Remove output from pkill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ stop: ## Stops webpack
 ifeq ($(OS),Windows_NT)
 	wmic process where "Caption='node.exe' and CommandLine like '%webpack%'" call terminate
 else
-	@pkill -fl webpack || true
+	@pkill -f webpack || true
 endif
 
 restart: | stop run ## Restarts the app


### PR DESCRIPTION
`-l` seems to be a non-standard flag that's supported on Mac, not Ubuntu, so we can't use that to have the killed processes output. `-f` is still needed since that causes it to match process arguments as well (since previous versions of webpack ran as `node webpack`).

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/7512