### PR TITLE
Cypress/E2E: Fix E2E tests for new sidebar feature

### DIFF
--- a/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -9,8 +9,11 @@ exports[`components/sidebar should match snapshot 1`] = `
 >
   <Connect(SidebarHeader) />
   <div
+    aria-label="channel navigator region"
     className="a11y__region"
     data-a11y-sort-order="6"
+    id="lhsNavigator"
+    role="application"
   >
     <Connect(ChannelNavigator)
       canCreateChannel={true}
@@ -41,8 +44,11 @@ exports[`components/sidebar should match snapshot when direct channels modal is 
 >
   <Connect(SidebarHeader) />
   <div
+    aria-label="channel navigator region"
     className="a11y__region"
     data-a11y-sort-order="6"
+    id="lhsNavigator"
+    role="application"
   >
     <Connect(ChannelNavigator)
       canCreateChannel={true}
@@ -77,8 +83,11 @@ exports[`components/sidebar should match snapshot when more channels modal is op
 >
   <Connect(SidebarHeader) />
   <div
+    aria-label="channel navigator region"
     className="a11y__region"
     data-a11y-sort-order="6"
+    id="lhsNavigator"
+    role="application"
   >
     <Connect(ChannelNavigator)
       canCreateChannel={true}

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -164,6 +164,8 @@ export default class Sidebar extends React.PureComponent<Props, State> {
             return (<div/>);
         }
 
+        const ariaLabel = Utils.localizeMessage('accessibility.sections.lhsNavigator', 'channel navigator region');
+
         return (
             <div
                 id='SidebarContainer'
@@ -174,6 +176,9 @@ export default class Sidebar extends React.PureComponent<Props, State> {
             >
                 <SidebarHeader/>
                 <div
+                    id='lhsNavigator'
+                    role='application'
+                    aria-label={ariaLabel}
                     className='a11y__region'
                     data-a11y-sort-order='6'
                 >

--- a/components/sidebar/sidebar_channel/sidebar_channel_icon/sidebar_channel_icon.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_icon/sidebar_channel_icon.tsx
@@ -19,7 +19,10 @@ export default class SidebarChannelIcon extends React.PureComponent<Props> {
             );
         } else if (this.props.hasDraft) {
             return (
-                <i className='icon icon-pencil-outline'/>
+                <i
+                    data-testid='draftIcon'
+                    className='icon icon-pencil-outline'
+                />
             );
         }
 

--- a/components/sidebar/sidebar_channel_list/__snapshots__/sidebar_channel_list.test.tsx.snap
+++ b/components/sidebar/sidebar_channel_list/__snapshots__/sidebar_channel_list.test.tsx.snap
@@ -2,11 +2,13 @@
 
 exports[`SidebarChannelList should match snapshot 1`] = `
 <div
+  aria-label="channel sidebar region"
   className="SidebarNavContainer a11y__region"
   data-a11y-disable-nav={false}
   data-a11y-sort-order="7"
-  id="sidebar-left"
+  id="lhsList"
   onTransitionEnd={[Function]}
+  role="application"
 >
   <UnreadChannelIndicator
     content={

--- a/components/sidebar/sidebar_channel_list/sidebar_channel_list.tsx
+++ b/components/sidebar/sidebar_channel_list/sidebar_channel_list.tsx
@@ -498,11 +498,15 @@ export default class SidebarChannelList extends React.PureComponent<Props, State
             />
         );
 
+        const ariaLabel = Utils.localizeMessage('accessibility.sections.lhsList', 'channel sidebar region');
+
         return (
 
             // NOTE: id attribute added to temporarily support the desktop app's at-mention DOM scraping of the old sidebar
             <div
-                id='sidebar-left'
+                id='lhsList'
+                role='application'
+                aria-label={ariaLabel}
                 className={classNames('SidebarNavContainer a11y__region', {
                     disabled: this.props.isUnreadFilterEnabled,
                 })}

--- a/components/user_settings/display/user_settings_theme/__snapshots__/custom_theme_chooser.test.jsx.snap
+++ b/components/user_settings/display/user_settings_theme/__snapshots__/custom_theme_chooser.test.jsx.snap
@@ -103,6 +103,7 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
             />
           }
           onChange={[Function]}
+          value="#0b428c"
         />
       </div>
       <div
@@ -597,7 +598,7 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         onClick={[Function]}
         onCopy={[Function]}
         onPaste={[Function]}
-        value="{\\"sidebarBg\\":\\"#145dbf\\",\\"sidebarText\\":\\"#ffffff\\",\\"sidebarUnreadText\\":\\"#ffffff\\",\\"sidebarTextHoverBg\\":\\"#4578bf\\",\\"sidebarTextActiveBorder\\":\\"#579eff\\",\\"sidebarTextActiveColor\\":\\"#ffffff\\",\\"sidebarHeaderBg\\":\\"#1153ab\\",\\"sidebarHeaderTextColor\\":\\"#ffffff\\",\\"onlineIndicator\\":\\"#06d6a0\\",\\"awayIndicator\\":\\"#ffbc42\\",\\"dndIndicator\\":\\"#f74343\\",\\"mentionBg\\":\\"#ffffff\\",\\"mentionBj\\":\\"#ffffff\\",\\"mentionColor\\":\\"#145dbf\\",\\"centerChannelBg\\":\\"#ffffff\\",\\"centerChannelColor\\":\\"#3d3c40\\",\\"newMessageSeparator\\":\\"#ff8800\\",\\"linkColor\\":\\"#2389d7\\",\\"buttonBg\\":\\"#166de0\\",\\"buttonColor\\":\\"#ffffff\\",\\"errorTextColor\\":\\"#fd5960\\",\\"mentionHighlightBg\\":\\"#ffe577\\",\\"mentionHighlightLink\\":\\"#166de0\\",\\"codeTheme\\":\\"github\\"}"
+        value="{\\"sidebarBg\\":\\"#145dbf\\",\\"sidebarText\\":\\"#ffffff\\",\\"sidebarUnreadText\\":\\"#ffffff\\",\\"sidebarTextHoverBg\\":\\"#4578bf\\",\\"sidebarTextActiveBorder\\":\\"#579eff\\",\\"sidebarTextActiveColor\\":\\"#ffffff\\",\\"sidebarHeaderBg\\":\\"#1153ab\\",\\"sidebarTeamBarBg\\":\\"#0b428c\\",\\"sidebarHeaderTextColor\\":\\"#ffffff\\",\\"onlineIndicator\\":\\"#06d6a0\\",\\"awayIndicator\\":\\"#ffbc42\\",\\"dndIndicator\\":\\"#f74343\\",\\"mentionBg\\":\\"#ffffff\\",\\"mentionBj\\":\\"#ffffff\\",\\"mentionColor\\":\\"#145dbf\\",\\"centerChannelBg\\":\\"#ffffff\\",\\"centerChannelColor\\":\\"#3d3c40\\",\\"newMessageSeparator\\":\\"#ff8800\\",\\"linkColor\\":\\"#2389d7\\",\\"buttonBg\\":\\"#166de0\\",\\"buttonColor\\":\\"#ffffff\\",\\"errorTextColor\\":\\"#fd5960\\",\\"mentionHighlightBg\\":\\"#ffe577\\",\\"mentionHighlightLink\\":\\"#166de0\\",\\"codeTheme\\":\\"github\\"}"
       />
       <div
         className="mt-3"

--- a/components/user_settings/display/user_settings_theme/__snapshots__/custom_theme_chooser.test.jsx.snap
+++ b/components/user_settings/display/user_settings_theme/__snapshots__/custom_theme_chooser.test.jsx.snap
@@ -103,7 +103,6 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
             />
           }
           onChange={[Function]}
-          value="#0b428c"
         />
       </div>
       <div
@@ -598,7 +597,7 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         onClick={[Function]}
         onCopy={[Function]}
         onPaste={[Function]}
-        value="{\\"sidebarBg\\":\\"#145dbf\\",\\"sidebarText\\":\\"#ffffff\\",\\"sidebarUnreadText\\":\\"#ffffff\\",\\"sidebarTextHoverBg\\":\\"#4578bf\\",\\"sidebarTextActiveBorder\\":\\"#579eff\\",\\"sidebarTextActiveColor\\":\\"#ffffff\\",\\"sidebarHeaderBg\\":\\"#1153ab\\",\\"sidebarTeamBarBg\\":\\"#0b428c\\",\\"sidebarHeaderTextColor\\":\\"#ffffff\\",\\"onlineIndicator\\":\\"#06d6a0\\",\\"awayIndicator\\":\\"#ffbc42\\",\\"dndIndicator\\":\\"#f74343\\",\\"mentionBg\\":\\"#ffffff\\",\\"mentionBj\\":\\"#ffffff\\",\\"mentionColor\\":\\"#145dbf\\",\\"centerChannelBg\\":\\"#ffffff\\",\\"centerChannelColor\\":\\"#3d3c40\\",\\"newMessageSeparator\\":\\"#ff8800\\",\\"linkColor\\":\\"#2389d7\\",\\"buttonBg\\":\\"#166de0\\",\\"buttonColor\\":\\"#ffffff\\",\\"errorTextColor\\":\\"#fd5960\\",\\"mentionHighlightBg\\":\\"#ffe577\\",\\"mentionHighlightLink\\":\\"#166de0\\",\\"codeTheme\\":\\"github\\"}"
+        value="{\\"sidebarBg\\":\\"#145dbf\\",\\"sidebarText\\":\\"#ffffff\\",\\"sidebarUnreadText\\":\\"#ffffff\\",\\"sidebarTextHoverBg\\":\\"#4578bf\\",\\"sidebarTextActiveBorder\\":\\"#579eff\\",\\"sidebarTextActiveColor\\":\\"#ffffff\\",\\"sidebarHeaderBg\\":\\"#1153ab\\",\\"sidebarHeaderTextColor\\":\\"#ffffff\\",\\"onlineIndicator\\":\\"#06d6a0\\",\\"awayIndicator\\":\\"#ffbc42\\",\\"dndIndicator\\":\\"#f74343\\",\\"mentionBg\\":\\"#ffffff\\",\\"mentionBj\\":\\"#ffffff\\",\\"mentionColor\\":\\"#145dbf\\",\\"centerChannelBg\\":\\"#ffffff\\",\\"centerChannelColor\\":\\"#3d3c40\\",\\"newMessageSeparator\\":\\"#ff8800\\",\\"linkColor\\":\\"#2389d7\\",\\"buttonBg\\":\\"#166de0\\",\\"buttonColor\\":\\"#ffffff\\",\\"errorTextColor\\":\\"#fd5960\\",\\"mentionHighlightBg\\":\\"#ffe577\\",\\"mentionHighlightLink\\":\\"#166de0\\",\\"codeTheme\\":\\"github\\"}"
       />
       <div
         className="mt-3"

--- a/e2e/cypress/integration/accessibility/accessibility_nav_diff_regions_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_nav_diff_regions_spec.js
@@ -101,10 +101,16 @@ describe('Verify Quick Navigation support across different regions in the app', 
         verifyNavSupport('#lhsHeader', 'team menu region', '5');
 
         // # Change the focus to the LHS sidebar
-        cy.get('#headerInfo button').focus().tab({shift: true}).tab().tab();
+        cy.get('#headerInfo button').focus().tab();
+
+        // * Verify nav support in LHS channel navigator
+        verifyNavSupport('#lhsNavigator', 'channel navigator region', '6');
+
+        // # Change the focus to the LHS sidebar
+        cy.get('#headerInfo button').focus().tab().tab().tab().tab();
 
         // * Verify nav support in LHS sidebar
-        verifyNavSupport('#lhsList', 'channel sidebar region', '6');
+        verifyNavSupport('#lhsList', 'channel sidebar region', '7');
     });
 
     it('MM-T1460_6 Verify Navigation Support in Channel Header', () => {

--- a/e2e/cypress/integration/accessibility/accessibility_post_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_post_spec.js
@@ -253,9 +253,9 @@ describe('Verify Accessibility Support in Post', () => {
 
     it('MM-T1462 Verify incoming messages are read', () => {
         // # Make channel as read by switching back and forth to testChannel
-        cy.get('#sidebarChannelContainer').should('be.visible').findByText('Off-Topic').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
         cy.get('#postListContent', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-        cy.get('#sidebarChannelContainer').should('be.visible').findByText(testChannel.display_name).click();
+        cy.uiGetLhsSection('CHANNELS').findByText(testChannel.display_name).click();
         cy.get('#postListContent', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Submit a post as another user

--- a/e2e/cypress/integration/account_settings/general/nickname_spec.js
+++ b/e2e/cypress/integration/account_settings/general/nickname_spec.js
@@ -146,8 +146,8 @@ describe('Account Settings > Sidebar > General', () => {
             // # Close modal
             cy.get('body').type('{esc}');
 
-            // # Click More... in the sidebar
-            cy.get('#moreDirectMessage').scrollIntoView().should('be.visible').click();
+            // # Open DM modal from the sidebar
+            cy.uiAddDirectMessage().click();
 
             // # Go to direct messages modal
             cy.get('.more-modal').should('be.visible').within(() => {

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_not_cloud_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_not_cloud_spec.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @account_setting
+
+describe('Account Settings > Sidebar > Channel Switcher', () => {
+    let testUser;
+    let testTeam;
+
+    before(() => {
+        // # Login as test user
+        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+        });
+    });
+
+    beforeEach(() => {
+        // # Visit town-square
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+    });
+
+    it('Cmd/Ctrl+Shift+L closes Channel Switch modal and sets focus to post textbox', () => {
+        // # Type CTRL/CMD+K
+        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+
+        // * Channel switcher hint should be visible
+        cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');
+
+        // # Type CTRL/CMD+shift+L
+        cy.findByRole('textbox', {name: 'quick switch input'}).cmdOrCtrlShortcut('{shift}L');
+
+        // * Suggestion list should be visible
+        cy.get('#suggestionList').should('not.be.visible');
+
+        // * focus should be on the input box
+        cy.get('#post_textbox').should('be.focused');
+    });
+
+    it('Cmd/Ctrl+Shift+M closes Channel Switch modal and sets focus to mentions', () => {
+        // # patch user info
+        cy.apiPatchMe({notify_props: {first_name: 'false', mention_keys: testUser.username}});
+
+        // # Type CTRL/CMD+K
+        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+
+        // * Channel switcher hint should be visible
+        cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');
+
+        // # Type CTRL/CMD+shift+m
+        cy.findByRole('textbox', {name: 'quick switch input'}).cmdOrCtrlShortcut('{shift}M');
+
+        // * Suggestion list should be visible
+        cy.get('#suggestionList').should('not.be.visible');
+
+        // * searchbox should appear
+        cy.get('#searchBox').should('have.attr', 'value', `${testUser.username} @${testUser.username} `);
+        cy.get('.sidebar--right__title').should('contain', 'Recent Mentions');
+    });
+});

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -8,19 +8,25 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @account_setting
+// Group: @account_setting @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('Account Settings > Sidebar > Channel Switcher', () => {
-    let testUser;
     let testChannel;
     let testTeam;
 
     before(() => {
-        // # Login as test user
-        cy.apiInitSetup({loginAfter: true}).then(({team, channel, user}) => {
-            testUser = user;
+        cy.shouldNotRunOnCloudEdition();
+
+        // # Update config
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableLegacySidebar: true,
+            },
+        });
+
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             testChannel = channel;
             testTeam = team;
 
@@ -43,7 +49,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         enableOrDisableChannelSwitcher(true);
 
         // # Click the sidebar switcher button
-        cy.get('#sidebarSwitcherButton').click();
+        cy.uiGetChannelSwitcher().click();
 
         verifyChannelSwitch(testTeam, testChannel);
     });
@@ -66,44 +72,6 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         cy.typeCmdOrCtrl().type('K', {release: true});
 
         verifyChannelSwitch(testTeam, testChannel);
-    });
-
-    it('Cmd/Ctrl+Shift+L closes Channel Switch modal and sets focus to post textbox', () => {
-        // # Type CTRL/CMD+K
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
-
-        // * Channel switcher hint should be visible
-        cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');
-
-        // # Type CTRL/CMD+shift+L
-        cy.findByRole('textbox', {name: 'quick switch input'}).cmdOrCtrlShortcut('{shift}L');
-
-        // * Suggestion list should be visible
-        cy.get('#suggestionList').should('not.be.visible');
-
-        // * focus should be on the input box
-        cy.get('#post_textbox').should('be.focused');
-    });
-
-    it('Cmd/Ctrl+Shift+M closes Channel Switch modal and sets focus to mentions', () => {
-        // # patch user info
-        cy.apiPatchMe({notify_props: {first_name: 'false', mention_keys: testUser.username}});
-
-        // # Type CTRL/CMD+K
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
-
-        // * Channel switcher hint should be visible
-        cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');
-
-        // # Type CTRL/CMD+shift+m
-        cy.findByRole('textbox', {name: 'quick switch input'}).cmdOrCtrlShortcut('{shift}M');
-
-        // * Suggestion list should be visible
-        cy.get('#suggestionList').should('not.be.visible');
-
-        // * searchbox should appear
-        cy.get('#searchBox').should('have.attr', 'value', `${testUser.username} @${testUser.username} `);
-        cy.get('.sidebar--right__title').should('contain', 'Recent Mentions');
     });
 
     it('MM-T305 Changes to Account Settings are not saved when user does not click on Save button', () => {

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -49,7 +49,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         enableOrDisableChannelSwitcher(true);
 
         // # Click the sidebar switcher button
-        cy.uiGetChannelSwitcher().click();
+        cy.get('#sidebarSwitcherButton').click();
 
         verifyChannelSwitch(testTeam, testChannel);
     });

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
@@ -8,11 +8,13 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @account_setting
+// Group: @account_setting @not_cloud
 
 describe('Account Settings > Sidebar > Channel Switcher', () => {
     before(() => {
-        // # Update config and visit town-square channel
+        cy.shouldNotRunOnCloudEdition();
+
+        // # Update config
         cy.apiUpdateConfig({
             ServiceSettings: {
                 EnableLegacySidebar: true,

--- a/e2e/cypress/integration/archived_channel/archived_leave_channel_spec.js
+++ b/e2e/cypress/integration/archived_channel/archived_leave_channel_spec.js
@@ -118,6 +118,7 @@ describe('Leave an archived channel', () => {
             });
         });
     });
+
     it('MM-T1672_1 User can close archived channel (1/2)', () => {
         // # Open a channel that's not the town square
         cy.visit(`/${testTeam.name}/channels/off-topic`);
@@ -155,6 +156,7 @@ describe('Leave an archived channel', () => {
             cy.url().should('include', `${testTeam.name}/channels/off-topic`);
         });
     });
+
     it('MM-T1672_2 User can close archived channel (2/2)', () => {
         // # Add text to channel you land on (after closing the archived channel via Close Channel button)
         // * Able to add test
@@ -284,11 +286,11 @@ describe('Leave an archived channel', () => {
         cy.get('#channelHeaderTitle').should('contain', testChannel.display_name);
 
         // * Archived icon is visible in header
-        cy.get('#channelHeaderInfo .icon__archive').should('be.visible');
+        cy.get('#channelHeaderInfo .icon-archive-outline').should('be.visible');
 
         // * Channel is listed In drawer
         cy.get(`#sidebarItem_${testChannel.name}`).should('be.visible');
-        cy.get(`#sidebarItem_${testChannel.name} .icon__archive`).should('be.visible');
+        cy.get(`#sidebarItem_${testChannel.name} .icon-archive-outline`).should('be.visible');
 
         // * footer shows you are viewing an archived channel
         cy.get('#channelArchivedMessage').should('be.visible');
@@ -315,10 +317,10 @@ describe('Leave an archived channel', () => {
             // * Channel is listed In drawer
             // * Channel name visible in header
             cy.get(`#sidebarItem_${channelName}`).should('be.visible');
-            cy.get(`#sidebarItem_${channelName} .icon__archive`).should('be.visible');
+            cy.get(`#sidebarItem_${channelName} .icon-archive-outline`).should('be.visible');
 
             // * Archived icon is visible in header
-            cy.get('#channelHeaderInfo .icon__archive').should('be.visible');
+            cy.get('#channelHeaderInfo .icon-archive-outline').should('be.visible');
 
             // * Footer shows "You are viewing an archived channel. New messages cannot be posted. Close Channel"
             cy.get('#channelArchivedMessage').should('be.visible');

--- a/e2e/cypress/integration/archived_channel/join_archived_channel_spec.js
+++ b/e2e/cypress/integration/archived_channel/join_archived_channel_spec.js
@@ -112,8 +112,8 @@ function verifyViewingArchivedChannel(channel) {
     cy.get('#channelHeaderInfo .icon__archive').should('be.visible');
 
     // * Verify that the channel is visible in the sidebar with the archived icon
-    cy.get(`#sidebarItem_${channel.name}`).should('be.visible');
-    cy.get(`#sidebarItem_${channel.name} .icon__archive`).should('be.visible');
+    cy.get(`#sidebarItem_${channel.name}`).should('be.visible').
+        find('.icon-archive-outline').should('be.visible');
 
     // * Verify that the archived channel banner is visible at the bottom of the channel view
     cy.get('#channelArchivedMessage').should('be.visible');

--- a/e2e/cypress/integration/bot_accounts/sidebar_display_spec.js
+++ b/e2e/cypress/integration/bot_accounts/sidebar_display_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @bot_accounts
+// Group: @bot_accounts @not_cloud
 
 import {createBotPatch} from '../../support/api/bots';
 import {generateRandomUser} from '../../support/api/user';
@@ -21,6 +21,8 @@ describe('Bot accounts', () => {
     let createdUsers;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         cy.apiUpdateConfig({
             ServiceSettings: {
                 EnableBotAccountCreation: true,

--- a/e2e/cypress/integration/channel/archived_channels_1_spec.js
+++ b/e2e/cypress/integration/channel/archived_channels_1_spec.js
@@ -18,9 +18,6 @@ describe('Leave an archived channel', () => {
 
     before(() => {
         cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
             TeamSettings: {
                 ExperimentalViewArchivedChannels: true,
             },
@@ -302,9 +299,6 @@ describe('Leave an archived channel', () => {
     it('MM-T1696 - When clicking Browse Channels no options for archived channels are shown when the feature is disabled', () => {
         cy.apiAdminLogin();
         cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: 'default_on',
-            },
             TeamSettings: {
                 ExperimentalViewArchivedChannels: false,
             },

--- a/e2e/cypress/integration/channel/archived_channels_2_spec.js
+++ b/e2e/cypress/integration/channel/archived_channels_2_spec.js
@@ -19,9 +19,6 @@ describe('Leave an archived channel', () => {
 
     before(() => {
         cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
             TeamSettings: {
                 ExperimentalViewArchivedChannels: true,
             },

--- a/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
+++ b/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
@@ -103,7 +103,7 @@ describe('channel name tooltips', () => {
 
     it('Should show tooltip on hover - user with a long username', () => {
         // # Open a DM with the user
-        cy.get('#addDirectChannel').should('be.visible').click();
+        cy.uiAddDirectMessage().click();
         cy.focused().as('searchBox').type(longUser.username, {force: true});
 
         // * Verify that the user is selected in the results list before typing enter

--- a/e2e/cypress/integration/channel/channel_settings_spec.js
+++ b/e2e/cypress/integration/channel/channel_settings_spec.js
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 

--- a/e2e/cypress/integration/channel/channel_settings_spec.js
+++ b/e2e/cypress/integration/channel/channel_settings_spec.js
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
@@ -28,34 +29,6 @@ describe('Channel Settings', () => {
 
             // # Visit town-square channel
             cy.visit(`/${testTeam.name}/channels/town-square`);
-        });
-    });
-
-    it('C15052 All channel types have appropriate close button', () => {
-        cy.get('#publicChannelList').find('a.sidebar-item').each(($el) => {
-            cy.wrap($el).find('span.btn-close').should('not.exist');
-        });
-
-        cy.get('#privateChannelList').find('a.sidebar-item').each(($el) => {
-            cy.wrap($el).find('span.btn-close').should('not.exist');
-        });
-
-        // add a direct message incase there is not one
-        cy.get('#addDirectChannel').click();
-        cy.get('.more-modal__row.clickable').first().click();
-        cy.get('#saveItems').click();
-
-        // click on all the messages to make sure there are none left unread
-        cy.get('#directChannelList').find('a.sidebar-item').each(($el) => {
-            cy.wrap($el).as('channel');
-
-            // Click to mark as unread
-            cy.get('@channel').click({force: true});
-
-            cy.get('#postListContent').should('be.visible');
-
-            // check for the close button
-            cy.get('@channel').find('span.btn-close').should('exist');
         });
     });
 
@@ -100,7 +73,9 @@ describe('Channel Settings', () => {
         cy.get('#toggleMute').should('be.visible');
 
         // # Verify that off topic is last in the list of channels
-        cy.get('#publicChannelList').children().not('[data-testid="morePublicButton"]').last().should('contain', 'Off-Topic').get('a').should('have.class', 'muted');
+        cy.uiGetLhsSection('CHANNELS').find('.SidebarChannel').
+            last().should('contain', 'Off-Topic').
+            get('a').should('have.class', 'muted');
 
         // # Go to channel dropdown > Unmute channel
         cy.get('#channelHeaderDropdownIcon').click();
@@ -113,6 +88,7 @@ describe('Channel Settings', () => {
         cy.get('#toggleMute').should('not.be.visible');
 
         // # Verify that off topic is not last in the list of channels
-        cy.get('#publicChannelList').children().not('[data-testid="morePublicButton"]').last().should('not.contain', 'Off-Topic');
+        cy.uiGetLhsSection('CHANNELS').find('.SidebarChannel').
+            last().should('not.contain', 'Off-Topic');
     });
 });

--- a/e2e/cypress/integration/channel/close_direct_group_spec.js
+++ b/e2e/cypress/integration/channel/close_direct_group_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @channel @channel_settings
+// Group: @channel @channel_settings @not_cloud
 
 // Make sure that the current channel is Town Square and that the
 // channel identified by the passed name is no longer in the channel
@@ -27,6 +27,13 @@ describe('Close direct messages', () => {
     let testTeam;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableLegacySidebar: true,
+            },
+        });
+
         cy.apiInitSetup().then(({team, user}) => {
             testUser = user;
             testTeam = team;
@@ -82,6 +89,13 @@ describe('Close group messages', () => {
 
     before(() => {
         cy.apiAdminLogin();
+        cy.shouldNotRunOnCloudEdition();
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableLegacySidebar: true,
+            },
+        });
+
         cy.apiInitSetup().then(({team, user}) => {
             testUser = user;
             testTeam = team;

--- a/e2e/cypress/integration/channel/more_channels_spec.js
+++ b/e2e/cypress/integration/channel/more_channels_spec.js
@@ -60,10 +60,8 @@ describe('Channels', () => {
         cy.apiLogin(otherUser);
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        // # Go to LHS and click "More..." under Public Channels group
-        cy.get('#publicChannelList').should('be.visible').within(() => {
-            cy.findByText('More...').scrollIntoView().should('be.visible').click();
-        });
+        // # Go to LHS and click 'Browse Channels'
+        cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
         cy.get('#moreChannelsModal').should('be.visible').within(() => {
             // * Dropdown should be visible, defaulting to "Public Channels"
@@ -105,10 +103,8 @@ describe('Channels', () => {
             cy.findByText('Archive').should('be.visible').click();
         });
 
-        // # Go to LHS and click "More..." under Public Channels group
-        cy.get('#publicChannelList').should('be.visible').within(() => {
-            cy.findByText('More...').scrollIntoView().should('be.visible').click();
-        });
+        // # Go to LHS and click 'Browse Channels'
+        cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
         cy.get('#moreChannelsModal').should('be.visible').within(() => {
             // # CLick dropdown to open selection
@@ -141,7 +137,7 @@ describe('Channels', () => {
         cy.get('#sidebarItem_town-square').click();
 
         // * Assert that archived channel doesn't show up in LHS list
-        cy.get('#publicChannelList').should('not.contain', testChannel.display_name);
+        cy.get('#lhsList').should('not.contain', testChannel.display_name);
     });
 
     it('MM-T1702 Search works when changing public/archived options in the dropdown', () => {
@@ -193,10 +189,8 @@ describe('Channels', () => {
             cy.visit(`/${testTeam.name}/channels/town-square`);
         });
 
-        // # Go to LHS and click "More..." under Public Channels group
-        cy.get('#publicChannelList').should('be.visible').within(() => {
-            cy.findByText('More...').scrollIntoView().should('be.visible').click();
-        });
+        // # Go to LHS and click 'Browse Channels'
+        cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
         // * Dropdown should be visible, defaulting to "Public Channels"
         cy.get('#channelsMoreDropdown').should('be.visible').within((el) => {
@@ -247,10 +241,8 @@ function verifyMoreChannelsModalWithArchivedSelection(isEnabled, testUser, testT
 }
 
 function verifyMoreChannelsModal(isEnabled) {
-    // # Select "More..." on the left hand side menu
-    cy.get('#publicChannelList').should('be.visible').within(() => {
-        cy.findByText('More...').scrollIntoView().should('be.visible').click({force: true});
-    });
+    // # Go to LHS and click 'Browse Channels'
+    cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
     // * Verify that the more channels modal is open and with or without option to view archived channels
     cy.get('#moreChannelsModal').should('be.visible').within(() => {

--- a/e2e/cypress/integration/channel/more_public_channels_spec.js
+++ b/e2e/cypress/integration/channel/more_public_channels_spec.js
@@ -42,16 +42,15 @@ describe('more public channels', () => {
         });
     });
 
-    it('MM-T1664 Channels dont disappear from More Channels modal', () => {
+    it('MM-T1664 Channels do not disappear from More Channels modal', () => {
         // # Login as other user
         cy.apiLogin(otherUser);
 
         // # Go to town square
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        // # Go to LHS and click "More..." under Public Channels group
-        cy.findByRole('list', {name: 'public channels'}).
-            findByText('More...').scrollIntoView().should('be.visible').click();
+        // # Go to LHS and click 'Browse Channels'
+        cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
         // * Assert that the moreChannelsModel is visible
         cy.findByRole('dialog', {name: 'More Channels'}).should('be.visible').within(() => {
@@ -83,9 +82,8 @@ describe('more public channels', () => {
         // # Go to town square
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        // # Go to LHS and click "More..." under Public Channels group
-        cy.findByRole('list', {name: 'public channels'}).
-            findByText('More...').scrollIntoView().should('be.visible').click();
+        // # Go to LHS and click 'Browse Channels'
+        cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
         // * Assert the moreChannelsModel is visible
         cy.findByRole('dialog', {name: 'More Channels'}).should('be.visible').within(() => {

--- a/e2e/cypress/integration/channel_settings/channel_name_validations_spec.js
+++ b/e2e/cypress/integration/channel_settings/channel_name_validations_spec.js
@@ -32,7 +32,7 @@ describe('Channel routing', () => {
 
     it('MM-T884_1 Renaming channel name validates against two user IDs being used in URL', () => {
         // # click on create public channel
-        cy.get('#createPublicChannel').click();
+        cy.uiBrowseOrCreateChannel('Create New Channel').click();
 
         // * Verify that the new channel modal is visible
         cy.get('.new-channel__modal').should('be.visible').within(() => {
@@ -59,7 +59,7 @@ describe('Channel routing', () => {
 
     it('MM-T884_2 Creating new channel validates against two user IDs being used as channel name', () => {
         // # click on create public channel
-        cy.get('#createPublicChannel').click();
+        cy.uiBrowseOrCreateChannel('Create New Channel').click();
 
         // * Verify that the new channel modal is visible
         cy.get('.new-channel__modal').should('be.visible').within(() => {

--- a/e2e/cypress/integration/channel_sidebar/category_collapsing_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/category_collapsing_spec.js
@@ -18,12 +18,6 @@ describe('Channel sidebar', () => {
     const sysadmin = getAdminAccount();
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         cy.apiInitSetup({loginAfter: true});
     });
 

--- a/e2e/cypress/integration/channel_sidebar/category_muting_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/category_muting_spec.js
@@ -21,12 +21,6 @@ describe('Category muting', () => {
     let testUser;
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         cy.apiInitSetup({loginAfter: true}).then((({team, user}) => {
             testTeam = team;
             testUser = user;

--- a/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
@@ -25,12 +25,6 @@ describe('Channel sidebar', () => {
     let testUser;
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
             testTeam = team;

--- a/e2e/cypress/integration/channel_sidebar/custom_categories_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/custom_categories_spec.js
@@ -17,12 +17,6 @@ import {clickCategoryMenuItem} from './helpers';
 
 describe('Channel sidebar', () => {
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);

--- a/e2e/cypress/integration/channel_sidebar/dm_category_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/dm_category_spec.js
@@ -20,13 +20,8 @@ describe('MM-T3156 DM category', () => {
     const sysadmin = getAdminAccount();
     let testUser;
     const usernames = [];
-    before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
 
+    before(() => {
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
             testUser = user;

--- a/e2e/cypress/integration/channel_sidebar/dm_gm_behaviour_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/dm_gm_behaviour_spec.js
@@ -17,13 +17,6 @@ describe('DM category', () => {
     const sysadmin = getAdminAccount();
     let testUser;
     before(() => {
-        // # Enable channel sidebar organization
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: 'default_on',
-            },
-        });
-
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
             testUser = user;

--- a/e2e/cypress/integration/channel_sidebar/drag_and_drop_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/drag_and_drop_spec.js
@@ -20,12 +20,6 @@ describe('Channel sidebar', () => {
     let channelName;
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         cy.apiInitSetup({loginAfter: true});
     });
 

--- a/e2e/cypress/integration/channel_sidebar/group_unreads_separately_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/group_unreads_separately_spec.js
@@ -1,0 +1,145 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @channel_sidebar
+
+import {getAdminAccount} from '../../support/env';
+
+describe('Channel sidebar - group unreads separately', () => {
+    let testTeam;
+    let testChannel;
+
+    beforeEach(() => {
+        cy.apiAdminLogin().then(() => {
+            cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+                testTeam = team;
+                testChannel = channel;
+
+                cy.visit(`/${team.name}/channels/town-square`);
+
+                // # Toggle the unreads category setting
+                enableOrDisableUnreadsCategory();
+
+                // # Receive a message to the new channel
+                cy.postMessageAs({sender: getAdminAccount(), message: 'test message', channelId: testChannel.id});
+            });
+        });
+    });
+
+    it('MM-T3719_1 Unreads category should show only if there is an unread message', () => {
+        // * Verify UNREADS category is shown and that the channel is in there
+        cy.get('.SidebarChannelGroup:contains(UNREADS)').should('be.visible').within(() => {
+            cy.get('.SidebarChannelGroupHeader:contains(UNREADS)').should('be.visible');
+            cy.get(`.SidebarChannel.unread:contains(${testChannel.display_name})`).should('be.visible');
+        });
+
+        // # Click on the unread channel
+        cy.get(`.SidebarChannel.unread .SidebarLink:contains(${testChannel.display_name})`).should('be.visible').click();
+
+        // * Verify we've switched to the new channel
+        cy.url().should('include', `/${testTeam.name}/channels/${testChannel.name}`);
+
+        // * Verify the channel is no longer unread but hasn't left the unreads category
+        cy.get('.SidebarChannelGroup:contains(UNREADS)').should('be.visible').get(`.SidebarChannel:not(.unread):contains(${testChannel.display_name})`).should('be.visible');
+
+        // # Switch to another channel
+        cy.get('.SidebarLink:contains(Town Square)').should('be.visible').click();
+
+        // * Verify unreads category has disappeared
+        cy.get('.SidebarChannelGroupHeader:contains(UNREADS)').should('not.be.visible');
+
+        // * Verify channel is in the CHANNELS category
+        cy.get('.SidebarChannelGroup:contains(CHANNELS)').should('be.visible').get(`.SidebarChannel:contains(${testChannel.display_name})`).should('be.visible');
+    });
+
+    it('MM-T3719_2 Unreads category should disappear when the setting is turned off', () => {
+        // * Verify UNREADS category is shown and that the channel is in there
+        cy.get('.SidebarChannelGroup:contains(UNREADS)').should('be.visible').within(() => {
+            cy.get('.SidebarChannelGroupHeader:contains(UNREADS)').should('be.visible');
+            cy.get(`.SidebarChannel.unread:contains(${testChannel.display_name})`).should('be.visible');
+        });
+
+        // # Disable the unreads category
+        enableOrDisableUnreadsCategory(false);
+
+        // * Verify unreads category has disappeared
+        cy.get('.SidebarChannelGroupHeader:contains(UNREADS)').should('not.be.visible');
+
+        // * Verify that the channel is in the CHANNELS category
+        cy.get('.SidebarChannelGroup:contains(CHANNELS)').should('be.visible').get(`.SidebarChannel.unread:contains(${testChannel.display_name})`).should('be.visible');
+    });
+
+    it('MM-T3719_3 Channels marked as unread should appear in the unreads category', () => {
+        // # Click on the unread channel
+        cy.get(`.SidebarChannel.unread .SidebarLink:contains(${testChannel.display_name})`).should('be.visible').click();
+
+        // # Switch to another channel
+        cy.get('.SidebarLink:contains(Town Square)').should('be.visible').click();
+
+        // * Verify that the channel is currently in the CHANNELS category
+        cy.get('.SidebarChannelGroup:contains(CHANNELS)').should('be.visible').get(`.SidebarChannel:not(.unread):contains(${testChannel.display_name})`).should('be.visible');
+
+        // # Switch back to the test channel
+        cy.get(`.SidebarChannel:not(.unread) .SidebarLink:contains(${testChannel.display_name})`).should('be.visible').click();
+
+        // # Mark the last message as unread
+        cy.getLastPostId().then((postId) => {
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
+        });
+
+        // * Verify that the channel appears in the UNREADS section
+        cy.get('.SidebarChannelGroup:contains(UNREADS)').should('be.visible').get(`.SidebarChannel.unread:contains(${testChannel.display_name})`).should('be.visible');
+    });
+
+    it('MM-T3719_4 Read channels should not enter the unreads category', () => {
+        // # Switch to a read channel
+        cy.get('.SidebarLink:contains(Off-Topic)').should('be.visible').click();
+
+        // * Verify channel is not in the UNREADS category
+        cy.get('.SidebarChannelGroup:contains(CHANNELS)').should('be.visible').get('.SidebarChannel:not(.unread):contains(Off-Topic)').should('be.visible');
+    });
+});
+
+function navigateToSidebarSettings() {
+    cy.get('#channel_view').should('be.visible');
+    cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+    cy.get('#accountSettings').should('be.visible').click();
+    cy.get('#accountSettingsModal').should('be.visible');
+
+    cy.get('#sidebarButton').should('be.visible');
+    cy.get('#sidebarButton').click();
+
+    cy.get('#sidebarLi.active').should('be.visible');
+    cy.get('#sidebarTitle > .tab-header').should('have.text', 'Sidebar Settings');
+}
+
+function toggleOnOrOffUnreadsCategory(toggleOn = true) {
+    navigateToSidebarSettings();
+
+    cy.get('#showUnreadsCategoryEdit').click();
+
+    if (toggleOn) {
+        cy.findByTestId('showUnreadsCategoryOn').click();
+    } else {
+        cy.findByTestId('showUnreadsCategoryOff').click();
+    }
+}
+
+function enableOrDisableUnreadsCategory(enable = true) {
+    toggleOnOrOffUnreadsCategory(enable);
+
+    cy.get('#saveSetting').click();
+    if (enable) {
+        cy.get('#showUnreadsCategoryDesc').should('have.text', 'On');
+    } else {
+        cy.get('#showUnreadsCategoryDesc').should('have.text', 'Off');
+    }
+    cy.get('#accountSettingsHeader > .close').click();
+}

--- a/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
@@ -14,12 +14,6 @@ import {getRandomId} from '../../utils';
 
 describe('Channel sidebar', () => {
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);

--- a/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
@@ -17,12 +17,6 @@ describe('Channel switching', () => {
     const sysadmin = getAdminAccount();
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);

--- a/e2e/cypress/integration/channel_sidebar/legacy_sidebar_settings_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/legacy_sidebar_settings_spec.js
@@ -8,21 +8,18 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @channel_sidebar
+// Group: @channel_sidebar @not_cloud
 
 describe('Legacy sidebar settings', () => {
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
+        cy.shouldNotRunOnCloudEdition();
 
         // # Login as test user and visit town-square
         cy.apiInitSetup().then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
         });
     });
+
     it('MM-T2002 Should toggle the legacy sidebar when Enable Legacy Sidebar setting is toggled', () => {
         // * Verify the the new sidebar is currently displayed
         cy.get('#SidebarContainer').should('be.visible');

--- a/e2e/cypress/integration/channel_sidebar/new_category_badge_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/new_category_badge_spec.js
@@ -14,12 +14,6 @@ import {getRandomId} from '../../utils';
 
 describe('New category badge', () => {
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);

--- a/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
@@ -15,12 +15,6 @@ import {getRandomId} from '../../utils';
 
 describe('Channel sidebar', () => {
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);

--- a/e2e/cypress/integration/channel_sidebar/sidebar_category_menu_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/sidebar_category_menu_spec.js
@@ -12,12 +12,6 @@
 
 describe('Sidebar category menu', () => {
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: 'default_on',
-            },
-        });
-
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
         });

--- a/e2e/cypress/integration/channel_sidebar/sidebar_channel_menu_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/sidebar_channel_menu_spec.js
@@ -27,12 +27,6 @@ describe('Sidebar channel menu', () => {
     let userName;
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
             teamName = team.name;
             userName = user.username;

--- a/e2e/cypress/integration/channel_sidebar/unread_filter_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/unread_filter_spec.js
@@ -24,12 +24,6 @@ describe('Channel sidebar unread filter', () => {
     let testUser;
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         cy.apiInitSetup({loginAfter: true}).then(({user}) => {
             testUser = user;
 
@@ -39,7 +33,7 @@ describe('Channel sidebar unread filter', () => {
 
     it('MM-T3441 should change the filter label when the unread filter changes state', () => {
         // * Verify that the unread filter is in all channels state
-        cy.get('#sidebar-left').should('be.visible').within(() => {
+        cy.findByRole('application', {name: 'channel sidebar region'}).within(() => {
             cy.findAllByText('UNREADS').should('not.exist');
             cy.findAllByRole('button', {name: 'CHANNELS'}).should('be.visible');
             cy.findAllByRole('button', {name: 'DIRECT MESSAGES'}).should('be.visible');
@@ -48,7 +42,7 @@ describe('Channel sidebar unread filter', () => {
         enableUnreadFilter();
 
         // * Verify that the unread filter is in filter by unread state
-        cy.get('#sidebar-left').should('be.visible').within(() => {
+        cy.findByRole('application', {name: 'channel sidebar region'}).within(() => {
             cy.findAllByText('UNREADS').should('be.visible');
             cy.findAllByRole('button', {name: 'CHANNELS'}).should('not.exist');
             cy.findAllByRole('button', {name: 'DIRECT MESSAGES'}).should('not.exist');
@@ -57,7 +51,7 @@ describe('Channel sidebar unread filter', () => {
         disableUnreadFilter();
 
         // * Verify that the unread filter is back in all channels state
-        cy.get('#sidebar-left').should('be.visible').within(() => {
+        cy.findByRole('application', {name: 'channel sidebar region'}).within(() => {
             cy.findAllByText('UNREADS').should('not.exist');
             cy.findAllByRole('button', {name: 'CHANNELS'}).should('be.visible');
             cy.findAllByRole('button', {name: 'DIRECT MESSAGES'}).should('be.visible');

--- a/e2e/cypress/integration/emoji/react_to_last_message_shortcut_spec.js
+++ b/e2e/cypress/integration/emoji/react_to_last_message_shortcut_spec.js
@@ -72,9 +72,7 @@ describe('Keyboard shortcut for adding reactions to last message in channel or t
 
     it('Should open emoji picker for last message by shortcut in the channel view when the focus is not on the center text box', () => {
         // # Click anywhere to take focus away from center text box
-        cy.get('#lhsList').within(() => {
-            cy.findByText('Town Square').click();
-        });
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
 
         // # Emulate react to last message shortcut without focus on center
         pressShortcutReactToLastMessage();
@@ -299,9 +297,7 @@ describe('Keyboard shortcut for adding reactions to last message in channel or t
         cy.wait(TIMEOUTS.FIVE_SEC);
 
         // # Click anywhere to take focus away from RHS text box
-        cy.get('#lhsList').within(() => {
-            cy.findByText('Town Square').click();
-        });
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
 
         // # Focus back on Center textbox and enter shortcut
         pressShortcutReactToLastMessage('CENTER');
@@ -353,9 +349,7 @@ describe('Keyboard shortcut for adding reactions to last message in channel or t
         cy.wait(TIMEOUTS.FIVE_SEC);
 
         // # Click anywhere to take focus away from RHS text box
-        cy.get('#lhsList').within(() => {
-            cy.findByText('Town Square').click();
-        });
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
 
         // # Enter shortcut without focus on Center textbox
         pressShortcutReactToLastMessage();

--- a/e2e/cypress/integration/enterprise/accessibility/accessibility_modals_dialogs_spec.js
+++ b/e2e/cypress/integration/enterprise/accessibility/accessibility_modals_dialogs_spec.js
@@ -88,7 +88,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
 
     it('MM-T1466 Accessibility Support in Direct Messages Dialog screen', () => {
         // * Verify the aria-label in create direct message button
-        cy.get('#addDirectChannel').should('have.attr', 'aria-label', 'write a direct message').click();
+        cy.uiAddDirectMessage().click();
 
         // * Verify the accessibility support in Direct Messages Dialog`
         cy.get('#moreDmModal').should('have.attr', 'role', 'dialog').and('have.attr', 'aria-labelledby', 'moreDmModalLabel').within(() => {
@@ -140,9 +140,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
                 cy.reload();
 
                 // * Verify the aria-label in more public channels button
-                cy.get('#sidebarPublicChannelsMore', {timeout: TIMEOUTS.ONE_MIN}).
-                    should('be.visible').
-                    and('have.attr', 'aria-label', 'See more public channels').click();
+                cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
                 // * Verify the accessibility support in More Channels Dialog`
                 cy.get('#moreChannelsModal').

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_sysadmin_onboarding_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_sysadmin_onboarding_spec.js
@@ -17,12 +17,6 @@ describe('Cloud Onboarding - Sysadmin', () => {
     let sysadmin;
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         // # Check if with license and has matching database
         cy.apiRequireLicenseForFeature('Cloud');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
@@ -46,9 +46,7 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
         // # Create private channel, do not add new user to it (sets @privateChannel alias)
         createPrivateChannel(testTeam.id).then((channel) => {
             // # Go to off-topic channel to partially reload the page
-            cy.get('#sidebarChannelContainer').should('be.visible').within(() => {
-                cy.findAllByText('Off-Topic').should('be.visible').click();
-            });
+            cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
 
             // # Search for the private channel
             searchForChannel(channel.name);
@@ -63,9 +61,7 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
         // # Create private channel and add new user to it (sets @privateChannel alias)
         createPrivateChannel(testTeam.id, testUser).then((channel) => {
             // # Go to off-topic channel to partially reload the page
-            cy.get('#sidebarChannelContainer').should('be.visible').within(() => {
-                cy.findAllByText('Off-Topic').should('be.visible').click();
-            });
+            cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
 
             // # Search for the private channel
             searchForChannel(channel.name);
@@ -100,9 +96,7 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
             // # Create a private channel where the new user is not a member of
             createPrivateChannel(teamResponse.data.id).then((channel) => {
                 // # Go to off-topic channel to partially reload the page
-                cy.get('#sidebarChannelContainer').should('be.visible').within(() => {
-                    cy.findAllByText('Off-Topic').should('be.visible').click();
-                });
+                cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
 
                 // # Search for the private channel
                 searchForChannel(channel.name);

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
@@ -335,7 +335,7 @@ describe('Autocomplete with Elasticsearch - Users', () => {
             const thor = testUsers.thor;
 
             // # Open of the add direct message modal
-            cy.get('#addDirectChannel').click({force: true});
+            cy.uiAddDirectMessage().click();
 
             // # Type username into input
             cy.get('.more-direct-channels').

--- a/e2e/cypress/integration/enterprise/group_mentions/group_mentions_posts_spec.js
+++ b/e2e/cypress/integration/enterprise/group_mentions/group_mentions_posts_spec.js
@@ -176,7 +176,7 @@ describe('Group Mentions', () => {
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Trigger DM with a user
-        cy.get('#addDirectChannel').click();
+        cy.uiAddDirectMessage().click();
         cy.get('.more-modal__row.clickable').first().click();
         cy.get('#saveItems').click();
 
@@ -217,7 +217,7 @@ describe('Group Mentions', () => {
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Trigger DM with couple of users
-        cy.get('#addDirectChannel').click();
+        cy.uiAddDirectMessage().click();
         cy.get('.more-modal__row.clickable').first().click();
         cy.get('.more-modal__row.clickable').eq(1).click();
         cy.get('#saveItems').click();

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -70,10 +70,7 @@ describe('Guest Account - Guest User Experience', () => {
         });
 
         // * Verify Reduced Options in LHS
-        const missingLHSOptions = ['#createPublicChannel', "li[data-testid='morePublicButton']", '#createPrivateChannel'];
-        missingLHSOptions.forEach((missingOption) => {
-            cy.get(missingOption).should('not.exist');
-        });
+        cy.findByRole('button', {name: 'Add Channel Dropdown'}).should('not.exist');
 
         // * Verify Guest Badge in Channel Header
         cy.get('#channelHeaderDescription').within(($el) => {
@@ -96,7 +93,7 @@ describe('Guest Account - Guest User Experience', () => {
         cy.get('#member_popover').click();
 
         // * Verify list of Users in Direct Messages Dialog
-        cy.get('#addDirectChannel').click().wait(TIMEOUTS.FIVE_SEC);
+        cy.uiAddDirectMessage().click().wait(TIMEOUTS.FIVE_SEC);
         cy.get('#multiSelectList').should('be.visible').within(($el) => {
             // * Verify only 2 users - Guest and sysadmin are listed
             cy.wrap($el).children().should('have.length', 2);
@@ -121,7 +118,7 @@ describe('Guest Account - Guest User Experience', () => {
         cy.get('#channel-header').click();
 
         // * Verify Guest User can see only 1 additional channel in LHS plus town-square and off-topic
-        cy.get('#publicChannelList').find('a').should('have.length', 3);
+        cy.uiGetLhsSection('CHANNELS').find('.SidebarChannel').should('have.length', 3);
 
         // * Verify list of Users a Guest User can see in Team Members dialog
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
@@ -148,10 +145,7 @@ describe('Guest Account - Guest User Experience', () => {
         cy.uiCloseMainMenu();
 
         // * Verify Options in LHS are changed
-        const missingLHSOptions = ['#createPublicChannel', "li[data-testid='morePublicButton']", '#createPrivateChannel'];
-        missingLHSOptions.forEach((missingOption) => {
-            cy.get(missingOption).should('be.visible');
-        });
+        cy.findByRole('button', {name: 'Add Channel Dropdown'}).should('be.visible');
 
         // * Verify Guest Badge in Channel Header is removed
         cy.get('#sidebarItem_town-square').click();

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
@@ -32,7 +32,6 @@ describe('MM-18045 Verify Guest User Identification in different screens', () =>
             },
             ServiceSettings: {
                 EnableEmailInvitations: true,
-                EnableLegacySidebar: true,
             },
         });
 
@@ -150,7 +149,7 @@ describe('MM-18045 Verify Guest User Identification in different screens', () =>
 
     it('Verify Guest Badge in Switch Channel Dialog', () => {
         // # Click the sidebar switcher button
-        cy.get('#sidebarSwitcherButton').click();
+        cy.uiGetChannelSwitcher().click();
 
         // # Type the guest user name on Channel switcher input
         cy.findByRole('textbox', {name: 'quick switch input'}).type(guest.username).wait(TIMEOUTS.HALF_SEC);
@@ -167,7 +166,7 @@ describe('MM-18045 Verify Guest User Identification in different screens', () =>
 
     it('MM-T1377 Verify Guest Badge in DM Search dialog', () => {
         // #Click on plus icon of Direct Messages
-        cy.get('#addDirectChannel').click().wait(TIMEOUTS.HALF_SEC);
+        cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
 
         // # Search for the Guest User
         cy.focused().type(guest.username, {force: true}).wait(TIMEOUTS.HALF_SEC);
@@ -182,7 +181,7 @@ describe('MM-18045 Verify Guest User Identification in different screens', () =>
 
     it('Verify Guest Badge in DM header and GM header', () => {
         // # Open a DM with Guest User
-        cy.get('#addDirectChannel').click().wait(TIMEOUTS.HALF_SEC);
+        cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
         cy.focused().type(guest.username, {force: true}).type('{enter}', {force: true}).wait(TIMEOUTS.HALF_SEC);
         cy.get('#saveItems').click().wait(TIMEOUTS.HALF_SEC);
 
@@ -193,7 +192,7 @@ describe('MM-18045 Verify Guest User Identification in different screens', () =>
         });
 
         // # Open a GM with Guest User and Sysadmin
-        cy.get('#addDirectChannel').click().wait(TIMEOUTS.HALF_SEC);
+        cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
         cy.focused().type(guest.username, {force: true}).type('{enter}', {force: true}).wait(TIMEOUTS.HALF_SEC);
         cy.get('#saveItems').click().wait(TIMEOUTS.HALF_SEC);
 

--- a/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -264,7 +264,7 @@ describe('Guest Account - Member Invitation Flow', () => {
         cy.get('#headerTeamName').should('have.text', testTeam.display_name);
 
         // * Verify if user has access to the default channels
-        cy.get('#sidebarChannelContainer').within(() => {
+        cy.uiGetLhsSection('CHANNELS').within(() => {
             cy.findByText('Off-Topic').should('be.visible');
             cy.findByText('Town Square').should('be.visible');
         });
@@ -299,7 +299,7 @@ describe('Guest Account - Member Invitation Flow', () => {
             cy.get('@teamButton').click().wait(TIMEOUTS.TWO_SEC);
 
             // * Verify if user has access to the default channels in the invited teams
-            cy.get('#sidebarChannelContainer').within(() => {
+            cy.uiGetLhsSection('CHANNELS').within(() => {
                 cy.findByText('Off-Topic').should('be.visible');
                 cy.findByText('Town Square').should('be.visible');
             });

--- a/e2e/cypress/integration/enterprise/ldap/ldap_group_sync_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_group_sync_spec.js
@@ -227,7 +227,7 @@ context('ldap', () => {
 
             // # Go to team page to look for this channel in public channel directory
             cy.visit(`/${testTeam.name}`);
-            cy.get('#sidebarPublicChannelsMore').click();
+            cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
             // * Search private channel name and make sure it isn't there in public channel directory
             cy.get('#searchChannelsTextbox').type(`${testChannel.display_name}`);
@@ -396,7 +396,7 @@ context('ldap', () => {
                 cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
                 // # Click the sidebar switcher button
-                cy.get('#sidebarSwitcherButton').click();
+                cy.uiGetChannelSwitcher().click();
 
                 // * Channel switcher hint should be visible
                 cy.get('#quickSwitchHint', {timeout: TIMEOUTS.TWO_SEC}).should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');
@@ -421,7 +421,7 @@ context('ldap', () => {
                 cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
                 // # Click the sidebar switcher button
-                cy.get('#sidebarSwitcherButton').click();
+                cy.uiGetChannelSwitcher().click();
 
                 // * Channel switcher hint should be visible
                 cy.get('#quickSwitchHint', {timeout: TIMEOUTS.TWO_SEC}).should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');
@@ -447,9 +447,11 @@ context('ldap', () => {
             ).then(({channel: publicChannel}) => {
                 cy.apiLogin(testUser);
 
-                // # Click more under public channels
+                // # Visit off-topic channel
                 cy.visit(`/${testTeam.name}/channels/off-topic`);
-                cy.get('#sidebarPublicChannelsMore').click();
+
+                // # Go to LHS and click 'Browse Channels'
+                cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
                 // * Search public channel and ensure it appears in the list
                 cy.get('#searchChannelsTextbox').type(`${publicChannel.display_name}`);
@@ -462,9 +464,11 @@ context('ldap', () => {
                 // # Login as a normal user
                 cy.apiLogin(testUser);
 
-                // # Click more under public channels
+                // # Visit off-topic channel
                 cy.visit(`/${testTeam.name}/channels/off-topic`);
-                cy.get('#sidebarPublicChannelsMore').click();
+
+                // # Go to LHS and click 'Browse Channels'
+                cy.uiBrowseOrCreateChannel('Browse Channels').click();
 
                 // * Search private channel name and make sure it isn't there in public channel directory
                 cy.get('#searchChannelsTextbox').type(`${publicChannel.display_name}`);

--- a/e2e/cypress/integration/enterprise/ldap/ldap_guest_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_guest_spec.js
@@ -159,7 +159,7 @@ describe('LDAP guest', () => {
         // # Create team if no membership
         cy.skipOrCreateTeam(testSettings, getRandomId()).then(() => {
             // * Verify user is a member
-            cy.get('#createPublicChannel').should('exist');
+            cy.findByRole('button', {name: 'Add Channel Dropdown'}).should('exist');
 
             // # Demote the user
             demoteUserToGuest(user2Data);
@@ -170,10 +170,10 @@ describe('LDAP guest', () => {
                 cy.doLDAPLogin(testSettings);
 
                 // * Check if user is in the team
-                cy.get('#addDirectChannel').should('exist');
+                cy.uiAddDirectMessage().should('exist');
 
                 // * Check the user is a guest
-                cy.get('#createPublicChannel').should('not.exist');
+                cy.findByRole('button', {name: 'Add Channel Dropdown'}).should('not.exist');
             });
         });
     });

--- a/e2e/cypress/integration/enterprise/permissions/team_permissions_spec.js
+++ b/e2e/cypress/integration/enterprise/permissions/team_permissions_spec.js
@@ -150,8 +150,11 @@ describe('Team Permissions', () => {
         // # Go to main channel
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        // * Verify that the create private channel `+` button is not present
-        cy.get('#createPrivateChannel').should('not.exist');
+        // # Click on create new channel at LHS
+        cy.uiBrowseOrCreateChannel('Create New Channel').click();
+
+        // * Verify that the create private channel is not present
+        cy.findByRole('dialog', {name: 'New Channel'}).find('.radio').should('have.length', 1).and('contain', 'Public').and('not.contain', 'Private');
     });
 
     it('MM-T2900 As a Channel Admin, the test user is now able to add or remove other users from public channel', () => {

--- a/e2e/cypress/integration/enterprise/saml/saml_guest_member_spec.js
+++ b/e2e/cypress/integration/enterprise/saml/saml_guest_member_spec.js
@@ -67,9 +67,6 @@ describe('SAML Guest', () => {
             UsernameAttribute: 'username',
             LoginButtonText: loginButtonText,
         },
-        ServiceSettings: {
-            EnableLegacySidebar: false,
-        },
     };
 
     let testSettings;

--- a/e2e/cypress/integration/enterprise/system_console/about/edition_and_license_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/about/edition_and_license_spec.js
@@ -34,19 +34,19 @@ describe('System console', () => {
             // * Login as system admin and go the channel we created earlier and expect the create public channel button is visible
             cy.apiAdminLogin();
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
-            cy.get('#createPublicChannel', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+            cy.findByRole('button', {name: 'Add Channel Dropdown'}).should('be.visible');
             cy.wait(TIMEOUTS.FIVE_SEC);
 
             // * Login as team admin and go the channel we created earlier and expect the create public channel button is visible
             cy.apiLogin(testUserTeamAdmin);
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
-            cy.get('#createPublicChannel', {timeout: TIMEOUTS.ONE_MIN}).should('not.be.visible');
+            cy.findByRole('button', {name: 'Add Channel Dropdown'}).should('not.be.visible');
             cy.wait(TIMEOUTS.FIVE_SEC);
 
             // * Login as non-team admin and go the channel we created earlier and expect the create public channel button is not visible
             cy.apiLogin(testUserNonTeamAdmin);
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
-            cy.get('#createPublicChannel', {timeout: TIMEOUTS.ONE_MIN}).should('not.be.visible');
+            cy.findByRole('button', {name: 'Add Channel Dropdown'}).should('not.be.visible');
             cy.wait(TIMEOUTS.FIVE_SEC);
         };
 

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -155,10 +155,10 @@ describe('Integrations', () => {
         cy.postMessage('/leave');
 
         // * Verity Off-Topic is not shown in LHS
-        cy.get('#sidebarChannelContainer').should('be.visible').should('not.contain', 'Off-Topic');
+        cy.get('#lhsList').should('be.visible').should('not.contain', 'Off-Topic');
 
         // * Verify user is redirected to Town Square
-        cy.get('#sidebarChannelContainer').should('be.visible').should('contain', 'Town Square');
+        cy.uiGetLhsSection('CHANNELS').find('.active').should('contain', 'Town Square');
         cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
     });
 

--- a/e2e/cypress/integration/integrations/builtin_commands/groupmsg_command_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/groupmsg_command_spec.js
@@ -20,7 +20,6 @@ describe('Integrations', () => {
     let townSquareUrl;
 
     before(() => {
-        cy.apiAdminLogin();
         cy.apiInitSetup().then(({team, user}) => {
             testUser = user;
             townSquareUrl = `/${team.name}/channels/town-square`;
@@ -48,7 +47,7 @@ describe('Integrations', () => {
             });
 
             // # Go back to town-square channel
-            cy.contains('.sidebar-item', 'Town Square').click();
+            cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         }
 
         loginAndVisitChannel(testUser, townSquareUrl);

--- a/e2e/cypress/integration/integrations/builtin_commands/invite_command_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/invite_command_spec.js
@@ -67,11 +67,10 @@ describe('Integrations', () => {
             cy.visit(`${testTeam.name}/channels/town-square`);
 
             // * Added user sees channel added to LHS, mention badge
-            cy.get('#sidebarChannelContainer', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').within(() => {
-                cy.findByLabelText(`${testChannel.display_name.toLowerCase()} public channel 1 mention`).
-                    should('be.visible').
-                    click();
-            });
+            cy.uiGetLhsSection('CHANNELS').
+                findByLabelText(`${testChannel.display_name.toLowerCase()} public channel 1 mention`).
+                should('be.visible').
+                click();
 
             // * Added user sees system message "username added to the channel by username."
             cy.uiWaitUntilMessagePostedIncludes(`You were added to the channel by @${testUser.username}`);
@@ -90,7 +89,7 @@ describe('Integrations', () => {
         // * User added to channel as expected
         cy.uiWaitUntilMessagePostedIncludes(`${userToInviteGM.username} added to ${testChannel.name} channel.`);
 
-        cy.get('#addDirectChannel').click();
+        cy.uiAddDirectMessage().click();
         cy.get('#selectItems').type(`${userToInviteDM.username}`).wait(TIMEOUTS.ONE_SEC);
         cy.get('#multiSelectList').findByText(`@${userToInviteDM.username}`).click();
         cy.findByText('Go').click();
@@ -118,11 +117,10 @@ describe('Integrations', () => {
         loginAndVisitChannel(userToInvite, townSquareUrl);
 
         // * Added user sees channel added to LHS, mention badge.
-        cy.get('#sidebarChannelContainer', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').within(() => {
-            cy.findByLabelText(`${testChannel.display_name.toLowerCase()} public channel 1 mention`).
-                should('be.visible').
-                click();
-        });
+        cy.uiGetLhsSection('CHANNELS').
+            findByLabelText(`${testChannel.display_name.toLowerCase()} public channel 1 mention`).
+            should('be.visible').
+            click();
 
         // * Added user sees system message "username added to the channel by username."
         cy.uiWaitUntilMessagePostedIncludes(`You were added to the channel by @${testUser.username}`);
@@ -140,7 +138,7 @@ describe('Integrations', () => {
         // * Error appears: "We couldn't find the user. They may have been deactivated by the System Administrator."
         cy.uiWaitUntilMessagePostedIncludes('We couldn\'t find the user. They may have been deactivated by the System Administrator.');
 
-        cy.get('#addDirectChannel').click();
+        cy.uiAddDirectMessage().click();
         cy.get('#selectItems').type(`${userDM.username}`).wait(TIMEOUTS.ONE_SEC);
         cy.get('#multiSelectList').findByText(`@${userDM.username}`).click();
         cy.findByText('Go').click();
@@ -166,7 +164,7 @@ describe('Integrations', () => {
         // * Error appears: "[username] is already in the channel"
         cy.uiWaitUntilMessagePostedIncludes(`${userToInvite.username} is already in the channel.`);
 
-        cy.get('#addDirectChannel').click();
+        cy.uiAddDirectMessage().click();
         cy.get('#selectItems').type(`${userDM.username}`).wait(TIMEOUTS.ONE_SEC);
         cy.get('#multiSelectList').findByText(`@${userDM.username}`).click();
         cy.findByText('Go').click();
@@ -184,7 +182,7 @@ describe('Integrations', () => {
 
         // # As UserA create a new public channel
         loginAndVisitChannel(testUser, townSquareUrl);
-        cy.get('#createPublicChannel', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click();
+        cy.uiBrowseOrCreateChannel('Create New Channel').click();
         cy.get('#newChannelName').type(`${userA.username}-channel`);
         cy.get('#submitNewChannel').click();
         cy.get('#postListContent').should('be.visible');
@@ -192,7 +190,7 @@ describe('Integrations', () => {
         cy.apiLogout();
         loginAndVisitChannel(userB, townSquareUrl);
 
-        cy.get('#addDirectChannel', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click();
+        cy.uiAddDirectMessage().click();
         cy.get('#selectItems').type(`${userDM.username}`).wait(TIMEOUTS.ONE_SEC);
         cy.get('#multiSelectList').findByText(`@${userDM.username}`).click();
         cy.findByText('Go').click();

--- a/e2e/cypress/integration/integrations/builtin_commands/user_status_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/user_status_spec.js
@@ -46,11 +46,11 @@ describe('Integrations', () => {
         verifyUserStatus(offline);
 
         // # Switch to off-topic channel
-        cy.findByLabelText('public channels').findByText('Off-Topic').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
         cy.findByLabelText('channel header region').findByText('Off-Topic').should('be.visible');
 
         // # Then switch back to town-square channel again
-        cy.findByLabelText('public channels').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.findByLabelText('channel header region').findByText('Town Square').should('be.visible');
 
         // * Should not appear "New Messages" line

--- a/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
+++ b/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
@@ -93,7 +93,7 @@ describe('Prompting set status', () => {
 
 const openDM = (username) => {
     // # Click '+' to open DM and wait for some time to get the DM modal fully loaded
-    cy.get('#addDirectChannel').click().wait(TIMEOUTS.TWO_SEC);
+    cy.uiAddDirectMessage().click().wait(TIMEOUTS.TWO_SEC);
 
     // # Type username and wait for some time to load users list
     cy.get('#selectItems').should('be.visible').type(`${username}`).wait(TIMEOUTS.TWO_SEC);

--- a/e2e/cypress/integration/integrations/slash_commands_spec.js
+++ b/e2e/cypress/integration/integrations/slash_commands_spec.js
@@ -65,38 +65,38 @@ describe('Integrations', () => {
         cy.visit(testChannelUrl1);
 
         // # User 1 Create a private channel, with ${channelName}
-        cy.get('#createPrivateChannel').click();
+        cy.uiBrowseOrCreateChannel('Create New Channel').click();
         cy.get('#private').click();
         cy.get('#newChannelName').type(privateChannelName);
         cy.get('#submitNewChannel').click();
 
         // # User, who is a member of the channel, try /join command without tilde
-        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.postMessage(`/join ${privateChannelName}`);
 
         // * Private channel should be active
-        cy.get('#privateChannelList').get('.active').should('contain', privateChannelName);
+        cy.uiGetLhsSection('CHANNELS').get('.active').should('contain', privateChannelName);
 
         // # User, who is a member of the channel, try /join command with tilde
-        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.postMessage(`/join ~${privateChannelName}`);
 
         // * private channel should be active
-        cy.get('#privateChannelList').get('.active').should('contain', privateChannelName);
+        cy.uiGetLhsSection('CHANNELS').find('.active').should('contain', privateChannelName);
 
         // # Login with user without privilege
         cy.apiLogin(user2);
         cy.visit(testChannelUrl1);
 
         // # User, who is *not* a member of the channel, try /join command without tilde
-        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.postMessage(`/join ${privateChannelName}`);
 
         // * Error message should be presented.
         cy.getLastPost().should('contain', 'An error occurred while joining the channel.').and('contain', 'System');
 
         // # User, who is *not* a member of the channel, try /join command with tilde
-        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.postMessage(`/join ~${privateChannelName}`);
 
         // * Error message should be presented.
@@ -110,38 +110,38 @@ describe('Integrations', () => {
         cy.visit(testChannelUrl1);
 
         // # User 1 Create a private channel, with ${channelName}
-        cy.get('#createPrivateChannel').click();
+        cy.uiBrowseOrCreateChannel('Create New Channel').click();
         cy.get('#private').click();
         cy.get('#newChannelName').type(privateChannelName);
         cy.get('#submitNewChannel').click();
 
         // # User, who is a member of the channel, try /open command without tilde
-        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.postMessage(`/open ${privateChannelName}`);
 
         // * Private channel should be active
-        cy.get('#privateChannelList').get('.active').should('contain', privateChannelName);
+        cy.uiGetLhsSection('CHANNELS').find('.active').should('contain', privateChannelName);
 
         // # User, who is a member of the channel, try /open command with tilde
-        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.postMessage(`/open ~${privateChannelName}`);
 
         // * Private channel should be active
-        cy.get('#privateChannelList').get('.active').should('contain', privateChannelName);
+        cy.uiGetLhsSection('CHANNELS').find('.active').should('contain', privateChannelName);
 
         // # Login with user without privilege
         cy.apiLogin(user2);
         cy.visit(testChannelUrl1);
 
         // # User, who is *not* a member of the channel, try /open command without tilde
-        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.postMessage(`/open ${privateChannelName}`);
 
         // * Error message should be presented.
         cy.getLastPost().should('contain', 'An error occurred while joining the channel.').and('contain', 'System');
 
         // # User, who is *not* a member of the channel, try /open command with tilde
-        cy.get('#publicChannelList').findByText('Town Square').click();
+        cy.uiGetLhsSection('CHANNELS').findByText('Town Square').click();
         cy.postMessage(`/open ~${privateChannelName}`);
 
         // * Error message should be presented.

--- a/e2e/cypress/integration/keyboard_shortcuts/alt_option_plus_up_down_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/alt_option_plus_up_down_spec.js
@@ -46,23 +46,23 @@ describe('Keyboard Shortcuts', () => {
         });
     });
 
-    it('Alt/Option + Up', () => {
+    it('MM-T1229 Alt/Option + Up', () => {
         cy.visit(`/${testTeam.name}/messages/@${sysadmin.username}`);
 
         // * Verify that the channel is loaded
         cy.get('#channelHeaderTitle').should('contain', sysadmin.username);
 
         // * Switch to channels by Alt+Up/Down keypress and verify
-        verifyChannelSwitch(testTeam.name, privateChannel, dmWithSysadmin, '{uparrow}');
-        verifyChannelSwitch(testTeam.name, townSquare, privateChannel, '{uparrow}');
-        verifyChannelSwitch(testTeam.name, offTopic, townSquare, '{uparrow}');
+        verifyChannelSwitch(testTeam.name, townSquare, dmWithSysadmin, '{uparrow}');
+        verifyChannelSwitch(testTeam.name, privateChannel, townSquare, '{uparrow}');
+        verifyChannelSwitch(testTeam.name, offTopic, privateChannel, '{uparrow}');
         verifyChannelSwitch(testTeam.name, publicChannel, offTopic, '{uparrow}');
 
         // * Should switch to bottom of channel list when current channel is at the very top
         verifyChannelSwitch(testTeam.name, dmWithSysadmin, publicChannel, '{uparrow}');
     });
 
-    it('Alt/Option + Down', () => {
+    it('MM-T1230 Alt/Option + Down', () => {
         cy.visit(`/${testTeam.name}/channels/${publicChannel.name}`);
 
         // * Verify that the channel is loaded
@@ -70,9 +70,9 @@ describe('Keyboard Shortcuts', () => {
 
         // # Switch to channels by Alt+Up/Down keypress and verify
         verifyChannelSwitch(testTeam.name, offTopic, publicChannel, '{downarrow}');
-        verifyChannelSwitch(testTeam.name, townSquare, offTopic, '{downarrow}');
-        verifyChannelSwitch(testTeam.name, privateChannel, townSquare, '{downarrow}');
-        verifyChannelSwitch(testTeam.name, dmWithSysadmin, privateChannel, '{downarrow}');
+        verifyChannelSwitch(testTeam.name, privateChannel, offTopic, '{downarrow}');
+        verifyChannelSwitch(testTeam.name, townSquare, privateChannel, '{downarrow}');
+        verifyChannelSwitch(testTeam.name, dmWithSysadmin, townSquare, '{downarrow}');
 
         // * Should switch to top of channel list when current channel is at the very bottom
         verifyChannelSwitch(testTeam.name, publicChannel, dmWithSysadmin, '{downarrow}');

--- a/e2e/cypress/integration/keyboard_shortcuts/alt_option_plus_up_down_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/alt_option_plus_up_down_spec.js
@@ -90,7 +90,7 @@ function verifyChannelSwitch(teamName, toChannel, fromChannel, arrowKey) {
         cy.url().should('include', `/${teamName}/channels/${toChannel.name}`);
     }
 
-    cy.get('#sidebarChannelContainer').should('be.visible').within(() => {
+    cy.get('#lhsList').should('be.visible').within(() => {
         // * Verify that the toChannel is active in LHS
         verifyClass(toChannel, 'have.class');
 

--- a/e2e/cypress/integration/keyboard_shortcuts/keyboard_shortcuts_one_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/keyboard_shortcuts_one_spec.js
@@ -61,7 +61,7 @@ describe('Keyboard Shortcuts', () => {
             cy.get('#channelIntro').contains('.channel-intro__title', `Beginning of ${testChannel.display_name}`).should('be.visible');
 
             // # Verify that the right channel is displayed in LHS
-            cy.contains('.sidebar-item', testChannel.display_name);
+            cy.uiGetLhsSection('CHANNELS').findByText(testChannel.display_name).should('be.visible');
 
             // # Verify that the current user(sysadmin) created the channel
             cy.get('#channelIntro').contains('.channel-intro__content', `This is the start of the ${testChannel.display_name} channel, created by sysadmin`).should('be.visible');
@@ -80,7 +80,7 @@ describe('Keyboard Shortcuts', () => {
             // # Create two public channels
             for (let index = 0; index < 2; index++) {
                 const otherUserId = otherUser.id;
-                cy.apiCreateChannel(team.id, 'public', 'public').then(({channel}) => {
+                cy.apiCreateChannel(team.id, `a-public-${index}`, `A Public ${index}`).then(({channel}) => {
                     publicChannels.push(channel);
                     cy.apiAddUserToTeam(team.id, otherUserId).then(() => {
                         cy.apiAddUserToChannel(channel.id, otherUserId);
@@ -91,7 +91,7 @@ describe('Keyboard Shortcuts', () => {
             // # Create two private channels
             for (let index = 0; index < 2; index++) {
                 const otherUserId = otherUser.id;
-                cy.apiCreateChannel(team.id, 'private', 'private', 'P').then(({channel}) => {
+                cy.apiCreateChannel(team.id, `b-private-${index}`, `B Private ${index}`, 'P').then(({channel}) => {
                     privateChannels.push(channel);
                     cy.apiAddUserToChannel(channel.id, otherUserId);
                 });
@@ -239,7 +239,7 @@ describe('Keyboard Shortcuts', () => {
             // # Create two public channels
             for (let index = 0; index < 2; index++) {
                 const otherUserId = otherUser.id;
-                cy.apiCreateChannel(team.id, 'public', 'public').then(({channel}) => {
+                cy.apiCreateChannel(team.id, `a-public-${index}`, `A Public ${index}`).then(({channel}) => {
                     publicChannels.push(channel);
                     cy.apiAddUserToTeam(team.id, otherUserId).then(() => {
                         cy.apiAddUserToChannel(channel.id, otherUserId);
@@ -250,7 +250,7 @@ describe('Keyboard Shortcuts', () => {
             // # Create two private channels
             for (let index = 0; index < 2; index++) {
                 const otherUserId = otherUser.id;
-                cy.apiCreateChannel(team.id, 'private', 'private', 'P').then(({channel}) => {
+                cy.apiCreateChannel(team.id, `b-private-${index}`, `B Private ${index}`).then(({channel}) => {
                     privateChannels.push(channel);
                     cy.apiAddUserToChannel(channel.id, otherUserId);
                 });

--- a/e2e/cypress/integration/messaging/at_mentions_spec.js
+++ b/e2e/cypress/integration/messaging/at_mentions_spec.js
@@ -129,8 +129,6 @@ describe('at-mention', () => {
             'Town Square', {body, tag: body, requireInteraction: false, silent: false});
 
         // * Verify unread mentions badge
-        cy.get('#publicChannel').scrollIntoView();
-
         cy.get('#sidebarItem_town-square').
             scrollIntoView().
             find('#unreadMentions').
@@ -170,7 +168,6 @@ describe('at-mention', () => {
         cy.get('@notifySpy').should('be.not.called');
 
         // * Verify unread mentions badge does not exist
-        cy.get('#publicChannel').scrollIntoView();
         cy.get('#sidebarItem_town-square').
             scrollIntoView().
             find('#unreadMentions').
@@ -211,7 +208,6 @@ describe('at-mention', () => {
             cy.get('@notifySpy').should('be.not.called');
 
             // * Verify unread mentions badge does not exist
-            cy.get('#publicChannel').scrollIntoView();
             cy.get('#sidebarItem_town-square').
                 find('#unreadMentions').
                 should('be.not.visible');
@@ -249,8 +245,6 @@ describe('at-mention', () => {
 
         // # Check mention on town-square channel
         // * Verify unread mentions badge
-        cy.get('#publicChannel').scrollIntoView();
-
         cy.get('#sidebarItem_town-square').
             scrollIntoView().
             find('#unreadMentions').
@@ -280,8 +274,6 @@ describe('at-mention', () => {
         cy.postMessageAs({sender: admin, message: message2, channelId: offTopicChannelId});
 
         // * Verify unread mentions badge
-        cy.get('#publicChannel').scrollIntoView();
-
         cy.get('#sidebarItem_off-topic').
             scrollIntoView().
             find('#unreadMentions').

--- a/e2e/cypress/integration/messaging/channel_read_after_permalink_spec.js
+++ b/e2e/cypress/integration/messaging/channel_read_after_permalink_spec.js
@@ -71,12 +71,9 @@ describe('Messaging', () => {
                 cy.visit(`/${testTeam.name}/channels/town-square`);
 
                 // # Check Message is in Unread List
-                cy.get('#unreadsChannelList').should('be.visible').within(() => {
-                    cy.get('#sidebarItem_' + testChannel.name).
-                        scrollIntoView().
-                        should('be.visible').
-                        and('have.attr', 'aria-label', `${testChannel.display_name.toLowerCase()} public channel 1 mention`);
-                });
+                cy.uiGetLhsSection('UNREADS').find('#sidebarItem_' + testChannel.name).
+                    should('be.visible').
+                    and('have.attr', 'aria-label', `${testChannel.display_name.toLowerCase()} public channel 1 mention`);
 
                 // # Read the message and click the permalink
                 clickLink(testChannel);
@@ -88,18 +85,17 @@ describe('Messaging', () => {
                 cy.wait(TIMEOUTS.FIVE_SEC).url().should('include', `/${testTeam.name}/messages/@${testUser.username}`).and('not.include', `/${postId}`);
 
                 // # Channel should still be visible
-                cy.get('#publicChannelList', {force: true}).scrollIntoView().should('be.visible').within(() => {
+                cy.findAllByRole('button', {name: 'CHANNELS'}).first().parent().next().should('be.visible').within(() => {
                     cy.get('#sidebarItem_' + testChannel.name).
-                        scrollIntoView().
                         should('be.visible').
                         and('have.attr', 'aria-label', `${testChannel.display_name.toLowerCase()} public channel`);
                 });
 
                 // * Check the channel is not under the unread channel list
-                cy.get('#unreadsChannelList').find('#sidebarItem_' + testChannel.name).should('not.exist');
+                cy.uiGetLhsSection('UNREADS').findByText(testChannel.name).should('not.exist');
 
                 // * Check the channel is not marked as unread
-                cy.get('#sidebarItem_' + testChannel.name).invoke('attr', 'aria-label').should('not.include', 'unread');
+                cy.uiGetLhsSection('CHANNELS').find('#sidebarItem_' + testChannel.name).invoke('attr', 'aria-label').should('not.include', 'unread');
             });
         });
     });

--- a/e2e/cypress/integration/messaging/ctrl_cmd_k_open_dm_with_mouse_spec.js
+++ b/e2e/cypress/integration/messaging/ctrl_cmd_k_open_dm_with_mouse_spec.js
@@ -73,8 +73,6 @@ describe('Messaging', () => {
         cy.visit(`/${testTeam.name}`);
 
         // * Check that the DM exists and receives the message with mention
-        cy.get('#directChannelList').should('be.visible').within(() => {
-            cy.findByLabelText(`${firstUser.username} 1 mention`).should('exist');
-        });
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByLabelText(`${firstUser.username} 1 mention`).should('exist');
     });
 });

--- a/e2e/cypress/integration/messaging/direct_message_spec.js
+++ b/e2e/cypress/integration/messaging/direct_message_spec.js
@@ -103,8 +103,8 @@ describe('Direct Message', () => {
         // # Stub notifications API
         spyNotificationAs('withNotification', 'granted');
 
-        // # Click on More... section
-        cy.get('#moreDirectMessage').click().wait(TIMEOUTS.HALF_SEC);
+        // # Open DM modal
+        cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
 
         // # Search for your username
         cy.get('#selectItems input').
@@ -179,7 +179,7 @@ describe('Direct Message', () => {
         });
 
         // * Assert that channel appears as muted on the LHS
-        cy.get('#directChannelList .muted').first().should('contain', otherUser.username);
+        cy.uiGetLhsSection('DIRECT MESSAGES').find('.muted').first().should('contain', otherUser.username);
 
         // # Clicks on UnMute Channel
         cy.get('#channelHeaderDropdownButton button').click().then(() => {
@@ -190,6 +190,6 @@ describe('Direct Message', () => {
         });
 
         // * Assert that channel does not appear as muted on the LHS
-        cy.get('#directChannelList .muted').should('not.exist');
+        cy.uiGetLhsSection('DIRECT MESSAGES').find('.muted').should('not.exist');
     });
 });

--- a/e2e/cypress/integration/messaging/dm_list_of_users_spec.js
+++ b/e2e/cypress/integration/messaging/dm_list_of_users_spec.js
@@ -36,10 +36,7 @@ describe('Messaging', () => {
             cy.visit(`/${testTeam.name}/channels/town-square`);
 
             // # Click on '+' sign to open DM modal
-            cy.findByLabelText('write a direct message').should('be.visible').click();
-
-            // * Verify that the DM modal is open
-            cy.get('#moreDmModal').should('be.visible').contains('Direct Messages');
+            cy.uiAddDirectMessage().click();
 
             // # Search for the deactivated user
             cy.get('#selectItems input').should('be.focused').type(deactivatedUser.email, {force: true});
@@ -64,7 +61,7 @@ describe('Messaging', () => {
             cy.externalActivateUser(deactivatedUser.id, false);
 
             // # Click on '+' sign to open DM modal
-            cy.findByLabelText('write a direct message').should('be.visible').click();
+            cy.uiAddDirectMessage().click();
 
             // * Verify that the DM modal is open
             cy.get('#moreDmModal').should('be.visible').contains('Direct Messages');

--- a/e2e/cypress/integration/messaging/draft_with_only_2_byte_characters_spec.js
+++ b/e2e/cypress/integration/messaging/draft_with_only_2_byte_characters_spec.js
@@ -46,7 +46,7 @@ describe('Messaging', () => {
         cy.get('#sidebarItem_town-square').click();
 
         // * Check that the draft icon does not exist next to the Test Channel name
-        cy.get(`#sidebarItem_${testChannel.name}`).should('not.have.descendants', '#draftIcon');
+        cy.get(`#sidebarItem_${testChannel.name}`).findByTestId('draftIcon').should('not.exist');
 
         // # Return to the channel where the 2 byte character was posted
         cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);

--- a/e2e/cypress/integration/messaging/group_message_spec.js
+++ b/e2e/cypress/integration/messaging/group_message_spec.js
@@ -49,7 +49,7 @@ describe('Group Message', () => {
         const otherUser2 = users[1];
 
         // # Click on '+' sign to open DM modal
-        cy.findByLabelText('write a direct message').should('be.visible').click();
+        cy.uiAddDirectMessage().click();
 
         // * Verify that the DM modal is open
         cy.get('#moreDmModal').should('be.visible').contains('Direct Messages');
@@ -79,7 +79,7 @@ describe('Group Message', () => {
         cy.get('#post_textbox').type('Hi!').type('{enter}');
 
         // # Click on '+' sign to open DM modal
-        cy.findByLabelText('write a direct message').should('be.visible').click();
+        cy.uiAddDirectMessage().click();
 
         // * Verify that the DM modal is open
         cy.get('#moreDmModal').should('be.visible').contains('Direct Messages');
@@ -246,10 +246,10 @@ describe('Group Message', () => {
             const channelName = loc.pathname.split('/').slice(-1)[0];
 
             // # Remove GM from the LHS
-            cy.get(`#sidebarItem_${channelName} .btn-close`).first().click({force: true}).wait(TIMEOUTS.HALF_SEC);
+            cy.uiGetChannelSidebarMenu(channelName).findByText('Close Conversation').click();
 
-            // # Click on More...
-            cy.get('#moreDirectMessage').click().wait(TIMEOUTS.HALF_SEC);
+            // # Open DM modal
+            cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
 
             // # Open previously closed group message
             cy.get('#selectItems input').type(`${participants[0].username}`).wait(TIMEOUTS.HALF_SEC);
@@ -269,7 +269,7 @@ describe('Group Message', () => {
 
 const createGroupMessageWith = (users) => {
     const defaultUserLimit = 7;
-    cy.get('#addDirectChannel').click().wait(TIMEOUTS.HALF_SEC);
+    cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
     cy.get('#multiSelectHelpMemberInfo').should('contain', 'You can add 7 more people');
 
     users.forEach((user, index) => {

--- a/e2e/cypress/integration/messaging/header_not_cloud_spec.js
+++ b/e2e/cypress/integration/messaging/header_not_cloud_spec.js
@@ -35,7 +35,7 @@ describe('Header', () => {
         // # Create a bot
         cy.apiCreateBot().then(({bot}) => {
             // # Open a DM with the bot
-            cy.get('#addDirectChannel').click();
+            cy.uiAddDirectMessage().click();
             cy.get('.more-modal__list .more-modal__row');
             cy.get('#moreDmModal input').
                 type(bot.username, {force: true}).
@@ -61,7 +61,7 @@ describe('Header', () => {
         });
 
         // # Open a DM with the bot
-        cy.get('#addDirectChannel').click();
+        cy.uiAddDirectMessage().click();
         cy.get('.more-modal__list .more-modal__row');
         cy.get('#moreDmModal input').
             type('matterpoll', {force: true}).

--- a/e2e/cypress/integration/messaging/header_spec.js
+++ b/e2e/cypress/integration/messaging/header_spec.js
@@ -47,7 +47,7 @@ describe('Header', () => {
         cy.uiChangeMessageDisplaySetting('COMPACT');
 
         // # Open a DM with other user
-        cy.get('#addDirectChannel').click().wait(TIMEOUTS.HALF_SEC);
+        cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
         cy.focused().type(otherUser.username, {force: true}).type('{enter}', {force: true}).wait(TIMEOUTS.HALF_SEC);
         cy.get('#saveItems').click().wait(TIMEOUTS.HALF_SEC);
 

--- a/e2e/cypress/integration/messaging/local_date_time_spec.js
+++ b/e2e/cypress/integration/messaging/local_date_time_spec.js
@@ -49,7 +49,7 @@ describe('Messaging', () => {
         const testCases = [
             {
                 name: 'in English',
-                publicChannel: 'PUBLIC CHANNELS',
+                publicChannel: 'CHANNELS',
                 locale: 'en',
                 manualTimezone: 'UTC',
                 localTimes: [
@@ -61,7 +61,7 @@ describe('Messaging', () => {
             },
             {
                 name: 'in Spanish',
-                publicChannel: 'CANALES PÚBLICOS',
+                publicChannel: 'CANALES',
                 locale: 'es',
                 manualTimezone: 'UTC',
                 localTimes: [
@@ -73,7 +73,7 @@ describe('Messaging', () => {
             },
             {
                 name: 'in react-intl unsupported timezone',
-                publicChannel: 'PUBLIC CHANNELS',
+                publicChannel: 'CHANNELS',
                 locale: 'en',
                 manualTimezone: 'NZ-CHAT',
                 localTimes: [

--- a/e2e/cypress/integration/messaging/message_draft_spec.js
+++ b/e2e/cypress/integration/messaging/message_draft_spec.js
@@ -29,8 +29,7 @@ describe('Message Draft', () => {
         cy.url().should('include', `/${testTeam.name}/channels/town-square`);
 
         // * Validate if the draft icon is not visible on the sidebar before making a draft
-        cy.get('#publicChannel').scrollIntoView();
-        cy.get('#sidebarItem_town-square #draftIcon').should('be.not.visible');
+        cy.get('#sidebarItem_town-square').findByTestId('draftIcon').should('not.exist');
 
         // # Type in some text into the text area of the opened channel
         cy.get('#post_textbox').type('comm');
@@ -42,6 +41,6 @@ describe('Message Draft', () => {
         cy.url().should('include', `/${testTeam.name}/channels/off-topic`);
 
         // * Validate if the draft icon is visible on side bar on the previous channel with a draft
-        cy.get('#sidebarItem_town-square #draftIcon').should('be.visible');
+        cy.get('#sidebarItem_town-square').findByTestId('draftIcon').should('be.visible');
     });
 });

--- a/e2e/cypress/integration/messaging/message_draft_then_switch_channel_spec.js
+++ b/e2e/cypress/integration/messaging/message_draft_then_switch_channel_spec.js
@@ -64,15 +64,15 @@ describe('Message Draft and Switch Channels', () => {
 });
 
 function verifyDraftIcon(channelName, isVisible) {
-    cy.get('#sidebar-left').findByLabelText(`${channelName.toLowerCase()} public channel`).
+    cy.uiGetLhsSection('CHANNELS').findByLabelText(`${channelName.toLowerCase()} public channel`).
         should('be.visible').
-        find('#draftIcon').
+        findByTestId('draftIcon').
         should(isVisible ? 'be.visible' : 'not.exist');
 }
 
 function openChannelFromLhs(teamName, displayName, name) {
     // # Go to test channel and check if it opened correctly
-    cy.get('#sidebar-left').findByText(displayName).click();
+    cy.uiGetLhsSection('CHANNELS').findByText(displayName).click();
     cy.url().should('include', `/${teamName}/channels/${name || displayName.toLowerCase()}`);
 }
 

--- a/e2e/cypress/integration/messaging/message_draft_with_attachment_then_switch_channel_spec.js
+++ b/e2e/cypress/integration/messaging/message_draft_with_attachment_then_switch_channel_spec.js
@@ -33,7 +33,7 @@ describe('Message Draft with attachment and Switch Channels', () => {
         cy.url().should('include', '/channels/' + testChannel1.name);
 
         // # Validate if the draft icon is not visible on the sidebar before making a draft
-        cy.get(`#sidebarItem_${testChannel1.name} #draftIcon`).should('be.not.visible');
+        cy.get(`#sidebarItem_${testChannel1.name}`).findByTestId('draftIcon').should('not.exist');
 
         // # Upload a file on center view
         cy.get('#fileUploadInput').attachFile('mattermost-icon.png');
@@ -45,6 +45,6 @@ describe('Message Draft with attachment and Switch Channels', () => {
         cy.url().should('include', '/channels/' + testChannel2.name);
 
         // # Validate if the draft icon is visible in side bar for the previous channel
-        cy.get(`#sidebarItem_${testChannel1.name} #draftIcon`).scrollIntoView().should('be.visible');
+        cy.get(`#sidebarItem_${testChannel1.name}`).findByTestId('draftIcon').should('be.visible');
     });
 });

--- a/e2e/cypress/integration/multi_team_and_dm/close_current_dm_redirects_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/close_current_dm_redirects_spec.js
@@ -45,7 +45,7 @@ describe('Direct messages: redirections', () => {
         sendDirectMessageToUser(firstDMUser, 'hi');
 
         // # Close the direct message via 'x' button right of the username in the direct messages's list
-        closeDirectMessageViaXButton(testUser, firstDMUser, testTeam);
+        closeDirectMessage(testUser, firstDMUser, testTeam);
 
         // * Expect to be redirected to off-topic channel, check channel title and url
         expectActiveChannelToBe('Off-Topic', offTopicChannelUrl);
@@ -71,7 +71,7 @@ describe('Direct messages: redirections', () => {
         sendDirectMessageToUser(secondDMUser, 'hi second');
 
         // # Close the direct message previously opened with the first user
-        closeDirectMessageViaXButton(testUser, firstDMUser, testTeam);
+        closeDirectMessage(testUser, firstDMUser, testTeam);
 
         // * Expect channel title and url to secondDMUser's username
         expectActiveChannelToBe(secondDMUser.username, `/messages/@${secondDMUser.username}`);
@@ -101,7 +101,7 @@ const expectActiveChannelToBe = (title, url) => {
 
 const sendDirectMessageToUser = (user, message) => {
     // # Open a new direct message with firstDMUser
-    cy.get('#addDirectChannel').click();
+    cy.uiAddDirectMessage().click();
 
     // # Type username
     cy.get('#selectItems input').should('be.enabled').type(`@${user.username}`, {force: true});
@@ -130,7 +130,7 @@ const sendDirectMessageToUser = (user, message) => {
         type('{enter}');
 };
 
-const closeDirectMessageViaXButton = (sender, recipient, team) => {
+const closeDirectMessage = (sender, recipient, team) => {
     // # Find the username in the 'Direct Messages' list and trigger the 'x' button to appear (hover over the username)
     cy.apiGetChannelsForUser(sender.id, team.id).then(({channels}) => {
         // Get the name of the channel to build the CSS selector for that specific DM link in the sidebar
@@ -138,8 +138,7 @@ const closeDirectMessageViaXButton = (sender, recipient, team) => {
             channel.type === 'D' && channel.name.includes(recipient.id),
         );
 
-        // # Close the DM via 'x' button next to username in direct message list
-        cy.get(`#sidebarItem_${channelDmWithFirstUser.name} .btn-close`).
-            click({force: true});
+        // # Close the DM via sidebar channel menu
+        cy.uiGetChannelSidebarMenu(channelDmWithFirstUser.name).findByText('Close Conversation').click();
     });
 };

--- a/e2e/cypress/integration/multi_team_and_dm/close_gm_via_menu_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/close_gm_via_menu_spec.js
@@ -10,8 +10,6 @@
 // Stage: @prod
 // Group: @multi_team_and_dm
 
-import * as TIMEOUTS from '../../fixtures/timeouts';
-
 describe('Multi-user group messages', () => {
     let testUser;
     let testTeam;
@@ -34,7 +32,7 @@ describe('Multi-user group messages', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Open the 'Direct messages' dialog to create a new direct message
-        cy.get('#addDirectChannel', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').click();
+        cy.uiAddDirectMessage().should('be.visible').click();
 
         // # Add 3 users to a group message
         addUsersToGMViaModal(3);

--- a/e2e/cypress/integration/multi_team_and_dm/dm_more_searching_from_page_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/dm_more_searching_from_page_spec.js
@@ -40,7 +40,7 @@ describe('Multi Team and DM', () => {
 
     it('MM-T446 DM More... searching from page 2 of user list', () => {
         // # Open the Direct Message modal
-        cy.findByLabelText('write a direct message').click();
+        cy.uiAddDirectMessage().click();
 
         // # Move to the next page of users
         cy.findByText('Next').click();

--- a/e2e/cypress/integration/multi_team_and_dm/dm_more_show_user_count_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/dm_more_show_user_count_spec.js
@@ -48,7 +48,7 @@ describe('Multi Team and DM', () => {
 
     it('MM-T444 DM More... show user count', () => {
         // # Open the Direct Message modal
-        cy.findByLabelText('See more direct messages').click();
+        cy.uiAddDirectMessage().click();
 
         cy.get('#multiSelectHelpMemberInfo > :nth-child(2)').then((number) => {
             // # Grab total number of users before filter applied

--- a/e2e/cypress/integration/multi_team_and_dm/existing_channel_name_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/existing_channel_name_spec.js
@@ -29,8 +29,8 @@ describe('Channel', () => {
         cy.reload();
 
         cy.get('@channel').then((channel) => {
-            // * Verify new public or private channel cannot be created with existing public channel name
-            channelNameTest('PUBLIC CHANNELS', channel);
+            // * Verify new public channel cannot be created with existing public channel name
+            verifyChannel(channel);
         });
     });
 
@@ -40,22 +40,20 @@ describe('Channel', () => {
         cy.reload();
 
         cy.get('@channel').then((channel) => {
-            // * Verify new public or private channel cannot be created with existing private channel name
-            channelNameTest('PRIVATE CHANNELS', channel);
+            // * Verify new private channel cannot be created with existing private channel name
+            verifyChannel(channel);
         });
     });
 });
 
 /**
 * Creates a channel with existing name and verify that error is shown
-* @param {String} channelTypeID - ID of public or private channel to create
 * @param {String} newChannelName - New channel name to assign
+* @param {boolean} makePrivate - Set to false to make public channel (default), otherwise true as private channel
 */
 function verifyExistingChannelError(newChannelName, makePrivate = false) {
-    const channelTypeID = makePrivate ? '#createPrivateChannel' : '#createPublicChannel';
-
     // Click on '+' button for Public or Private Channel
-    cy.get(channelTypeID).click({force: true});
+    cy.uiBrowseOrCreateChannel('Create New Channel').click();
 
     if (makePrivate) {
         cy.get('#private').check({force: true}).as('channelType');
@@ -78,34 +76,30 @@ function verifyExistingChannelError(newChannelName, makePrivate = false) {
 
 /**
 * Attempts to create public and private channels with existing `channelName` and verifies error
-* @param {String} channelTypeHeading - PUBLIC CHANNELS or PRIVATE CHANNELS
 * @param {String} channelName - Existing channel name that is also being tested for error
-* var - origChannelLength:    The original number of channels in PUBLIC CHANNELS or PRIVATE CHANNELS
 */
-function channelNameTest(channelTypeHeading, channel) {
-    const listSelector = channelTypeHeading === 'PUBLIC CHANNELS' ? '#publicChannelList' : '#privateChannelList';
-
-    // # Find how many public channels there are and store as origChannelLength
-    cy.get(`${listSelector} a.sidebar-item`).its('length').as('origChannelLength');
+function verifyChannel(channel) {
+    // # Find current number of channels
+    cy.uiGetLhsSection('CHANNELS').find('.SidebarChannel').its('length').as('origChannelLength');
 
     // * Verify channel `channelName` exists
-    cy.get('#sidebarChannelContainer').should('contain', channel.display_name);
+    cy.uiGetLhsSection('CHANNELS').should('contain', channel.display_name);
 
-    // * Verify new public channel cannot be created with existing public channel name; see verifyExistingChannelError function
+    // * Verify new public channel cannot be created with existing public channel name
     verifyExistingChannelError(channel.name);
 
     // # Click on Cancel button to move out of New Channel Modal
     cy.get('#cancelNewChannel').contains('Cancel').click();
 
-    // * Verify new private channel cannot be created with existing public channel name:
+    // * Verify new private channel cannot be created with existing public channel name
     verifyExistingChannelError(channel.name, true);
 
     // # Click on Cancel button to move out of New Channel Modal
     cy.get('#cancelNewChannel').contains('Cancel').click();
 
-    // * Verify the number of channels is still the same as before (by comparing it to origChannelLenth)
+    // * Verify the number of channels is still the same as before
     cy.get('@origChannelLength').then((origChannelLength) => {
-        cy.get(`${listSelector} a.sidebar-item`).its('length').should('equal', origChannelLength);
+        cy.uiGetLhsSection('CHANNELS').find('.SidebarChannel').its('length').should('equal', origChannelLength);
     });
 }
 

--- a/e2e/cypress/integration/multi_team_and_dm/favorite_and_close_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/favorite_and_close_spec.js
@@ -10,17 +10,6 @@
 // Stage: @prod
 // Group: @multi_team_and_dm
 
-// Make sure that the current channel is Town Square and that the
-// channel identified by the passed name is no longer in the channel
-// sidebar
-function verifyChannelWasProperlyClosed(channelName) {
-    // * Make sure that we have switched channels
-    cy.get('#channelHeaderTitle').should('contain', 'Town Square');
-
-    // * Make sure the old DM no longer exists
-    cy.get('#sidebarItem_' + channelName).should('not.exist');
-}
-
 describe('Close group messages', () => {
     let testUser;
     let otherUser1;
@@ -54,10 +43,10 @@ describe('Close group messages', () => {
             cy.get('#toggleFavorite').click();
 
             // * Check that the channel is on top of favorites list
-            cy.get('#favoriteChannelList > li:nth-child(2) > div > a').should('have.attr', 'id', 'sidebarItem_' + channel.name);
+            cy.uiGetLhsSection('FAVORITES').find('.SidebarChannel').first().should('contain', channel.display_name.replace(`, ${testUser.username}`, ''));
 
             // # Click on the x button on the sidebar channel item
-            cy.get('#sidebarItem_' + channel.name + '>span.btn-close').click({force: true});
+            cy.uiGetChannelSidebarMenu(channel.name).findByText('Close Conversation').click();
 
             verifyChannelWasProperlyClosed(channel.name);
         });
@@ -78,5 +67,16 @@ describe('Close group messages', () => {
 
             return cy.wrap(channel);
         });
+    }
+
+    // Make sure that the current channel is Town Square and that the
+    // channel identified by the passed name is no longer in the channel
+    // sidebar
+    function verifyChannelWasProperlyClosed(channelName) {
+        // * Make sure that we have switched channels
+        cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+
+        // * Make sure the old DM no longer exists
+        cy.get('#sidebarItem_' + channelName).should('not.exist');
     }
 });

--- a/e2e/cypress/integration/multi_team_and_dm/gm_add_user_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/gm_add_user_spec.js
@@ -53,8 +53,7 @@ describe('Multi-user group messages', () => {
         cy.contains('#channelHeaderTitle', 'Town Square');
 
         // # Open the 'Direct messages' dialog
-        cy.get('#addDirectChannel').
-            click();
+        cy.uiAddDirectMessage().click();
 
         // # Start typing part of a username that matches previously created users
         cy.get('#selectItems input').

--- a/e2e/cypress/integration/multi_team_and_dm/max_gm_members_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/max_gm_members_spec.js
@@ -32,7 +32,7 @@ describe('Multi-user group messages', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Open the 'Direct messages' dialog to create a new direct message
-        cy.get('#addDirectChannel').click();
+        cy.uiAddDirectMessage().click();
 
         // # Add the maximum amount of users to a group message (7)
         addUsersToGMViaModal(7);

--- a/e2e/cypress/integration/multi_team_and_dm/multi_team_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/multi_team_spec.js
@@ -68,14 +68,14 @@ describe('Send a DM', () => {
         cy.get(`#${teamB.name}TeamButton`, {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click();
 
         // * Channel list in the LHS is scrolled to the top.
-        cy.get('#publicChannelList').get('.active').should('contain', 'Town Square');
+        cy.uiGetLhsSection('CHANNELS').get('.active').should('contain', 'Town Square');
 
         // * Verify team display name changes correctly.
         cy.get('#headerTeamName', {timeout: TIMEOUTS.ONE_MIN}).should('contain', teamB.display_name);
 
         // * DM Channel list should be the same on both teams with no missing names.
-        cy.get('#directChannelList').findByText(`${userB.username}`).should('be.visible');
-        cy.get('#directChannelList').findByText(`${userC.username}`).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(userB.username).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(userC.username).should('be.visible');
 
         // # Post a message in Town Square in Team B
         cy.postMessage('Hello World');
@@ -92,8 +92,8 @@ describe('Send a DM', () => {
         cy.get('#sidebarItem_town-square').should('not.have.class', 'unread-title');
 
         // * DM Channel list should be the same on both teams with no missing names.
-        cy.get('#directChannelList').findByText(`${userB.username}`).should('be.visible');
-        cy.get('#directChannelList').findByText(`${userC.username}`).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(userB.username).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(userC.username).should('be.visible');
 
         // * Channel viewed on a team before switching should be the one that displays after switching back (Town Square does not briefly show).
         cy.url().should('include', `/${teamA.name}/messages/@${userC.username}`);

--- a/e2e/cypress/integration/multi_team_and_dm/send_dm_user_no_team_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/send_dm_user_no_team_spec.js
@@ -46,7 +46,7 @@ describe('Send a DM', () => {
         cy.apiLogout();
         cy.apiLogin(userB);
         cy.visit(testChannelUrl);
-        cy.get('#addDirectChannel').click();
+        cy.uiAddDirectMessage().click();
         cy.get('#selectItems').type(`${userA.username}`);
         cy.findByText('Loading').should('be.visible');
         cy.findByText('Loading').should('not.exist');
@@ -58,7 +58,7 @@ describe('Send a DM', () => {
         cy.uiWaitUntilMessagePostedIncludes(MESSAGES.SMALL);
 
         // * The DM appears in your LHS / channel drawer even though other user isn't on any teams
-        cy.get('#directChannelList').findByText(`${userA.username}`).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(userA.username).should('be.visible');
 
         // # Have User A re-join one of the teams
         cy.apiAddUserToTeam(team1.id, userA.id);
@@ -68,6 +68,6 @@ describe('Send a DM', () => {
         cy.apiLogin(userA);
         cy.visit(testChannelUrl);
         cy.get('#postListContent', {timeout: TIMEOUTS.TWO_MIN}).should('be.visible');
-        cy.get('#directChannelList').findByText(`${userB.username}`).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(userB.username).should('be.visible');
     });
 });

--- a/e2e/cypress/integration/notifications/browser_tab_notification_spec.js
+++ b/e2e/cypress/integration/notifications/browser_tab_notification_spec.js
@@ -45,7 +45,7 @@ describe('Notifications', () => {
             // # Remove mention notification (for initial channel).
             cy.apiLogin(user1);
             cy.visit(testTeam1TownSquareUrl);
-            cy.get('#publicChannelList').get('.unread-title').click();
+            cy.get('#lhsList').get('.unread-title').click();
             cy.apiLogout();
         });
     });
@@ -113,7 +113,7 @@ describe('Notifications', () => {
         cy.visit(testTeam2TownSquareUrl);
 
         // # Create a new channel
-        cy.get('#createPublicChannel').should('be.visible').click();
+        cy.uiBrowseOrCreateChannel('Create New Channel').click();
         cy.wait(TIMEOUTS.HALF_SEC);
         cy.get('#newChannelName').should('be.visible').type('new-channel');
         cy.get('#submitNewChannel').click();
@@ -123,7 +123,7 @@ describe('Notifications', () => {
         cy.get('#member_popover').should('be.visible').click();
         cy.contains('Manage Members').click();
         cy.contains('Add Members').click();
-        cy.contains(`${user1.username}`).click();
+        cy.get('.channel-switcher__content input').should('exist').type(`${user1.username}{enter}`);
         cy.get('#saveItems').click();
         cy.wait(TIMEOUTS.HALF_SEC);
 

--- a/e2e/cypress/integration/notifications/desktop_notifications_spec.js
+++ b/e2e/cypress/integration/notifications/desktop_notifications_spec.js
@@ -264,7 +264,7 @@ describe('Desktop notifications', () => {
                 });
 
                 // * Notification badge is aligned 10px to the right of LHS
-                cy.get(`#sidebarItem_${channel.name} .badge`).should('exist').and('have.css', 'margin', '0px 10px 0px 0px');
+                cy.get(`#sidebarItem_${channel.name} .badge`).should('exist').and('have.css', 'margin', '0px 3px 0px 6px');
             });
         });
     });

--- a/e2e/cypress/integration/notifications/direct_messages_do_not_add_indicator_spec.js
+++ b/e2e/cypress/integration/notifications/direct_messages_do_not_add_indicator_spec.js
@@ -19,12 +19,6 @@ describe('Notifications', () => {
     let siteName;
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         cy.apiInitSetup().then(({team, user}) => {
             team1 = team;
             user1 = user;

--- a/e2e/cypress/integration/search/search_user_post_spec.js
+++ b/e2e/cypress/integration/search/search_user_post_spec.js
@@ -48,11 +48,11 @@ describe('Search in DMs', () => {
         });
     });
 
-    it('S14672 Search "in:[username]" returns results in DMs', () => {
+    it('MM-T358 Search "in:[username]" returns results in DMs', () => {
         const message = 'Hello' + Date.now();
 
         // # Ensure Direct Message is visible in LHS sidebar
-        cy.get('#directChannel').scrollIntoView().should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').should('be.visible');
 
         // # Create new DM channel with user's email
         createNewDMChannel(otherUser.email);

--- a/e2e/cypress/integration/search/search_user_post_spec.js
+++ b/e2e/cypress/integration/search/search_user_post_spec.js
@@ -15,7 +15,7 @@
  * @param {String} text - DM channel name
  */
 function createNewDMChannel(channelname) {
-    cy.get('#addDirectChannel').scrollIntoView().click();
+    cy.uiAddDirectMessage().scrollIntoView().click();
 
     cy.get('#selectItems').within(() => {
         cy.get('input[type="text"]').scrollIntoView().type(channelname, {force: true});

--- a/e2e/cypress/integration/search_autocomplete/channels_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/channels_spec.js
@@ -42,9 +42,7 @@ describe('Autocomplete without Elasticsearch - Channel', () => {
         // # Create private channel, do not add new user to it (sets @privateChannel alias)
         createPrivateChannel(testTeam.id).then((channel) => {
             // # Go to off-topic channel to partially reload the page
-            cy.get('#sidebarChannelContainer').should('be.visible').within(() => {
-                cy.findAllByText('Off-Topic').should('be.visible').click();
-            });
+            cy.uiGetLhsSection('CHANNELS').findAllByText('Off-Topic').click();
 
             // # Search for the private channel
             searchForChannel(channel.name);
@@ -57,9 +55,7 @@ describe('Autocomplete without Elasticsearch - Channel', () => {
 
     it('private channel I do belong to appears', () => {
         // # Go to off-topic channel to partially reload the page
-        cy.get('#sidebarChannelContainer').should('be.visible').within(() => {
-            cy.findAllByText('Off-Topic').should('be.visible').click();
-        });
+        cy.uiGetLhsSection('CHANNELS').findAllByText('Off-Topic').click();
 
         // # Create private channel and add new user to it (sets @privateChannel alias)
         createPrivateChannel(testTeam.id, testUser).then((channel) => {
@@ -96,9 +92,7 @@ describe('Autocomplete without Elasticsearch - Channel', () => {
             // # Create a private channel where the new user is not a member of
             createPrivateChannel(teamResponse.data.id).then((channel) => {
                 // # Go to off-topic channel to partially reload the page
-                cy.get('#sidebarChannelContainer').should('be.visible').within(() => {
-                    cy.findAllByText('Off-Topic').should('be.visible').click();
-                });
+                cy.uiGetLhsSection('CHANNELS').findAllByText('Off-Topic').click();
 
                 // # Search for the private channel
                 searchForChannel(channel.name);

--- a/e2e/cypress/integration/search_autocomplete/users_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/users_spec.js
@@ -332,7 +332,7 @@ describe('Autocomplete without Elasticsearch - Users', () => {
             const thor = testUsers.thor;
 
             // # Open of the add direct message modal
-            cy.get('#addDirectChannel').click({force: true});
+            cy.uiAddDirectMessage().click({force: true});
 
             // # Type username into input
             cy.get('.more-direct-channels').

--- a/e2e/cypress/integration/subpath/subpath_dm_search_spec.js
+++ b/e2e/cypress/integration/subpath/subpath_dm_search_spec.js
@@ -53,8 +53,8 @@ describe('Subpath Direct Message Search', () => {
                 // # Go to town square channel of primary subpath server
                 cy.visit(`/${testTeam.name}/channels/town-square`);
 
-                // # Click on More... section
-                cy.get('#moreDirectMessage', {timeout: TIMEOUTS.ONE_MIN}).click().wait(TIMEOUTS.HALF_SEC);
+                // # Open DM modal
+                cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
 
                 // # Search for username from other subpath server
                 cy.get('#selectItems input').

--- a/e2e/cypress/integration/system_console/user_management/users_deactivation_spec.js
+++ b/e2e/cypress/integration/system_console/user_management/users_deactivation_spec.js
@@ -37,13 +37,13 @@ describe('System Console > User Management > Deactivation', () => {
                 cy.sendDirectMessageToUsers([user1, user2], message);
 
                 // * Verify names on the LHS are still ordered alphabetically
-                cy.get('#directChannelList .active .sidebar-item__name').should('contain', user1.username + ', ' + user2.username);
+                cy.uiGetLhsSection('DIRECT MESSAGES').find('.active').should('contain', user1.username + ', ' + user2.username);
 
                 // # Deactivate user 1
                 cy.apiDeactivateUser(user1.id);
 
                 // * Verify names on the LHS are still ordered alphabetically
-                cy.get('#directChannelList .active .sidebar-item__name').should('contain', user1.username + ', ' + user2.username);
+                cy.uiGetLhsSection('DIRECT MESSAGES').find('.active').should('contain', user1.username + ', ' + user2.username);
 
                 // # Search for the message send in the GM
                 cy.uiSearchPosts(message);
@@ -69,7 +69,7 @@ describe('System Console > User Management > Deactivation', () => {
             cy.apiDeactivateUser(other.id);
 
             // # Open Channel Switcher
-            cy.get('#sidebarSwitcherButton').click();
+            cy.uiGetChannelSwitcher().click();
 
             // # Type the user name on Channel switcher input
             cy.get('#quickSwitchInput').type(other.username).wait(TIMEOUTS.HALF_SEC);
@@ -78,10 +78,10 @@ describe('System Console > User Management > Deactivation', () => {
             cy.get('[data-testid="' + other.username + '"]').contains('Deactivated');
 
             // # Close Channel Switcher
-            cy.get('#quickSwitchModalLabel .close').click();
+            cy.uiClose();
 
-            // # Open DM More... Modal
-            cy.get('#moreDirectMessage').click();
+            // # Open DM Modal
+            cy.uiAddDirectMessage().click();
 
             // # Type the guest user name on Channel switcher input
             cy.get('.more-direct-channels #selectItems').type(other.username).wait(TIMEOUTS.HALF_SEC);
@@ -110,8 +110,8 @@ describe('System Console > User Management > Deactivation', () => {
                 // # Deactivate user 2
                 cy.apiDeactivateUser(user2.id);
 
-                // # Open DM More... Modal
-                cy.get('#moreDirectMessage').click().wait(TIMEOUTS.HALF_SEC);
+                // # Open DM Modal
+                cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
 
                 // # Type the user name of user1 on Channel switcher input
                 cy.get('.more-direct-channels #selectItems').type(user1.username).wait(TIMEOUTS.HALF_SEC);
@@ -153,7 +153,9 @@ describe('System Console > User Management > Deactivation', () => {
             cy.get('#channelHeaderDescription .status').should('not.be.visible');
 
             // * Verify archived icon is shown in LHS
-            cy.get('#directChannelList .active .icon__archive').scrollIntoView().should('be.visible');
+            cy.uiGetLhsSection('DIRECT MESSAGES').
+                find('.active').should('be.visible').
+                find('.icon-archive-outline').should('be.visible');
         });
     });
 });

--- a/e2e/cypress/integration/system_console/user_management/users_reactivation_spec.js
+++ b/e2e/cypress/integration/system_console/user_management/users_reactivation_spec.js
@@ -38,7 +38,7 @@ describe('System Console > User Management > Reactivation', () => {
                 cy.sendDirectMessageToUser(user2, MESSAGES.SMALL);
 
                 // # Open DM More... Modal
-                cy.get('#moreDirectMessage').click().wait(TIMEOUTS.HALF_SEC);
+                cy.uiAddDirectMessage().click().wait(TIMEOUTS.HALF_SEC);
 
                 // # Type the user name of the other user on Channel switcher input
                 cy.get('.more-direct-channels #selectItems').type(id).wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/integration/system_console/user_management_spec.js
+++ b/e2e/cypress/integration/system_console/user_management_spec.js
@@ -275,8 +275,8 @@ describe('User Management', () => {
         });
 
         // * User does show up in DM More menu so that DM channels can be viewed.
-        cy.get('#directChannelList').findByText(`${otherUser.username}`).should('not.be.visible');
-        cy.get('#moreDirectMessage').should('be.visible').click();
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(otherUser.username).should('not.be.visible');
+        cy.uiAddDirectMessage().click();
 
         // * Verify that new messages cannot be posted.
         cy.get('#moreDmModal').should('be.visible').within(() => {
@@ -310,8 +310,8 @@ describe('User Management', () => {
             join(', ');
 
         // # Observe DM and GM in LHS.
-        cy.get('#directChannelList').findByText(displayName).should('be.visible');
-        cy.get('#directChannelList').findByText(`${otherUser.username}`).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(displayName).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(otherUser.username).should('be.visible');
 
         // # System Console > Users Deactivate the user.
         cy.apiLogout().apiAdminLogin();
@@ -321,13 +321,13 @@ describe('User Management', () => {
         cy.apiLogin(testUser).visit(`/${testTeam.name}/channels/${testChannel.name}`).wait(TIMEOUTS.HALF_SEC);
 
         // * On returning to the team the DM has been removed from LHS.
-        cy.get('#directChannelList').findByText(`${otherUser.username}`).should('not.be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(otherUser.username).should('not.be.visible');
 
         // * GM stays in LHS channel list.
-        cy.get('#directChannelList').findByText(displayName).should('be.visible');
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(displayName).should('be.visible');
 
         // # Open GM channel.
-        cy.get('#directChannelList').findByText(displayName).click().wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetLhsSection('DIRECT MESSAGES').findByText(displayName).click().wait(TIMEOUTS.HALF_SEC);
 
         // * GM still has message box (is not archived)
         cy.findByTestId('post_textbox').should('be.visible');

--- a/e2e/cypress/integration/team_settings/closed_team_invite_with_specific_domain_spec.js
+++ b/e2e/cypress/integration/team_settings/closed_team_invite_with_specific_domain_spec.js
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 

--- a/e2e/cypress/integration/team_settings/closed_team_invite_with_specific_domain_spec.js
+++ b/e2e/cypress/integration/team_settings/closed_team_invite_with_specific_domain_spec.js
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 

--- a/e2e/cypress/integration/team_settings/teams_spec.js
+++ b/e2e/cypress/integration/team_settings/teams_spec.js
@@ -37,11 +37,6 @@ describe('Teams Suite', () => {
             testTeam = team;
             testUser = user;
         });
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: 'true',
-            },
-        });
     });
 
     it('MM-T393 Cancel out of leaving team', () => {

--- a/e2e/cypress/integration/websocket/channel_created/new_sidebar_spec.js
+++ b/e2e/cypress/integration/websocket/channel_created/new_sidebar_spec.js
@@ -13,14 +13,6 @@
 import {getRandomId} from '../../../utils';
 
 describe('Handle removed user - new sidebar', () => {
-    before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-    });
-
     it('MM-27202 should add new channels to the sidebar when created from another session', () => {
         // # Start with a new team
         const teamName = `team-${getRandomId()}`;

--- a/e2e/cypress/integration/websocket/handle_new_post_spec.js
+++ b/e2e/cypress/integration/websocket/handle_new_post_spec.js
@@ -22,12 +22,6 @@ describe('Handle new post', () => {
     let user1;
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         cy.apiInitSetup().then(({channel, team, user}) => {
             channel1 = channel;
             team1 = team;

--- a/e2e/cypress/integration/websocket/handle_removed_user/new_sidebar_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user/new_sidebar_spec.js
@@ -23,12 +23,6 @@ describe('Handle removed user - new sidebar', () => {
     const sidebarItemClass = '.SidebarChannel';
 
     before(() => {
-        cy.apiUpdateConfig({
-            ServiceSettings: {
-                EnableLegacySidebar: false,
-            },
-        });
-
         cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             cy.visit(`/${team.name}/channels/${channel.name}`);
         });

--- a/e2e/cypress/integration/websocket/handle_removed_user/old_sidebar_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user/old_sidebar_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @websocket
+// Group: @websocket @not_cloud
 
 import {getRandomId} from '../../../utils';
 
@@ -23,6 +23,15 @@ describe('Handle removed user - old sidebar', () => {
     const sidebarItemClass = '.sidebar-item';
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
+        // # Update config
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableLegacySidebar: true,
+            },
+        });
+
         cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             cy.visit(`/${team.name}/channels/${channel.name}`);
         });

--- a/e2e/cypress/support/api/cloud_default_config.json
+++ b/e2e/cypress/support/api/cloud_default_config.json
@@ -28,7 +28,7 @@
         "EnableBotAccountCreation": true,
         "EnableSVGs": true,
         "EnableLatex": false,
-        "EnableLegacySidebar": true
+        "EnableLegacySidebar": false
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/e2e/cypress/support/api/on_prem_default_config.json
+++ b/e2e/cypress/support/api/on_prem_default_config.json
@@ -82,7 +82,7 @@
         "EnableBotAccountCreation": true,
         "EnableSVGs": true,
         "EnableLatex": false,
-        "EnableLegacySidebar": true
+        "EnableLegacySidebar": false
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/e2e/cypress/support/ldap_commands.js
+++ b/e2e/cypress/support/ldap_commands.js
@@ -18,6 +18,7 @@ Cypress.Commands.add('doLDAPLogin', (settings = {}, useEmail = false) => {
     // # Go to login page
     cy.apiLogout();
     cy.visit('/login');
+    cy.wait(TIMEOUTS.FIVE_SEC);
     cy.checkLoginPage(settings);
     cy.performLDAPLogin(settings, useEmail);
 });

--- a/e2e/cypress/support/ui/channel.js
+++ b/e2e/cypress/support/ui/channel.js
@@ -9,14 +9,9 @@ Cypress.Commands.add('uiCreateChannel', ({
     isPrivate = false,
     purpose = '',
     header = '',
-    isNewSidebar = false,
 }) => {
-    if (isNewSidebar) {
-        cy.get('#SidebarContainer .AddChannelDropdown_dropdownButton').click();
-        cy.get('#showNewChannel button').click();
-    } else {
-        cy.get('#createPrivateChannel').click();
-    }
+    cy.get('#SidebarContainer .AddChannelDropdown_dropdownButton').click();
+    cy.get('#showNewChannel button').click();
 
     cy.get('#newChannelModalLabel').should('be.visible');
     if (isPrivate) {
@@ -75,7 +70,7 @@ Cypress.Commands.add('uiLeaveChannel', (isPrivate = false) => {
 });
 
 Cypress.Commands.add('goToDm', (username) => {
-    cy.get('#addDirectChannel').click({force: true});
+    cy.uiAddDirectMessage().click({force: true});
 
     // # Start typing part of a username that matches previously created users
     cy.get('#selectItems input').type(username, {force: true});

--- a/e2e/cypress/support/ui/index.js
+++ b/e2e/cypress/support/ui/index.js
@@ -3,6 +3,7 @@
 
 import './account_settings_modal';
 import './announcement_bar';
+import './channel';
 import './channel_sidebar';
 import './common';
 import './extend_testing_library';
@@ -10,6 +11,6 @@ import './menu';
 import './modal';
 import './post_dropdown_menu';
 import './search';
+import './sidebar_left';
 import './system';
-import './channel';
 import './team';

--- a/e2e/cypress/support/ui/sidebar_left.d.ts
+++ b/e2e/cypress/support/ui/sidebar_left.d.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `ui` prefix, e.g. `uiCheckLicenseExists`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable {
+
+        /**
+         * Get LHS section
+         * @param {string} section - section such as UNREADS, CHANNELS, FAVORITES, DIRECT MESSAGES and other custom category
+         *
+         * @example
+         *   cy.uiGetLhsSection('CHANNELS');
+         */
+        uiGetLhsSection(section: string): Chainable;
+
+        /**
+         * Open menu to browse or create channel
+         * @param {string} item - dropdown menu. If set, it will do click action.
+         *
+         * @example
+         *   cy.uiBrowseOrCreateChannel('Browse Channels');
+         */
+        uiBrowseOrCreateChannel(item: string): Chainable;
+
+        /**
+         * Get "+" button to write a direct message
+         * @example
+         *   cy.uiAddDirectMessage();
+         */
+        uiAddDirectMessage(): Chainable;
+
+        /**
+         * Get a button for channel switcher
+         * @example
+         *   cy.uiGetChannelSwitcher();
+         */
+        uiGetChannelSwitcher(): Chainable;
+
+        /**
+         * Open menu of a channel in the sidebar
+         * @param {string} channelName - name of channel, ex. 'town-square'
+         *
+         * @example
+         *   cy.uiGetChannelSidebarMenu('town-square');
+         */
+        uiGetChannelSidebarMenu(channelName: string): Chainable;
+    }
+}

--- a/e2e/cypress/support/ui/sidebar_left.js
+++ b/e2e/cypress/support/ui/sidebar_left.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+Cypress.Commands.add('uiGetLhsSection', (section) => {
+    if (section === 'UNREADS') {
+        return cy.findByText(section).parent().parent().parent();
+    }
+
+    return cy.findAllByRole('button', {name: section}).first().parent().parent().parent();
+});
+
+Cypress.Commands.add('uiBrowseOrCreateChannel', (item) => {
+    cy.findByRole('button', {name: 'Add Channel Dropdown'}).should('be.visible').click();
+    cy.get('.dropdown-menu').should('be.visible');
+
+    if (item) {
+        cy.findByRole('menuitem', {name: item});
+    }
+});
+
+Cypress.Commands.add('uiAddDirectMessage', () => {
+    return cy.findByRole('button', {name: 'Write a direct message'});
+});
+
+Cypress.Commands.add('uiGetChannelSwitcher', () => {
+    return cy.get('#lhsNavigator').findByRole('button', {name: 'Channel Switcher'});
+});
+
+Cypress.Commands.add('uiGetChannelSidebarMenu', (channelName) => {
+    cy.get(`#sidebarItem_${channelName}`).find('.SidebarMenu_menuButton').click({force: true});
+
+    return cy.get('.dropdown-menu').should('be.visible');
+});

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -108,7 +108,7 @@ Cypress.Commands.add('uiPostMessageQuickly', (message) => {
 function postMessageAndWait(textboxSelector, message) {
     // Add explicit wait to let the page load freely since `cy.get` seemed to block
     // some operation which caused to prolong complete page loading.
-    cy.wait(TIMEOUTS.THREE_SEC);
+    cy.wait(TIMEOUTS.HALF_SEC);
 
     cy.get(textboxSelector, {timeout: TIMEOUTS.HALF_MIN}).as('textboxSelector');
     cy.get('@textboxSelector').should('be.visible').clear().type(`${message}{enter}`).wait(TIMEOUTS.HALF_SEC);
@@ -229,7 +229,7 @@ Cypress.Commands.add('compareLastPostHTMLContentFromFile', (file, timeout = TIME
  */
 Cypress.Commands.add('sendDirectMessageToUser', (user, message) => {
     // # Open a new direct message with firstDMUser
-    cy.get('#addDirectChannel').click();
+    cy.uiAddDirectMessage().click();
 
     // # Type username
     cy.get('#selectItems input').should('be.enabled').type(`@${user.username}`, {force: true});
@@ -265,7 +265,7 @@ Cypress.Commands.add('sendDirectMessageToUser', (user, message) => {
  */
 Cypress.Commands.add('sendDirectMessageToUsers', (users, message) => {
     // # Open a new direct message
-    cy.get('#addDirectChannel').click();
+    cy.uiAddDirectMessage().click();
 
     users.forEach((user) => {
         // # Type username
@@ -296,26 +296,6 @@ Cypress.Commands.add('sendDirectMessageToUsers', (users, message) => {
     cy.get('#post_textbox').
         type(message).
         type('{enter}');
-});
-
-/**
- * Close a DM via the X button
- * @param {User} sender - the one currently observing and who will close the DM
- * @param {User} recipient - the other user in a DM
- * @param {String} team - a team where the sender is member of
- */
-Cypress.Commands.add('closeDirectMessageViaXButton', (sender, recipient, team) => {
-    // # Find the username in the 'Direct Messages' list and trigger the 'x' button to appear (hover over the username)
-    cy.apiGetChannelsForUser(sender.id, team.id).then(({channels}) => {
-        // Get the name of the channel to build the CSS selector for that specific DM link in the sidebar
-        const channelDmWithFirstUser = channels.find((channel) =>
-            channel.type === 'D' && channel.name.includes(recipient.id),
-        );
-
-        // # Close the DM via 'x' button next to username in direct message list
-        cy.get(`#sidebarItem_${channelDmWithFirstUser.name} .btn-close`).
-            click({force: true});
-    });
 });
 
 // ***********************************************************

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -32,6 +32,7 @@
   "accessibility.sections.channelHeader": "channel header region",
   "accessibility.sections.lhsHeader": "team menu region",
   "accessibility.sections.lhsList": "channel sidebar region",
+  "accessibility.sections.lhsNavigator": "channel navigator region",
   "accessibility.sections.rhs": "{regionTitle} complimentary region",
   "accessibility.sections.rhsContent": "message details complimentary region",
   "accessibility.sections.rhsFooter": "reply input region",


### PR DESCRIPTION
#### Summary
This PR fixes the failed tests on cloud edition (almost 20%) due to the new sidebar feature - https://mm-cypress-report.s3.amazonaws.com/3318-cloud-feb-24-mm-ee-test:prerelease/mochawesome.html.

- Added/modified test IDs and accessibility - `lhsNavigator` and `lhsList`, accessibility with `role=application`
- Made tests with new sidebar by default
- Remained some tests of legacy sidebar to on-prem edition


Test report with fixes in this PR - https://3378-258381479-gh.circle-artifacts.com/0/~/mattermost/e2e/results/mochawesome-report/mochawesome.html