### PR TITLE
Cypress/E2E: Add request on first E2E test

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -16,6 +16,7 @@
         "dbConnection": "postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable\u0026connect_timeout=10",
         "enableApplitools": false,
         "enableVisualTest": false,
+        "firstTest": false,
         "keycloakAppName": "mattermost",
         "keycloakBaseUrl": "http://localhost:8484",
         "ldapServer": "localhost",

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -108,9 +108,6 @@ before(() => {
         } else {
             // # Create and login a newly created user as sysadmin
             cy.apiCreateAdmin().then(({sysadmin}) => {
-                // Sends dummy call to update the config after creating an admin user.
-                // Without this, first call to `cy.apiUpdateConfig()` consistently getting time out error in CI against remote server.
-                cy.externalRequest({user: sysadmin, method: 'put', path: 'config', data: getDefaultConfig(), failOnStatusCode: false});
                 cy.apiAdminLogin().then(() => sysadminSetup(sysadmin));
             });
         }
@@ -154,6 +151,12 @@ function printServerDetails() {
 }
 
 function sysadminSetup(user) {
+    if (Cypress.env('firstTest')) {
+        // Sends dummy call to update the config to server
+        // Without this, first call to `cy.apiUpdateConfig()` consistently getting time out error in CI against remote server.
+        cy.externalRequest({user, method: 'put', path: 'config', data: getDefaultConfig(), failOnStatusCode: false});
+    }
+
     if (!user.email_verified) {
         cy.apiVerifyUserEmailById(user.id);
     }

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -105,6 +105,7 @@ async function runTests() {
                 enableVisualTest: ENABLE_VISUAL_TEST,
                 enableApplitools: Boolean(APPLITOOLS_API_KEY),
                 batchName: APPLITOOLS_BATCH_NAME,
+                firstTest: j === 0,
             },
             reporter: 'cypress-multi-reporters',
             reporterOptions: {


### PR DESCRIPTION
#### Summary
Timeout error on first request to update the config consistently happened before on fresh remote test server. However, lately, I'm seeing the same to server pre-generated with sample data (using `sampledata` CLI command). With that, I just moved the dummy call to a common logic and add a `CYPRESS_firstTest` environment variable so it will trigger on first test only upon running `node run_tests.js` (the one we're using in CI). In local dev, it's set to `false` by default.
