### PR TITLE
Upgrading Compliance Export tests to prod

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/compliance/download_compliance_export_file_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/download_compliance_export_file_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 import * as TIMEOUTS from '../../../../fixtures/timeouts';


### PR DESCRIPTION
The following test -- T3439 -- has been passing for the last 5 runs. The other two tests, T3435 and T3438 had already been passing consistently, hence proposing to promote the entire spec to prod.
![Screen Shot 2021-02-18 at 5 49 05 PM](https://user-images.githubusercontent.com/691331/108445747-c892b380-7211-11eb-80be-80f325d1229b.png)
