### PR TITLE
Fix custom status possible race condition

### DIFF
--- a/selectors/views/custom_status.ts
+++ b/selectors/views/custom_status.ts
@@ -15,7 +15,7 @@ export function makeGetCustomStatus(): (state: GlobalState, userID?: string) => 
     return createSelector(
         (state: GlobalState, userID?: string) => (userID ? getUser(state, userID) : getCurrentUser(state)),
         (user) => {
-            const userProps = user.props || {};
+            const userProps = user && user.props ? user.props : {};
             return userProps.customStatus && JSON.parse(userProps.customStatus);
         },
     );

--- a/selectors/views/custom_status.ts
+++ b/selectors/views/custom_status.ts
@@ -15,7 +15,7 @@ export function makeGetCustomStatus(): (state: GlobalState, userID?: string) => 
     return createSelector(
         (state: GlobalState, userID?: string) => (userID ? getUser(state, userID) : getCurrentUser(state)),
         (user) => {
-            const userProps = user && user.props ? user.props : {};
+            const userProps = user?.props || {};
             return userProps.customStatus && JSON.parse(userProps.customStatus);
         },
     );


### PR DESCRIPTION
#### Summary
Fix custom status possible race condition. Looks like in some cases the user
requests is not yet in the redux-store whenever this is trying to show the
custom status. So it fails. This new approach simply ignore that situation.

#### Ticket Link
[MM-33047](https://mattermost.atlassian.net/browse/MM-33047)