### PR TITLE
Fix App parser

### DIFF
--- a/components/suggestion/command_provider/app_command_parser.test.ts
+++ b/components/suggestion/command_provider/app_command_parser.test.ts
@@ -282,6 +282,11 @@ describe('AppCommandParser', () => {
             expect(res).toHaveLength(1);
         });
 
+        test('string matches case insensitive', () => {
+            const res = parser.getSuggestionsBase('/JiRa');
+            expect(res).toHaveLength(1);
+        });
+
         test('string is past base command', () => {
             const res = parser.getSuggestionsBase('/jira ');
             expect(res).toHaveLength(0);
@@ -307,6 +312,16 @@ describe('AppCommandParser', () => {
                     expect(parsed.state).toBe(ParseState.EndCommand);
                     expect(parsed.binding?.label).toBe('create');
                     expect(parsed.incomplete).toBe('--project');
+                    expect(parsed.incompleteStart).toBe(19);
+                }},
+            },
+            {
+                title: 'full command case insensitive',
+                command: '/JiRa IsSuE CrEaTe --PrOjEcT P  --SuMmArY = "SUM MA RY" --VeRbOsE --EpIc=epic2',
+                submit: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.EndCommand);
+                    expect(parsed.binding?.label).toBe('create');
+                    expect(parsed.incomplete).toBe('--PrOjEcT');
                     expect(parsed.incompleteStart).toBe(19);
                 }},
             },
@@ -432,6 +447,30 @@ describe('AppCommandParser', () => {
                 }},
             },
             {
+                title: 'happy full create case insensitive',
+                command: '/JiRa IsSuE CrEaTe --PrOjEcT `P 1`  --SuMmArY "SUM MA RY" --VeRbOsE --EpIc=epic2',
+                autocomplete: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.EndValue);
+                    expect(parsed.binding?.label).toBe('create');
+                    expect(parsed.form?.call?.url).toBe('/create-issue');
+                    expect(parsed.incomplete).toBe('epic2');
+                    expect(parsed.incompleteStart).toBe(75);
+                    expect(parsed.values?.project).toBe('P 1');
+                    expect(parsed.values?.epic).toBeUndefined();
+                    expect(parsed.values?.summary).toBe('SUM MA RY');
+                    expect(parsed.values?.verbose).toBe('true');
+                }},
+                submit: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.EndValue);
+                    expect(parsed.binding?.label).toBe('create');
+                    expect(parsed.form?.call?.url).toBe('/create-issue');
+                    expect(parsed.values?.project).toBe('P 1');
+                    expect(parsed.values?.epic).toBe('epic2');
+                    expect(parsed.values?.summary).toBe('SUM MA RY');
+                    expect(parsed.values?.verbose).toBe('true');
+                }},
+            },
+            {
                 title: 'partial epic',
                 command: '/jira issue create --project KT --summary "great feature" --epic M',
                 autocomplete: {verify: (parsed: ParsedCommand): void => {
@@ -507,7 +546,7 @@ describe('AppCommandParser', () => {
                 title: 'error: unmatched tick',
                 command: '/jira issue view --project `P 1',
                 autocomplete: {verify: (parsed: ParsedCommand): void => {
-                    expect(parsed.state).toBe(ParseState.EndValue);
+                    expect(parsed.state).toBe(ParseState.TickValue);
                     expect(parsed.binding?.label).toBe('view');
                     expect(parsed.form?.call?.url).toBe('/view-issue');
                     expect(parsed.incomplete).toBe('P 1');
@@ -521,7 +560,7 @@ describe('AppCommandParser', () => {
                 title: 'error: unmatched quote',
                 command: '/jira issue view --project "P \\1',
                 autocomplete: {verify: (parsed: ParsedCommand): void => {
-                    expect(parsed.state).toBe(ParseState.EndValue);
+                    expect(parsed.state).toBe(ParseState.QuotedValue);
                     expect(parsed.binding?.label).toBe('view');
                     expect(parsed.form?.call?.url).toBe('/view-issue');
                     expect(parsed.incomplete).toBe('P 1');
@@ -594,7 +633,19 @@ describe('AppCommandParser', () => {
             expect(suggestions).toEqual([
                 {
                     suggestion: '/issue',
-                    complete: '/jira issue ',
+                    complete: '/jira issue',
+                    hint: '',
+                    description: 'Interact with Jira issues',
+                },
+            ]);
+        });
+
+        test('subcommand 1 case insensitive', async () => {
+            const suggestions = await parser.getSuggestions('/JiRa ');
+            expect(suggestions).toEqual([
+                {
+                    suggestion: '/issue',
+                    complete: '/JiRa issue',
                     hint: '',
                     description: 'Interact with Jira issues',
                 },
@@ -606,7 +657,19 @@ describe('AppCommandParser', () => {
             expect(suggestions).toEqual([
                 {
                     suggestion: '/issue',
-                    complete: '/jira issue ',
+                    complete: '/jira issue',
+                    hint: '',
+                    description: 'Interact with Jira issues',
+                },
+            ]);
+        });
+
+        test('subcommand 2 case insensitive', async () => {
+            const suggestions = await parser.getSuggestions('/JiRa IsSuE');
+            expect(suggestions).toEqual([
+                {
+                    suggestion: '/issue',
+                    complete: '/JiRa issue',
                     hint: '',
                     description: 'Interact with Jira issues',
                 },
@@ -618,13 +681,31 @@ describe('AppCommandParser', () => {
             expect(suggestions).toEqual([
                 {
                     suggestion: '/view',
-                    complete: '/jira issue view ',
+                    complete: '/jira issue view',
                     hint: '',
                     description: 'View details of a Jira issue',
                 },
                 {
                     suggestion: '/create',
-                    complete: '/jira issue create ',
+                    complete: '/jira issue create',
+                    hint: '',
+                    description: 'Create a new Jira issue',
+                },
+            ]);
+        });
+
+        test('subcommand 2 with a space case insensitive', async () => {
+            const suggestions = await parser.getSuggestions('/JiRa IsSuE ');
+            expect(suggestions).toEqual([
+                {
+                    suggestion: '/view',
+                    complete: '/JiRa IsSuE view',
+                    hint: '',
+                    description: 'View details of a Jira issue',
+                },
+                {
+                    suggestion: '/create',
+                    complete: '/JiRa IsSuE create',
                     hint: '',
                     description: 'Create a new Jira issue',
                 },
@@ -636,7 +717,19 @@ describe('AppCommandParser', () => {
             expect(suggestions).toEqual([
                 {
                     suggestion: '/create',
-                    complete: '/jira issue create ',
+                    complete: '/jira issue create',
+                    hint: '',
+                    description: 'Create a new Jira issue',
+                },
+            ]);
+        });
+
+        test('subcommand 3 partial case insensitive', async () => {
+            const suggestions = await parser.getSuggestions('/JiRa IsSuE C');
+            expect(suggestions).toEqual([
+                {
+                    suggestion: '/create',
+                    complete: '/JiRa IsSuE create',
                     hint: '',
                     description: 'Create a new Jira issue',
                 },
@@ -647,7 +740,7 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue view ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue view ',
+                    complete: '/jira issue view',
                     description: 'The Jira issue key',
                     hint: 'MM-11343',
                     suggestion: '/',
@@ -659,7 +752,7 @@ describe('AppCommandParser', () => {
             let suggestions = await parser.getSuggestions('/jira issue view -');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue view --project ',
+                    complete: '/jira issue view --project',
                     description: 'The Jira project description',
                     hint: 'The Jira project hint',
                     suggestion: '/--project',
@@ -669,7 +762,7 @@ describe('AppCommandParser', () => {
             suggestions = await parser.getSuggestions('/jira issue view --');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue view --project ',
+                    complete: '/jira issue view --project',
                     description: 'The Jira project description',
                     hint: 'The Jira project hint',
                     suggestion: '/--project',
@@ -688,25 +781,56 @@ describe('AppCommandParser', () => {
                     suggestion: '/Execute Current Command',
                 },
                 {
-                    complete: '/jira issue create --project ',
+                    complete: '/jira issue create --project',
                     description: 'The Jira project description',
                     hint: 'The Jira project hint',
                     suggestion: '/--project',
                 },
                 {
-                    complete: '/jira issue create --summary ',
+                    complete: '/jira issue create --summary',
                     description: 'The Jira issue summary',
                     hint: 'The thing is working great!',
                     suggestion: '/--summary',
                 },
                 {
-                    complete: '/jira issue create --verbose ',
+                    complete: '/jira issue create --verbose',
                     description: 'display details',
                     hint: 'yes or no!',
                     suggestion: '/--verbose',
                 },
                 {
-                    complete: '/jira issue create --epic ',
+                    complete: '/jira issue create --epic',
+                    description: 'The Jira epic',
+                    hint: 'The thing is working great!',
+                    suggestion: '/--epic',
+                },
+            ]);
+        });
+
+        test('used flags do not appear', async () => {
+            const suggestions = await parser.getSuggestions('/jira issue create --project KT ');
+            expect(suggestions).toEqual([
+                {
+                    complete: '/jira issue create --project KT _execute_current_command',
+                    description: 'Select this option or use Ctrl+Enter to execute the current command.',
+                    hint: '',
+                    iconData: '_execute_current_command',
+                    suggestion: '/Execute Current Command',
+                },
+                {
+                    complete: '/jira issue create --project KT --summary',
+                    description: 'The Jira issue summary',
+                    hint: 'The thing is working great!',
+                    suggestion: '/--summary',
+                },
+                {
+                    complete: '/jira issue create --project KT --verbose',
+                    description: 'display details',
+                    hint: 'yes or no!',
+                    suggestion: '/--verbose',
+                },
+                {
+                    complete: '/jira issue create --project KT --epic',
                     description: 'The Jira epic',
                     hint: 'The thing is working great!',
                     suggestion: '/--epic',
@@ -718,7 +842,7 @@ describe('AppCommandParser', () => {
             const mid = await parser.getSuggestions('/jira issue create --project KT --summ');
             expect(mid).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary ',
+                    complete: '/jira issue create --project KT --summary',
                     description: 'The Jira issue summary',
                     hint: 'The thing is working great!',
                     suggestion: '/--summary',
@@ -728,10 +852,58 @@ describe('AppCommandParser', () => {
             const full = await parser.getSuggestions('/jira issue create --project KT --summary');
             expect(full).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary ',
+                    complete: '/jira issue create --project KT --summary',
                     description: 'The Jira issue summary',
                     hint: 'The thing is working great!',
                     suggestion: '/--summary',
+                },
+            ]);
+        });
+
+        test('empty text value suggestion', async () => {
+            const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary ');
+            expect(suggestions).toEqual([
+                {
+                    complete: '/jira issue create --project KT --summary',
+                    description: 'The Jira issue summary',
+                    hint: 'The thing is working great!',
+                    suggestion: '/Sum',
+                },
+            ]);
+        });
+
+        test('partial text value suggestion', async () => {
+            const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary Sum');
+            expect(suggestions).toEqual([
+                {
+                    complete: '/jira issue create --project KT --summary Sum',
+                    description: 'The Jira issue summary',
+                    hint: 'The thing is working great!',
+                    suggestion: '/Sum',
+                },
+            ]);
+        });
+
+        test('quote text value suggestion close quotes', async () => {
+            const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "Sum');
+            expect(suggestions).toEqual([
+                {
+                    complete: '/jira issue create --project KT --summary "Sum"',
+                    description: 'The Jira issue summary',
+                    hint: 'The thing is working great!',
+                    suggestion: '/Sum',
+                },
+            ]);
+        });
+
+        test('tick text value suggestion close quotes', async () => {
+            const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary `Sum');
+            expect(suggestions).toEqual([
+                {
+                    complete: '/jira issue create --project KT --summary `Sum`',
+                    description: 'The Jira issue summary',
+                    hint: 'The thing is working great!',
+                    suggestion: '/Sum',
                 },
             ]);
         });
@@ -740,7 +912,7 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create --summary ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --summary ',
+                    complete: '/jira issue create --summary',
                     description: 'The Jira issue summary',
                     hint: 'The thing is working great!',
                     suggestion: '/',
@@ -757,7 +929,7 @@ describe('AppCommandParser', () => {
 
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project special-value ',
+                    complete: '/jira issue create --project special-value',
                     suggestion: '/special-value',
                     description: 'special-label',
                     hint: '',
@@ -770,13 +942,13 @@ describe('AppCommandParser', () => {
             let suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic Dylan Epic ',
+                    complete: '/jira issue create --project KT --summary "great feature" --epic Dylan Epic',
                     suggestion: '/Dylan Epic',
                     description: '',
                     hint: '',
                 },
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic Michael Epic ',
+                    complete: '/jira issue create --project KT --summary "great feature" --epic Michael Epic',
                     suggestion: '/Michael Epic',
                     description: '',
                     hint: '',
@@ -786,7 +958,7 @@ describe('AppCommandParser', () => {
             suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic M');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic Michael Epic ',
+                    complete: '/jira issue create --project KT --summary "great feature" --epic Michael Epic',
                     suggestion: '/Michael Epic',
                     description: '',
                     hint: '',
@@ -798,10 +970,10 @@ describe('AppCommandParser', () => {
         });
 
         test('filled out form shows execute', async () => {
-            const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic epicvalue ');
+            const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic epicvalue --verbose true ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic epicvalue _execute_current_command',
+                    complete: '/jira issue create --project KT --summary "great feature" --epic epicvalue --verbose true _execute_current_command',
                     suggestion: '/Execute Current Command',
                     description: 'Select this option or use Ctrl+Enter to execute the current command.',
                     iconData: '_execute_current_command',

--- a/components/suggestion/command_provider/app_command_parser.test.ts
+++ b/components/suggestion/command_provider/app_command_parser.test.ts
@@ -867,7 +867,7 @@ describe('AppCommandParser', () => {
                     complete: '/jira issue create --project KT --summary',
                     description: 'The Jira issue summary',
                     hint: 'The thing is working great!',
-                    suggestion: '/Sum',
+                    suggestion: '/',
                 },
             ]);
         });

--- a/components/suggestion/command_provider/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser.ts
@@ -5,7 +5,7 @@
 
 import {getAppBindings} from 'mattermost-redux/selectors/entities/apps';
 
-import {AppBindingLocations, AppCallTypes, AppFieldTypes} from 'mattermost-redux/constants/apps';
+import {AppBindingLocations, AppCallResponseTypes, AppCallTypes, AppFieldTypes} from 'mattermost-redux/constants/apps';
 
 import {
     AppCall,
@@ -90,7 +90,7 @@ export class ParsedCommand {
     };
 
     errorMessage = (): string => {
-        return this.error + '\n\n' + this.command + '\n' + ' '.repeat(this.i) + '^';
+        return 'Parsing error: ' + this.error + '.\n```\n' + this.command + '\n' + ' '.repeat(this.i) + '^\n```';
     }
 
     // matchBinding finds the closest matching command binding.
@@ -144,7 +144,7 @@ export class ParsedCommand {
             }
 
             case ParseState.EndCommand: {
-                const binding = bindings.find((b: AppBinding) => b.label === this.incomplete);
+                const binding = bindings.find((b: AppBinding) => b.label === this.incomplete.toLowerCase());
                 if (!binding) {
                     // gone as far as we could, this token doesn't match a sub-command.
                     // return the state from the last matching binding
@@ -248,8 +248,10 @@ export class ParsedCommand {
             }
 
             case ParseState.ParameterSeparator: {
+                this.incompleteStart = this.i;
                 switch (c) {
                 case '':
+                    this.state = ParseState.StartParameter;
                     return this;
                 case ' ':
                 case '\t': {
@@ -288,7 +290,7 @@ export class ParsedCommand {
                 case ' ':
                 case '\t':
                 case '=': {
-                    const field = fields.find((f) => f.label === this.incomplete);
+                    const field = fields.find((f) => f.label === this.incomplete.toLowerCase());
                     if (!field) {
                         return this.asError('command does not accept flag ' + this.incomplete);
                     }
@@ -384,10 +386,12 @@ export class ParsedCommand {
                     if (!autocompleteMode) {
                         return this.asError('matching double quote expected before end of input');
                     }
-                    this.state = ParseState.EndValue;
-                    break;
+                    return this;
                 }
                 case '"': {
+                    if (this.incompleteStart === this.i-1) {
+                        return this.asError('empty values are not allowed');
+                    }
                     this.i++;
                     this.state = ParseState.EndValue;
                     break;
@@ -416,10 +420,12 @@ export class ParsedCommand {
                     if (!autocompleteMode) {
                         return this.asError('matching tick quote expected before end of input');
                     }
-                    this.state = ParseState.EndValue;
-                    break;
+                    return this;
                 }
                 case '`': {
+                    if (this.incompleteStart === this.i-1) {
+                        return this.asError('empty values are not allowed');
+                    }
                     this.i++;
                     this.state = ParseState.EndValue;
                     break;
@@ -507,6 +513,7 @@ export class AppCommandParser {
 
     // getSuggestionsBase is a synchronous function that returns results for base commands
     public getSuggestionsBase = (pretext: string): AutocompleteSuggestionWithComplete[] => {
+        const command = pretext.toLowerCase();
         const result: AutocompleteSuggestionWithComplete[] = [];
 
         const bindings = this.getCommandBindings();
@@ -519,7 +526,7 @@ export class AppCommandParser {
             if (base[0] !== '/') {
                 base = '/' + base;
             }
-            if (base.startsWith(pretext)) {
+            if (base.startsWith(command)) {
                 result.push({
                     suggestion: base,
                     complete: base,
@@ -603,11 +610,12 @@ export class AppCommandParser {
             return choice as AutocompleteSuggestionWithComplete;
         }
 
-        let complete = parsed.command.substring(0, parsed.incompleteStart);
-        complete += choice.complete || choice.suggestion;
-        if (!complete.endsWith(' ')) {
-            complete += ' ';
+        let goBackSpace = 0;
+        if (choice.complete === '') {
+            goBackSpace = 1;
         }
+        let complete = parsed.command.substring(0, parsed.incompleteStart - goBackSpace);
+        complete += choice.complete || choice.suggestion;
         choice.hint = choice.hint || '';
         choice.suggestion = '/' + choice.suggestion;
 
@@ -656,6 +664,7 @@ export class AppCommandParser {
 
     // isAppCommand determines if subcommand/form suggestions need to be returned
     isAppCommand = (pretext: string): boolean => {
+        const command = pretext.toLowerCase();
         for (const binding of this.getCommandBindings()) {
             let base = binding.app_id;
             if (!base) {
@@ -666,7 +675,7 @@ export class AppCommandParser {
                 base = '/' + base;
             }
 
-            if (pretext.startsWith(base + ' ')) {
+            if (command.startsWith(base + ' ')) {
                 return true;
             }
         }
@@ -713,6 +722,11 @@ export class AppCommandParser {
                 return undefined;
             }
             callResponse = res.data;
+            if (callResponse?.type === AppCallResponseTypes.ERROR) {
+                const errorMessage = callResponse.error || 'Unknown error.';
+                this.displayError(errorMessage);
+                return undefined;
+            }
         } catch (e) {
             this.displayError(e);
             return undefined;
@@ -754,7 +768,7 @@ export class AppCommandParser {
         const result: AutocompleteSuggestion[] = [];
 
         bindings.forEach((b) => {
-            if (b.label.toLowerCase().startsWith(parsed.incomplete)) {
+            if (b.label.toLowerCase().startsWith(parsed.incomplete.toLowerCase())) {
                 result.push({
                     complete: b.label,
                     suggestion: b.label,
@@ -786,9 +800,11 @@ export class AppCommandParser {
         case ParseState.EndValue:
         case ParseState.FlagValueSeparator:
         case ParseState.NonspaceValue:
-        case ParseState.QuotedValue:
-        case ParseState.TickValue:
             return this.getValueSuggestions(parsed);
+        case ParseState.QuotedValue:
+            return this.getValueSuggestions(parsed, '"');
+        case ParseState.TickValue:
+            return this.getValueSuggestions(parsed, '`');
         }
         return [];
     }
@@ -841,7 +857,7 @@ export class AppCommandParser {
             prefix = prefix.substring(1);
         }
 
-        const applicable = parsed.form.fields.filter((field) => field.label && field.label.startsWith(parsed.incomplete));
+        const applicable = parsed.form.fields.filter((field) => field.label && field.label.startsWith(parsed.incomplete.toLowerCase()) && !parsed.values[field.name]);
         if (applicable) {
             return applicable.map((f) => {
                 let suffix = '';
@@ -863,7 +879,7 @@ export class AppCommandParser {
     }
 
     // getSuggestionsForField gets suggestions for a positional or flag field value
-    getValueSuggestions = async (parsed: ParsedCommand): Promise<AutocompleteSuggestion[]> => {
+    getValueSuggestions = async (parsed: ParsedCommand, delimiter?: string): Promise<AutocompleteSuggestion[]> => {
         if (!parsed || !parsed.field) {
             return [];
         }
@@ -882,9 +898,14 @@ export class AppCommandParser {
             return this.getStaticSelectSuggestions(parsed);
         }
 
+        let complete = parsed.incomplete;
+        if (complete && delimiter) {
+            complete = delimiter + complete + delimiter;
+        }
+
         return [{
-            complete: '',
-            suggestion: '',
+            complete,
+            suggestion: parsed.incomplete,
             description: f.description,
             hint: f.hint,
         }];

--- a/components/suggestion/command_provider/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser.ts
@@ -389,7 +389,7 @@ export class ParsedCommand {
                     return this;
                 }
                 case '"': {
-                    if (this.incompleteStart === this.i-1) {
+                    if (this.incompleteStart === this.i - 1) {
                         return this.asError('empty values are not allowed');
                     }
                     this.i++;
@@ -423,7 +423,7 @@ export class ParsedCommand {
                     return this;
                 }
                 case '`': {
-                    if (this.incompleteStart === this.i-1) {
+                    if (this.incompleteStart === this.i - 1) {
                         return this.asError('empty values are not allowed');
                     }
                     this.i++;

--- a/components/suggestion/command_provider/command_provider.tsx
+++ b/components/suggestion/command_provider/command_provider.tsx
@@ -113,12 +113,11 @@ export default class CommandProvider extends Provider {
             return false;
         }
 
-        const command = pretext.toLowerCase();
-        if (this.appCommandParser?.isAppCommand(command)) {
-            this.appCommandParser.getSuggestions(command).then((matches) => {
+        if (this.appCommandParser?.isAppCommand(pretext)) {
+            this.appCommandParser.getSuggestions(pretext).then((matches) => {
                 const terms = matches.map((suggestion) => suggestion.complete);
                 resultCallback({
-                    matchedPretext: command,
+                    matchedPretext: pretext,
                     terms,
                     items: matches,
                     component: CommandSuggestion,

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -343,7 +343,7 @@ export default class SuggestionBox extends React.PureComponent {
 
     handleChange = (e) => {
         const textbox = this.getTextbox();
-        const pretext = textbox.value.substring(0, textbox.selectionEnd).toLowerCase();
+        const pretext = textbox.value.substring(0, textbox.selectionEnd);
 
         if (!this.composing && this.pretext !== pretext) {
             this.handlePretextChanged(pretext);


### PR DESCRIPTION
#### Summary
Fix several parser problems:
- Commands are case insensitive and they respect the casing of parameters
- Text value suggestion will not clean the value added
- Text value suggestion will not add an extra space when it is empty
- Quoted and ticked text value suggestion will close the quote and tick
- Command and flag suggestions will not add double space
- Use codeblocks to show errors so the arrow points the right position
- Slightly improve errors view
- Correct case where selecting a suggestion may not introduce the previous space
- Added call error management
- Remove already completed fields
- Quoted and ticked empty values will result in parsing error

Added several tests, not sure if they cover all cases.

#### Ticket Link
None

#### Related Pull Requests
None

#### Screenshots
None