### PR TITLE
Cypress/E2E: Fix E2E due to recent change in at-mention suggestion list

### DIFF
--- a/e2e/cypress/integration/account_settings/general/fullname_spec.js
+++ b/e2e/cypress/integration/account_settings/general/fullname_spec.js
@@ -41,7 +41,7 @@ describe('Account Settings > Sidebar > General', () => {
             // # Open Full Name section
             cy.get('#nameDesc').click();
 
-            // * Set first name value
+            // # Set first name value
             cy.get('#firstName').clear().type(newFirstName);
 
             // # Save form
@@ -58,19 +58,19 @@ describe('Account Settings > Sidebar > General', () => {
         // # Type in user's first name substring
         cy.get('#post_textbox').clear().type(`@${newFirstName.substring(0, 11)}`);
 
-        // # Verify that the testUser is selected from mention autocomplete
+        // * Verify that the testUser is selected from mention autocomplete
         cy.uiVerifyAtMentionInSuggestionList('Channel Members', {...testUser, first_name: newFirstName}, true);
 
         // # Press tab on text input
         cy.get('#post_textbox').tab();
 
-        // # Verify that after enter user`s username match
+        // * Verify that after enter user's username match
         cy.get('#post_textbox').should('have.value', `@${username} `);
 
         // # Click enter in post textbox
         cy.get('#post_textbox').type('{enter}');
 
-        // # Verify that message has been post in chat
+        // * Verify that message has been post in chat
         cy.get(`[data-mention="${username}"]`).
             last().
             scrollIntoView().

--- a/e2e/cypress/integration/account_settings/general/fullname_spec.js
+++ b/e2e/cypress/integration/account_settings/general/fullname_spec.js
@@ -13,8 +13,8 @@
 import {getRandomId} from '../../../utils';
 
 describe('Account Settings > Sidebar > General', () => {
-    // # number to identify particular user
     const randomId = getRandomId();
+    const newFirstName = `정트리나${randomId}/trina.jung/집단사무국(CO)`;
 
     let testTeam;
     let testUser;
@@ -42,40 +42,36 @@ describe('Account Settings > Sidebar > General', () => {
             cy.get('#nameDesc').click();
 
             // * Set first name value
-            cy.get('#firstName').clear().type(`정트리나${randomId}/trina.jung/집단사무국(CO)`);
+            cy.get('#firstName').clear().type(newFirstName);
 
-            // # save form
+            // # Save form
             cy.get('#saveSetting').click();
         });
     });
 
     it('MM-T183 Filtering by first name with Korean characters', () => {
+        const {username} = testUser;
+
         cy.apiLogin(otherUser);
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        // # type in user`s firstName substring
-        cy.get('#post_textbox').clear().type(`@정트리나${randomId}`);
+        // # Type in user`s firstName substring
+        cy.get('#post_textbox').clear().type(`@${newFirstName.substring(0, 11)}`);
 
-        cy.findByTestId(testUser.username, {exact: false}).within((name) => {
-            cy.wrap(name).prev('.suggestion-list__divider').
-                should('have.text', 'Channel Members');
-            cy.wrap(name).find('.mention--align').
-                should('have.text', `@${testUser.username}`);
-            cy.wrap(name).find('.ml-2').
-                should('have.text', `정트리나${randomId}/trina.jung/집단사무국(CO) ${testUser.last_name} (${testUser.nickname})`);
-        });
+        // # Verify that the testUser is selected from mention autocomplete
+        cy.uiVerifyAtMentionInSuggestionList('Channel Members', {...testUser, first_name: newFirstName}, true);
 
         // # Press tab on text input
         cy.get('#post_textbox').tab();
 
-        // # verify that after enter user`s username match
-        cy.get('#post_textbox').should('have.value', `@${testUser.username} `);
+        // # Verify that after enter user`s username match
+        cy.get('#post_textbox').should('have.value', `@${username} `);
 
-        // # click enter in post textbox
+        // # Click enter in post textbox
         cy.get('#post_textbox').type('{enter}');
 
-        // # verify that message has been post in chat
-        cy.get(`[data-mention="${testUser.username}"]`).
+        // # Verify that message has been post in chat
+        cy.get(`[data-mention="${username}"]`).
             last().
             scrollIntoView().
             should('be.visible');
@@ -117,4 +113,3 @@ describe('Account Settings -> General -> Full Name', () => {
         cy.get('#nameDesc').should('be.visible').should('contain', testUser.first_name + '_new ' + testUser.last_name);
     });
 });
-

--- a/e2e/cypress/integration/account_settings/general/fullname_spec.js
+++ b/e2e/cypress/integration/account_settings/general/fullname_spec.js
@@ -55,7 +55,7 @@ describe('Account Settings > Sidebar > General', () => {
         cy.apiLogin(otherUser);
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        // # Type in user`s firstName substring
+        // # Type in user's first name substring
         cy.get('#post_textbox').clear().type(`@${newFirstName.substring(0, 11)}`);
 
         // # Verify that the testUser is selected from mention autocomplete

--- a/e2e/cypress/integration/enterprise/accessibility/accessibility_input_fields_spec.js
+++ b/e2e/cypress/integration/enterprise/accessibility/accessibility_input_fields_spec.js
@@ -12,44 +12,6 @@
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
-function verifySearchAutocomplete(index, type = 'user') {
-    cy.get('#search-autocomplete__popover').find('.search-autocomplete__item').eq(index).should('be.visible').and('have.class', 'selected a11y--focused').within((el) => {
-        if (type === 'user') {
-            cy.get('.mention--align').invoke('text').then((text) => {
-                cy.get('.mention__fullname').invoke('text').then((fullName) => {
-                    const position = text.length - fullName.length;
-                    const usernameFullNameNickName = [text.slice(0, position), fullName].join(' ').replace('@', '').replace('(you)', '').replace('(', '').replace(')', '').toLowerCase();
-                    cy.wrap(el).parents('#searchFormContainer').find('.sr-only').should('have.attr', 'aria-live', 'polite').and('have.text', usernameFullNameNickName);
-                });
-            });
-        } else if (type === 'channel') {
-            cy.get('.search-autocomplete__name').invoke('text').then((text) => {
-                const channel = text.split('~')[1].toLowerCase().trim();
-                cy.wrap(el).parents('#searchFormContainer').find('.sr-only').should('have.attr', 'aria-live', 'polite').and('have.text', channel);
-            });
-        }
-    });
-}
-
-function verifyMessageAutocomplete(index, type = 'user') {
-    cy.get('#suggestionList').find('.mentions__name').eq(index).should('be.visible').and('have.class', 'suggestion--selected').within((el) => {
-        if (type === 'user') {
-            cy.wrap(el).invoke('text').then((text) => {
-                cy.get('.ml-2').invoke('text').then((fullName) => {
-                    const position = text.length - fullName.length;
-                    const usernameFullNameNickName = [text.slice(0, position), fullName].join(' ').replace('@', '').replace('(you)', '').replace('(', '').replace(')', '').toLowerCase();
-                    cy.wrap(el).parents('.textarea-wrapper').find('.sr-only').should('have.attr', 'aria-live', 'polite').and('have.text', usernameFullNameNickName);
-                });
-            });
-        } else if (type === 'channel') {
-            cy.wrap(el).invoke('text').then((text) => {
-                const channel = text.split('~')[0].toLowerCase().trim();
-                cy.wrap(el).parents('.textarea-wrapper').find('.sr-only').should('have.attr', 'aria-live', 'polite').and('have.text', channel);
-            });
-        }
-    });
-}
-
 describe('Verify Accessibility Support in different input fields', () => {
     let testTeam;
     let testChannel;
@@ -249,3 +211,49 @@ describe('Verify Accessibility Support in different input fields', () => {
         });
     });
 });
+
+function getUserMentionAriaLabel(rawFullText, fullName) {
+    const position = rawFullText.length - fullName.length;
+    return [rawFullText.slice(0, position), fullName].
+        join(' ').
+        replace('(you)', '').
+        replace(/[@()]/g, '').
+        toLowerCase().
+        trim();
+}
+
+function verifySearchAutocomplete(index, type = 'user') {
+    cy.get('#search-autocomplete__popover').find('.search-autocomplete__item').eq(index).should('be.visible').and('have.class', 'selected a11y--focused').within((el) => {
+        if (type === 'user') {
+            cy.get('.mention--align').invoke('text').then((text) => {
+                cy.get('.mention__fullname').invoke('text').then((fullName) => {
+                    const usernameFullNameNickName = getUserMentionAriaLabel(text, fullName);
+                    cy.wrap(el).parents('#searchFormContainer').find('.sr-only').should('have.attr', 'aria-live', 'polite').and('have.text', usernameFullNameNickName);
+                });
+            });
+        } else if (type === 'channel') {
+            cy.get('.search-autocomplete__name').invoke('text').then((text) => {
+                const channel = text.split('~')[1].toLowerCase().trim();
+                cy.wrap(el).parents('#searchFormContainer').find('.sr-only').should('have.attr', 'aria-live', 'polite').and('have.text', channel);
+            });
+        }
+    });
+}
+
+function verifyMessageAutocomplete(index, type = 'user') {
+    cy.get('#suggestionList').find('.mentions__name').eq(index).should('be.visible').and('have.class', 'suggestion--selected').within((el) => {
+        if (type === 'user') {
+            cy.wrap(el).invoke('text').then((text) => {
+                cy.get('.light').invoke('text').then((fullName) => {
+                    const usernameFullNameNickName = getUserMentionAriaLabel(text, fullName);
+                    cy.wrap(el).parents('.textarea-wrapper').find('.sr-only').should('have.attr', 'aria-live', 'polite').and('have.text', usernameFullNameNickName);
+                });
+            });
+        } else if (type === 'channel') {
+            cy.wrap(el).invoke('text').then((text) => {
+                const channel = text.split('~')[0].toLowerCase().trim();
+                cy.wrap(el).parents('.textarea-wrapper').find('.sr-only').should('have.attr', 'aria-live', 'polite').and('have.text', channel);
+            });
+        }
+    });
+}

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
@@ -238,9 +238,6 @@ module.exports = {
         cy.get('#suggestionList', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
 
         // # Verify user appears in results post-change
-        return cy.findByTestId(`mentionSuggestion_${user.username}`, {exact: false}).within((name) => {
-            cy.wrap(name).find('.mention--align').should('have.text', `@${user.username}`);
-            cy.wrap(name).find('.ml-2').should('have.text', `${user.first_name} ${user.last_name} (${user.nickname})`);
-        });
+        return cy.uiVerifyAtMentionSuggestion(user);
     },
 };

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
@@ -237,7 +237,7 @@ module.exports = {
         // * Suggestion list should appear
         cy.get('#suggestionList', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
 
-        // # Verify user appears in results post-change
+        // * Verify user appears in results post-change
         return cy.uiVerifyAtMentionSuggestion(user);
     },
 };

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
@@ -54,12 +54,9 @@ describe('Autocomplete with Elasticsearch - Users', () => {
                         should('be.visible').
                         clear();
                 },
-                verifySuggestion: (...expectedtestUsers) => {
-                    expectedtestUsers.forEach((user) => {
-                        cy.findByTestId(`mentionSuggestion_${user.username}`, {exact: false}).within((name) => {
-                            cy.wrap(name).find('.mention--align').should('have.text', `@${user.username}`);
-                            cy.wrap(name).find('.ml-2').should('have.text', `${user.first_name} ${user.last_name} (${user.nickname})`);
-                        });
+                verifySuggestion: (...expectedUsers) => {
+                    expectedUsers.forEach((user) => {
+                        cy.uiVerifyAtMentionSuggestion(user);
                     });
                 },
             };
@@ -178,8 +175,8 @@ describe('Autocomplete with Elasticsearch - Users', () => {
                         as('input').
                         clear();
                 },
-                verifySuggestion: (...expectedtestUsers) => {
-                    expectedtestUsers.forEach((user) => {
+                verifySuggestion: (...expectedUsers) => {
+                    expectedUsers.forEach((user) => {
                         cy.findByTestId(user.username).
                             should('be.visible').
                             and('have.text', `@${user.username} - ${user.first_name} ${user.last_name} (${user.nickname})`);
@@ -317,18 +314,10 @@ describe('Autocomplete with Elasticsearch - Users', () => {
                 type('@odinson');
 
             // * Thor should be a channel member
-            cy.findByTestId(thor.username, {exact: false}).within((name) => {
-                cy.wrap(name).prev('.suggestion-list__divider').should('have.text', 'Channel Members');
-                cy.wrap(name).find('.mention--align').should('have.text', `@${thor.username}`);
-                cy.wrap(name).find('.ml-2').should('have.text', `${thor.first_name} ${thor.last_name} (${thor.nickname})`);
-            });
+            cy.uiVerifyAtMentionInSuggestionList('Channel Members', thor, true);
 
             // * Loki should NOT be a channel member
-            cy.findByTestId(loki.username, {exact: false}).within((name) => {
-                cy.wrap(name).prev('.suggestion-list__divider').should('have.text', 'Not in Channel');
-                cy.wrap(name).find('.mention--align').should('have.text', `@${loki.username}`);
-                cy.wrap(name).find('.ml-2').should('have.text', `${loki.first_name} ${loki.last_name} (${loki.nickname})`);
-            });
+            cy.uiVerifyAtMentionInSuggestionList('Not in Channel', loki, false);
         });
 
         it('DM can be opened with a user not on your team or in your DM channel sidebar', () => {

--- a/e2e/cypress/integration/search_autocomplete/renaming_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/renaming_spec.js
@@ -45,10 +45,7 @@ function searchAndVerifyUser(user) {
     cy.get('#suggestionList', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
 
     // # Verify user appears in results post-change
-    return cy.findByTestId(`mentionSuggestion_${user.username}`, {exact: false}).within((name) => {
-        cy.wrap(name).find('.mention--align').should('have.text', `@${user.username}`);
-        cy.wrap(name).find('.ml-2').should('have.text', `${user.first_name} ${user.last_name} (${user.nickname})`);
-    });
+    return cy.uiVerifyAtMentionSuggestion(user);
 }
 
 describe('Autocomplete without Elasticsearch - Renaming', () => {

--- a/e2e/cypress/integration/search_autocomplete/renaming_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/renaming_spec.js
@@ -44,7 +44,7 @@ function searchAndVerifyUser(user) {
     // * Suggestion list should appear
     cy.get('#suggestionList', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
 
-    // # Verify user appears in results post-change
+    // * Verify user appears in results post-change
     return cy.uiVerifyAtMentionSuggestion(user);
 }
 

--- a/e2e/cypress/integration/search_autocomplete/users_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/users_spec.js
@@ -10,6 +10,8 @@
 // Stage: @prod
 // Group: @autocomplete
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 import {getTestUsers} from '../enterprise/elasticsearch_autocomplete/helpers';
 
 describe('Autocomplete without Elasticsearch - Users', () => {
@@ -46,17 +48,14 @@ describe('Autocomplete without Elasticsearch - Users', () => {
         describe('search for user in message input box', () => {
             const area = {
                 getInput: () => {
-                    cy.get('#post_textbox').
+                    cy.wait(TIMEOUTS.HALF_SEC).get('#post_textbox').
                         as('input').
                         should('be.visible').
                         clear();
                 },
                 verifySuggestion: (...expectedUsers) => {
                     expectedUsers.forEach((user) => {
-                        cy.findByTestId(`mentionSuggestion_${user.username}`, {exact: false}).within((name) => {
-                            cy.wrap(name).find('.mention--align').should('have.text', `@${user.username}`);
-                            cy.wrap(name).find('.ml-2').should('have.text', `${user.first_name} ${user.last_name} (${user.nickname})`);
-                        });
+                        cy.uiVerifyAtMentionSuggestion(user);
                     });
                 },
             };
@@ -307,25 +306,17 @@ describe('Autocomplete without Elasticsearch - Users', () => {
             });
 
             // # Start an at mention that should return 2 users (in this case, the users share a last name)
-            cy.get('#post_textbox').
+            cy.wait(TIMEOUTS.HALF_SEC).get('#post_textbox').
                 as('input').
                 should('be.visible').
                 clear().
                 type('@odinson');
 
             // * Thor should be a channel member
-            cy.findByTestId(thor.username, {exact: false}).within((name) => {
-                cy.wrap(name).prev('.suggestion-list__divider').should('have.text', 'Channel Members');
-                cy.wrap(name).find('.mention--align').should('have.text', `@${thor.username}`);
-                cy.wrap(name).find('.ml-2').should('have.text', `${thor.first_name} ${thor.last_name} (${thor.nickname})`);
-            });
+            cy.uiVerifyAtMentionInSuggestionList('Channel Members', thor, true);
 
             // * Loki should NOT be a channel member
-            cy.findByTestId(loki.username, {exact: false}).within((name) => {
-                cy.wrap(name).prev('.suggestion-list__divider').should('have.text', 'Not in Channel');
-                cy.wrap(name).find('.mention--align').should('have.text', `@${loki.username}`);
-                cy.wrap(name).find('.ml-2').should('have.text', `${loki.first_name} ${loki.last_name} (${loki.nickname})`);
-            });
+            cy.uiVerifyAtMentionInSuggestionList('Not in Channel', loki, false);
         });
 
         it('DM can be opened with a user not on your team or in your DM channel sidebar', () => {

--- a/e2e/cypress/support/ui/index.js
+++ b/e2e/cypress/support/ui/index.js
@@ -13,5 +13,6 @@ import './modal';
 import './post_dropdown_menu';
 import './search';
 import './sidebar_left';
+import './suggestion_list';
 import './system';
 import './team';

--- a/e2e/cypress/support/ui/suggestion_list.d.ts
+++ b/e2e/cypress/support/ui/suggestion_list.d.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `ui` prefix, e.g. `uiCheckLicenseExists`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable {
+
+        /**
+         * Verify user's at-mention in the suggestion list
+         * @param {UserProfile} sectionDividerName - name of the section in suggestion list, ex. "Channel Members"
+         * @param {UserProfile} user - user object
+         * @param {boolean} isSelected - check if user is selected with false as default
+         *
+         * @example
+         *   cy.uiVerifyAtMentionInSuggestionList('Channel Members', user, true);
+         */
+        uiVerifyAtMentionInSuggestionList(sectionDividerName: string, user: UserProfile, isSelected: boolean): Chainable;
+
+        /**
+         * Verify user's at-mention suggestion
+         * @param {UserProfile} user - user object
+         * @param {boolean} isSelected - check if user is selected with false as default
+         *
+         * @example
+         *   cy.uiVerifyAtMentionSuggestion(user, true);
+         */
+        uiVerifyAtMentionSuggestion(user: UserProfile, isSelected: boolean): Chainable;
+    }
+}

--- a/e2e/cypress/support/ui/suggestion_list.js
+++ b/e2e/cypress/support/ui/suggestion_list.js
@@ -2,15 +2,15 @@
 // See LICENSE.txt for license information.
 
 Cypress.Commands.add('uiVerifyAtMentionInSuggestionList', (sectionDividerName, user, isSelected = false) => {
-    // # Verify that the suggestion list is open and visible
+    // * Verify that the suggestion list is open and visible
     return cy.get('#suggestionList').should('be.visible').within(() => {
         if (sectionDividerName) {
-            // # Verify the section name is as expected
+            // * Verify the section name is as expected
             cy.get('.suggestion-list__divider').findByText(sectionDividerName).should('be.visible');
             cy.get('.suggestion-list__divider').next().findByTestId(`mentionSuggestion_${user.username}`).should('be.visible');
         }
 
-        // # Verify that the user is selected
+        // * Verify that the user is selected
         return cy.uiVerifyAtMentionSuggestion(user, isSelected);
     });
 });
@@ -23,7 +23,7 @@ Cypress.Commands.add('uiVerifyAtMentionSuggestion', (user, isSelected = false) =
         nickname,
     } = user;
 
-    // # Verify that the user is selected
+    // * Verify that the user is selected
     cy.findByTestId(`mentionSuggestion_${username}`).as('selectedMentionSuggestion').should('be.visible');
     if (isSelected) {
         cy.get('@selectedMentionSuggestion').should('have.class', 'suggestion--selected');

--- a/e2e/cypress/support/ui/suggestion_list.js
+++ b/e2e/cypress/support/ui/suggestion_list.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+Cypress.Commands.add('uiVerifyAtMentionInSuggestionList', (sectionDividerName, user, isSelected = false) => {
+    // # Verify that the suggestion list is open and visible
+    return cy.get('#suggestionList').should('be.visible').within(() => {
+        if (sectionDividerName) {
+            // # Verify the section name is as expected
+            cy.get('.suggestion-list__divider').findByText(sectionDividerName).should('be.visible');
+            cy.get('.suggestion-list__divider').next().findByTestId(`mentionSuggestion_${user.username}`).should('be.visible');
+        }
+
+        // # Verify that the user is selected
+        return cy.uiVerifyAtMentionSuggestion(user, isSelected);
+    });
+});
+
+Cypress.Commands.add('uiVerifyAtMentionSuggestion', (user, isSelected = false) => {
+    const {
+        username,
+        first_name: firstName,
+        last_name: lastName,
+        nickname,
+    } = user;
+
+    // # Verify that the user is selected
+    cy.findByTestId(`mentionSuggestion_${username}`).as('selectedMentionSuggestion').should('be.visible');
+    if (isSelected) {
+        cy.get('@selectedMentionSuggestion').should('have.class', 'suggestion--selected');
+    }
+
+    cy.get('@selectedMentionSuggestion').findByText(`@${username}`).should('be.visible');
+    cy.get('@selectedMentionSuggestion').findByText(`${firstName} ${lastName} (${nickname})`).should('be.visible');
+
+    return cy.findByTestId(`mentionSuggestion_${username}`);
+});


### PR DESCRIPTION
#### Summary
Fix E2E due to [recent change in at-mention suggestion list](https://github.com/mattermost/mattermost-webapp/pull/7441) (with custom status), specifically related to the removal of [`.ml-2` class name](https://github.com/mattermost/mattermost-webapp/pull/7441/files#diff-38d76f42942a8534f255c0e3ee4e767dc70ff0083f309dfdbf47d5ebb7362cdcR176)

Added `cy.uiVerifyAtMentionInSuggestionList` and `cy. uiVerifyAtMentionSuggestion` to global custom commands to easily verify suggestion list, specifically for at-mention.

#### Ticket Link
none
