### PR TITLE
Cypress/E2E: Add filter for tests not for cloud

### DIFF
--- a/e2e/cypress/integration/auth_sso/authentication_2_spec.js
+++ b/e2e/cypress/integration/auth_sso/authentication_2_spec.js
@@ -122,28 +122,6 @@ describe('Authentication', () => {
         });
     });
 
-    it('MM-T1775 - Maximum Login Attempts field resets to default after saving invalid value', () => {
-        cy.visit('/admin_console/authentication/password');
-
-        cy.findByPlaceholderText('E.g.: "10"', {timeout: TIMEOUTS.ONE_MIN}).clear().type('ten');
-
-        cy.findByRole('button', {name: 'Save'}).click();
-
-        // * Ensure error appears when saving a password outside of the limits
-        cy.findByPlaceholderText('E.g.: "10"').invoke('val').should('equal', '10');
-    });
-
-    it('MM-T1776 - Maximum Login Attempts field successfully saves valid change', () => {
-        cy.visit('/admin_console/authentication/password');
-
-        cy.findByPlaceholderText('E.g.: "10"', {timeout: TIMEOUTS.ONE_MIN}).clear().type('2');
-
-        cy.findByRole('button', {name: 'Save'}).click();
-
-        // * Ensure error appears when saving a password outside of the limits
-        cy.findByPlaceholderText('E.g.: "10"').invoke('val').should('equal', '2');
-    });
-
     it('MM-T1777 - Multi-factor Authentication option hidden in Account Settings when disabled', () => {
         cy.apiUpdateConfig({
             ServiceSettings: {

--- a/e2e/cypress/integration/auth_sso/authentication_not_cloud_spec.js
+++ b/e2e/cypress/integration/auth_sso/authentication_not_cloud_spec.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @system_console @authentication @not_cloud
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('Authentication', () => {
+    before(() => {
+        cy.shouldNotRunOnCloudEdition();
+    });
+
+    beforeEach(() => {
+        // # Log in as admin.
+        cy.apiAdminLogin();
+    });
+
+    it('MM-T1775 - Maximum Login Attempts field resets to default after saving invalid value', () => {
+        cy.visit('/admin_console/authentication/password');
+
+        cy.findByPlaceholderText('E.g.: "10"', {timeout: TIMEOUTS.ONE_MIN}).clear().type('ten');
+
+        cy.findByRole('button', {name: 'Save'}).click();
+
+        // * Ensure error appears when saving a password outside of the limits
+        cy.findByPlaceholderText('E.g.: "10"').invoke('val').should('equal', '10');
+
+        // * Verify that the config remain the same
+        cy.apiGetConfig().then(({config}) => {
+            expect(config.ServiceSettings.MaximumLoginAttempts).to.equal(10);
+        });
+    });
+
+    it('MM-T1776 - Maximum Login Attempts field successfully saves valid change', () => {
+        cy.visit('/admin_console/authentication/password');
+
+        cy.findByPlaceholderText('E.g.: "10"', {timeout: TIMEOUTS.ONE_MIN}).clear().type('2');
+
+        cy.findByRole('button', {name: 'Save'}).click();
+
+        // * Ensure error appears when saving a password outside of the limits
+        cy.findByPlaceholderText('E.g.: "10"').invoke('val').should('equal', '2');
+
+        // * Verify that the config have changed
+        cy.apiGetConfig().then(({config}) => {
+            expect(config.ServiceSettings.MaximumLoginAttempts).to.equal(2);
+        });
+    });
+});

--- a/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
+++ b/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @channel
+// Group: @channel @not_cloud
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
@@ -40,6 +40,15 @@ describe('channel name tooltips', () => {
     let testTeam;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
+        // # Update config
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableLegacySidebar: true,
+            },
+        });
+
         // # Login as new user and visit town-square
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;

--- a/e2e/cypress/integration/enterprise/system_console/cluster_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/cluster_spec.js
@@ -7,10 +7,12 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @system_console @high_availability
+// Group: @enterprise @system_console @high_availability @not_cloud
 
 describe('Cluster', () => {
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // * Check if server has license
         cy.apiRequireLicense();
 

--- a/e2e/cypress/integration/enterprise/system_console/environment_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/environment_spec.js
@@ -8,12 +8,13 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise
+// Group: @enterprise @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('Environment', () => {
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
         cy.apiInitSetup();
     });
 

--- a/e2e/cypress/integration/enterprise/system_console/helpers.js
+++ b/e2e/cypress/integration/enterprise/system_console/helpers.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import accessRules from '../../../fixtures/system-roles-console-access';
+import disabledTests from '../../../fixtures/console-example-inputs';
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
+function noAccessFunc(section) {
+    // * If it's a no-access permission, we just need to check that the section doesn't exist in the side bar
+    cy.findByTestId(section).should('not.exist');
+}
+
+function readOnlyFunc(section) {
+    // * If it's a read only permission, we need to make sure that the section does exist in the sidebar however the inputs in that section is disabled (read only)
+    cy.findByTestId(section).should('exist');
+    checkInputsShould('be.disabled', section);
+}
+
+function readWriteFunc(section) {
+    // * If we have read + write (can edit) permissions, we need to make the section exists and also that the inputs are all enabled
+    cy.findByTestId(section).should('exist');
+    checkInputsShould('be.enabled', section);
+}
+
+function checkInputsShould(shouldString, section) {
+    const {disabledInputs} = disabledTests.find((item) => item.section === section);
+    Cypress._.forEach(disabledInputs, ({path, selector}) => {
+        if (path.length && selector.length) {
+            cy.visit(path, {timeout: TIMEOUTS.HALF_MIN});
+            cy.findByTestId(selector, {timeout: TIMEOUTS.ONE_MIN}).should(shouldString);
+        }
+    });
+}
+
+export function makeUserASystemRole(testUsers, role) {
+    // # Login as each new role.
+    cy.apiAdminLogin();
+
+    // # Go the system console.
+    cy.visit('/admin_console/user_management/system_roles');
+    cy.contains('System Roles', {timeout: TIMEOUTS.ONE_MIN}).should('exist').and('be.visible');
+
+    // # Click on edit for the role
+    cy.findByTestId(`${role}_edit`).click();
+
+    // # Click Add People button
+    cy.findByRole('button', {name: 'Add People'}).click().wait(TIMEOUTS.HALF_SEC);
+
+    // # Type in user name
+    cy.findByText('Search for people').type(`${testUsers[role].email}`);
+
+    // # Find the user and click on him
+    cy.get('#multiSelectList').should('be.visible').children().first().click({force: true});
+
+    // # Click add button
+    cy.findByRole('button', {name: 'Add'}).click().wait(TIMEOUTS.HALF_SEC);
+
+    // # Click save button
+    cy.findByRole('button', {name: 'Save'}).click().wait(TIMEOUTS.HALF_SEC);
+}
+
+export function forEachConsoleSection(testUsers, roleName) {
+    const ACCESS_NONE = 'none';
+    const ACCESS_READ_ONLY = 'read';
+    const ACCESS_READ_WRITE = 'read+write';
+
+    const user = testUsers[roleName];
+
+    // # Login as each new role.
+    cy.apiLogin(user);
+
+    // # Go the system console.
+    cy.visit('/admin_console');
+    cy.get('.admin-sidebar', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+    accessRules.forEach((rule) => {
+        const {section} = rule;
+        const access = rule[roleName];
+        switch (access) {
+        case ACCESS_NONE:
+            noAccessFunc(section);
+            break;
+        case ACCESS_READ_ONLY:
+            readOnlyFunc(section);
+            break;
+        case ACCESS_READ_WRITE:
+            readWriteFunc(section);
+            break;
+        }
+    });
+}

--- a/e2e/cypress/integration/enterprise/system_console/limited_console_access_not_cloud_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/limited_console_access_not_cloud_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @system_console
+// Group: @enterprise @system_console @not_cloud
 
 import {forEachConsoleSection, makeUserASystemRole} from './helpers';
 
@@ -17,6 +17,7 @@ describe('Limited console access', () => {
     const testUsers = {};
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
         cy.apiRequireLicense();
 
         Cypress._.forEach(roleNames, (roleName) => {
@@ -26,23 +27,13 @@ describe('Limited console access', () => {
         });
     });
 
-    it('MM-T3387 - Verify the Admin Role - System User Manager', () => {
-        const role = 'system_user_manager';
+    it('MM-T3386 - Verify the Admin Role - System Manager', () => {
+        const role = 'system_manager';
 
-        // # Make the user a System User Manager
+        // # Make the user a System  Manager
         makeUserASystemRole(testUsers, role);
 
-        // * Login as the new user and verify the role permissions (ensure they really are a system user manager)
-        forEachConsoleSection(testUsers, role);
-    });
-
-    it('MM-T3388 - Verify the Admin Role - System Read Only Admin', () => {
-        const role = 'system_read_only_admin';
-
-        // # Make the user a System Ready Only Manager
-        makeUserASystemRole(testUsers, role);
-
-        // * Login as the new user and verify the role permissions (ensure they really are a system read only manager)
+        // * Login as the new user and verify the role permissions (ensure they really are a system manager)
         forEachConsoleSection(testUsers, role);
     });
 });

--- a/e2e/cypress/integration/messaging/visual_verification_of_tooltips_on_top_nav_channel_icons_posts_spec.js
+++ b/e2e/cypress/integration/messaging/visual_verification_of_tooltips_on_top_nav_channel_icons_posts_spec.js
@@ -8,13 +8,22 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @messaging
+// Group: @messaging @not_cloud
 
 describe('Messaging', () => {
     let testTeam;
     let testChannelName;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
+        // # Update config
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableLegacySidebar: true,
+            },
+        });
+
         // # Login as test user and visit the newly created test channel
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;
@@ -72,7 +81,7 @@ describe('Messaging', () => {
         downloadLink().trigger('mouseout');
 
         // * Long channel name (shown truncated on the LHS)
-        cy.findByRole('application', {name: 'channel sidebar region'}).findByText(testChannelName).should('be.visible').as('longChannelAtSidebar');
+        cy.uiGetLhsSection('CHANNELS').findByText(testChannelName).should('be.visible').as('longChannelAtSidebar');
         cy.get('@longChannelAtSidebar').trigger('mouseover');
         verifyTooltip(testChannelName);
         cy.get('@longChannelAtSidebar').trigger('mouseout');

--- a/e2e/cypress/integration/system_console/environment_spec.js
+++ b/e2e/cypress/integration/system_console/environment_spec.js
@@ -8,6 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
+// Group: @not_cloud
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
@@ -17,6 +18,7 @@ describe('Environment', () => {
 
     const mattermostIcon = 'mattermost-icon_128x128.png';
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
         cy.apiInitSetup().then(({team}) => {
             testTeam = team;
             townsquareLink = `/${team.name}/channels/town-square`;
@@ -246,6 +248,7 @@ describe('Environment', () => {
 
         const amazonS3BucketName = 'test';
         const amazonS3PathPrefix = 'test';
+        cy.findByTestId('FileSettings.MaxFileSizenumber').clear().type(52428800);
         cy.findByTestId('FileSettings.AmazonS3Bucketinput').clear().type(amazonS3BucketName);
         cy.findByTestId('FileSettings.AmazonS3PathPrefixinput').clear().type(amazonS3PathPrefix);
 

--- a/e2e/cypress/integration/system_console/site_configuration/link_customization_not_cloud_spec.js
+++ b/e2e/cypress/integration/system_console/site_configuration/link_customization_not_cloud_spec.js
@@ -37,7 +37,6 @@ describe('SupportSettings', () => {
         cy.visit('/admin_console/site_config/customization');
     });
 
-    // not cloud
     it('MM-T1032 - Customization: Custom Terms and Privacy links in the About modal', () => {
         // # Edit links in the TOS and Privacy fields
         cy.findByTestId('SupportSettings.TermsOfServiceLinkinput').clear().type(tosLink);
@@ -56,7 +55,6 @@ describe('SupportSettings', () => {
         cy.get('#privacyLink').should('contain', 'Privacy Policy').and('have.attr', 'href').and('equal', defaultPrivacyLink);
     });
 
-    // not cloud
     it('MM-T1034 - Customization: Blank TOS link field (About modal)', () => {
         // # Empty the "terms of services" field
         cy.findByTestId('SupportSettings.TermsOfServiceLinkinput').type('any').clear();
@@ -73,7 +71,6 @@ describe('SupportSettings', () => {
         cy.get('#tosLink').should('contain', 'Terms of Service').and('have.attr', 'href').and('equal', defaultTosLink);
     });
 
-    // not cloud
     it('MM-T1035 - Customization Blank Privacy hides the link', () => {
         cy.findByTestId('SupportSettings.PrivacyPolicyLinkinput').clear();
 
@@ -107,7 +104,6 @@ describe('SupportSettings', () => {
         cy.get('#privacy_link').should('not.exist');
     });
 
-    // not cloud
     it('MM-T1037 - Customization Custom Support Email', () => {
         // # Edit links in the support email field
         cy.findByTestId('SupportSettings.SupportEmailinput').clear().type(email);
@@ -133,7 +129,6 @@ describe('SupportSettings', () => {
         });
     });
 
-    // not cloud
     it('MM-T1039 - Customization App download link - Remove', () => {
         // # Edit links in the support email field
         cy.findByTestId('NativeAppSettings.AppDownloadLinkinput').type('any').clear();

--- a/e2e/cypress/integration/system_console/site_configuration/link_customization_not_cloud_spec.js
+++ b/e2e/cypress/integration/system_console/site_configuration/link_customization_not_cloud_spec.js
@@ -1,0 +1,175 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @not_cloud @system_console
+
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
+describe('SupportSettings', () => {
+    const tosLink = 'https://github.com/mattermost/platform/blob/master/README.md';
+    const privacyLink = 'https://github.com/mattermost/platform/blob/master/README.md';
+    const email = 'bot@mattermost.com';
+
+    const defaultTosLink = 'https://about.mattermost.com/default-terms/';
+    const defaultPrivacyLink = 'https://about.mattermost.com/default-privacy-policy/';
+
+    let testTeam;
+
+    beforeEach(() => {
+        cy.shouldNotRunOnCloudEdition();
+
+        // # Login as admin and reset config
+        cy.apiAdminLogin();
+        cy.apiUpdateConfig();
+
+        cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
+        });
+
+        // # Visit customization system console page
+        cy.visit('/admin_console/site_config/customization');
+    });
+
+    // not cloud
+    it('MM-T1032 - Customization: Custom Terms and Privacy links in the About modal', () => {
+        // # Edit links in the TOS and Privacy fields
+        cy.findByTestId('SupportSettings.TermsOfServiceLinkinput').clear().type(tosLink);
+        cy.findByTestId('SupportSettings.PrivacyPolicyLinkinput').clear().type(privacyLink);
+
+        // # Save setting
+        saveSetting();
+
+        // # Open about modal
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+        cy.get('#about').click();
+
+        // * Verify that links do not change and they open to default pages
+        cy.get('#tosLink').should('contain', 'Terms of Service').and('have.attr', 'href').and('equal', defaultTosLink);
+        cy.get('#privacyLink').should('contain', 'Privacy Policy').and('have.attr', 'href').and('equal', defaultPrivacyLink);
+    });
+
+    // not cloud
+    it('MM-T1034 - Customization: Blank TOS link field (About modal)', () => {
+        // # Empty the "terms of services" field
+        cy.findByTestId('SupportSettings.TermsOfServiceLinkinput').type('any').clear();
+
+        // # Save setting
+        saveSetting();
+
+        // # Open about modal
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+        cy.get('#about').click();
+
+        // * Verify that tos link is set to default
+        cy.get('#tosLink').should('contain', 'Terms of Service').and('have.attr', 'href').and('equal', defaultTosLink);
+    });
+
+    // not cloud
+    it('MM-T1035 - Customization Blank Privacy hides the link', () => {
+        cy.findByTestId('SupportSettings.PrivacyPolicyLinkinput').clear();
+
+        // # Save setting
+        saveSetting();
+
+        // # Open about modal
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+        cy.get('#about').click();
+
+        // * Verify that tos link is there
+        cy.get('#tosLink').should('be.visible').and('contain', 'Terms of Service');
+
+        // * Verify that privacy link is there
+        cy.get('#privacyLink').should('contain', 'Privacy Policy').and('have.attr', 'href').and('equal', defaultPrivacyLink);
+
+        // # Logout
+        cy.apiLogout();
+
+        // * Verify that the user was redirected to the login page after the logout
+        cy.url().should('include', '/login');
+
+        // * Verify no privacy link
+        cy.get('#privacy_link').should('not.exist');
+
+        // # Visit signup page
+        cy.get('#signup').click();
+
+        // * Verify no privacy link
+        cy.get('#privacy_link').should('not.exist');
+    });
+
+    // not cloud
+    it('MM-T1037 - Customization Custom Support Email', () => {
+        // # Edit links in the support email field
+        cy.findByTestId('SupportSettings.SupportEmailinput').clear().type(email);
+
+        // # Save setting
+        saveSetting();
+
+        // # Create new user to run tutorial
+        cy.apiCreateUser({bypassTutorial: false}).then(({user: user1}) => {
+            cy.apiAddUserToTeam(testTeam.id, user1.id);
+
+            cy.apiLogin(user1);
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            // # Hit "Next" twice
+            cy.get('#tutorialNextButton').click();
+            cy.get('#tutorialNextButton').click();
+
+            // * Verify that proper email is displayed
+            cy.get('#supportInfo').within(() => {
+                cy.get('a').should('have.attr', 'href').and('equal', 'mailto:' + email);
+            });
+        });
+    });
+
+    // not cloud
+    it('MM-T1039 - Customization App download link - Remove', () => {
+        // # Edit links in the support email field
+        cy.findByTestId('NativeAppSettings.AppDownloadLinkinput').type('any').clear();
+
+        // # Save setting
+        saveSetting();
+
+        // # Click Main Menu
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+
+        // * Verify that app link does not exist
+        cy.get('#nativeAppLink').should('not.exist');
+
+        // # Create new user to run tutorial
+        cy.apiCreateUser({bypassTutorial: false}).then(({user: user1}) => {
+            cy.apiAddUserToTeam(testTeam.id, user1.id);
+
+            cy.apiLogin(user1);
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            // # Hit "Next"
+            cy.get('#tutorialNextButton').click();
+
+            // * Verify that app download link does not exist
+            cy.get('#appDownloadLink').should('not.exist');
+        });
+    });
+});
+
+function saveSetting() {
+    // # Click save button, and verify text and visibility
+    cy.get('#saveSetting').
+        should('have.text', 'Save').
+        and('be.enabled').
+        click().
+        should('be.disabled').
+        wait(TIMEOUTS.HALF_SEC);
+}

--- a/e2e/cypress/integration/system_console/site_configuration/link_customization_spec.js
+++ b/e2e/cypress/integration/system_console/site_configuration/link_customization_spec.js
@@ -9,6 +9,7 @@
 
 // Stage: @prod
 // Group: @not_cloud @system_console
+
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('SupportSettings', () => {
@@ -17,17 +18,15 @@ describe('SupportSettings', () => {
     const aboutLink = 'http://www.mattermost.org/features/';
     const helpLink = 'https://github.com/mattermost/platform/blob/master/doc/help/README.md';
     const problemLink = 'https://forum.mattermost.org/c/general/trouble-shoot';
-    const email = 'bot@mattermost.com';
 
     const defaultTosLink = 'https://about.mattermost.com/default-terms/';
-    const defaultPrivacyLink = 'https://about.mattermost.com/default-privacy-policy/';
 
     let testTeam;
 
     beforeEach(() => {
-        // # as many of the tests logout the user, ensure it's logged
-        // in as an admin before each test
+        // # Login as admin and reset config
         cy.apiAdminLogin();
+        cy.apiUpdateConfig();
 
         cy.apiInitSetup().then(({team}) => {
             testTeam = team;
@@ -94,27 +93,9 @@ describe('SupportSettings', () => {
         cy.get('#help_link').should('contain', 'Help').and('have.attr', 'href').and('equal', helpLink);
     });
 
-    it('MM-T1032 - Customization: Custom Terms and Privacy links in the About modal', () => {
-        // # Edit links in the TOS and Privacy fields
-        cy.findByTestId('SupportSettings.TermsOfServiceLinkinput').clear().type(tosLink);
-        cy.findByTestId('SupportSettings.PrivacyPolicyLinkinput').clear().type(privacyLink);
-
-        // # Save setting
-        saveSetting();
-
-        // # Open about modal
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#about').click();
-
-        // * Verify that links do not change and they open to default pages
-        cy.get('#tosLink').should('contain', 'Terms of Service').and('have.attr', 'href').and('equal', defaultTosLink);
-        cy.get('#privacyLink').should('contain', 'Privacy Policy').and('have.attr', 'href').and('equal', defaultPrivacyLink);
-    });
-
     it('MM-T1033 - Customization: Blank TOS link field (login page)', () => {
         // # Empty the "terms of services" field
-        cy.findByTestId('SupportSettings.TermsOfServiceLinkinput').clear();
+        cy.findByTestId('SupportSettings.TermsOfServiceLinkinput').type('any').clear();
 
         // # Save setting
         saveSetting();
@@ -129,59 +110,10 @@ describe('SupportSettings', () => {
         cy.get('#terms_link').should('contain', 'Terms').and('have.attr', 'href').and('equal', defaultTosLink);
     });
 
-    it('MM-T1034 - Customization: Blank TOS link field (About modal)', () => {
-        // # Empty the "terms of services" field
-        cy.findByTestId('SupportSettings.TermsOfServiceLinkinput').clear();
-
-        // # Save setting
-        saveSetting();
-
-        // # Open about modal
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#about').click();
-
-        // * Verify that tos link is set to default
-        cy.get('#tosLink').should('contain', 'Terms of Service').and('have.attr', 'href').and('equal', defaultTosLink);
-    });
-
-    it('MM-T1035 - Customization Blank Privacy hides the link', () => {
-        cy.findByTestId('SupportSettings.PrivacyPolicyLinkinput').clear();
-
-        // # Save setting
-        saveSetting();
-
-        // # Open about modal
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#about').click();
-
-        // * Verify that tos link is there
-        cy.get('#tosLink').should('be.visible').and('contain', 'Terms of Service');
-
-        // * Verify that privacy link is there
-        cy.get('#privacyLink').should('contain', 'Privacy Policy').and('have.attr', 'href').and('equal', defaultPrivacyLink);
-
-        // # Logout
-        cy.apiLogout();
-
-        // * Verify that the user was redirected to the login page after the logout
-        cy.url().should('include', '/login');
-
-        // * Verify no privacy link
-        cy.get('#privacy_link').should('not.exist');
-
-        // # Visit signup page
-        cy.get('#signup').click();
-
-        // * Verify no privacy link
-        cy.get('#privacy_link').should('not.exist');
-    });
-
     it('MM-T1036 - Customization: Blank Help and Report a Problem hides options from main menu', () => {
         // # Change help and report links to blanks
-        cy.findByTestId('SupportSettings.HelpLinkinput').clear();
-        cy.findByTestId('SupportSettings.ReportAProblemLinkinput').clear();
+        cy.findByTestId('SupportSettings.HelpLinkinput').type('any').clear();
+        cy.findByTestId('SupportSettings.ReportAProblemLinkinput').type('any').clear();
 
         // # Save setting
         saveSetting();
@@ -195,31 +127,6 @@ describe('SupportSettings', () => {
 
         // * Verify that help link does not exist
         cy.get('#helpLink').should('not.exist');
-    });
-
-    it('MM-T1037 - Customization Custom Support Email', () => {
-        // # Edit links in the support email field
-        cy.findByTestId('SupportSettings.SupportEmailinput').clear().type(email);
-
-        // # Save setting
-        saveSetting();
-
-        // # Create new user to run tutorial
-        cy.apiCreateUser({bypassTutorial: false}).then(({user: user1}) => {
-            cy.apiAddUserToTeam(testTeam.id, user1.id);
-
-            cy.apiLogin(user1);
-            cy.visit(`/${testTeam.name}/channels/town-square`);
-
-            // # Hit "Next" twice
-            cy.get('#tutorialNextButton').click();
-            cy.get('#tutorialNextButton').click();
-
-            // * Verify that proper email is displayed
-            cy.get('#supportInfo').within(() => {
-                cy.get('a').should('have.attr', 'href').and('equal', 'mailto:' + email);
-            });
-        });
     });
 
     it('MM-T1038 - Customization App download link - Change to different', () => {
@@ -242,36 +149,7 @@ describe('SupportSettings', () => {
         });
     });
 
-    it('MM-T1039 - Customization App download link - Remove', () => {
-        // # Edit links in the support email field
-        cy.findByTestId('NativeAppSettings.AppDownloadLinkinput').clear();
-
-        // # Save setting
-        saveSetting();
-
-        // # Click Main Menu
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-
-        // * Verify that app link does not exist
-        cy.get('#nativeAppLink').should('not.exist');
-
-        // # Create new user to run tutorial
-        cy.apiCreateUser({bypassTutorial: false}).then(({user: user1}) => {
-            cy.apiAddUserToTeam(testTeam.id, user1.id);
-
-            cy.apiLogin(user1);
-            cy.visit(`/${testTeam.name}/channels/town-square`);
-
-            // # Hit "Next"
-            cy.get('#tutorialNextButton').click();
-
-            // * Verify that app download link does not exist
-            cy.get('#appDownloadLink').should('not.exist');
-        });
-    });
-
-    it('MM-T3289 - Help (Ask community link setting)', () => {
+    it('MM-T3289_1 - Help (Ask community link setting)', () => {
         // * Verify enable ask community link to be true by default
         cy.findByTestId('SupportSettings.EnableAskCommunityLinktrue').should('be.checked');
 
@@ -304,7 +182,7 @@ describe('SupportSettings', () => {
         });
     });
 
-    it('MM-T3289 - Help (Ask community link setting) 2', () => {
+    it('MM-T3289_2 - Help (Ask community link setting)', () => {
         // Disable setting for ask community
         cy.findByTestId('SupportSettings.EnableAskCommunityLinkfalse').click();
 

--- a/e2e/cypress/integration/system_console/site_configuration/link_customization_spec.js
+++ b/e2e/cypress/integration/system_console/site_configuration/link_customization_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @not_cloud @system_console
+// Group: @system_console
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 


### PR DESCRIPTION
#### Summary
Add filter for tests not for cloud. Those tests typically requires server configuration that are not writable in Cloud edition.
