### PR TITLE
MM-33209 Downgrade serialize-error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15338,15 +15338,7 @@
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
       "requires": {
-        "icu4c-data": "0.64.2"
-      },
-      "dependencies": {
-        "icu4c-data": {
-          "version": "0.64.2",
-          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-          "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
-          "dev": true
-        }
+        "icu4c-data": "0.63.2"
       }
     },
     "function-bind": {
@@ -20267,8 +20259,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#041dc98731d1317c7d4f8014d79f81d1e9e80663",
-      "from": "github:mattermost/mattermost-redux#041dc98731d1317c7d4f8014d79f81d1e9e80663",
+      "version": "github:mattermost/mattermost-redux#e0bc76cd9ff859ec84f62de3ca4d59faa7755cd7",
+      "from": "github:mattermost/mattermost-redux#e0bc76cd9ff859ec84f62de3ca4d59faa7755cd7",
       "requires": {
         "core-js": "3.8.3",
         "form-data": "3.0.0",
@@ -20283,7 +20275,7 @@
         "remote-redux-devtools": "0.5.16",
         "reselect": "4.0.0",
         "rudder-sdk-js": "1.0.14",
-        "serialize-error": "8.0.1",
+        "serialize-error": "6.0.0",
         "shallow-equals": "1.0.0"
       },
       "dependencies": {
@@ -25548,11 +25540,11 @@
       }
     },
     "serialize-error": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.0.1.tgz",
-      "integrity": "sha512-r5o60rWFS+8/b49DNAbB+GXZA0SpDpuWE758JxDKgRTga05r3U5lwyksE91dYKDhXSmnu36RALj615E6Aj5pSg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-6.0.0.tgz",
+      "integrity": "sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==",
       "requires": {
-        "type-fest": "^0.20.2"
+        "type-fest": "^0.12.0"
       }
     },
     "serialize-javascript": {
@@ -27759,9 +27751,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
+      "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.1.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#be741d411d4642c4cd3e009645f4cb6baa7e92bb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#041dc98731d1317c7d4f8014d79f81d1e9e80663",
+    "mattermost-redux": "github:mattermost/mattermost-redux#e0bc76cd9ff859ec84f62de3ca4d59faa7755cd7",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",


### PR DESCRIPTION
The Selenium tests that QA use run on Firefox 54, and the new version of serialize-error fails to load on there because it uses slightly newer syntax (https://caniuse.com/mdn-javascript_statements_try_catch_optional_catch_binding, supported in Firefox 58+). Selenium will be upgraded or removed at some point, but this will fix it in the meantime.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33209

#### Related Pull Requests
https://github.com/mattermost/mattermost-redux/pull/1372