### PR TITLE
MM-33237 Update webpack-livereload-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28820,13 +28820,14 @@
       }
     },
     "webpack-livereload-plugin": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-2.3.0.tgz",
-      "integrity": "sha512-vVBLQLlNpElt2sfsBG+XLDeVbQFS4RrniVU8Hi1/hX5ycSfx6mtW8MEEITr2g0Cvo36kuPWShFFDuy+DS7KFMA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-3.0.0.tgz",
+      "integrity": "sha512-B4EEpLUkgkj0iHqAbf96mDxeRMWWH/s9lM2shJbKWaE4C5QTplodKCI8J4YdbPfNypFB3cgoO9TfW31ol5YmKA==",
       "dev": true,
       "requires": {
         "anymatch": "^3.1.1",
         "portfinder": "^1.0.17",
+        "schema-utils": ">1.0.0",
         "tiny-lr": "^1.1.1"
       },
       "dependencies": {
@@ -28838,6 +28839,17 @@
           "requires": {
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "webpack": "5.20.2",
     "webpack-cli": "4.5.0",
     "webpack-dev-server": "3.11.2",
-    "webpack-livereload-plugin": "2.3.0",
+    "webpack-livereload-plugin": "3.0.0",
     "webpack-node-externals": "2.5.2",
     "webpack-pwa-manifest": "4.3.0",
     "yup": "0.32.8"


### PR DESCRIPTION
The latest version of webpack-livereload-plugin didn't support Webpack 5 as of last week, but this new one does.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33237