### PR TITLE
MM-33245 Fix casing on contenthash for CSS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -267,8 +267,8 @@ var config = {
             COMMIT_HASH: JSON.stringify(childProcess.execSync('git rev-parse HEAD || echo dev').toString()),
         }),
         new MiniCssExtractPlugin({
-            filename: '[name].[contentHash].css',
-            chunkFilename: '[name].[contentHash].css',
+            filename: '[name].[contenthash].css',
+            chunkFilename: '[name].[contenthash].css',
         }),
         new HtmlWebpackPlugin({
             filename: 'root.html',


### PR DESCRIPTION
As Caleb pointed out to me, the casing was incorrect for `contenthash`. I don't know when in the upgrade process that broken, but we went from 0.9.0 to 1.3.5 with that plugin, so it could've been any time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33245