### PR TITLE
MM-33285 Turn off snapshotting of node_modules and minor webpack changes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,6 +136,9 @@ var config = {
         filename: '[name].[contenthash].js',
         chunkFilename: '[name].[contenthash].js',
     },
+    snapshot: {
+        managedPaths: [],
+    },
     module: {
         rules: [
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -133,7 +133,7 @@ var config = {
     entry: ['./root.jsx', 'root.html'],
     output: {
         publicPath,
-        filename: '[name].[hash].js',
+        filename: '[name].[contenthash].js',
         chunkFilename: '[name].[contenthash].js',
     },
     module: {
@@ -159,7 +159,7 @@ var config = {
                 exclude: [/en\.json$/],
                 use: [
                     {
-                        loader: 'file-loader?name=i18n/[name].[hash].[ext]',
+                        loader: 'file-loader?name=i18n/[name].[contenthash].[ext]',
                     },
                 ],
             },
@@ -195,7 +195,7 @@ var config = {
                     {
                         loader: 'file-loader',
                         options: {
-                            name: 'files/[hash].[ext]',
+                            name: 'files/[contenthash].[ext]',
                         },
                     },
                     {
@@ -210,7 +210,7 @@ var config = {
                     {
                         loader: 'file-loader',
                         options: {
-                            name: 'files/[hash].[ext]',
+                            name: 'files/[contenthash].[ext]',
                         },
                     },
                 ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,7 +132,6 @@ if (DEV) {
 var config = {
     entry: ['./root.jsx', 'root.html'],
     output: {
-        path: path.join(__dirname, 'dist'),
         publicPath,
         filename: '[name].[hash].js',
         chunkFilename: '[name].[contenthash].js',


### PR DESCRIPTION
Most of this is just some changes that were recommended by the migration guide for Webpack 5, but the important one is that setting `snapshot.managedPaths` to empty means we're no longer going to be snapshotting `node_modules` when running webpack in watch mode since that broke mattermost-redux's `npm run dev:watch`. We could look at re-enabling that in the future, but changing it didn't seem to have a notable effect on build times for me.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33285