### PR TITLE
MM-23040: remove teamType prop from ChannelController

### DIFF
--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -32,13 +32,12 @@ import ProductNoticesModal from 'components/product_notices_modal';
 export default class ChannelController extends React.Component {
     static propTypes = {
         pathName: PropTypes.string.isRequired,
-        teamType: PropTypes.string.isRequired,
         fetchingChannels: PropTypes.bool.isRequired,
         useLegacyLHS: PropTypes.bool.isRequired,
     };
 
     shouldComponentUpdate(nextProps) {
-        return this.props.teamType !== nextProps.teamType || this.props.pathName !== nextProps.pathName || this.props.fetchingChannels !== nextProps.fetchingChannels || this.props.useLegacyLHS !== nextProps.useLegacyLHS;
+        return this.props.pathName !== nextProps.pathName || this.props.fetchingChannels !== nextProps.fetchingChannels || this.props.useLegacyLHS !== nextProps.useLegacyLHS;
     }
 
     componentDidMount() {
@@ -78,7 +77,7 @@ export default class ChannelController extends React.Component {
                 <ProductNoticesModal/>
                 <div className='container-fluid'>
                     <SidebarRight/>
-                    <SidebarRightMenu teamType={this.props.teamType}/>
+                    <SidebarRightMenu/>
                     <Route component={PreferredTeamSidebar}/>
                     <Route component={PreferredSidebar}/>
                     {!this.props.fetchingChannels && <Route component={CenterChannel}/>}

--- a/components/channel_layout/channel_controller.test.jsx
+++ b/components/channel_layout/channel_controller.test.jsx
@@ -9,7 +9,6 @@ import ChannelController from './channel_controller.jsx';
 describe('components/channel_layout/ChannelController', () => {
     const props = {
         pathName: 'test',
-        teamType: 'test',
         fetchingChannels: false,
         useLegacyLHS: true,
     };

--- a/components/needs_team/needs_team.tsx
+++ b/components/needs_team/needs_team.tsx
@@ -125,9 +125,8 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
 
     static getDerivedStateFromProps(nextProps: Props, state: State) {
         if (state.prevTeam !== nextProps.match.params.team) {
-            const team = nextProps.teamsList ?
-                nextProps.teamsList.find((teamObj: Team) =>
-                    teamObj.name === nextProps.match.params.team) : null;
+            const team = nextProps.teamsList ? nextProps.teamsList.find((teamObj: Team) =>
+                teamObj.name === nextProps.match.params.team) : null;
             return {
                 prevTeam: nextProps.match.params.team,
                 team: (team || null),

--- a/components/needs_team/needs_team.tsx
+++ b/components/needs_team/needs_team.tsx
@@ -297,7 +297,6 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
         if (this.state.team === null) {
             return <div/>;
         }
-        const teamType = this.state.team ? this.state.team.type : '';
 
         return (
             <Switch>
@@ -325,7 +324,6 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
                     render={(renderProps) => (
                         <ChannelController
                             pathName={renderProps.location.pathname}
-                            teamType={teamType}
                             fetchingChannels={!this.state.finishedFetchingChannels}
                             useLegacyLHS={this.props.useLegacyLHS}
                         />


### PR DESCRIPTION
#### Summary
As per @hmhealey comments in the linked ticket, remove `teamType` prop now that the new channel sidebar code is merged.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-23040