### PR TITLE
[MM-33397] revert lhs ID for backward compatibility

### DIFF
--- a/components/sidebar/sidebar_channel_list/__snapshots__/sidebar_channel_list.test.tsx.snap
+++ b/components/sidebar/sidebar_channel_list/__snapshots__/sidebar_channel_list.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SidebarChannelList should match snapshot 1`] = `
   className="SidebarNavContainer a11y__region"
   data-a11y-disable-nav={false}
   data-a11y-sort-order="7"
-  id="lhsList"
+  id="sidebar-left"
   onTransitionEnd={[Function]}
   role="application"
 >

--- a/components/sidebar/sidebar_channel_list/sidebar_channel_list.tsx
+++ b/components/sidebar/sidebar_channel_list/sidebar_channel_list.tsx
@@ -504,7 +504,7 @@ export default class SidebarChannelList extends React.PureComponent<Props, State
 
             // NOTE: id attribute added to temporarily support the desktop app's at-mention DOM scraping of the old sidebar
             <div
-                id='lhsList'
+                id='sidebar-left'
                 role='application'
                 aria-label={ariaLabel}
                 className={classNames('SidebarNavContainer a11y__region', {

--- a/e2e/cypress/integration/accessibility/accessibility_keyboard_usability_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_keyboard_usability_spec.js
@@ -137,7 +137,7 @@ describe('Verify Accessibility keyboard usability across different regions in th
             cy.clickPostCommentIcon(postId);
 
             // * Verify Screen reader should not switch to virtual cursor mode. This is handled by adding a role=application attribute
-            const regions = ['#lhsHeader', '#lhsList', '#rhsContent', '.search__form', '#centerChannelFooter'];
+            const regions = ['#lhsHeader', '#sidebar-left', '#rhsContent', '.search__form', '#centerChannelFooter'];
             regions.forEach((region) => {
                 cy.get(region).should('have.attr', 'role', 'application');
             });

--- a/e2e/cypress/integration/accessibility/accessibility_nav_diff_regions_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_nav_diff_regions_spec.js
@@ -110,7 +110,7 @@ describe('Verify Quick Navigation support across different regions in the app', 
         cy.get('#headerInfo button').focus().tab().tab().tab().tab();
 
         // * Verify nav support in LHS sidebar
-        verifyNavSupport('#lhsList', 'channel sidebar region', '7');
+        verifyNavSupport('#sidebar-left', 'channel sidebar region', '7');
     });
 
     it('MM-T1460_6 Verify Navigation Support in Channel Header', () => {

--- a/e2e/cypress/integration/channel/more_channels_spec.js
+++ b/e2e/cypress/integration/channel/more_channels_spec.js
@@ -137,7 +137,7 @@ describe('Channels', () => {
         cy.get('#sidebarItem_town-square').click();
 
         // * Assert that archived channel doesn't show up in LHS list
-        cy.get('#lhsList').should('not.contain', testChannel.display_name);
+        cy.get('#sidebar-left').should('not.contain', testChannel.display_name);
     });
 
     it('MM-T1702 Search works when changing public/archived options in the dropdown', () => {

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -155,7 +155,7 @@ describe('Integrations', () => {
         cy.postMessage('/leave');
 
         // * Verity Off-Topic is not shown in LHS
-        cy.get('#lhsList').should('be.visible').should('not.contain', 'Off-Topic');
+        cy.get('#sidebar-left').should('be.visible').should('not.contain', 'Off-Topic');
 
         // * Verify user is redirected to Town Square
         cy.uiGetLhsSection('CHANNELS').find('.active').should('contain', 'Town Square');

--- a/e2e/cypress/integration/keyboard_shortcuts/alt_option_plus_up_down_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/alt_option_plus_up_down_spec.js
@@ -90,7 +90,7 @@ function verifyChannelSwitch(teamName, toChannel, fromChannel, arrowKey) {
         cy.url().should('include', `/${teamName}/channels/${toChannel.name}`);
     }
 
-    cy.get('#lhsList').should('be.visible').within(() => {
+    cy.get('#sidebar-left').should('be.visible').within(() => {
         // * Verify that the toChannel is active in LHS
         verifyClass(toChannel, 'have.class');
 

--- a/e2e/cypress/integration/notifications/browser_tab_notification_spec.js
+++ b/e2e/cypress/integration/notifications/browser_tab_notification_spec.js
@@ -45,7 +45,7 @@ describe('Notifications', () => {
             // # Remove mention notification (for initial channel).
             cy.apiLogin(user1);
             cy.visit(testTeam1TownSquareUrl);
-            cy.get('#lhsList').get('.unread-title').click();
+            cy.get('#sidebar-left').get('.unread-title').click();
             cy.apiLogout();
         });
     });

--- a/e2e/cypress/integration/notifications/unread_on_public_channel_spec.js
+++ b/e2e/cypress/integration/notifications/unread_on_public_channel_spec.js
@@ -54,7 +54,7 @@ describe('Notifications', () => {
                         wait(TIMEOUTS.ONE_SEC);
 
                     // # scroll to the last channel
-                    cy.get('#lhsList li').last().scrollIntoView();
+                    cy.get('#sidebar-left li').last().scrollIntoView();
                 });
             });
         });


### PR DESCRIPTION
#### Summary
while the new name might fit better, the current and previous desktop app version use the id for detecting if the user is logged into Mattermost. Since we can't change current installations, we need to revert back to the previous ID and plan the change for future versions.

#### Ticket Link

[MM-33397](https://mattermost.atlassian.net/browse/MM-33397)

#### Additional notes
@saturninoabril one of the e2e tests failed for me (browser_tab_notification_spec) but I don't think it was due to this change, can you take a look at it?