### PR TITLE
Cypress/E2E: Promote and demote E2E tests

### DIFF
--- a/e2e/cypress/integration/archived_channel/archive_channel_search_spec.js
+++ b/e2e/cypress/integration/archived_channel/archive_channel_search_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel
 
 import {getRandomId} from '../../utils';

--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @enterprise @ldap
 
 import ldapUsers from '../../../fixtures/ldap_users.json';

--- a/e2e/cypress/integration/enterprise/system_console/compliance/compliance_export_multiple_post_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/compliance_export_multiple_post_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 import * as TIMEOUTS from '../../../../fixtures/timeouts';

--- a/e2e/cypress/integration/enterprise/system_console/compliance/compliance_export_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/compliance_export_ui_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 import * as TIMEOUTS from '../../../../fixtures/timeouts';

--- a/e2e/cypress/integration/mark_as_unread/mark_gm_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_gm_as_unread_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @mark_as_unread
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/long_draft_spec.js
+++ b/e2e/cypress/integration/messaging/long_draft_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/message_edit_post_clear_text_spec.js
+++ b/e2e/cypress/integration/messaging/message_edit_post_clear_text_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/receive_message_on_socket_reconnect_spec.js
+++ b/e2e/cypress/integration/messaging/receive_message_on_socket_reconnect_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/visual_verification_of_tooltips_on_top_nav_channel_icons_posts_spec.js
+++ b/e2e/cypress/integration/messaging/visual_verification_of_tooltips_on_top_nav_channel_icons_posts_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging @not_cloud
 
 describe('Messaging', () => {

--- a/e2e/cypress/integration/plugins/upgrade_spec.js
+++ b/e2e/cypress/integration/plugins/upgrade_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @system_console @plugin
 
 /**

--- a/e2e/cypress/integration/system_console/user_management_spec.js
+++ b/e2e/cypress/integration/system_console/user_management_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @system_console
 
 import {getEmailUrl, splitEmailBodyText, getRandomId} from '../../utils';


### PR DESCRIPTION
#### Summary
Those demoted tests were found to be flaky and some of them were attempted to fix but to no avail. Will put on unstable tests and will further investigate separately.

Note:
- `system_console/user_management_spec.js` - affected by recent change on Email redesign - https://github.com/mattermost/mattermost-server/pull/16824. Also, we might need to extract other tests that require email verification into separate spec file.