### PR TITLE
Cypress/E2E: Organize and add keys of Elasticsearch autocomplete for channel

### DIFF
--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
@@ -13,12 +13,12 @@ import {getAdminAccount} from '../../../support/env';
 
 import {
     createPrivateChannel,
+    createPublicChannel,
     enableElasticSearch,
-    searchForChannel,
+    searchAndVerifyChannel,
 } from './helpers';
 
 describe('Autocomplete with Elasticsearch - Channel', () => {
-    const admin = getAdminAccount();
     let testTeam;
     let testUser;
 
@@ -33,140 +33,88 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
         cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
             testUser = user;
             testTeam = team;
-
-            cy.visit(`/${testTeam.name}/channels/town-square`);
         });
     });
 
-    afterEach(() => {
-        cy.reload();
+    beforeEach(() => {
+        // # Visit town-square channel
+        cy.visit(`/${testTeam.name}/channels/town-square`);
     });
 
-    it("private channel I don't belong to does not appear", () => {
-        // # Create private channel, do not add new user to it (sets @privateChannel alias)
-        createPrivateChannel(testTeam.id).then((channel) => {
-            // # Go to off-topic channel to partially reload the page
-            cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
-
-            // # Search for the private channel
-            searchForChannel(channel.name);
-
-            // * And it should not appear
-            cy.findByTestId(channel.name).
-                should('not.exist');
-        });
-    });
-
-    it('private channel I do belong to appears', () => {
+    it('MM-T2510_1 Private channel I do belong to appears', () => {
         // # Create private channel and add new user to it (sets @privateChannel alias)
         createPrivateChannel(testTeam.id, testUser).then((channel) => {
             // # Go to off-topic channel to partially reload the page
             cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
 
-            // # Search for the private channel
-            searchForChannel(channel.name);
-
-            // * Suggestion list should appear
-            cy.get('#suggestionList').should('be.visible');
-
-            // * Channel should appear in the list
-            cy.findByTestId(channel.name).
-                should('be.visible');
+            // * Private channel in suggestion list should appear
+            searchAndVerifyChannel(channel);
         });
     });
 
-    it('channel outside of team does not appear', () => {
+    it("MM-T2510_2 Private channel I don't belong to does not appear", () => {
+        // # Create private channel, do not add new user to it (sets @privateChannel alias)
+        createPrivateChannel(testTeam.id).then((channel) => {
+            // # Go to off-topic channel to partially reload the page
+            cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
+
+            // * Private channel should not appear on search
+            searchAndVerifyChannel(channel, false);
+        });
+    });
+
+    it('MM-T2510_3 Private channel left does not appear', () => {
+        // # Create private channel and add new user to it (sets @privateChannel alias)
+        createPrivateChannel(testTeam.id, testUser).then((channel) => {
+            // # Visit private channel
+            cy.visit(`/${testTeam.name}/channels/${channel.name}`);
+
+            // # Leave private channel
+            cy.uiOpenChannelMenu('Leave Channel');
+            cy.findByRoleExtended('button', {name: 'Yes, leave channel'}).should('be.visible').click();
+
+            // # Go to off-topic channel to partially reload the page
+            cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
+
+            // * Private channel should not appear on search
+            searchAndVerifyChannel(channel, false);
+        });
+    });
+
+    it('MM-T2510_4 Channel outside of team does not appear', () => {
         const teamName = 'elastic-private-' + Date.now();
-        const baseUrl = Cypress.config('baseUrl');
 
         // # As admin, create a new team that the new user is not a member of
-        cy.task('externalRequest', {
-            user: admin,
+        cy.externalRequest({
+            user: getAdminAccount(),
             path: 'teams',
-            baseUrl,
             method: 'post',
             data: {
                 name: teamName,
                 display_name: teamName,
                 type: 'O',
             },
-        }).then((teamResponse) => {
-            expect(teamResponse.status).to.equal(201);
-
+        }).then(({data: team}) => {
             // # Create a private channel where the new user is not a member of
-            createPrivateChannel(teamResponse.data.id).then((channel) => {
+            createPrivateChannel(team.id).then((channel) => {
                 // # Go to off-topic channel to partially reload the page
                 cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
 
-                // # Search for the private channel
-                searchForChannel(channel.name);
-
-                // * Channel should not appear in the search results
-                cy.findByTestId(channel.name).
-                    should('not.exist');
-            });
-        });
-    });
-
-    describe('channel with', () => {
-        let channelId;
-
-        before(() => {
-            // # Login as admin
-            cy.apiAdminLogin();
-            cy.visit(`/${testTeam.name}`);
-
-            const name = 'hellothere';
-
-            // # Create a new channel
-            cy.apiCreateChannel(testTeam.id, name, name).then(({channel}) => {
-                channelId = channel.id;
+                // * Private channel should not appear on search
+                searchAndVerifyChannel(channel, false);
+                cy.uiClose();
             });
 
-            // * Verify channel without special characters appears normally
-            searchForChannel(name);
+            return cy.wrap({team});
+        }).then(({team}) => {
+            // # Create a private channel where the new user is not a member of
+            createPublicChannel(team.id).then((publicChannel) => {
+                // # Go to off-topic channel to partially reload the page
+                cy.uiGetLhsSection('CHANNELS').findByText('Off-Topic').click();
 
-            cy.reload();
-        });
-
-        it('dots appears', () => {
-            const name = 'hello.there';
-
-            // Change name of channel
-            cy.apiPatchChannel(channelId, {display_name: name});
-
-            // * Search for channel should work
-            searchForChannel(name);
-        });
-
-        it('dashes appears', () => {
-            const name = 'hello-there';
-
-            // Change name of channel
-            cy.apiPatchChannel(channelId, {display_name: name});
-
-            // * Search for channel should work
-            searchForChannel(name);
-        });
-
-        it('underscores appears', () => {
-            const name = 'hello_there';
-
-            // Change name of channel
-            cy.apiPatchChannel(channelId, {display_name: name});
-
-            // * Search for channel should work
-            searchForChannel(name);
-        });
-
-        it('dots, dashes, and underscores appears', () => {
-            const name = 'he.llo-the_re';
-
-            // Change name of channel
-            cy.apiPatchChannel(channelId, {display_name: name});
-
-            // * Search for channel should work
-            searchForChannel(name);
+                // * Public channel should not appear on search
+                searchAndVerifyChannel(publicChannel, false);
+            });
         });
     });
 });

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_with_special_characters_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_with_special_characters_spec.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @elasticsearch @autocomplete
+
+import {
+    enableElasticSearch,
+    searchAndVerifyChannel,
+} from './helpers';
+
+describe('Autocomplete with Elasticsearch - Channel', () => {
+    let testChannel;
+    let teamName;
+
+    before(() => {
+        // * Check if server has license for Elasticsearch
+        cy.apiRequireLicenseForFeature('Elasticsearch');
+
+        // # Enable Elasticsearch
+        enableElasticSearch();
+
+        // # Login as test user, create a new channel and go to town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            teamName = team.name;
+            const name = 'hellothere';
+
+            cy.apiCreateChannel(team.id, name, name).then(({channel}) => {
+                testChannel = channel;
+            });
+        });
+    });
+
+    beforeEach(() => {
+        // # Visit town-square channel
+        cy.visit(`/${teamName}/channels/town-square`);
+    });
+
+    it('MM-T2517_1 Channels with dot returned in autocomplete suggestions', () => {
+        const name = 'hello.there';
+
+        // # Change the name of channel
+        cy.apiPatchChannel(testChannel.id, {display_name: name});
+
+        // * Search for channel should work
+        searchAndVerifyChannel({...testChannel, display_name: name});
+    });
+
+    it('MM-T2517_2 Channels with dash returned in autocomplete suggestions', () => {
+        const name = 'hello-there';
+
+        // # Change the name of channel
+        cy.apiPatchChannel(testChannel.id, {display_name: name});
+
+        // * Search for channel should work
+        searchAndVerifyChannel({...testChannel, display_name: name});
+    });
+
+    it('MM-T2517_3 Channels with underscore returned in autocomplete suggestions', () => {
+        const name = 'hello_there';
+
+        // # Change the name of channel
+        cy.apiPatchChannel(testChannel.id, {display_name: name});
+
+        // * Search for channel should work
+        searchAndVerifyChannel({...testChannel, display_name: name});
+    });
+
+    it('MM-T2517_4 Channels with dot, dash and underscore returned in autocomplete suggestions', () => {
+        const name = 'he.llo-the_re';
+
+        // # Change the name of channel
+        cy.apiPatchChannel(testChannel.id, {display_name: name});
+
+        // * Search for channel should work
+        searchAndVerifyChannel({...testChannel, display_name: name});
+    });
+});

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
@@ -23,12 +23,63 @@ function startAtMention(string) {
     cy.get('#suggestionList').should('be.visible');
 }
 
+function searchForChannel(name) {
+    // # Open up channel switcher
+    cy.typeCmdOrCtrl().type('k').wait(TIMEOUTS.ONE_SEC);
+
+    // # Clear out and type in the name
+    cy.findByRole('textbox', {name: 'quick switch input'}).
+        should('be.visible').
+        as('input').
+        clear().
+        type(name);
+}
+
+function createChannel(channelType, teamId, userToAdd = null) {
+    // # Create a channel as sysadmin
+    return cy.externalRequest({
+        user: admin,
+        method: 'POST',
+        path: 'channels',
+        data: {
+            team_id: teamId,
+            name: 'test-channel' + Date.now(),
+            display_name: 'Test Channel ' + Date.now(),
+            type: channelType,
+            header: '',
+            purpose: '',
+        },
+    }).then(({data: channel}) => {
+        if (userToAdd) {
+            // # Get user profile by email
+            return cy.apiGetUserByEmail(userToAdd.email).then(({user}) => {
+                // # Add user to team
+                cy.externalRequest({
+                    user: admin,
+                    method: 'post',
+                    path: `channels/${channel.id}/members`,
+                    data: {user_id: user.id},
+                }).then(() => {
+                    // # Explicitly wait to give some time to index before searching
+                    cy.wait(TIMEOUTS.TWO_SEC);
+                    return cy.wrap(channel);
+                });
+            });
+        }
+
+        // # Explicitly wait to give some time to index before searching
+        cy.wait(TIMEOUTS.TWO_SEC);
+        return cy.wrap(channel);
+    });
+}
+
 module.exports = {
     withTimestamp,
     createEmail,
     startAtMention,
+    searchForChannel,
     enableElasticSearch: () => {
-        // Enable elastic search via the API
+        // # Enable elastic search via the API
         cy.apiUpdateConfig({
             ElasticsearchSettings: {
                 EnableAutocomplete: true,
@@ -38,30 +89,31 @@ module.exports = {
             },
         });
 
-        // Navigate to the elastic search setting page
+        // # Navigate to the elastic search setting page
         cy.visit('/admin_console/environment/elasticsearch');
 
-        // Test the connection and verify that we are successful
+        // * Test the connection and verify that we are successful
         cy.contains('button', 'Test Connection').click();
         cy.get('.alert-success').should('have.text', 'Test successful. Configuration saved.');
 
-        // Index so we are up to date
+        // # Index so we are up to date
         cy.contains('button', 'Index Now').click();
 
-        // Small wait to ensure new row is added
+        // # Small wait to ensure new row is added
         cy.wait(TIMEOUTS.ONE_SEC).get('.job-table__table').find('tbody > tr').eq(0).as('firstRow');
 
-        // Newest row should eventually result in Success
-        cy.waitUntil(() => {
+        // * Newest row should eventually result in Success
+        const checkFirstRow = () => {
             return cy.get('@firstRow').then((el) => {
                 return el.find('.status-icon-success').length > 0;
             });
-        }
-        , {
+        };
+        const options = {
             timeout: TIMEOUTS.TWO_MIN,
             interval: TIMEOUTS.TWO_SEC,
             errorMsg: 'Reindex did not succeed in time',
-        });
+        };
+        cy.waitUntil(checkFirstRow, options);
     },
     getTestUsers: () => {
         // Reverse the timestamp so that on search,
@@ -153,88 +205,31 @@ module.exports = {
                 password: 'passwd',
                 first_name: 'z3First',
                 last_name: 'z3Last',
-                email: createEmail('undercore', reverseTimeStamp),
+                email: createEmail('underscore', reverseTimeStamp),
                 nickname: 'z3Nick',
             },
         };
     },
     createPrivateChannel: (teamId, userToAdd = null) => {
-        const baseUrl = Cypress.config('baseUrl');
-
-        // As the sysadmin, create a private channel
-        return cy.task('externalRequest', {
-            user: admin,
-            method: 'post',
-            baseUrl,
-            path: 'channels',
-            data: {
-                team_id: teamId,
-                name: 'private' + Date.now(),
-                display_name: 'private' + Date.now(),
-                type: 'P',
-                header: '',
-                purpose: '',
-            },
-        }).then((privateResponse) => {
-            expect(privateResponse.status).to.equal(201);
-            const channel = privateResponse.data;
-
-            // If we have a user to add to the team, add them now
-            if (userToAdd) {
-                // First get the user details by email of the user
-                return cy.apiGetUserByEmail(userToAdd.email).then(({user}) => {
-                    // Add user to team
-                    cy.task('externalRequest', {
-                        user: admin,
-                        method: 'post',
-                        baseUrl,
-                        path: `channels/${channel.id}/members`,
-                        data: {
-                            user_id: user.id,
-                        },
-                    }).then((addResponse) => {
-                        expect(addResponse.status).to.equal(201);
-
-                        // explicitly wait to give some to index before searching
-                        cy.wait(TIMEOUTS.TWO_SEC);
-                        return cy.wrap(channel);
-                    });
-                });
-            }
-
-            // explicitly wait to give some to index before searching
-            cy.wait(TIMEOUTS.TWO_SEC);
-            return cy.wrap(channel);
-        });
+        // # Create a private channel as sysadmin
+        return createChannel('P', teamId, userToAdd);
     },
-    searchForChannel: (name) => {
-        // Open up channel switcher
-        cy.typeCmdOrCtrl().type('k');
-
-        // Clear out and type in the name
-        cy.findByRole('textbox', {name: 'quick switch input'}).
-            should('be.visible').
-            as('input').
-            clear().
-            type(name);
+    createPublicChannel: (teamId, userToAdd = null) => {
+        // # Create a public channel as sysadmin
+        return createChannel('O', teamId, userToAdd);
     },
-    searchAndVerifyChannel: (channel) => {
-        // # Type cmd-K to open channel switcher
-        cy.typeCmdOrCtrl().type('k');
+    searchAndVerifyChannel: (channel, shouldExist = true) => {
+        const name = channel.display_name;
+        searchForChannel(name);
 
-        // # Search for channel's display name
-        cy.findByRole('textbox', {name: 'quick switch input'}).
-            should('be.visible').
-            as('input').
-            clear().
-            type(channel.display_name);
-
-        // * Suggestions should appear
-        cy.get('#suggestionList', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
-
-        // * Channel should appear
-        cy.findByTestId(channel.name).
-            should('be.visible');
+        if (shouldExist) {
+            // * Channel should appear in suggestions list
+            cy.get('#suggestionList').findByRole('button', {name}).should('be.visible');
+        } else {
+            // * Suggestion list and channel item should not appear
+            cy.get('#suggestionList').should('not.exist');
+            cy.findByRole('button', {name}).should('not.exist');
+        }
     },
     searchAndVerifyUser: (user) => {
         // # Start @ mentions autocomplete with username


### PR DESCRIPTION
#### Summary
Organize, add keys and match test case of Elasticsearch autocomplete for channel
- MM-T2510
- MM-T2517

#### Screenshots
![Screen Shot 2021-03-03 at 9 27 30 PM](https://user-images.githubusercontent.com/5334504/109813235-08bd5180-7c68-11eb-806a-051fb0e8acec.png)
![Screen Shot 2021-03-03 at 9 29 45 PM](https://user-images.githubusercontent.com/5334504/109813244-0b1fab80-7c68-11eb-8f43-4c4217594062.png)
