### PR TITLE
[MM-33033] Use box-shadow for create post border instead of border

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -4,19 +4,19 @@
     .custom-textarea {
         border-radius: 4px;
         background: transparent;
-        border: 1px solid rgba(v(center-channel-color-rgb), 0.24);
+        border: none;
+        box-shadow: inset 0 0 0 1px rgba(v(center-channel-color-rgb), 0.24);
         height: 100%;
         line-height: 20px;
         min-height: 46px;
         overflow: hidden;
         resize: none;
+        transition: none;
         white-space: pre-wrap;
         word-wrap: break-word;
 
         &:focus {
-            border: 2px solid rgba(v(center-channel-color-rgb), 0.32);
-            box-shadow: none;
-            padding: 11px 0 11px 14px;
+            box-shadow: inset 0 0 0 2px rgba(v(center-channel-color-rgb), 0.32);
         }
 
         &.bad-connection {
@@ -389,7 +389,7 @@
     .custom-textarea {
         bottom: 0;
         max-height: calc(50vh - 40px);
-        padding: 12px 0 12px 15px;
+        padding: 13px 0 12px 16px;
         resize: none;
         cursor: auto;
 
@@ -510,10 +510,6 @@
                     @include opacity(.9);
                 }
             }
-        }
-
-        textarea {
-            box-shadow: none;
         }
     }
 


### PR DESCRIPTION
#### Summary
Using a `border` for the create post `textarea` was causing some undesirable shifting effects that happened mostly on focus/blur. So I've changed them both over to using a `box-shadow` that does not affect the position of the text inside.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33033