### PR TITLE
[MM-35501] Remove Determining Ancillary Permissions from Frontend to Backend

### DIFF
--- a/components/admin_console/system_roles/system_role/system_role.tsx
+++ b/components/admin_console/system_roles/system_role/system_role.tsx
@@ -200,31 +200,18 @@ export default class SystemRole extends React.PureComponent<Props, State> {
             ...updatedPermissions,
         };
 
-        let updatedRolePermissions: string[] = [];
-
-        // Determine required ancillary permissions...
-        role.permissions.forEach((permission) => {
-            if (permission.startsWith('sysconsole_')) {
-                const permissionShortName = permission.replace(/sysconsole_(read|write)_/, '');
-                if (!(permissionShortName in permissionsToUpdate)) {
-                    const ancillary = Permissions.SYSCONSOLE_ANCILLARY_PERMISSIONS[permission] || [];
-                    updatedRolePermissions.push(...ancillary, permission);
-                }
-            }
-        });
+        let updatedRolePermissions: string[] = [...role.permissions];
 
         Object.keys(permissionsToUpdate).forEach((permissionShortName) => {
             const value = permissionsToUpdate[permissionShortName];
             if (value) {
                 const readPermission = `sysconsole_read_${permissionShortName}`;
                 const writePermission = `sysconsole_write_${permissionShortName}`;
-                const readAncillary = Permissions.SYSCONSOLE_ANCILLARY_PERMISSIONS[readPermission] || [];
-                const writeAncillary = Permissions.SYSCONSOLE_ANCILLARY_PERMISSIONS[writePermission] || [];
 
                 if (value === writeAccess) {
-                    updatedRolePermissions.push(...readAncillary, ...writeAncillary, readPermission, writePermission);
+                    updatedRolePermissions.push(readPermission, writePermission);
                 } else {
-                    updatedRolePermissions.push(...readAncillary, readPermission);
+                    updatedRolePermissions.push(readPermission);
                 }
             }
         });

--- a/components/admin_console/system_roles/system_role/system_role.tsx
+++ b/components/admin_console/system_roles/system_role/system_role.tsx
@@ -200,7 +200,8 @@ export default class SystemRole extends React.PureComponent<Props, State> {
             ...updatedPermissions,
         };
 
-        let updatedRolePermissions: string[] = [...role.permissions];
+        let updatedRolePermissions: string[] = role.permissions.
+            filter((permission) => permission.startsWith('sysconsole_') && !(permission.replace(/sysconsole_(read|write)_/, '') in permissionsToUpdate));
 
         Object.keys(permissionsToUpdate).forEach((permissionShortName) => {
             const value = permissionsToUpdate[permissionShortName];


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Currently, we are determining the ancillary permissions required on the front-end. This should be done on the backend.
This will allow us to eliminate having to keep a copy of ancillary permissions on the front-end.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-33501

Redux: https://github.com/mattermost/mattermost-redux/pull/1392
Server: https://github.com/mattermost/mattermost-server/pull/17061