### PR TITLE
MM-24009: remove redux-action-buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20259,8 +20259,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#d0f596779f5e25c5d6c1de577ae55bd727d47cd8",
-      "from": "github:mattermost/mattermost-redux#d0f596779f5e25c5d6c1de577ae55bd727d47cd8",
+      "version": "github:mattermost/mattermost-redux#d302222cbbf466ad53f923e512770868ad3532a7",
+      "from": "github:mattermost/mattermost-redux#d302222cbbf466ad53f923e512770868ad3532a7",
       "requires": {
         "core-js": "3.8.3",
         "form-data": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20259,15 +20259,14 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#affa75ca39ec9fa6f9bb51d5b455affe9f4cdfd3",
-      "from": "github:mattermost/mattermost-redux#affa75ca39ec9fa6f9bb51d5b455affe9f4cdfd3",
+      "version": "github:mattermost/mattermost-redux#d0f596779f5e25c5d6c1de577ae55bd727d47cd8",
+      "from": "github:mattermost/mattermost-redux#d0f596779f5e25c5d6c1de577ae55bd727d47cd8",
       "requires": {
         "core-js": "3.8.3",
         "form-data": "3.0.0",
         "gfycat-sdk": "1.4.18",
         "moment-timezone": "0.5.32",
         "redux": "4.0.5",
-        "redux-action-buffer": "1.2.0",
         "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
         "redux-persist": "4.9.1",
         "redux-persist-node-storage": "2.0.0",
@@ -24508,11 +24507,6 @@
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
       }
-    },
-    "redux-action-buffer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.2.0.tgz",
-      "integrity": "sha1-LsCh2JnMn29EzN60Me5SrUHdl1U="
     },
     "redux-batched-actions": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.1.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#be741d411d4642c4cd3e009645f4cb6baa7e92bb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#affa75ca39ec9fa6f9bb51d5b455affe9f4cdfd3",
+    "mattermost-redux": "github:mattermost/mattermost-redux#d0f596779f5e25c5d6c1de577ae55bd727d47cd8",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.1.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#be741d411d4642c4cd3e009645f4cb6baa7e92bb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#d0f596779f5e25c5d6c1de577ae55bd727d47cd8",
+    "mattermost-redux": "github:mattermost/mattermost-redux#d302222cbbf466ad53f923e512770868ad3532a7",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",

--- a/store/index.js
+++ b/store/index.js
@@ -212,5 +212,5 @@ export default function configureStore(initialState) {
         detectNetwork: detect,
     };
 
-    return configureServiceStore(initialState, appReducer, offlineOptions, getAppReducer, {enableBuffer: false});
+    return configureServiceStore(initialState, appReducer, offlineOptions, getAppReducer);
 }


### PR DESCRIPTION
#### Summary
This PR complements https://github.com/mattermost/mattermost-redux/pull/1393 to remove the dependency on the effectively unused redux-action-buffer.

It is a first step towards removing redux-offline altogether.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-24009
