### PR TITLE
Use App id to install App from Marketplace

### DIFF
--- a/actions/marketplace.ts
+++ b/actions/marketplace.ts
@@ -122,7 +122,7 @@ export function installPlugin(id: string, version: string) {
 // installApp installed an App using a given URL via the /apps install slash command.
 //
 // On success, it also requests the current state of the plugins to reflect the newly installed plugin.
-export function installApp(id: string, url: string) {
+export function installApp(id: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc): Promise<boolean> => {
         dispatch({
             type: ActionTypes.INSTALLING_MARKETPLACE_ITEM,
@@ -149,7 +149,7 @@ export function installApp(id: string, url: string) {
             team_id: teamID,
         };
 
-        const result = await dispatch(executeCommand('/apps install --force --url ' + url + ' --app-secret some-secret', args));
+        const result = await dispatch(executeCommand('/apps install --app-id ' + id, args));
         if (isError(result)) {
             dispatch({
                 type: ActionTypes.INSTALLING_MARKETPLACE_ITEM_FAILED,

--- a/components/plugin_marketplace/marketplace_item/marketplace_item_app/__snapshots__/marketplace_item_app.test.tsx.snap
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item_app/__snapshots__/marketplace_item_app.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render 1`] = `
     installed={false}
     installing={false}
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}
@@ -66,7 +65,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render installed a
     installed={true}
     installing={false}
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}
@@ -107,7 +105,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with empty 
     installing={false}
     labels={Array []}
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}
@@ -146,7 +143,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with no hom
     installed={false}
     installing={false}
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}
@@ -185,7 +181,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with no plu
     installed={false}
     installing={false}
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}
@@ -234,7 +229,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with one la
       ]
     }
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}
@@ -275,7 +269,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with server
     installed={false}
     installing={false}
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}
@@ -329,7 +322,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with two la
       ]
     }
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}
@@ -370,7 +362,6 @@ exports[`components/MarketplaceItemApp MarketplaceItem when installing 1`] = `
     installing={false}
     isInstalling={true}
     name="name"
-    rootUrl="http://example.com/install"
     trackEvent={[MockFunction]}
     updateDetails={null}
     versionLabel={null}

--- a/components/plugin_marketplace/marketplace_item/marketplace_item_app/marketplace_item_app.test.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item_app/marketplace_item_app.test.tsx
@@ -13,7 +13,6 @@ describe('components/MarketplaceItemApp', () => {
             name: 'name',
             description: 'test plugin',
             homepageUrl: 'http://example.com',
-            rootUrl: 'http://example.com/install',
             installed: false,
             installing: false,
             trackEvent: jest.fn(() => {}),

--- a/components/plugin_marketplace/marketplace_item/marketplace_item_app/marketplace_item_app.test.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item_app/marketplace_item_app.test.tsx
@@ -159,7 +159,7 @@ describe('components/MarketplaceItemApp', () => {
             expect(props.trackEvent).toBeCalledWith('plugins', 'ui_marketplace_install_app', {
                 app_id: 'id',
             });
-            expect(props.actions.installApp).toHaveBeenCalledWith('id', 'http://example.com/install');
+            expect(props.actions.installApp).toHaveBeenCalledWith('id');
         });
     });
 });

--- a/components/plugin_marketplace/marketplace_item/marketplace_item_app/marketplace_item_app.tsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item_app/marketplace_item_app.tsx
@@ -17,7 +17,6 @@ export type MarketplaceItemAppProps = {
     name: string;
     description?: string;
     homepageUrl?: string;
-    rootUrl: string;
 
     installed: boolean;
     labels?: MarketplaceLabel[];
@@ -28,7 +27,7 @@ export type MarketplaceItemAppProps = {
     trackEvent: (category: string, event: string, props?: unknown) => void;
 
     actions: {
-        installApp: (id: string, url: string) => Promise<boolean>;
+        installApp: (id: string) => Promise<boolean>;
         closeMarketplaceModal: () => void;
     };
 };
@@ -39,7 +38,7 @@ export default class MarketplaceItemApp extends React.PureComponent <Marketplace
             app_id: this.props.id,
         });
 
-        this.props.actions.installApp(this.props.id, this.props.rootUrl).then((res) => {
+        this.props.actions.installApp(this.props.id).then((res) => {
             if (res) {
                 this.props.actions.closeMarketplaceModal();
             }

--- a/components/plugin_marketplace/marketplace_list/marketplace_list.tsx
+++ b/components/plugin_marketplace/marketplace_list/marketplace_list.tsx
@@ -87,7 +87,6 @@ export default class MarketplaceList extends React.PureComponent <MarketplaceLis
                             name={i.manifest.display_name}
                             description={i.manifest.description}
                             homepageUrl={i.manifest.homepage_url}
-                            rootUrl={i.manifest.root_url}
                             installed={i.installed}
                             labels={i.labels}
                         />

--- a/package-lock.json
+++ b/package-lock.json
@@ -15303,10 +15303,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "0.64.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -16343,12 +16340,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
-    },
-    "icu4c-data": {
-      "version": "0.64.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
       "dev": true
     },
     "identity-obj-proxy": {
@@ -20208,8 +20199,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#90918d94d5a1b74bd53003dba2abbe1fe9bf7797",
-      "from": "github:mattermost/mattermost-redux#90918d94d5a1b74bd53003dba2abbe1fe9bf7797",
+      "version": "github:mattermost/mattermost-redux#df0f1569515aed11aee54815ed04110acf091a44",
+      "from": "github:mattermost/mattermost-redux#df0f1569515aed11aee54815ed04110acf091a44",
       "requires": {
         "core-js": "3.8.3",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.1.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#be741d411d4642c4cd3e009645f4cb6baa7e92bb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#90918d94d5a1b74bd53003dba2abbe1fe9bf7797",
+    "mattermost-redux": "github:mattermost/mattermost-redux#df0f1569515aed11aee54815ed04110acf091a44",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",


### PR DESCRIPTION
#### Summary
Given that only AWS apps will be installable via the Marketplace the app id can be used directly to install it. The secret is also not needed given that authentication is done via the lambda invocation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33511

#### Related Pull Requests
- Has redux changes: https://github.com/mattermost/mattermost-redux/pull/1394
