### PR TITLE
Cypress/E2E: Fix channel name tooltips

### DIFF
--- a/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
+++ b/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
@@ -112,7 +112,7 @@ describe('channel name tooltips', () => {
 
     it('Should show tooltip on hover - user with a long username', () => {
         // # Open a DM with the user
-        cy.uiAddDirectMessage().click();
+        cy.findByRole('button', {name: 'write a direct message'}).click();
         cy.focused().as('searchBox').type(longUser.username, {force: true});
 
         // * Verify that the user is selected in the results list before typing enter


### PR DESCRIPTION
#### Summary
- This is using legacy sidebar, so I just needed to update this in the test rather than globally.
- I also made sure there are no other tests that uses both legacy sidebar and `uiAddDirectMessage`

#### Ticket Link
NA