### PR TITLE
Cypress/E2E: Replaced file upload input selector

### DIFF
--- a/e2e/cypress/integration/accessibility/accessibility_image_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_image_spec.js
@@ -31,7 +31,7 @@ describe('Verify Accessibility Support in Different Images', () => {
         });
 
         // # Upload an image in the post
-        cy.get('#fileUploadInput').attachFile('small-image.png');
+        cy.uiUploadFiles().attachFile('small-image.png');
         cy.postMessage('Image upload');
 
         // * Verify accessibility in images uploaded in a post

--- a/e2e/cypress/integration/enterprise/system_console/compliance/helpers.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/helpers.js
@@ -90,7 +90,7 @@ export function gotoTeamAndPostImage() {
         originalSize: {width: 400, height: 400},
         thumbnailSize: {width: 400, height: 400},
     };
-    cy.get('#fileUploadInput').attachFile(file.filename);
+    cy.uiUploadFiles().attachFile(file.filename);
 
     // # Wait until the image is uploaded
     cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {

--- a/e2e/cypress/integration/files_and_attachments/cancel_file_upload_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/cancel_file_upload_spec.js
@@ -30,7 +30,7 @@ describe('Upload Files', () => {
         cy.route({...options, response: {client_ids: [], file_infos: []}});
 
         // # Post an image in center channel
-        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(hugeImage);
+        cy.uiUploadFiles().attachFile(hugeImage);
 
         // * Verify thumbnail of ongoing file upload
         cy.get('.file-preview__container').should('be.visible').within(() => {
@@ -51,7 +51,7 @@ describe('Upload Files', () => {
 
         // # Post a different file in center channel
         const filename = 'long_text_post.txt';
-        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(filename);
+        cy.uiUploadFiles().attachFile(filename);
         cy.postMessage('{enter}');
 
         // * Verify the file is successfully posted as last post

--- a/e2e/cypress/integration/files_and_attachments/edit_message_with_attachment_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/edit_message_with_attachment_spec.js
@@ -32,7 +32,7 @@ describe('Edit Message with Attachment', () => {
 
     it('MM-T2268 - Edit Message with Attachment', () => {
         // # Upload file
-        cy.get('#fileUploadInput').attachFile('mattermost-icon.png');
+        cy.uiUploadFiles().attachFile('mattermost-icon.png');
 
         // # Wait for file to upload
         cy.wait(TIMEOUTS.TWO_SEC);

--- a/e2e/cypress/integration/files_and_attachments/file_previews_2_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/file_previews_2_spec.js
@@ -35,7 +35,7 @@ describe('Upload Files - Generic', () => {
         const filename = route.split('/').pop();
 
         // # Post file in center channel
-        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(route);
+        cy.uiUploadFiles().attachFile(route);
         cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
             return el.find('.post-image__thumbnail').length > 0;
         }));
@@ -103,7 +103,7 @@ describe('Upload Files - Generic', () => {
         const filename = route.split('/').pop();
 
         // # Post file in center channel
-        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(route);
+        cy.uiUploadFiles().attachFile(route);
         cy.wait(TIMEOUTS.ONE_SEC);
         cy.get('#create_post').find('.file-preview').within(() => {
             // * Thumbnail exist

--- a/e2e/cypress/integration/files_and_attachments/helpers.js
+++ b/e2e/cypress/integration/files_and_attachments/helpers.js
@@ -21,7 +21,7 @@ export function testAudioFile(fileProperties) {
     const filename = route.split('/').pop();
 
     // # Post file in center channel
-    cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(route);
+    cy.uiUploadFiles().attachFile(route);
     cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
         return el.find('.post-image__thumbnail').length > 0;
     }));
@@ -70,7 +70,7 @@ export function testImage(imageProperties) {
     const aspectRatio = originalWidth / originalHeight;
 
     // # Post an image in center channel
-    cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(route);
+    cy.uiUploadFiles().attachFile(route);
     cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
         return el.find('.post-image__thumbnail').length > 0;
     }));
@@ -121,7 +121,7 @@ export function testGenericFile(fileProperties) {
     const filename = route.split('/').pop();
 
     // # Post file in center channel
-    cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(route);
+    cy.uiUploadFiles().attachFile(route);
     cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
         return el.find('.post-image__thumbnail').length > 0;
     }));
@@ -164,7 +164,7 @@ export function testVideoFile(fileProperties) {
     const filename = route.split('/').pop();
 
     // # Post file in center channel
-    cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(route);
+    cy.uiUploadFiles().attachFile(route);
     cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
         return el.find('.post-image__thumbnail').length > 0;
     }));

--- a/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
@@ -219,7 +219,7 @@ describe('Image Link Preview', () => {
 
         listOfMinWidthHeightImages.forEach((imageWithMinWidthHeight) => {
             // # Upload Image as attachment and post it
-            cy.get('#fileUploadInput').attachFile(imageWithMinWidthHeight.filename);
+            cy.uiUploadFiles().attachFile(imageWithMinWidthHeight.filename);
             cy.postMessage(`file uploaded-${imageWithMinWidthHeight.filename}`);
 
             // # Get the last uploaded image post

--- a/e2e/cypress/integration/files_and_attachments/upload_files_not_cloud_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/upload_files_not_cloud_spec.js
@@ -59,7 +59,7 @@ describe('Upload Files', () => {
             const attachmentFilename = 'jpg-image-file.jpg';
 
             // # Make a post with a file attached
-            cy.get('#fileUploadInput').attachFile(attachmentFilename);
+            cy.uiUploadFiles().attachFile(attachmentFilename);
             cy.postMessage('Post with attachment to be deleted');
 
             // # Get the last post
@@ -151,7 +151,7 @@ describe('Upload Files', () => {
 
         commonTypeFiles.forEach((file) => {
             // # Make a post with a file attached
-            cy.get('#fileUploadInput').attachFile(file);
+            cy.uiUploadFiles().attachFile(file);
             cy.postMessage(`Attached with ${file}`);
 
             // # Get the last post

--- a/e2e/cypress/integration/files_and_attachments/upload_files_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/upload_files_spec.js
@@ -48,7 +48,7 @@ describe('Upload Files', () => {
         const aspectRatio = originalWidth / originalHeight;
 
         // # Post an image in center channel
-        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(filename);
+        cy.uiUploadFiles().attachFile(filename);
         cy.get('.post-image').should('be.visible');
         cy.postMessage('{enter}');
 
@@ -107,7 +107,7 @@ describe('Upload Files', () => {
 
         attachmentFilesList.forEach((file) => {
             // # Attach the file as attachment and post a message
-            cy.get('#fileUploadInput').attachFile(file.filename);
+            cy.uiUploadFiles().attachFile(file.filename);
             cy.postMessage(MESSAGES.SMALL);
 
             // # Get the post id of the last message
@@ -166,7 +166,7 @@ describe('Upload Files', () => {
     it('MM-T341 Download link on preview - Image file (non SVG)', () => {
         ['bmp-image-file.bmp', 'png-image-file.png', 'jpg-image-file.jpg', 'gif-image-file.gif', 'tiff-image-file.tif'].
             forEach((image) => {
-                cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(image);
+                cy.uiUploadFiles().attachFile(image);
                 cy.get('.post-image').should('be.visible');
                 cy.postMessage(MESSAGES.SMALL);
                 cy.uiWaitUntilMessagePostedIncludes(MESSAGES.SMALL);
@@ -196,7 +196,7 @@ describe('Upload Files', () => {
         const filename = 'huge-image.jpg';
 
         // # Post an image in center channel
-        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(filename);
+        cy.uiUploadFiles().attachFile(filename);
         cy.get('.post-image').should('be.visible');
         cy.postMessage('{enter}');
 
@@ -227,7 +227,7 @@ describe('Upload Files', () => {
     it('MM-T337 CTRL/CMD+U - Five files on one message, thumbnails while uploading', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
         const filename = 'huge-image.jpg';
-        cy.get('#centerChannelFooter').find('#fileUploadInput').
+        cy.uiUploadFiles().
             attachFile(filename).
             attachFile(filename).
             attachFile(filename).
@@ -260,7 +260,7 @@ describe('Upload Files', () => {
         const imageType = 'JPG';
 
         // # Attach an image but don't post it yet
-        cy.get('#fileUploadInput').attachFile(imageFilename);
+        cy.uiUploadFiles().attachFile(imageFilename);
 
         // # Scan inside of the message footer region
         cy.get('#postCreateFooter').should('be.visible').within(() => {
@@ -304,7 +304,7 @@ describe('Upload Files', () => {
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Attach file
-        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(filename);
+        cy.uiUploadFiles().attachFile(filename);
         cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
             return el.find('.post-image.normal').length > 0;
         }));
@@ -389,7 +389,7 @@ describe('Upload Files', () => {
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Upload files
-        cy.get('#centerChannelFooter').find('#fileUploadInput').
+        cy.uiUploadFiles().
             attachFile(attachmentFilesList[0].filename).
             attachFile(attachmentFilesList[1].filename).
             attachFile(attachmentFilesList[2].filename).

--- a/e2e/cypress/integration/messaging/file_upload_in_center_channel_spec.js
+++ b/e2e/cypress/integration/messaging/file_upload_in_center_channel_spec.js
@@ -31,7 +31,7 @@ describe('Messaging', () => {
 
         // # upload an image
         const IMAGE_NAME = 'huge-image.jpg';
-        cy.get('#fileUploadInput').attachFile(IMAGE_NAME);
+        cy.uiUploadFiles().attachFile(IMAGE_NAME);
         waitForImageUpload();
 
         // # post it with a message

--- a/e2e/cypress/integration/messaging/image_attachment_spec.js
+++ b/e2e/cypress/integration/messaging/image_attachment_spec.js
@@ -32,7 +32,7 @@ describe('Image attachment', () => {
 
     it('Image smaller than 48px in both width and height', () => {
         // # Upload a file on center view
-        cy.get('#fileUploadInput').attachFile('small-image.png');
+        cy.uiUploadFiles().attachFile('small-image.png');
 
         verifyImageInPostFooter();
 
@@ -63,7 +63,7 @@ describe('Image attachment', () => {
 
     it('Image with height smaller than 48px', () => {
         // # Upload a file on center view
-        cy.get('#fileUploadInput').attachFile('image-small-height.png');
+        cy.uiUploadFiles().attachFile('image-small-height.png');
 
         verifyImageInPostFooter();
 
@@ -93,7 +93,7 @@ describe('Image attachment', () => {
 
     it('Image with width smaller than 48px', () => {
         // # Upload a file on center view
-        cy.get('#fileUploadInput').attachFile('image-small-width.png');
+        cy.uiUploadFiles().attachFile('image-small-width.png');
 
         verifyImageInPostFooter();
 
@@ -126,7 +126,7 @@ describe('Image attachment', () => {
 
     it('Image with width and height bigger than 48px', () => {
         // # Upload a file on center view
-        cy.get('#fileUploadInput').attachFile('MM-logo-horizontal.png');
+        cy.uiUploadFiles().attachFile('MM-logo-horizontal.png');
 
         verifyImageInPostFooter();
 
@@ -152,7 +152,7 @@ describe('Image attachment', () => {
 
     it('opens image preview window when image is clicked', () => {
         // # Upload a file on center view
-        cy.get('#fileUploadInput').attachFile('MM-logo-horizontal.png');
+        cy.uiUploadFiles().attachFile('MM-logo-horizontal.png');
 
         verifyImageInPostFooter();
 
@@ -184,7 +184,7 @@ describe('Image attachment', () => {
 
     it('opens image preview window when small image is clicked', () => {
         // # Upload a file on center view
-        cy.get('#fileUploadInput').attachFile('small-image.png');
+        cy.uiUploadFiles().attachFile('small-image.png');
 
         verifyImageInPostFooter();
 

--- a/e2e/cypress/integration/messaging/long_post_attachments_spec.js
+++ b/e2e/cypress/integration/messaging/long_post_attachments_spec.js
@@ -25,7 +25,7 @@ function verifyImageInPostFooter(verifyExistence = true) {
 function postAttachments() {
     // Add 4 attachments to a post
     [...Array(4)].forEach(() => {
-        cy.get('#fileUploadInput').attachFile('small-image.png');
+        cy.uiUploadFiles().attachFile('small-image.png');
     });
 
     // # verify the attachment at the footer

--- a/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
@@ -97,7 +97,7 @@ describe('Messaging', () => {
 
 function uploadFileAndAddAutocompleteThenVerifyNoOverlap() {
     // # Upload file
-    cy.get('#fileUploadInput').attachFile('mattermost-icon.png');
+    cy.uiUploadFiles().attachFile('mattermost-icon.png');
 
     // # Create and then type message to use
     cy.get('#post_textbox').clear();

--- a/e2e/cypress/integration/messaging/message_draft_with_attachment_then_switch_channel_spec.js
+++ b/e2e/cypress/integration/messaging/message_draft_with_attachment_then_switch_channel_spec.js
@@ -36,7 +36,7 @@ describe('Message Draft with attachment and Switch Channels', () => {
         cy.get(`#sidebarItem_${testChannel1.name}`).findByTestId('draftIcon').should('not.exist');
 
         // # Upload a file on center view
-        cy.get('#fileUploadInput').attachFile('mattermost-icon.png');
+        cy.uiUploadFiles().attachFile('mattermost-icon.png');
 
         // # Go to test channel without submitting the draft in the previous channel
         cy.get(`#sidebarItem_${testChannel2.name}`).click({force: true});

--- a/e2e/cypress/integration/messaging/message_edit_post_with_attachment_spec.js
+++ b/e2e/cypress/integration/messaging/message_edit_post_with_attachment_spec.js
@@ -31,7 +31,7 @@ describe('MM-13697 Edit Post with attachment', () => {
         cy.url().should('include', townsquareLink);
 
         // # Upload a file on center view
-        cy.get('#fileUploadInput').attachFile('mattermost-icon.png');
+        cy.uiUploadFiles().attachFile('mattermost-icon.png');
 
         // # Type 'This is sample text' and submit
         cy.postMessage('This is sample text');

--- a/e2e/cypress/integration/messaging/single_image_thumbnail_spec.js
+++ b/e2e/cypress/integration/messaging/single_image_thumbnail_spec.js
@@ -39,7 +39,7 @@ function verifySingleImageThumbnail({mode = null} = {}) {
     cy.apiSaveMessageDisplayPreference(displayMode[mode]);
 
     // # Make a post with some text and a single image
-    cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(filename);
+    cy.uiUploadFiles().attachFile(filename);
     cy.get('post-image__thumbnail').should('be.visible');
 
     cy.postMessage(MESSAGES.MEDIUM);

--- a/e2e/cypress/integration/scroll/default_images_collapsed_spec.js
+++ b/e2e/cypress/integration/scroll/default_images_collapsed_spec.js
@@ -27,7 +27,7 @@ describe('Scroll', () => {
         const filename = 'huge-image.jpg';
 
         // # Post an image in center channel
-        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(filename);
+        cy.uiUploadFiles().attachFile(filename);
 
         cy.get('.post-image').should('be.visible');
 

--- a/e2e/cypress/integration/scroll/fixed_width_spec.js
+++ b/e2e/cypress/integration/scroll/fixed_width_spec.js
@@ -45,7 +45,7 @@ describe('Scroll', () => {
         // Posting different type of images and Videos
         const commonTypeFiles = ['jpg-image-file.jpg', 'gif-image-file.gif', 'mp3-audio-file.mp3', 'mpeg-video-file.mpg'];
         commonTypeFiles.forEach((file) => {
-            cy.get('#fileUploadInput').attachFile(file);
+            cy.uiUploadFiles().attachFile(file);
             cy.postMessage(`Attached with ${file}`);
             cy.getLastPostId().as(`${file}PostId`);
         });

--- a/e2e/cypress/support/ui/index.js
+++ b/e2e/cypress/support/ui/index.js
@@ -10,6 +10,7 @@ import './compliance_export';
 import './extend_testing_library';
 import './menu';
 import './modal';
+import './post_draft';
 import './post_dropdown_menu';
 import './search';
 import './sidebar_left';

--- a/e2e/cypress/support/ui/post_draft.d.ts
+++ b/e2e/cypress/support/ui/post_draft.d.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `ui` prefix, e.g. `uiUploadFiles`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable {
+
+        /**
+         * Get upload files input to attach files
+         * @example
+         *   cy.uiUploadFiles();
+         */
+        uiUploadFiles(): Chainable;
+    }
+}

--- a/e2e/cypress/support/ui/post_draft.js
+++ b/e2e/cypress/support/ui/post_draft.js
@@ -1,0 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+Cypress.Commands.add('uiUploadFiles', () => {
+    return cy.get('.file-attachment-menu-item-input');
+});


### PR DESCRIPTION
#### Summary
- `#fileUploadInput` does not show up anymore in the DOM for file input
- Added global `uiUploadFiles` and used on all previous `#fileUploadInput`

Cypress Run: [webapp-pr-7634](https://app.circleci.com/pipelines/github/saturninoabril/mattermost-cypress-docker?branch=webapp-pr-7634)

#### Ticket Link
NA