### PR TITLE
Fix channel header dropdown icon size and count

### DIFF
--- a/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.tsx
@@ -238,7 +238,7 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
                             className='d-flex align-items-center'
                             onClick={() => this.fireActionAndClose(() => this.onClick(binding))}
                         >
-                            <span className='d-flex align-items-center overflow--ellipsis'>{(<img src={binding.icon}/>)}</span>
+                            <span className='d-flex align-items-center overflow--ellipsis icon'>{(<img src={binding.icon}/>)}</span>
                             <span>{binding.label}</span>
                         </a>
                     </li>
@@ -281,7 +281,7 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
                                     id='pluginCount'
                                     className='icon__text'
                                 >
-                                    {plugs.length}
+                                    {items.length}
                                 </span>
                             </React.Fragment>
                         </OverlayTrigger>


### PR DESCRIPTION
#### Summary
Channel header dropdown does not count bindings to set the count, and the icons resize instead of be of a predetermined size. This ticket fix both.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33530
https://mattermost.atlassian.net/browse/MM-33529