### PR TITLE
Fix multiword select options and keep quotes on complete values

### DIFF
--- a/components/suggestion/command_provider/app_command_parser.test.ts
+++ b/components/suggestion/command_provider/app_command_parser.test.ts
@@ -574,7 +574,7 @@ describe('AppCommandParser', () => {
                 title: 'missing required fields not a problem for parseCommand',
                 command: '/jira issue view --project "P 1"',
                 autocomplete: {verify: (parsed: ParsedCommand): void => {
-                    expect(parsed.state).toBe(ParseState.EndValue);
+                    expect(parsed.state).toBe(ParseState.EndQuotedValue);
                     expect(parsed.binding?.label).toBe('view');
                     expect(parsed.form?.call?.path).toBe('/view-issue');
                     expect(parsed.incomplete).toBe('P 1');
@@ -583,7 +583,7 @@ describe('AppCommandParser', () => {
                     expect(parsed.values?.issue).toBe(undefined);
                 }},
                 submit: {verify: (parsed: ParsedCommand): void => {
-                    expect(parsed.state).toBe(ParseState.EndValue);
+                    expect(parsed.state).toBe(ParseState.EndQuotedValue);
                     expect(parsed.binding?.label).toBe('view');
                     expect(parsed.form?.call?.path).toBe('/view-issue');
                     expect(parsed.values?.project).toBe('P 1');
@@ -930,8 +930,8 @@ describe('AppCommandParser', () => {
             expect(suggestions).toEqual([
                 {
                     complete: '/jira issue create --project special-value',
-                    suggestion: '/special-value',
-                    description: 'special-label',
+                    suggestion: '/special-label',
+                    description: '',
                     hint: '',
                     iconData: undefined,
                 },
@@ -942,13 +942,13 @@ describe('AppCommandParser', () => {
             let suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic Dylan Epic',
+                    complete: '/jira issue create --project KT --summary "great feature" --epic epic1',
                     suggestion: '/Dylan Epic',
                     description: '',
                     hint: '',
                 },
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic Michael Epic',
+                    complete: '/jira issue create --project KT --summary "great feature" --epic epic2',
                     suggestion: '/Michael Epic',
                     description: '',
                     hint: '',
@@ -958,7 +958,7 @@ describe('AppCommandParser', () => {
             suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic M');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic Michael Epic',
+                    complete: '/jira issue create --project KT --summary "great feature" --epic epic2',
                     suggestion: '/Michael Epic',
                     description: '',
                     hint: '',

--- a/components/suggestion/command_provider/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser.ts
@@ -53,6 +53,8 @@ export enum ParseState {
     QuotedValue,
     TickValue,
     EndValue,
+    EndQuotedValue,
+    EndTickedValue,
     Error,
 }
 
@@ -406,7 +408,7 @@ export class ParsedCommand {
                         return this.asError('empty values are not allowed');
                     }
                     this.i++;
-                    this.state = ParseState.EndValue;
+                    this.state = ParseState.EndQuotedValue;
                     break;
                 }
                 case '\\': {
@@ -440,7 +442,7 @@ export class ParsedCommand {
                         return this.asError('empty values are not allowed');
                     }
                     this.i++;
-                    this.state = ParseState.EndValue;
+                    this.state = ParseState.EndTickedValue;
                     break;
                 }
                 default: {
@@ -452,6 +454,8 @@ export class ParsedCommand {
                 break;
             }
 
+            case ParseState.EndTickedValue:
+            case ParseState.EndQuotedValue:
             case ParseState.EndValue: {
                 if (!this.field) {
                     return this.asError(Utils.localizeMessage('apps.error.parser.missing_field_value', 'Field value Expected.'));
@@ -826,8 +830,10 @@ export class AppCommandParser {
         case ParseState.FlagValueSeparator:
         case ParseState.NonspaceValue:
             return this.getValueSuggestions(parsed);
+        case ParseState.EndQuotedValue:
         case ParseState.QuotedValue:
             return this.getValueSuggestions(parsed, '"');
+        case ParseState.EndTickedValue:
         case ParseState.TickValue:
             return this.getValueSuggestions(parsed, '`');
         }
@@ -918,9 +924,9 @@ export class AppCommandParser {
         case AppFieldTypes.BOOL:
             return this.getBooleanSuggestions(parsed);
         case AppFieldTypes.DYNAMIC_SELECT:
-            return this.getDynamicSelectSuggestions(parsed);
+            return this.getDynamicSelectSuggestions(parsed, delimiter);
         case AppFieldTypes.STATIC_SELECT:
-            return this.getStaticSelectSuggestions(parsed);
+            return this.getStaticSelectSuggestions(parsed, delimiter);
         }
 
         let complete = parsed.incomplete;
@@ -937,19 +943,27 @@ export class AppCommandParser {
     }
 
     // getStaticSelectSuggestions returns suggestions specified in the field's options property
-    getStaticSelectSuggestions = (parsed: ParsedCommand): AutocompleteSuggestion[] => {
+    getStaticSelectSuggestions = (parsed: ParsedCommand, delimiter?: string): AutocompleteSuggestion[] => {
         const f = parsed.field as AutocompleteStaticSelect;
         const opts = f.options.filter((opt) => opt.label.toLowerCase().startsWith(parsed.incomplete.toLowerCase()));
-        return opts.map((opt) => ({
-            complete: opt.label,
-            suggestion: opt.label,
-            hint: '',
-            description: '',
-        }));
+        return opts.map((opt) => {
+            let complete = opt.value;
+            if (delimiter) {
+                complete = delimiter + complete + delimiter;
+            } else if (isMultiword(opt.value)) {
+                complete = '`' + complete + '`';
+            }
+            return {
+                complete,
+                suggestion: opt.label,
+                hint: '',
+                description: '',
+            };
+        });
     }
 
     // getDynamicSelectSuggestions fetches and returns suggestions from the server
-    getDynamicSelectSuggestions = async (parsed: ParsedCommand): Promise<AutocompleteSuggestion[]> => {
+    getDynamicSelectSuggestions = async (parsed: ParsedCommand, delimiter?: string): Promise<AutocompleteSuggestion[]> => {
         const f = parsed.field;
         if (!f) {
             return [];
@@ -996,12 +1010,20 @@ export class AppCommandParser {
             return [{suggestion: Utils.localizeMessage('apps.suggestion.no_dynamic', 'Received no data for dynamic suggestions')}];
         }
 
-        return items.map((s): AutocompleteSuggestion => ({
-            description: s.label,
-            suggestion: s.value,
-            hint: '',
-            iconData: s.icon_data,
-        }));
+        return items.map((s): AutocompleteSuggestion => {
+            let complete = s.value;
+            if (delimiter) {
+                complete = delimiter + complete + delimiter;
+            } else if (isMultiword(s.value)) {
+                complete = '`' + complete + '`';
+            }
+            return ({
+                complete,
+                suggestion: s.label,
+                hint: '',
+                iconData: s.icon_data,
+            });
+        });
     }
 
     // getUserSuggestions returns a suggestion with `@` if the user has not started typing
@@ -1057,4 +1079,16 @@ function makeSuggestionError(message: string) {
         {error: message},
     );
     return [{suggestion: errMsg}];
+}
+
+function isMultiword(value: string) {
+    if (value.indexOf(' ') !== -1) {
+        return true;
+    }
+
+    if (value.indexOf('\t') !== -1) {
+        return true;
+    }
+
+    return false;
 }

--- a/components/suggestion/command_provider/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser.ts
@@ -1021,6 +1021,7 @@ export class AppCommandParser {
                 complete,
                 suggestion: s.label,
                 hint: '',
+                description: '',
                 iconData: s.icon_data,
             });
         });


### PR DESCRIPTION
#### Summary
We allow multi-word select options by surrounding them by ticks.

We also fix the problem with closed quotes disappearing because of autocomplete.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33534
https://mattermost.atlassian.net/browse/MM-33419