### PR TITLE
MM-3295 - remove no longer necessary validation

### DIFF
--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -13,7 +13,6 @@ import {cmdOrCtrlPressed, isKeyPressed} from 'utils/utils';
 import {useSafeUrl} from 'utils/url';
 import * as UserAgent from 'utils/user_agent';
 import InvitationModal from 'components/invitation_modal';
-import UserLimitModal from 'components/user_limit_modal';
 
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
 import SystemPermissionGate from 'components/permissions_gates/system_permission_gate';
@@ -120,15 +119,6 @@ class MainMenu extends React.PureComponent {
         }
     }
 
-    shouldShowUpgradeModal = () => {
-        const {subscriptionStats, isCloud} = this.props;
-
-        if (subscriptionStats?.is_paid_tier === 'true') { // eslint-disable-line camelcase
-            return false;
-        }
-        return isCloud && subscriptionStats.remaining_seats <= 0;
-    }
-
     render() {
         const {currentUser, teamIsGroupConstrained, isLicensedForLDAPGroups} = this.props;
 
@@ -162,23 +152,6 @@ class MainMenu extends React.PureComponent {
                 id='invitePeople'
                 modalId={ModalIdentifiers.INVITATION}
                 dialogType={InvitationModal}
-                text={formatMessage({
-                    id: 'navbar_dropdown.invitePeople',
-                    defaultMessage: 'Invite People',
-                })}
-                extraText={formatMessage({
-                    id: 'navbar_dropdown.invitePeopleExtraText',
-                    defaultMessage: 'Add or invite people to the team',
-                })}
-                icon={this.props.mobile && <i className='fa fa-user-plus'/>}
-            />
-        );
-
-        const upgradeCloudModal = (
-            <Menu.ItemToggleModalRedux
-                id='invitePeople'
-                modalId={ModalIdentifiers.UPGRADE_CLOUD_ACCOUNT}
-                dialogType={UserLimitModal}
                 text={formatMessage({
                     id: 'navbar_dropdown.invitePeople',
                     defaultMessage: 'Invite People',
@@ -240,7 +213,7 @@ class MainMenu extends React.PureComponent {
                         teamId={this.props.teamId}
                         permissions={[Permissions.ADD_USER_TO_TEAM, Permissions.INVITE_GUEST]}
                     >
-                        {this.shouldShowUpgradeModal() ? upgradeCloudModal : invitePeopleModal}
+                        {invitePeopleModal}
                     </TeamPermissionGate>
                 </Menu.Group>
                 <Menu.Group>


### PR DESCRIPTION
#### Summary
As part of https://github.com/mattermost/mattermost-webapp/pull/7496 the logic to validate if users can invite was moved directly to the invitation modal component. This PR removes some extra validation logic. 


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32925
