### PR TITLE
MM-33581 Fix off-by-one error in wrapEmojis

### DIFF
--- a/utils/emoji_utils.test.jsx
+++ b/utils/emoji_utils.test.jsx
@@ -282,4 +282,24 @@ describe('wrapEmojis', () => {
             </span>,
         ]);
     });
+
+    test('should return a one character string if it contains no emojis', () => {
+        const input = 'a';
+
+        expect(wrapEmojis(input)).toBe(input);
+    });
+
+    test('should properly wrap an emoji followed by a single character', () => {
+        const input = '🌮a';
+
+        expect(wrapEmojis(input)).toEqual([
+            <span
+                key='0'
+                className='emoji'
+            >
+                {'🌮'}
+            </span>,
+            'a',
+        ]);
+    });
 });

--- a/utils/emoji_utils.tsx
+++ b/utils/emoji_utils.tsx
@@ -108,7 +108,7 @@ export function wrapEmojis(text: string): React.ReactNode {
         lastIndex = index + emoji.length;
     }
 
-    if (lastIndex < text.length - 1) {
+    if (lastIndex < text.length) {
         nodes.push(text.substring(lastIndex));
     }
 


### PR DESCRIPTION
Jelena found a weird bug this morning where we don't render the name of sidebar categories with one-character names. Turns out that happened because `wrapEmojis` had an off-by-one error that made it sometimes not include the last character in its input, so when that was called on a one-character name, it would return the empty string.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33581