### PR TITLE
only apply theme variable in context of main app

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -34,6 +34,10 @@
 
         .modal-header {
             background: var(--sidebar-header-bg);
+
+            .close {
+                color: var(--sidebar-header-text-color);
+            }
         }
     }
 
@@ -252,7 +256,7 @@
         .close {
             @include opacity(0.7);
             @include single-transition(all, .1s, ease-in);
-            color: v(sidebar-header-text-color);
+            color: white;
             height: 30px;
             line-height: 30px;
             position: absolute;


### PR DESCRIPTION
#### Summary
The system console modal header close button currently relies on the default css colour, using the theme variable for the default css colour applies the theme colour in the system console as well as the main app. This PR resets the default colour back to its original `white` and applies the theme variable in the context of the main app only.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33592

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3245614/110182605-1ba46300-7ddb-11eb-8beb-e797218f4fdc.png)

After:
![image](https://user-images.githubusercontent.com/3245614/110182657-337be700-7ddb-11eb-84d7-fee050ee02df.png)
