### PR TITLE
MM-33365 When new replies come in for a followed-thread, it also marks the channel that thread belongs to as unread.

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel_link/index.ts
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/index.ts
@@ -33,13 +33,16 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     if (member) {
         unreadMentions = member.mention_count;
 
-        if (isCollapsedThreadsEnabled(state)) {
-            const threadMentionCountInChannel = getThreadCountsInCurrentTeam(state)?.unread_mentions_per_channel?.[ownProps.channel.id] || 0;
-            unreadMentions -= threadMentionCountInChannel;
-        }
-
         if (ownProps.channel) {
             unreadMsgs = Math.max(ownProps.channel.total_msg_count - member.msg_count, 0);
+        }
+
+        if (isCollapsedThreadsEnabled(state)) {
+            const counts = getThreadCountsInCurrentTeam(state);
+            const threadMentionCountInChannel = counts?.unread_mentions_per_channel?.[ownProps.channel.id] || 0;
+            const threadReplyCountInChannel = counts?.unread_replies_per_channel?.[ownProps.channel.id] || 0;
+            unreadMentions -= threadMentionCountInChannel;
+            unreadMsgs -= threadReplyCountInChannel;
         }
 
         if (member.notify_props) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19626,8 +19626,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#7c9d2d7c52bd0fcd541fb91ca43c22fa2d53f1ff",
-      "from": "github:mattermost/mattermost-redux#7c9d2d7c52bd0fcd541fb91ca43c22fa2d53f1ff",
+      "version": "github:mattermost/mattermost-redux#86f30ac4e124dd9d28a6bf568cdb56122eef66fa",
+      "from": "github:mattermost/mattermost-redux#86f30ac4e124dd9d28a6bf568cdb56122eef66fa",
       "requires": {
         "core-js": "3.8.3",
         "form-data": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19635,8 +19635,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#6f6d9f8b3ef63a0d806314b394ebf77c2fd29341",
-      "from": "github:mattermost/mattermost-redux#6f6d9f8b3ef63a0d806314b394ebf77c2fd29341",
+      "version": "github:mattermost/mattermost-redux#7c9d2d7c52bd0fcd541fb91ca43c22fa2d53f1ff",
+      "from": "github:mattermost/mattermost-redux#7c9d2d7c52bd0fcd541fb91ca43c22fa2d53f1ff",
       "requires": {
         "core-js": "3.8.3",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.1.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#be741d411d4642c4cd3e009645f4cb6baa7e92bb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#7c9d2d7c52bd0fcd541fb91ca43c22fa2d53f1ff",
+    "mattermost-redux": "github:mattermost/mattermost-redux#86f30ac4e124dd9d28a6bf568cdb56122eef66fa",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.1.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#be741d411d4642c4cd3e009645f4cb6baa7e92bb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#6f6d9f8b3ef63a0d806314b394ebf77c2fd29341",
+    "mattermost-redux": "github:mattermost/mattermost-redux#7c9d2d7c52bd0fcd541fb91ca43c22fa2d53f1ff",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
take unread replies in threads into account for channel unread state
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-33365

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
Redux https://github.com/mattermost/mattermost-redux/pull/1397
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->