### PR TITLE
Remove autocomplete of ~ and @ for user and channel suggestions

### DIFF
--- a/components/suggestion/command_provider/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser.ts
@@ -891,14 +891,8 @@ export class AppCommandParser {
         const applicable = parsed.form.fields.filter((field) => field.label && field.label.startsWith(parsed.incomplete.toLowerCase()) && !parsed.values[field.name]);
         if (applicable) {
             return applicable.map((f) => {
-                let suffix = '';
-                if (f.type === AppFieldTypes.USER) {
-                    suffix = ' @';
-                } else if (f.type === AppFieldTypes.CHANNEL) {
-                    suffix = ' ~';
-                }
                 return {
-                    complete: prefix + (f.label || f.name) + suffix,
+                    complete: prefix + (f.label || f.name),
                     suggestion: '--' + (f.label || f.name),
                     description: f.description,
                     hint: f.hint,
@@ -1031,9 +1025,10 @@ export class AppCommandParser {
     getUserSuggestions = (parsed: ParsedCommand): AutocompleteSuggestion[] => {
         if (parsed.incomplete.trim().length === 0) {
             return [{
-                suggestion: '@',
+                complete: '',
+                suggestion: '',
                 description: parsed.field?.description || '',
-                hint: parsed.field?.hint || '',
+                hint: parsed.field?.hint || '@username',
             }];
         }
 
@@ -1044,9 +1039,10 @@ export class AppCommandParser {
     getChannelSuggestions = (parsed: ParsedCommand): AutocompleteSuggestion[] => {
         if (parsed.incomplete.trim().length === 0) {
             return [{
-                suggestion: '~',
+                complete: '',
+                suggestion: '',
                 description: parsed.field?.description || '',
-                hint: parsed.field?.hint || '',
+                hint: parsed.field?.hint || '~channelname',
             }];
         }
 


### PR DESCRIPTION
#### Summary
Remove autocomplete of ~ and @ for user and channel suggestions. There are still some minor problems with autocomplete due to ill behaviour from channel mentions provider. Ticket created for Webapp team [here](https://mattermost.atlassian.net/browse/MM-33674)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33657
https://mattermost.atlassian.net/browse/MM-33415