### PR TITLE
MM-33661 Spurious "join private channel" warning fix

### DIFF
--- a/components/channel_layout/channel_identifier_router/actions.ts
+++ b/components/channel_layout/channel_identifier_router/actions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {joinChannel, getChannelByNameAndTeamName, markGroupChannelOpen, fetchMyChannelsAndMembers} from 'mattermost-redux/actions/channels';
+import {joinChannel, getChannelByNameAndTeamName, getChannelMember, markGroupChannelOpen, fetchMyChannelsAndMembers} from 'mattermost-redux/actions/channels';
 import {getUser, getUserByUsername, getUserByEmail} from 'mattermost-redux/actions/users';
 import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserId, getUserByUsername as selectUserByUsername, getUser as selectUser, getUserByEmail as selectUserByEmail} from 'mattermost-redux/selectors/entities/users';
@@ -150,9 +150,22 @@ export function goToChannelByChannelName(match: Match, history: History): Action
         }
 
         let channel = getChannelsNameMapInTeam(state, teamObj!.id)[channelName];
+        if (!channel) {
+            const getChannelDispatchResult = await dispatch(getChannelByNameAndTeamName(team, channelName, true));
+            if ('data' in getChannelDispatchResult) {
+                channel = getChannelDispatchResult.data;
+            }
+        }
+
         let member;
         if (channel) {
             member = state.entities.channels.myMembers[channel.id];
+            if (!member) {
+                const membership = await dispatch(getChannelMember(channel.id, getCurrentUserId(state)));
+                if ('data' in membership) {
+                    member = membership.data;
+                }
+            }
         }
 
         if (!channel || !member) {
@@ -160,14 +173,10 @@ export function goToChannelByChannelName(match: Match, history: History): Action
             const user = getCurrentUser(getState());
             const isSystemAdmin = Utils.isSystemAdmin(user?.roles);
             if (isSystemAdmin) {
-                const getChannelDispatchResult = await dispatch(getChannelByNameAndTeamName(team, channelName, true));
-                if ('data' in getChannelDispatchResult) {
-                    channel = getChannelDispatchResult.data;
-                    if (channel.type === Constants.PRIVATE_CHANNEL) {
-                        const joinPromptResult = await dispatch(joinPrivateChannelPrompt(teamObj, channel));
-                        if ('data' in joinPromptResult && !joinPromptResult.data.join) {
-                            return {data: undefined};
-                        }
+                if (channel.type === Constants.PRIVATE_CHANNEL) {
+                    const joinPromptResult = await dispatch(joinPrivateChannelPrompt(teamObj, channel));
+                    if ('data' in joinPromptResult && !joinPromptResult.data.join) {
+                        return {data: undefined};
                     }
                 }
             }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {getChannel as getChannelAction, getChannelByNameAndTeamName, joinChannel} from 'mattermost-redux/actions/channels';
+import {getChannel as getChannelAction, getChannelByNameAndTeamName, getChannelMember, joinChannel} from 'mattermost-redux/actions/channels';
 import {getPost as getPostAction} from 'mattermost-redux/actions/posts';
 import {getTeamByName as getTeamByNameAction} from 'mattermost-redux/actions/teams';
 import {Client4} from 'mattermost-redux/client';
@@ -1841,19 +1841,28 @@ export async function handleFormattedTextClick(e, currentRelativeTeamUrl) {
                                 }
                             }
                         }
-                        if (channel && channel.type === Constants.PRIVATE_CHANNEL && !getMyChannelMemberships(state)[channel.id]) {
-                            const {data} = await store.dispatch(joinPrivateChannelPrompt(team, channel, false));
-                            if (data.join) {
-                                let error = false;
-                                if (!getTeamMemberships(state)[team.id]) {
-                                    const joinTeamResult = await store.dispatch(addUserToTeam(team.id, user.id));
-                                    error = joinTeamResult.error;
+                        if (channel && channel.type === Constants.PRIVATE_CHANNEL) {
+                            let member = getMyChannelMemberships(state)[channel.id];
+                            if (!member) {
+                                const membership = await store.dispatch(getChannelMember(channel.id, getCurrentUserId(state)));
+                                if ('data' in membership) {
+                                    member = membership.data;
                                 }
-                                if (!error) {
-                                    await store.dispatch(joinChannel(user.id, team.id, channel.id, channel.name));
+                            }
+                            if (!member) {
+                                const {data} = await store.dispatch(joinPrivateChannelPrompt(team, channel, false));
+                                if (data.join) {
+                                    let error = false;
+                                    if (!getTeamMemberships(state)[team.id]) {
+                                        const joinTeamResult = await store.dispatch(addUserToTeam(team.id, user.id));
+                                        error = joinTeamResult.error;
+                                    }
+                                    if (!error) {
+                                        await store.dispatch(joinChannel(user.id, team.id, channel.id, channel.name));
+                                    }
+                                } else {
+                                    return;
                                 }
-                            } else {
-                                return;
                             }
                         }
                     }


### PR DESCRIPTION
#### Summary
We are getting unwanted prompts on navigating to already joined private channel by switch between teams as the membership data is not present in the redux store. As a fix we will fallback to server check if membership is false from redux store data. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33661