### PR TITLE
Use type on call path, and minor refactoring

### DIFF
--- a/actions/apps.ts
+++ b/actions/apps.ts
@@ -3,7 +3,7 @@
 
 import {Client4} from 'mattermost-redux/client';
 import {Action, ActionFunc, DispatchFunc} from 'mattermost-redux/types/actions';
-import {AppCallResponse, AppCall, AppForm} from 'mattermost-redux/types/apps';
+import {AppCallResponse, AppForm, AppCallType, AppCallRequest} from 'mattermost-redux/types/apps';
 import {AppCallTypes, AppCallResponseTypes} from 'mattermost-redux/constants/apps';
 
 import {openModal} from 'actions/views/modals';
@@ -17,10 +17,10 @@ import {makeCallErrorResponse} from 'utils/apps';
 import {localizeAndFormatMessage, localizeMessage} from 'utils/utils';
 import {t} from 'utils/i18n';
 
-export function doAppCall<Res=unknown>(call: AppCall): ActionFunc {
+export function doAppCall<Res=unknown>(call: AppCallRequest, type: AppCallType): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         try {
-            const res = await Client4.executeAppCall(call) as AppCallResponse<Res>;
+            const res = await Client4.executeAppCall(call, type) as AppCallResponse<Res>;
             const responseType = res.type || AppCallResponseTypes.OK;
 
             switch (responseType) {
@@ -34,7 +34,7 @@ export function doAppCall<Res=unknown>(call: AppCall): ActionFunc {
                     return {data: makeCallErrorResponse(errMsg)};
                 }
 
-                if (call.type === AppCallTypes.SUBMIT) {
+                if (type === AppCallTypes.SUBMIT) {
                     dispatch(openAppsModal(res.form, call));
                 }
 
@@ -45,7 +45,7 @@ export function doAppCall<Res=unknown>(call: AppCall): ActionFunc {
                     return {data: makeCallErrorResponse(errMsg)};
                 }
 
-                if (call.type !== AppCallTypes.SUBMIT) {
+                if (type !== AppCallTypes.SUBMIT) {
                     const errMsg = localizeMessage('apps.error.responses.navigate.no_submit', 'Response type is `navigate`, but the call was not a submission.');
                     return {data: makeCallErrorResponse(errMsg)};
                 }
@@ -72,7 +72,7 @@ export function doAppCall<Res=unknown>(call: AppCall): ActionFunc {
     };
 }
 
-export function openAppsModal(form: AppForm, call: AppCall): Action {
+export function openAppsModal(form: AppForm, call: AppCallRequest): Action {
     return openModal({
         modalId: ModalIdentifiers.APPS_MODAL,
         dialogType: AppsForm,

--- a/actions/apps.ts
+++ b/actions/apps.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Client4} from 'mattermost-redux/client';
-import {Action, ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {Action, ActionFunc, DispatchFunc} from 'mattermost-redux/types/actions';
 import {AppCallResponse, AppForm, AppCallType, AppCallRequest} from 'mattermost-redux/types/apps';
 import {AppCallTypes, AppCallResponseTypes} from 'mattermost-redux/constants/apps';
 
@@ -18,7 +18,7 @@ import {localizeAndFormatMessage, localizeMessage} from 'utils/utils';
 import {t} from 'utils/i18n';
 
 export function doAppCall<Res=unknown>(call: AppCallRequest, type: AppCallType): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+    return async (dispatch: DispatchFunc) => {
         try {
             const res = await Client4.executeAppCall(call, type) as AppCallResponse<Res>;
             const responseType = res.type || AppCallResponseTypes.OK;
@@ -55,7 +55,7 @@ export function doAppCall<Res=unknown>(call: AppCallRequest, type: AppCallType):
                     return {data: res};
                 }
 
-                browserHistory.push(res.navigate_to_url.slice(getState().entities.general.config.SiteURL?.length));
+                browserHistory.push(res.navigate_to_url.slice(getSiteURL().length));
                 return {data: res};
             default: {
                 const errMsg = localizeAndFormatMessage(

--- a/actions/command.test.js
+++ b/actions/command.test.js
@@ -251,13 +251,15 @@ describe('executeCommand', () => {
                     team_id: '456',
                 },
                 raw_command: '/appid custom value1 --key2 value2',
-                type: 'submit',
                 path: 'https://someserver.com/command',
+                expand: {},
+                query: undefined,
+                selected_field: undefined,
                 values: {
                     key1: 'value1',
                     key2: {label: 'Value 2', value: 'value2'},
                 },
-            });
+            }, 'submit');
             expect(result).toEqual({data: true});
         });
     });

--- a/actions/command.ts
+++ b/actions/command.ts
@@ -121,10 +121,7 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
                         return createErrorMessage(localizeMessage('apps.error.commands.compose_call', 'Error composing command submission'));
                     }
 
-                    const res = await dispatch(doAppCall({
-                        ...call,
-                        type: AppCallTypes.SUBMIT,
-                    })) as {data: AppCallResponse};
+                    const res = await dispatch(doAppCall(call, AppCallTypes.SUBMIT)) as {data: AppCallResponse};
 
                     const callResp = res.data;
                     switch (callResp.type) {

--- a/actions/command.ts
+++ b/actions/command.ts
@@ -143,7 +143,7 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
                         ));
                     }
                 } catch (err) {
-                    return {error: createErrorMessage(err.message || localizeMessage('apps.error.unknown', 'Unknown error.'))};
+                    return createErrorMessage(err.message || localizeMessage('apps.error.unknown', 'Unknown error.'));
                 }
             }
         }

--- a/components/apps_form/__snapshots__/apps_form_container.test.jsx.snap
+++ b/components/apps_form/__snapshots__/apps_form_container.test.jsx.snap
@@ -14,10 +14,10 @@ exports[`components/apps_model/AppsFormContainer should match snapshot 1`] = `
       "context": Object {
         "app_id": "app",
         "channel_id": "channel",
-        "location": "/in_post",
         "post_id": "post",
         "team_id": "team",
       },
+      "expand": Object {},
       "path": "/form_url",
     }
   }
@@ -46,7 +46,6 @@ exports[`components/apps_model/AppsFormContainer should match snapshot 1`] = `
       "title": "Form Title",
     }
   }
-  isEmbedded={false}
   onHide={[Function]}
 />
 `;

--- a/components/apps_form/apps_form.tsx
+++ b/components/apps_form/apps_form.tsx
@@ -7,7 +7,7 @@ import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
 import {
     checkDialogElementForError, checkIfErrorsMatchElements,
 } from 'mattermost-redux/utils/integration_utils';
-import {AppCallResponse, AppField, AppForm, AppFormValue, AppFormValues, AppSelectOption, AppCall} from 'mattermost-redux/types/apps';
+import {AppCallResponse, AppField, AppForm, AppFormValues, AppSelectOption, AppCall} from 'mattermost-redux/types/apps';
 import {DialogElement} from 'mattermost-redux/types/integrations';
 import {AppCallResponseTypes} from 'mattermost-redux/constants/apps';
 
@@ -33,7 +33,7 @@ export type AppsFormProps = {
             };
         }) => Promise<{data: AppCallResponse<FormResponseData>}>;
         performLookupCall: (field: AppField, values: AppFormValues, userInput: string) => Promise<AppSelectOption[]>;
-        refreshOnSelect: (field: AppField, values: AppFormValues, value: AppFormValue) => Promise<{data: AppCallResponse<any>}>;
+        refreshOnSelect: (field: AppField, values: AppFormValues) => Promise<{data: AppCallResponse<any>}>;
     };
     emojiMap: EmojiMap;
 }
@@ -225,7 +225,7 @@ export class AppsForm extends React.PureComponent<Props, State> {
         const values = {...this.state.values, [name]: value};
 
         if (field.refresh) {
-            this.props.actions.refreshOnSelect(field, values, value);
+            this.props.actions.refreshOnSelect(field, values);
         }
 
         this.setState({values});

--- a/components/apps_form/apps_form_container.test.jsx
+++ b/components/apps_form/apps_form_container.test.jsx
@@ -48,10 +48,6 @@ describe('components/apps_model/AppsFormContainer', () => {
             doAppCall: jest.fn().mockResolvedValue({}),
         },
         onHide: jest.fn(),
-        postID: context.post_id,
-        channelID: context.channel_id,
-        teamID: context.team_id,
-        isEmbedded: false,
     };
 
     test('should match snapshot', () => {

--- a/components/apps_form/apps_form_container.test.jsx
+++ b/components/apps_form/apps_form_container.test.jsx
@@ -85,11 +85,10 @@ describe('components/apps_model/AppsFormContainer', () => {
                 context: {
                     app_id: 'app',
                     channel_id: 'channel',
-                    location: '/in_post',
                     post_id: 'post',
                     team_id: 'team',
                 },
-                type: 'submit',
+                expand: {},
                 path: '/form_url',
                 values: {
                     field1: 'value1',
@@ -98,7 +97,7 @@ describe('components/apps_model/AppsFormContainer', () => {
                         value: 'value2',
                     },
                 },
-            });
+            }, 'submit');
 
             expect(result).toEqual({
                 data: {
@@ -146,24 +145,21 @@ describe('components/apps_model/AppsFormContainer', () => {
                 context: {
                     app_id: 'app',
                     channel_id: 'channel',
-                    location: '/in_post',
                     post_id: 'post',
                     team_id: 'team',
                 },
-                type: 'lookup',
+                expand: {},
                 path: '/form_url',
+                query: 'My search',
+                selected_field: 'field2',
                 values: {
-                    name: 'field2',
-                    user_input: 'My search',
-                    values: {
-                        field1: 'value1',
-                        field2: {
-                            label: 'label2',
-                            value: 'value2',
-                        },
+                    field1: 'value1',
+                    field2: {
+                        label: 'label2',
+                        value: 'value2',
                     },
                 },
-            });
+            }, 'lookup');
 
             expect(result).toEqual([{
                 label: 'Fetched Label',

--- a/components/apps_form/index.ts
+++ b/components/apps_form/index.ts
@@ -6,9 +6,7 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {GlobalState} from 'mattermost-redux/types/store';
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
-import {AppCall, AppCallResponse, AppModalState} from 'mattermost-redux/types/apps';
-import {getPost} from 'mattermost-redux/selectors/entities/posts';
-import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {AppCallRequest, AppCallResponse, AppCallType, AppModalState} from 'mattermost-redux/types/apps';
 
 import {doAppCall} from 'actions/apps';
 import {getEmojiMap} from 'selectors/emojis';
@@ -16,21 +14,10 @@ import {getEmojiMap} from 'selectors/emojis';
 import AppsFormContainer from './apps_form_container';
 
 type Actions = {
-    doAppCall: (call: AppCall) => Promise<{data: AppCallResponse}>;
+    doAppCall: (call: AppCallRequest, type: AppCallType) => Promise<{data: AppCallResponse}>;
 };
 
-function mapStateToProps(state: GlobalState, ownProps: {modal?: AppModalState; postID?: string}) {
-    let postID: string | undefined;
-    let channelID: string | undefined;
-    let teamID: string | undefined;
-
-    if (ownProps.postID) {
-        const post = getPost(state, ownProps.postID);
-        postID = post.id;
-        channelID = post.channel_id;
-        teamID = getCurrentTeam(state).id;
-    }
-
+function mapStateToProps(state: GlobalState, ownProps: {modal?: AppModalState}) {
     const emojiMap = getEmojiMap(state);
     if (!ownProps.modal) {
         return {emojiMap};
@@ -39,9 +26,6 @@ function mapStateToProps(state: GlobalState, ownProps: {modal?: AppModalState; p
     return {
         modal: ownProps.modal,
         emojiMap,
-        postID,
-        channelID,
-        teamID,
     };
 }
 

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -8,8 +8,8 @@ import {Tooltip} from 'react-bootstrap';
 
 import Permissions from 'mattermost-redux/constants/permissions';
 import {Post} from 'mattermost-redux/types/posts';
-import {AppBinding, AppCall, AppCallResponse} from 'mattermost-redux/types/apps';
-import {AppCallResponseTypes, AppCallTypes} from 'mattermost-redux/constants/apps';
+import {AppBinding, AppCallRequest, AppCallResponse, AppCallType} from 'mattermost-redux/types/apps';
+import {AppCallResponseTypes, AppCallTypes, AppExpandLevels} from 'mattermost-redux/constants/apps';
 
 import {ActionResult} from 'mattermost-redux/types/actions';
 
@@ -26,6 +26,7 @@ import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 import DotsHorizontalIcon from 'components/widgets/icons/dots_horizontal';
 import {PluginComponent} from 'types/store/plugins';
 import {sendEphemeralPost} from 'actions/global_actions';
+import {createCallContext, createCallRequest} from 'utils/apps';
 
 const MENU_BOTTOM_MARGIN = 80;
 
@@ -98,7 +99,7 @@ type Props = {
         /**
          * Function to perform an app call
          */
-        doAppCall: (call: AppCall) => Promise<ActionResult>;
+        doAppCall: (call: AppCallRequest, type: AppCallType) => Promise<ActionResult>;
     }; // TechDebt: Made non-mandatory while converting to typescript
 
     canEdit: boolean;
@@ -283,18 +284,22 @@ class DotMenu extends React.PureComponent<Props, State> {
         if (!binding.call) {
             return;
         }
-        const res = await this.props.actions?.doAppCall({
-            ...binding.call,
-            type: AppCallTypes.SUBMIT,
-            context: {
-                app_id: binding.app_id,
-                location: binding.location,
-                team_id: this.props.teamId,
-                channel_id: this.props.post.channel_id,
-                post_id: this.props.post.id,
-                root_id: this.props.post.root_id,
+        const context = createCallContext(
+            binding.app_id,
+            binding.location,
+            this.props.post.channel_id,
+            this.props.teamId,
+            this.props.post.id,
+            this.props.post.root_id,
+        );
+        const call = createCallRequest(
+            binding.call,
+            context,
+            {
+                post: AppExpandLevels.ALL,
             },
-        });
+        );
+        const res = await this.props.actions?.doAppCall(call, AppCallTypes.SUBMIT);
 
         const callResp = (res as {data: AppCallResponse}).data;
         const ephemeral = (message: string) => sendEphemeralPost(message, this.props.post.channel_id, this.props.post.root_id);

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -59,7 +59,7 @@ type Props = {
         [componentName: string]: PluginComponent[];
     };
 
-    actions?: {
+    actions: {
 
         /**
          * Function flag the post
@@ -177,9 +177,9 @@ class DotMenu extends React.PureComponent<Props, State> {
 
     handleFlagMenuItemActivated = () => {
         if (this.props.isFlagged) {
-            this.props.actions?.unflagPost(this.props.post.id);
+            this.props.actions.unflagPost(this.props.post.id);
         } else {
-            this.props.actions?.flagPost(this.props.post.id);
+            this.props.actions.flagPost(this.props.post.id);
         }
     }
 
@@ -199,15 +199,15 @@ class DotMenu extends React.PureComponent<Props, State> {
 
     handlePinMenuItemActivated = () => {
         if (this.props.post.is_pinned) {
-            this.props.actions?.unpinPost(this.props.post.id);
+            this.props.actions.unpinPost(this.props.post.id);
         } else {
-            this.props.actions?.pinPost(this.props.post.id);
+            this.props.actions.pinPost(this.props.post.id);
         }
     }
 
     handleUnreadMenuItemActivated = (e: React.MouseEvent) => {
         e.preventDefault();
-        this.props.actions?.markPostAsUnread(this.props.post);
+        this.props.actions.markPostAsUnread(this.props.post);
     }
 
     handleDeleteMenuItemActivated = (e: React.MouseEvent) => {
@@ -223,11 +223,11 @@ class DotMenu extends React.PureComponent<Props, State> {
             },
         };
 
-        this.props.actions?.openModal(deletePostModalData);
+        this.props.actions.openModal(deletePostModalData);
     }
 
     handleEditMenuItemActivated = () => {
-        this.props.actions?.setEditingPost(
+        this.props.actions.setEditingPost(
             this.props.post.id,
             this.props.commentCount,
             this.props.location === Locations.CENTER ? 'post_textbox' : 'reply_textbox',
@@ -299,7 +299,7 @@ class DotMenu extends React.PureComponent<Props, State> {
                 post: AppExpandLevels.ALL,
             },
         );
-        const res = await this.props.actions?.doAppCall(call, AppCallTypes.SUBMIT);
+        const res = await this.props.actions.doAppCall(call, AppCallTypes.SUBMIT);
 
         const callResp = (res as {data: AppCallResponse}).data;
         const ephemeral = (message: string) => sendEphemeralPost(message, this.props.post.channel_id, this.props.post.root_id);

--- a/components/dot_menu/index.ts
+++ b/components/dot_menu/index.ts
@@ -15,7 +15,7 @@ import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/ac
 
 import {Post} from 'mattermost-redux/types/posts';
 
-import {AppCall} from 'mattermost-redux/types/apps';
+import {AppCallRequest, AppCallType} from 'mattermost-redux/types/apps';
 
 import {GlobalState} from 'types/store';
 
@@ -88,7 +88,7 @@ type Actions = {
     unpinPost: (postId: string) => void;
     openModal: (postId: any) => void;
     markPostAsUnread: (post: Post) => void;
-    doAppCall: (call: AppCall) => Promise<ActionResult>;
+    doAppCall: (call: AppCallRequest, type: AppCallType) => Promise<ActionResult>;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {

--- a/components/post_view/embedded_bindings/button_binding/__snapshots__/button_binding.test.tsx.snap
+++ b/components/post_view/embedded_bindings/button_binding/__snapshots__/button_binding.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`components/post_view/embedded_bindings/button_binding/ should match snapshot 1`] = `
 <button
+  key="some_location"
   onClick={[Function]}
 >
   <LoadingWrapper
@@ -9,6 +10,7 @@ exports[`components/post_view/embedded_bindings/button_binding/ should match sna
     text={null}
   >
     <Connect(Markdown)
+      message="some_label"
       options={
         Object {
           "autolinkedUrlSchemes": Array [],

--- a/components/post_view/embedded_bindings/button_binding/button_binding.test.tsx
+++ b/components/post_view/embedded_bindings/button_binding/button_binding.test.tsx
@@ -25,7 +25,10 @@ describe('components/post_view/embedded_bindings/button_binding/', () => {
         post,
         userId: 'user_id',
         binding,
-        actions: {doAppCall: jest.fn()},
+        actions: {
+            doAppCall: jest.fn(),
+            getChannel: jest.fn(),
+        },
     };
 
     test('should match snapshot', () => {

--- a/components/post_view/embedded_bindings/button_binding/button_binding.test.tsx
+++ b/components/post_view/embedded_bindings/button_binding/button_binding.test.tsx
@@ -17,6 +17,8 @@ describe('components/post_view/embedded_bindings/button_binding/', () => {
     } as Post;
 
     const binding = {
+        label: 'some_label',
+        location: 'some_location',
         call: {
             path: 'some_url',
         },
@@ -26,8 +28,12 @@ describe('components/post_view/embedded_bindings/button_binding/', () => {
         userId: 'user_id',
         binding,
         actions: {
-            doAppCall: jest.fn(),
-            getChannel: jest.fn(),
+            doAppCall: jest.fn(async () => {
+                return {data: {type: 'ok'}};
+            }),
+            getChannel: jest.fn(async (id: string) => {
+                return {data: {id, team_id: 'team_id'}};
+            }),
         },
     };
 

--- a/components/post_view/embedded_bindings/button_binding/button_binding.test.tsx
+++ b/components/post_view/embedded_bindings/button_binding/button_binding.test.tsx
@@ -42,11 +42,22 @@ describe('components/post_view/embedded_bindings/button_binding/', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should call handleAction on click', () => {
-        const wrapper = shallowWithIntl(<ButtonBinding {...baseProps}/>);
+    test('should call handleAction on click', (done) => {
+        const doAppCall = jest.fn(async () => {
+            done();
+            return {data: {type: 'ok'}};
+        });
+
+        const props = {
+            ...baseProps,
+            actions: {
+                ...baseProps.actions,
+                doAppCall,
+            },
+        };
+
+        const wrapper = shallowWithIntl(<ButtonBinding {...props}/>);
 
         wrapper.find('button').simulate('click');
-
-        expect(baseProps.actions.doAppCall).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/post_view/embedded_bindings/button_binding/button_binding.tsx
+++ b/components/post_view/embedded_bindings/button_binding/button_binding.tsx
@@ -3,25 +3,27 @@
 
 import React from 'react';
 
-import {AppBinding, AppCall, AppCallResponse} from 'mattermost-redux/types/apps';
+import {AppBinding, AppCallRequest, AppCallResponse, AppCallType} from 'mattermost-redux/types/apps';
 import {ActionResult} from 'mattermost-redux/types/actions';
-import {AppBindingLocations, AppCallResponseTypes, AppExpandLevels} from 'mattermost-redux/constants/apps';
+import {AppBindingLocations, AppCallResponseTypes, AppCallTypes, AppExpandLevels} from 'mattermost-redux/constants/apps';
 import {Post} from 'mattermost-redux/types/posts';
 
 import {injectIntl, IntlShape} from 'react-intl';
 
+import {Channel} from 'mattermost-redux/types/channels';
+
 import Markdown from 'components/markdown';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
-import {createCallRequest} from 'utils/apps';
+import {createCallContext, createCallRequest} from 'utils/apps';
 import {sendEphemeralPost} from 'actions/global_actions';
 
 type Props = {
     intl: IntlShape;
     binding: AppBinding;
-    userId: string;
     post: Post;
     actions: {
-        doAppCall: (call: AppCall) => Promise<ActionResult>;
+        doAppCall: (call: AppCallRequest, type: AppCallType) => Promise<ActionResult>;
+        getChannel: (channelId: string) => Promise<ActionResult>;
     };
 }
 
@@ -38,22 +40,32 @@ class ButtonBinding extends React.PureComponent<Props, State> {
     }
 
     handleClick = async () => {
-        const {binding, post, userId} = this.props;
+        const {binding, post} = this.props;
         if (!binding.call) {
             return;
         }
 
-        const call = createCallRequest(
-            binding.call,
-            userId,
+        let teamID = '';
+        const {data} = await this.props.actions.getChannel(post.channel_id) as {data?: any; error?: any};
+        if (data) {
+            const channel = data as Channel;
+            teamID = channel.team_id;
+        }
+
+        const context = createCallContext(
             binding.app_id,
-            AppBindingLocations.IN_POST + '/' + binding.location,
-            {post: AppExpandLevels.EXPAND_ALL},
+            AppBindingLocations.IN_POST + binding.location,
             post.channel_id,
+            teamID,
             post.id,
         );
+        const call = createCallRequest(
+            binding.call,
+            context,
+            {post: AppExpandLevels.EXPAND_ALL},
+        );
         this.setState({executing: true});
-        const res = await this.props.actions.doAppCall(call);
+        const res = await this.props.actions.doAppCall(call, AppCallTypes.SUBMIT);
 
         this.setState({executing: false});
         const callResp = (res as {data: AppCallResponse}).data;

--- a/components/post_view/embedded_bindings/button_binding/button_binding.tsx
+++ b/components/post_view/embedded_bindings/button_binding/button_binding.tsx
@@ -6,11 +6,10 @@ import React from 'react';
 import {AppBinding, AppCallRequest, AppCallResponse, AppCallType} from 'mattermost-redux/types/apps';
 import {ActionResult} from 'mattermost-redux/types/actions';
 import {AppBindingLocations, AppCallResponseTypes, AppCallTypes, AppExpandLevels} from 'mattermost-redux/constants/apps';
+import {Channel} from 'mattermost-redux/types/channels';
 import {Post} from 'mattermost-redux/types/posts';
 
 import {injectIntl, IntlShape} from 'react-intl';
-
-import {Channel} from 'mattermost-redux/types/channels';
 
 import Markdown from 'components/markdown';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
@@ -54,7 +53,7 @@ class ButtonBinding extends React.PureComponent<Props, State> {
 
         const context = createCallContext(
             binding.app_id,
-            AppBindingLocations.IN_POST + binding.location,
+            AppBindingLocations.IN_POST + '/' + binding.location,
             post.channel_id,
             teamID,
             post.id,

--- a/components/post_view/embedded_bindings/button_binding/index.ts
+++ b/components/post_view/embedded_bindings/button_binding/index.ts
@@ -2,33 +2,29 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
 
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
-import {AppCall} from 'mattermost-redux/types/apps';
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {AppCallRequest, AppCallType} from 'mattermost-redux/types/apps';
+
+import {getChannel} from 'mattermost-redux/actions/channels';
 
 import {doAppCall} from 'actions/apps';
 
 import ButtonBinding from './button_binding';
 
-function mapStateToProps(state: GlobalState) {
-    return {
-        userId: getCurrentUserId(state),
-    };
-}
-
 type Actions = {
-    doAppCall: (call: AppCall) => Promise<ActionResult>;
+    doAppCall: (call: AppCallRequest, type: AppCallType) => Promise<ActionResult>;
+    getChannel: (channelId: string) => Promise<ActionResult>;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Actions>({
             doAppCall,
+            getChannel,
         }, dispatch),
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ButtonBinding);
+export default connect(null, mapDispatchToProps)(ButtonBinding);

--- a/components/post_view/embedded_bindings/select_binding/index.ts
+++ b/components/post_view/embedded_bindings/select_binding/index.ts
@@ -6,31 +6,26 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
 
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {AppCallRequest, AppCallType} from 'mattermost-redux/types/apps';
 
-import {AppCall} from 'mattermost-redux/types/apps';
+import {getChannel} from 'mattermost-redux/actions/channels';
 
 import {doAppCall} from 'actions/apps';
-import {GlobalState} from 'types/store';
 
 import SelectBinding from './select_binding';
 
-function mapStateToProps(state: GlobalState) {
-    return {
-        userId: getCurrentUserId(state),
-    };
-}
-
 type Actions = {
-    doAppCall: (call: AppCall) => Promise<ActionResult>;
+    doAppCall: (call: AppCallRequest, type: AppCallType) => Promise<ActionResult>;
+    getChannel: (channelId: string) => Promise<ActionResult>;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Actions>({
             doAppCall,
+            getChannel,
         }, dispatch),
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SelectBinding);
+export default connect(null, mapDispatchToProps)(SelectBinding);

--- a/components/post_view/embedded_bindings/select_binding/select_binding.test.tsx
+++ b/components/post_view/embedded_bindings/select_binding/select_binding.test.tsx
@@ -21,7 +21,10 @@ describe('components/post_view/embedded_bindings/select_binding', () => {
         post,
         userId: 'user_id',
         binding,
-        actions: {doAppCall: jest.fn()},
+        actions: {
+            doAppCall: jest.fn(),
+            getChannel: jest.fn(),
+        },
     };
 
     test('should start with nothing selected', () => {

--- a/components/post_view/embedded_bindings/select_binding/select_binding.test.tsx
+++ b/components/post_view/embedded_bindings/select_binding/select_binding.test.tsx
@@ -22,8 +22,12 @@ describe('components/post_view/embedded_bindings/select_binding', () => {
         userId: 'user_id',
         binding,
         actions: {
-            doAppCall: jest.fn(),
-            getChannel: jest.fn(),
+            doAppCall: jest.fn(async () => {
+                return {data: {type: 'ok'}};
+            }),
+            getChannel: jest.fn(async (id: string) => {
+                return {data: {id, team_id: 'team_id'}};
+            }),
         },
     };
 

--- a/components/post_view/embedded_bindings/select_binding/select_binding.tsx
+++ b/components/post_view/embedded_bindings/select_binding/select_binding.tsx
@@ -85,7 +85,7 @@ class SelectBinding extends React.PureComponent<Props, State> {
 
         const context = createCallContext(
             binding.app_id,
-            AppBindingLocations.IN_POST + binding.location,
+            AppBindingLocations.IN_POST + '/' + binding.location,
             post.channel_id,
             teamID,
             post.id,

--- a/components/suggestion/command_provider/app_command_parser.test.ts
+++ b/components/suggestion/command_provider/app_command_parser.test.ts
@@ -632,10 +632,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira ');
             expect(suggestions).toEqual([
                 {
-                    suggestion: '/issue',
-                    complete: '/jira issue',
-                    hint: '',
-                    description: 'Interact with Jira issues',
+                    Suggestion: '/issue',
+                    Complete: '/jira issue',
+                    Hint: '',
+                    Description: 'Interact with Jira issues',
+                    IconData: '',
                 },
             ]);
         });
@@ -644,10 +645,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/JiRa ');
             expect(suggestions).toEqual([
                 {
-                    suggestion: '/issue',
-                    complete: '/JiRa issue',
-                    hint: '',
-                    description: 'Interact with Jira issues',
+                    Suggestion: '/issue',
+                    Complete: '/JiRa issue',
+                    Hint: '',
+                    Description: 'Interact with Jira issues',
+                    IconData: '',
                 },
             ]);
         });
@@ -656,10 +658,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue');
             expect(suggestions).toEqual([
                 {
-                    suggestion: '/issue',
-                    complete: '/jira issue',
-                    hint: '',
-                    description: 'Interact with Jira issues',
+                    Suggestion: '/issue',
+                    Complete: '/jira issue',
+                    Hint: '',
+                    Description: 'Interact with Jira issues',
+                    IconData: '',
                 },
             ]);
         });
@@ -668,10 +671,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/JiRa IsSuE');
             expect(suggestions).toEqual([
                 {
-                    suggestion: '/issue',
-                    complete: '/JiRa issue',
-                    hint: '',
-                    description: 'Interact with Jira issues',
+                    Suggestion: '/issue',
+                    Complete: '/JiRa issue',
+                    Hint: '',
+                    Description: 'Interact with Jira issues',
+                    IconData: '',
                 },
             ]);
         });
@@ -680,16 +684,18 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue ');
             expect(suggestions).toEqual([
                 {
-                    suggestion: '/view',
-                    complete: '/jira issue view',
-                    hint: '',
-                    description: 'View details of a Jira issue',
+                    Suggestion: '/view',
+                    Complete: '/jira issue view',
+                    Hint: '',
+                    Description: 'View details of a Jira issue',
+                    IconData: '',
                 },
                 {
-                    suggestion: '/create',
-                    complete: '/jira issue create',
-                    hint: '',
-                    description: 'Create a new Jira issue',
+                    Suggestion: '/create',
+                    Complete: '/jira issue create',
+                    Hint: '',
+                    Description: 'Create a new Jira issue',
+                    IconData: '',
                 },
             ]);
         });
@@ -698,16 +704,18 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/JiRa IsSuE ');
             expect(suggestions).toEqual([
                 {
-                    suggestion: '/view',
-                    complete: '/JiRa IsSuE view',
-                    hint: '',
-                    description: 'View details of a Jira issue',
+                    Suggestion: '/view',
+                    Complete: '/JiRa IsSuE view',
+                    Hint: '',
+                    Description: 'View details of a Jira issue',
+                    IconData: '',
                 },
                 {
-                    suggestion: '/create',
-                    complete: '/JiRa IsSuE create',
-                    hint: '',
-                    description: 'Create a new Jira issue',
+                    Suggestion: '/create',
+                    Complete: '/JiRa IsSuE create',
+                    Hint: '',
+                    Description: 'Create a new Jira issue',
+                    IconData: '',
                 },
             ]);
         });
@@ -716,10 +724,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue c');
             expect(suggestions).toEqual([
                 {
-                    suggestion: '/create',
-                    complete: '/jira issue create',
-                    hint: '',
-                    description: 'Create a new Jira issue',
+                    Suggestion: '/create',
+                    Complete: '/jira issue create',
+                    Hint: '',
+                    Description: 'Create a new Jira issue',
+                    IconData: '',
                 },
             ]);
         });
@@ -728,10 +737,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/JiRa IsSuE C');
             expect(suggestions).toEqual([
                 {
-                    suggestion: '/create',
-                    complete: '/JiRa IsSuE create',
-                    hint: '',
-                    description: 'Create a new Jira issue',
+                    Suggestion: '/create',
+                    Complete: '/JiRa IsSuE create',
+                    Hint: '',
+                    Description: 'Create a new Jira issue',
+                    IconData: '',
                 },
             ]);
         });
@@ -740,10 +750,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue view ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue view',
-                    description: 'The Jira issue key',
-                    hint: 'MM-11343',
-                    suggestion: '/',
+                    Complete: '/jira issue view',
+                    Description: 'The Jira issue key',
+                    Hint: 'MM-11343',
+                    Suggestion: '/',
+                    IconData: '',
                 },
             ]);
         });
@@ -752,20 +763,22 @@ describe('AppCommandParser', () => {
             let suggestions = await parser.getSuggestions('/jira issue view -');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue view --project',
-                    description: 'The Jira project description',
-                    hint: 'The Jira project hint',
-                    suggestion: '/--project',
+                    Complete: '/jira issue view --project',
+                    Description: 'The Jira project description',
+                    Hint: 'The Jira project hint',
+                    Suggestion: '/--project',
+                    IconData: '',
                 },
             ]);
 
             suggestions = await parser.getSuggestions('/jira issue view --');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue view --project',
-                    description: 'The Jira project description',
-                    hint: 'The Jira project hint',
-                    suggestion: '/--project',
+                    Complete: '/jira issue view --project',
+                    Description: 'The Jira project description',
+                    Hint: 'The Jira project hint',
+                    Suggestion: '/--project',
+                    IconData: '',
                 },
             ]);
         });
@@ -774,35 +787,39 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create _execute_current_command',
-                    description: 'Select this option or use Ctrl+Enter to execute the current command.',
-                    hint: '',
-                    iconData: '_execute_current_command',
-                    suggestion: '/Execute Current Command',
+                    Complete: '/jira issue create _execute_current_command',
+                    Description: 'Select this option or use Ctrl+Enter to execute the current command.',
+                    Hint: '',
+                    IconData: '_execute_current_command',
+                    Suggestion: '/Execute Current Command',
                 },
                 {
-                    complete: '/jira issue create --project',
-                    description: 'The Jira project description',
-                    hint: 'The Jira project hint',
-                    suggestion: '/--project',
+                    Complete: '/jira issue create --project',
+                    Description: 'The Jira project description',
+                    Hint: 'The Jira project hint',
+                    Suggestion: '/--project',
+                    IconData: '',
                 },
                 {
-                    complete: '/jira issue create --summary',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/--summary',
+                    Complete: '/jira issue create --summary',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/--summary',
+                    IconData: '',
                 },
                 {
-                    complete: '/jira issue create --verbose',
-                    description: 'display details',
-                    hint: 'yes or no!',
-                    suggestion: '/--verbose',
+                    Complete: '/jira issue create --verbose',
+                    Description: 'display details',
+                    Hint: 'yes or no!',
+                    Suggestion: '/--verbose',
+                    IconData: '',
                 },
                 {
-                    complete: '/jira issue create --epic',
-                    description: 'The Jira epic',
-                    hint: 'The thing is working great!',
-                    suggestion: '/--epic',
+                    Complete: '/jira issue create --epic',
+                    Description: 'The Jira epic',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/--epic',
+                    IconData: '',
                 },
             ]);
         });
@@ -811,29 +828,32 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create --project KT ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT _execute_current_command',
-                    description: 'Select this option or use Ctrl+Enter to execute the current command.',
-                    hint: '',
-                    iconData: '_execute_current_command',
-                    suggestion: '/Execute Current Command',
+                    Complete: '/jira issue create --project KT _execute_current_command',
+                    Description: 'Select this option or use Ctrl+Enter to execute the current command.',
+                    Hint: '',
+                    IconData: '_execute_current_command',
+                    Suggestion: '/Execute Current Command',
                 },
                 {
-                    complete: '/jira issue create --project KT --summary',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/--summary',
+                    Complete: '/jira issue create --project KT --summary',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/--summary',
+                    IconData: '',
                 },
                 {
-                    complete: '/jira issue create --project KT --verbose',
-                    description: 'display details',
-                    hint: 'yes or no!',
-                    suggestion: '/--verbose',
+                    Complete: '/jira issue create --project KT --verbose',
+                    Description: 'display details',
+                    Hint: 'yes or no!',
+                    Suggestion: '/--verbose',
+                    IconData: '',
                 },
                 {
-                    complete: '/jira issue create --project KT --epic',
-                    description: 'The Jira epic',
-                    hint: 'The thing is working great!',
-                    suggestion: '/--epic',
+                    Complete: '/jira issue create --project KT --epic',
+                    Description: 'The Jira epic',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/--epic',
+                    IconData: '',
                 },
             ]);
         });
@@ -842,20 +862,22 @@ describe('AppCommandParser', () => {
             const mid = await parser.getSuggestions('/jira issue create --project KT --summ');
             expect(mid).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/--summary',
+                    Complete: '/jira issue create --project KT --summary',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/--summary',
+                    IconData: '',
                 },
             ]);
 
             const full = await parser.getSuggestions('/jira issue create --project KT --summary');
             expect(full).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/--summary',
+                    Complete: '/jira issue create --project KT --summary',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/--summary',
+                    IconData: '',
                 },
             ]);
         });
@@ -864,10 +886,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/',
+                    Complete: '/jira issue create --project KT --summary',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/',
+                    IconData: '',
                 },
             ]);
         });
@@ -876,10 +899,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary Sum');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary Sum',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/Sum',
+                    Complete: '/jira issue create --project KT --summary Sum',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/Sum',
+                    IconData: '',
                 },
             ]);
         });
@@ -888,10 +912,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "Sum');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "Sum"',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/Sum',
+                    Complete: '/jira issue create --project KT --summary "Sum"',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/Sum',
+                    IconData: '',
                 },
             ]);
         });
@@ -900,10 +925,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary `Sum');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary `Sum`',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/Sum',
+                    Complete: '/jira issue create --project KT --summary `Sum`',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/Sum',
+                    IconData: '',
                 },
             ]);
         });
@@ -912,10 +938,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create --summary ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --summary',
-                    description: 'The Jira issue summary',
-                    hint: 'The thing is working great!',
-                    suggestion: '/',
+                    Complete: '/jira issue create --summary',
+                    Description: 'The Jira issue summary',
+                    Hint: 'The thing is working great!',
+                    Suggestion: '/',
+                    IconData: '',
                 },
             ]);
         });
@@ -929,11 +956,11 @@ describe('AppCommandParser', () => {
 
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project special-value',
-                    suggestion: '/special-label',
-                    description: '',
-                    hint: '',
-                    iconData: undefined,
+                    Complete: '/jira issue create --project special-value',
+                    Suggestion: '/special-label',
+                    Description: '',
+                    Hint: '',
+                    IconData: '',
                 },
             ]);
         });
@@ -942,26 +969,29 @@ describe('AppCommandParser', () => {
             let suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic epic1',
-                    suggestion: '/Dylan Epic',
-                    description: '',
-                    hint: '',
+                    Complete: '/jira issue create --project KT --summary "great feature" --epic epic1',
+                    Suggestion: '/Dylan Epic',
+                    Description: '',
+                    Hint: '',
+                    IconData: '',
                 },
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic epic2',
-                    suggestion: '/Michael Epic',
-                    description: '',
-                    hint: '',
+                    Complete: '/jira issue create --project KT --summary "great feature" --epic epic2',
+                    Suggestion: '/Michael Epic',
+                    Description: '',
+                    Hint: '',
+                    IconData: '',
                 },
             ]);
 
             suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic M');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic epic2',
-                    suggestion: '/Michael Epic',
-                    description: '',
-                    hint: '',
+                    Complete: '/jira issue create --project KT --summary "great feature" --epic epic2',
+                    Suggestion: '/Michael Epic',
+                    Description: '',
+                    Hint: '',
+                    IconData: '',
                 },
             ]);
 
@@ -973,11 +1003,11 @@ describe('AppCommandParser', () => {
             const suggestions = await parser.getSuggestions('/jira issue create --project KT --summary "great feature" --epic epicvalue --verbose true ');
             expect(suggestions).toEqual([
                 {
-                    complete: '/jira issue create --project KT --summary "great feature" --epic epicvalue --verbose true _execute_current_command',
-                    suggestion: '/Execute Current Command',
-                    description: 'Select this option or use Ctrl+Enter to execute the current command.',
-                    iconData: '_execute_current_command',
-                    hint: '',
+                    Complete: '/jira issue create --project KT --summary "great feature" --epic epicvalue --verbose true _execute_current_command',
+                    Suggestion: '/Execute Current Command',
+                    Description: 'Select this option or use Ctrl+Enter to execute the current command.',
+                    IconData: '_execute_current_command',
+                    Hint: '',
                 },
             ]);
         });

--- a/components/suggestion/command_provider/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser.ts
@@ -633,7 +633,7 @@ export class AppCommandParser {
     }
 
     expandOptions = async (parsed: ParsedCommand, values: AppCallValues) => {
-        if (!parsed.form) {
+        if (!parsed.form?.fields) {
             return true;
         }
 

--- a/components/suggestion/command_provider/command_provider.test.tsx
+++ b/components/suggestion/command_provider/command_provider.test.tsx
@@ -56,11 +56,11 @@ describe('CommandProvider', () => {
                 matchedPretext: '/jira issue',
                 terms: ['/jira issue'],
                 items: [{
-                    complete: '/jira issue',
-                    suggestion: '/issue',
-                    hint: 'hint',
-                    iconData: 'icon_data',
-                    description: 'description',
+                    Complete: '/jira issue',
+                    Suggestion: '/issue',
+                    Hint: 'hint',
+                    IconData: 'icon_data',
+                    Description: 'description',
                 }],
                 component: CommandSuggestion,
             };

--- a/components/suggestion/command_provider/command_provider.test.tsx
+++ b/components/suggestion/command_provider/command_provider.test.tsx
@@ -11,10 +11,10 @@ import CommandProvider, {CommandSuggestion, Results} from './command_provider';
 describe('CommandSuggestion', () => {
     const baseProps = {
         item: {
-            suggestion: '/invite',
-            hint: '@[username] ~[channel]',
-            description: 'Invite a user to a channel',
-            iconData: '',
+            Suggestion: '/invite',
+            Hint: '@[username] ~[channel]',
+            Description: 'Invite a user to a channel',
+            IconData: '',
         },
         isSelection: true,
         term: '/',

--- a/components/suggestion/command_provider/command_provider.tsx
+++ b/components/suggestion/command_provider/command_provider.tsx
@@ -6,8 +6,7 @@ import React from 'react';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getChannel, getCurrentChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-import {AutocompleteSuggestion, AutocompleteSuggestionWithComplete} from 'mattermost-redux/types/apps';
-import {ServerAutocompleteSuggestion} from 'mattermost-redux/types/integrations';
+import {AutocompleteSuggestion} from 'mattermost-redux/types/integrations';
 import {Post} from 'mattermost-redux/types/posts';
 
 import {Store} from 'redux';
@@ -41,17 +40,17 @@ export class CommandSuggestion extends Suggestion {
             className += ' suggestion--selected';
         }
         let symbolSpan = <span>{'/'}</span>;
-        if (item.iconData === EXECUTE_CURRENT_COMMAND_ITEM_ID) {
+        if (item.IconData === EXECUTE_CURRENT_COMMAND_ITEM_ID) {
             symbolSpan = <span className='block mt-1'>{'↵'}</span>;
         }
         let icon = <div className='slash-command__icon'>{symbolSpan}</div>;
-        if (item.iconData && item.iconData !== EXECUTE_CURRENT_COMMAND_ITEM_ID) {
+        if (item.IconData && item.IconData !== EXECUTE_CURRENT_COMMAND_ITEM_ID) {
             icon = (
                 <div
                     className='slash-command__icon'
                     style={{backgroundColor: 'transparent'}}
                 >
-                    <img src={item.iconData}/>
+                    <img src={item.IconData}/>
                 </div>);
         }
 
@@ -65,10 +64,10 @@ export class CommandSuggestion extends Suggestion {
                 {icon}
                 <div className='slash-command__info'>
                     <div className='slash-command__title'>
-                        {item.suggestion.substring(1) + ' ' + item.hint}
+                        {item.Suggestion.substring(1) + ' ' + item.Hint}
                     </div>
                     <div className='slash-command__desc'>
-                        {item.description}
+                        {item.Description}
                     </div>
                 </div>
             </div>
@@ -123,7 +122,7 @@ export default class CommandProvider extends Provider {
 
         if (this.appCommandParser?.isAppCommand(pretext)) {
             this.appCommandParser.getSuggestions(pretext).then((matches) => {
-                const terms = matches.map((suggestion) => suggestion.complete);
+                const terms = matches.map((suggestion) => suggestion.Complete);
                 resultCallback({
                     matchedPretext: pretext,
                     terms,
@@ -169,20 +168,20 @@ export default class CommandProvider extends Provider {
                                 hint = cmd.auto_complete_hint;
                             }
                             matches.push({
-                                suggestion: s,
-                                complete: '',
-                                hint,
-                                description: cmd.auto_complete_desc,
-                                iconData: '',
+                                Suggestion: s,
+                                Complete: '',
+                                Hint: hint,
+                                Description: cmd.auto_complete_desc,
+                                IconData: '',
                             });
                         }
                     }
                 });
 
-                matches = matches.sort((a, b) => a.suggestion.localeCompare(b.suggestion));
+                matches = matches.sort((a, b) => a.Suggestion.localeCompare(b.Suggestion));
 
                 // pull out the suggested commands from the returned data
-                const terms = matches.map((suggestion) => suggestion.suggestion);
+                const terms = matches.map((suggestion) => suggestion.Suggestion);
 
                 resultCallback({
                     matchedPretext: command,
@@ -212,8 +211,8 @@ export default class CommandProvider extends Provider {
         };
 
         Client4.getCommandAutocompleteSuggestionsList(command, teamId, args).then(
-            ((data: ServerAutocompleteSuggestion[]) => {
-                let matches: AutocompleteSuggestionWithComplete[] = [];
+            ((data: AutocompleteSuggestion[]) => {
+                let matches: AutocompleteSuggestion[] = [];
 
                 let cmd = 'Ctrl';
                 if (Utils.isMac()) {
@@ -228,11 +227,11 @@ export default class CommandProvider extends Provider {
                 data.forEach((s) => {
                     if (!this.contains(matches, this.triggerCharacter + s.Complete)) {
                         matches.push({
-                            complete: this.triggerCharacter + s.Complete,
-                            suggestion: this.triggerCharacter + s.Suggestion,
-                            hint: s.Hint,
-                            description: s.Description,
-                            iconData: s.IconData,
+                            Complete: this.triggerCharacter + s.Complete,
+                            Suggestion: this.triggerCharacter + s.Suggestion,
+                            Hint: s.Hint,
+                            Description: s.Description,
+                            IconData: s.IconData,
                         });
                     }
                 });
@@ -240,9 +239,9 @@ export default class CommandProvider extends Provider {
                 // sort only if we are looking at base commands
                 if (!pretext.includes(' ')) {
                     matches.sort((a, b) => {
-                        if (a.suggestion.toLowerCase() > b.suggestion.toLowerCase()) {
+                        if (a.Suggestion.toLowerCase() > b.Suggestion.toLowerCase()) {
                             return 1;
-                        } else if (a.suggestion.toLowerCase() < b.suggestion.toLowerCase()) {
+                        } else if (a.Suggestion.toLowerCase() < b.Suggestion.toLowerCase()) {
                             return -1;
                         }
                         return 0;
@@ -251,16 +250,16 @@ export default class CommandProvider extends Provider {
 
                 if (this.shouldAddExecuteItem(data, pretext)) {
                     matches.unshift({
-                        complete: pretext + EXECUTE_CURRENT_COMMAND_ITEM_ID,
-                        suggestion: '/Execute Current Command',
-                        hint: '',
-                        description: 'Select this option or use ' + cmd + '+Enter to execute the current command.',
-                        iconData: EXECUTE_CURRENT_COMMAND_ITEM_ID,
+                        Complete: pretext + EXECUTE_CURRENT_COMMAND_ITEM_ID,
+                        Suggestion: '/Execute Current Command',
+                        Hint: '',
+                        Description: 'Select this option or use ' + cmd + '+Enter to execute the current command.',
+                        IconData: EXECUTE_CURRENT_COMMAND_ITEM_ID,
                     });
                 }
 
                 // pull out the suggested commands from the returned data
-                const terms = matches.map((suggestion) => suggestion.complete);
+                const terms = matches.map((suggestion) => suggestion.Complete);
 
                 resultCallback({
                     matchedPretext: command,
@@ -272,7 +271,7 @@ export default class CommandProvider extends Provider {
         );
     }
 
-    shouldAddExecuteItem(data: ServerAutocompleteSuggestion[], pretext: string) {
+    shouldAddExecuteItem(data: AutocompleteSuggestion[], pretext: string) {
         if (data.length === 0) {
             return false;
         }
@@ -284,7 +283,7 @@ export default class CommandProvider extends Provider {
         return data.findIndex((item) => item.Suggestion === '') !== -1;
     }
 
-    contains(matches: AutocompleteSuggestionWithComplete[], complete: string) {
-        return matches.findIndex((match) => match.complete === complete) !== -1;
+    contains(matches: AutocompleteSuggestion[], complete: string) {
+        return matches.findIndex((match) => match.Complete === complete) !== -1;
     }
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2253,6 +2253,7 @@
   "apps.error.form.no_call": "`call` is not defined.",
   "apps.error.form.no_form": "`form` is not defined.",
   "apps.error.form.refresh": "There has been an error updating the modal. Contact the app developer. Details: {details}",
+  "apps.error.form.refresh_no_refresh": "Called refresh on no refresh field.",
   "apps.error.form.submit.pretext": "There has been an error submitting the modal. Contact the app developer. Details: {details}",
   "apps.error.parser.missing_field_value": "Field value Expected.",
   "apps.error.parser.missing_quote": "Matching double quote expected before end of input.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20208,8 +20208,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#6db852d88616463f5eae34b8c38beb9316e970a9",
-      "from": "github:mattermost/mattermost-redux#6db852d88616463f5eae34b8c38beb9316e970a9",
+      "version": "github:mattermost/mattermost-redux#d4b324bdcb69f0034aa42e450b86fe33e425a778",
+      "from": "github:mattermost/mattermost-redux#d4b324bdcb69f0034aa42e450b86fe33e425a778",
       "requires": {
         "core-js": "3.8.3",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.1.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#be741d411d4642c4cd3e009645f4cb6baa7e92bb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#6db852d88616463f5eae34b8c38beb9316e970a9",
+    "mattermost-redux": "github:mattermost/mattermost-redux#d4b324bdcb69f0034aa42e450b86fe33e425a778",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",

--- a/plugins/channel_header_plug/index.ts
+++ b/plugins/channel_header_plug/index.ts
@@ -9,7 +9,7 @@ import {getAppBindings} from 'mattermost-redux/selectors/entities/apps';
 import {AppBindingLocations} from 'mattermost-redux/constants/apps';
 import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
 
-import {AppCall} from 'mattermost-redux/types/apps';
+import {AppCallRequest, AppCallType} from 'mattermost-redux/types/apps';
 
 import {doAppCall} from 'actions/apps';
 import {GlobalState} from 'types/store';
@@ -29,7 +29,7 @@ function mapStateToProps(state: GlobalState) {
 }
 
 type Actions = {
-    doAppCall: (call: AppCall) => Promise<ActionResult>;
+    doAppCall: (call: AppCallRequest, type: AppCallType) => Promise<ActionResult>;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {

--- a/utils/apps.ts
+++ b/utils/apps.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {AppBinding, AppCall, AppCallValues, AppExpand} from 'mattermost-redux/types/apps';
+import {AppBinding, AppCall, AppCallRequest, AppCallValues, AppContext, AppExpand} from 'mattermost-redux/types/apps';
 import {GlobalState} from 'mattermost-redux/types/store';
 
 export function appsEnabled(state: GlobalState) {// eslint-disable-line @typescript-eslint/no-unused-vars
@@ -53,39 +53,44 @@ export function fillBindingsInformation(binding?: AppBinding) {
     }
 }
 
+export function createCallContext(
+    appID: string,
+    location?: string,
+    channelID?: string,
+    teamID?: string,
+    postID?: string,
+    rootID?: string,
+): AppContext {
+    return {
+        app_id: appID,
+        location,
+        channel_id: channelID,
+        team_id: teamID,
+        post_id: postID,
+        root_id: rootID,
+    };
+}
+
 export function createCallRequest(
     call: AppCall,
-    userId: string,
-    appId: string,
-    location: string,
-    expand: AppExpand = {},
-    channelId = '',
-    postId = '',
-    type = '',
-    rawCommand = '',
+    context: AppContext,
+    defaultExpand: AppExpand = {},
     values?: AppCallValues,
-): AppCall {
+    rawCommand?: string,
+    query?: string,
+    selectedField?: string,
+): AppCallRequest {
     return {
-        type,
-        path: call.path,
-        context: {
-            ...call.context,
-            acting_user_id: userId,
-            app_id: appId,
-            channel_id: channelId,
-            location,
-            post_id: postId,
-            user_id: userId,
-        },
-        values: {
-            ...call.values,
-            ...values,
-        },
+        ...call,
+        context,
+        values,
         expand: {
+            ...defaultExpand,
             ...call.expand,
-            ...expand,
         },
         raw_command: rawCommand,
+        query,
+        selected_field: selectedField,
     };
 }
 


### PR DESCRIPTION
#### Summary
Now instead of using the call type, we add the type to the path at redux level.

I also included here the AppCall/AppCallRequest needed changes.

The errors in CI are most probably due to redux PR not being merged. When the Redux PR is merged, I will update this PR dependencies.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33178

#### Related Pull Requests
Redux: https://github.com/mattermost/mattermost-redux/pull/1406
Mobile: https://github.com/mattermost/mattermost-mobile/pull/5221
Proxy: https://github.com/mattermost/mattermost-plugin-apps/pull/99
