### PR TITLE
MM-33330 - fixed SidebarLink background-color on hover

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1007,7 +1007,7 @@
 
     .SidebarChannel .SidebarLink:hover,
     .SidebarChannel .SidebarLink.menuOpen {
-        background: rgba(255, 255, 255, 0.08);
+        background-color: var(--sidebar-text-hover-bg);
 
         padding-right: 5px;
 
@@ -1026,6 +1026,7 @@
             visibility: hidden;
         }
     }
+
     .SidebarChannel.active .SidebarLink {
         background: rgba(255, 255, 255, 0.16);
 


### PR DESCRIPTION
#### Summary
fix for hover on SidebarLink to use correct color set from theme

#### Ticket Link
[MM-33330](https://mattermost.atlassian.net/browse/MM-33330)