### PR TITLE
Promoting regularly passing tests from 03/08 to 03/15

### DIFF
--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @elasticsearch @autocomplete
 
 import {getAdminAccount} from '../../../support/env';
@@ -23,7 +24,7 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
     let testUser;
 
     before(() => {
-        // * Check if server has license for Elasticsearch
+        // # Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 
         // # Enable Elasticsearch

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_with_special_characters_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_with_special_characters_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @elasticsearch @autocomplete
 
 import {

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @elasticsearch @autocomplete
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_team_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_team_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @elasticsearch @autocomplete
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/system_console_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/system_console_spec.js
@@ -7,13 +7,14 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @elasticsearch @autocomplete
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('Elasticsearch system console', () => {
     before(() => {
-        // * Check if server has license for Elasticsearch
+        // # Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 
         // # Enable Elasticsearch

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @elasticsearch @autocomplete
 
 import {enableElasticSearch, getTestUsers} from './helpers';

--- a/e2e/cypress/integration/enterprise/system_console/search_box_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/search_box_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/enterprise/system_console/support_packet_generation_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/support_packet_generation_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 // # Goes to the System Scheme page as System Admin

--- a/e2e/cypress/integration/messaging/long_draft_spec.js
+++ b/e2e/cypress/integration/messaging/long_draft_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/message_edit_post_clear_text_spec.js
+++ b/e2e/cypress/integration/messaging/message_edit_post_clear_text_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/permalink_click_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_click_spec.js
@@ -7,6 +7,7 @@
 // Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';


### PR DESCRIPTION
Promoting the tests from unstable to prod that were regularly passing between 03/08 to 03/15. Some of the autocomplete with Elasticsearch tests haven't been promoted in this PR since they need some cleanup.