### PR TITLE
Cypress/E2E: Fix tests for cloud

### DIFF
--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @elasticsearch @autocomplete
+// Group: @enterprise @elasticsearch @autocomplete @not_cloud
 
 import {getAdminAccount} from '../../../support/env';
 
@@ -24,6 +24,8 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
     let testUser;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // # Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_with_special_characters_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_with_special_characters_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @elasticsearch @autocomplete
+// Group: @enterprise @elasticsearch @autocomplete @not_cloud
 
 import {
     enableElasticSearch,
@@ -20,6 +20,8 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
     let teamName;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // * Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @elasticsearch @autocomplete
+// Group: @enterprise @elasticsearch @autocomplete @not_cloud
 
 import {getRandomId} from '../../../utils';
 
@@ -23,6 +23,8 @@ describe('Autocomplete with Elasticsearch - Renaming', () => {
     let testChannel;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // * Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_team_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_team_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @elasticsearch @autocomplete
+// Group: @enterprise @elasticsearch @autocomplete @not_cloud
 
 import {getRandomId} from '../../../utils';
 
@@ -24,6 +24,8 @@ describe('Autocomplete with Elasticsearch - Renaming Team', () => {
     let testChannel;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // * Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/system_console_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/system_console_spec.js
@@ -8,12 +8,14 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @elasticsearch @autocomplete
+// Group: @enterprise @elasticsearch @autocomplete @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('Elasticsearch system console', () => {
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // # Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_in_channel_switcher_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_in_channel_switcher_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @enterprise @elasticsearch @autocomplete
+// Group: @enterprise @elasticsearch @autocomplete @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
@@ -23,6 +23,8 @@ describe('Autocomplete with Elasticsearch - Users', () => {
     let testTeam;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // * Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_in_message_input_box_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_in_message_input_box_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @enterprise @elasticsearch @autocomplete
+// Group: @enterprise @elasticsearch @autocomplete @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
@@ -23,6 +23,8 @@ describe('Autocomplete with Elasticsearch - Users', () => {
     let testTeam;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // * Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @elasticsearch @autocomplete
+// Group: @enterprise @elasticsearch @autocomplete @not_cloud
 
 import {enableElasticSearch, getTestUsers} from './helpers';
 
@@ -18,6 +18,8 @@ describe('Autocomplete with Elasticsearch - Users', () => {
     let testTeam;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // * Check if server has license for Elasticsearch
         cy.apiRequireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/integrations/incoming_webhook_spec.js
+++ b/e2e/cypress/integration/enterprise/integrations/incoming_webhook_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @enterprise @incoming_webhook
+// Group: @enterprise @incoming_webhook @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 import {
@@ -20,6 +20,8 @@ describe('Incoming webhook', () => {
     let incomingWebhook;
 
     before(() => {
+        cy.shouldNotRunOnCloudEdition();
+
         // # Create and visit new channel and create incoming webhook
         cy.apiInitSetup().then(({team, channel}) => {
             testTeam = team;

--- a/e2e/cypress/integration/enterprise/system_console/compliance/compliance_export_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/compliance_export_ui_spec.js
@@ -84,59 +84,6 @@ describe('Compliance Export', () => {
         });
     });
 
-    it('MM-T3439 - Download Compliance Export Files - S3 Bucket Storage', () => {
-        // # Go to file storage settings Page
-        cy.visit('/admin_console/environment/file_storage');
-        cy.get('.admin-console__header', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('have.text', 'File Storage');
-
-        const {
-            minioAccessKey,
-            minioSecretKey,
-            minioS3Bucket,
-            minioS3Endpoint,
-            minioS3SSL,
-        } = Cypress.env();
-
-        // # Update S3 Storage settings
-        cy.findByTestId('FileSettings.DriverNamedropdown').select('amazons3');
-        cy.findByTestId('FileSettings.AmazonS3Bucketinput').clear().type(minioS3Bucket);
-        cy.findByTestId('FileSettings.AmazonS3AccessKeyIdinput').clear().type(minioAccessKey);
-        cy.findByTestId('FileSettings.AmazonS3SecretAccessKeyinput').clear().type(minioSecretKey);
-        cy.findByTestId('FileSettings.AmazonS3Endpointinput').clear().type(minioS3Endpoint);
-        cy.findByTestId(`FileSettings.AmazonS3SSL${minioS3SSL}`).check();
-
-        // # Save file storage settings
-        cy.findByTestId('saveSetting').click();
-        waitUntilConfigSave();
-
-        // # Test connection and verify that it's successful
-        cy.findByRole('button', {name: 'Test Connection'}).click();
-        cy.findByText('Connection was successful').should('be.visible');
-
-        // # Go to compliance page and enable export
-        cy.uiGoToCompliancePage();
-        cy.uiEnableComplianceExport();
-        cy.uiExportCompliance();
-
-        // # Navigate to a team and post an attachment
-        gotoTeamAndPostImage();
-
-        // # Go to compliance page and start export
-        cy.uiGoToCompliancePage();
-        cy.uiExportCompliance();
-
-        // # Get the first row
-        cy.get('.job-table__table').find('tbody > tr').eq(0).as('firstRow');
-
-        // # Get the download link
-        cy.get('@firstRow').findByText('Download').parents('a').should('exist').then((fileAttachment) => {
-            const fileURL = fileAttachment.attr('href');
-
-            // * Download link should not exist this time
-            cy.apiDownloadFileAndVerifyContentType(fileURL);
-        });
-    });
-
     it('MM-T1168 - Compliance Export - Run Now, entry appears in job table', () => {
         // # Go to compliance page and enable export
         cy.uiGoToCompliancePage();
@@ -220,10 +167,3 @@ describe('Compliance Export', () => {
         cy.get('@firstRow').find('td:eq(1)').should('have.text', 'Canceled');
     });
 });
-
-// # Wait until the Saving text becomes Save
-const waitUntilConfigSave = () => {
-    cy.waitUntil(() => cy.get('#saveSetting').then((el) => {
-        return el[0].innerText === 'Save';
-    }));
-};

--- a/e2e/cypress/integration/enterprise/system_console/compliance/s3_bucket_storage_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/s3_bucket_storage_spec.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @enterprise @system_console @not_cloud
+
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
+
+import {gotoTeamAndPostImage} from './helpers';
+
+describe('Compliance Export', () => {
+    before(() => {
+        cy.shouldNotRunOnCloudEdition();
+        cy.apiRequireLicenseForFeature('Compliance');
+
+        cy.apiUpdateConfig({
+            MessageExportSettings: {
+                ExportFormat: 'csv',
+                DownloadExportResults: true,
+            },
+        });
+    });
+
+    it('MM-T3439 - Download Compliance Export Files - S3 Bucket Storage', () => {
+        // # Go to file storage settings Page
+        cy.visit('/admin_console/environment/file_storage');
+        cy.get('.admin-console__header', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('have.text', 'File Storage');
+
+        const {
+            minioAccessKey,
+            minioSecretKey,
+            minioS3Bucket,
+            minioS3Endpoint,
+            minioS3SSL,
+        } = Cypress.env();
+
+        // # Update S3 Storage settings
+        cy.findByTestId('FileSettings.DriverNamedropdown').select('amazons3');
+        cy.findByTestId('FileSettings.AmazonS3Bucketinput').clear().type(minioS3Bucket);
+        cy.findByTestId('FileSettings.AmazonS3AccessKeyIdinput').clear().type(minioAccessKey);
+        cy.findByTestId('FileSettings.AmazonS3SecretAccessKeyinput').clear().type(minioSecretKey);
+        cy.findByTestId('FileSettings.AmazonS3Endpointinput').clear().type(minioS3Endpoint);
+        cy.findByTestId(`FileSettings.AmazonS3SSL${minioS3SSL}`).check();
+
+        // # Save file storage settings
+        cy.uiSaveConfig();
+
+        // # Test connection and verify that it's successful
+        cy.findByRole('button', {name: 'Test Connection'}).click();
+        cy.findByText('Connection was successful').should('be.visible');
+
+        // # Go to compliance page and enable export
+        cy.uiGoToCompliancePage();
+        cy.uiEnableComplianceExport();
+        cy.uiExportCompliance();
+
+        // # Navigate to a team and post an attachment
+        gotoTeamAndPostImage();
+
+        // # Go to compliance page and start export
+        cy.uiGoToCompliancePage();
+        cy.uiExportCompliance();
+
+        // # Get the first row
+        cy.get('.job-table__table').find('tbody > tr').eq(0).as('firstRow');
+
+        // # Get the download link
+        cy.get('@firstRow').findByText('Download').parents('a').should('exist').then((fileAttachment) => {
+            const fileURL = fileAttachment.attr('href');
+
+            // * Download link should not exist this time
+            cy.apiDownloadFileAndVerifyContentType(fileURL);
+        });
+    });
+});

--- a/e2e/cypress/integration/enterprise/system_console/support_packet_generation_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/support_packet_generation_spec.js
@@ -10,38 +10,14 @@
 // Stage: @prod
 // Group: @enterprise @system_console
 
-// # Goes to the System Scheme page as System Admin
-const goToAdminConsole = () => {
-    cy.apiAdminLogin();
-    cy.visit('/admin_console');
-};
-
-const goToSupportPacketGenerationModal = () => {
-    cy.findByRole('button', {name: 'Menu Icon'}).should('exist').click();
-
-    cy.findByRole('button', {name: 'Commercial Support dialog'}).click();
-
-    // * Ensure the download support packet button exist and that text regarding setting the proper settings exist
-    cy.findByRole('link', {name: 'Download Support Packet'}).should('exist');
-};
-
 describe('Support Packet Generation', () => {
     before(() => {
-        // Running on E10/E20 License
         cy.apiRequireLicense();
-        cy.apiAdminLogin();
-
-        cy.apiUpdateConfig({
-            LogSettings: {
-                EnableFile: true,
-                FileLevel: 'ERROR',
-            },
-        });
     });
 
     it('MM-T3849 - Commercial Support Dialog UI - E10/E20 License', () => {
         // # Go to System Console
-        goToAdminConsole();
+        cy.visit('/admin_console');
 
         goToSupportPacketGenerationModal();
 
@@ -50,12 +26,23 @@ describe('Support Packet Generation', () => {
 
     it('MM-T3818 - Commercial Support Dialog UI - Links', () => {
         // # Go to System Console
-        goToAdminConsole();
+        cy.visit('/admin_console');
 
         goToSupportPacketGenerationModal();
 
-        // * Veryify the links exist that take you to loggin page and ticket page exist
+        // * Verify that the "submit a support ticket." link exist and points to Customer Support Request page
         cy.findByRole('link', {name: 'submit a support ticket.'}).should('have.attr', 'href').and('include', 'https://support.mattermost.com/hc/en-us/requests/new');
+
+        // * Verify that the "here" link exist and points to Logging admin page
         cy.findByRole('link', {name: 'here'}).should('have.attr', 'href').and('include', '/admin_console/environment/logging');
     });
 });
+
+const goToSupportPacketGenerationModal = () => {
+    // # Open system menu and click Customer Support
+    cy.findByRole('button', {name: 'Menu Icon'}).should('exist').click();
+    cy.findByRole('button', {name: 'Commercial Support dialog'}).click();
+
+    // * Ensure the download support packet button exist and that text regarding setting the proper settings exist
+    cy.findByRole('link', {name: 'Download Support Packet'}).should('exist');
+};

--- a/e2e/cypress/integration/enterprise/visual_regression/system_console/about_section_spec.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/system_console/about_section_spec.js
@@ -25,9 +25,6 @@ describe('System Console - About', () => {
     ];
 
     before(() => {
-        // * Check if server has license for feature
-        cy.apiRequireLicenseForFeature('Elasticsearch');
-
         // # Go to system admin then verify admin console URL and header
         cy.visit('/admin_console/about/license');
         cy.url().should('include', '/admin_console/about/license');

--- a/e2e/cypress/integration/enterprise/visual_regression/system_console/authentication_section_spec.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/system_console/authentication_section_spec.js
@@ -73,9 +73,6 @@ describe('System Console - Authentication', () => {
     ];
 
     before(() => {
-        // * Check if server has license for feature
-        cy.apiRequireLicenseForFeature('Elasticsearch');
-
         // # Go to system admin then verify admin console URL and header
         cy.visit('/admin_console/about/license');
         cy.url().should('include', '/admin_console/about/license');

--- a/e2e/cypress/integration/enterprise/visual_regression/system_console/compliance_section_spec.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/system_console/compliance_section_spec.js
@@ -46,9 +46,6 @@ describe('System Console - Compliance', () => {
     ];
 
     before(() => {
-        // * Check if server has license for feature
-        cy.apiRequireLicenseForFeature('Elasticsearch');
-
         // # Go to system admin then verify admin console URL and header
         cy.visit('/admin_console/about/license');
         cy.url().should('include', '/admin_console/about/license');

--- a/e2e/cypress/integration/system_console/support_packet_generation_spec.js
+++ b/e2e/cypress/integration/system_console/support_packet_generation_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @system_console
+// Group: @system_console @te_only
 
 // # Go to the System Scheme page as System Admin
 const goToAdminConsole = () => {

--- a/e2e/cypress/support/task_commands.js
+++ b/e2e/cypress/support/task_commands.js
@@ -71,7 +71,12 @@ Cypress.Commands.add('externalRequest', ({user, method, path, data, failOnStatus
 
     return cy.task('externalRequest', {baseUrl, user, method, path, data}).then((response) => {
         // Temporarily ignore error related to Cloud
-        if (response.data && response.data.id !== 'ent.cloud.request_error' && failOnStatusCode) {
+        const cloudErrorId = [
+            'ent.cloud.request_error',
+            'api.cloud.get_subscription.error',
+        ];
+
+        if (response.data && !cloudErrorId.includes(response.data.id) && failOnStatusCode) {
             expect(response.status).to.be.oneOf([200, 201, 204]);
         }
 


### PR DESCRIPTION
#### Summary
- exclude tests related to Elasticsearch (ES) for cloud since config related to it is not writable
- remove unnecessary requirement to ES to some specs
- add option to ignore 'api.cloud.get_subscription.error'

#### Ticket Link
none, failed on Cloud test run
