### PR TITLE
Only use fake timers for tests that need them

### DIFF
--- a/components/admin_console/system_users/system_users.test.tsx
+++ b/components/admin_console/system_users/system_users.test.tsx
@@ -9,6 +9,8 @@ import {Constants, SearchUserTeamFilter, UserFilters} from 'utils/constants';
 
 jest.mock('actions/admin_actions');
 
+jest.useFakeTimers();
+
 describe('components/admin_console/system_users', () => {
     const USERS_PER_PAGE = 50;
     const defaultProps = {

--- a/components/channel_layout/channel_identifier_router/channel_identifier_router.test.tsx
+++ b/components/channel_layout/channel_identifier_router/channel_identifier_router.test.tsx
@@ -8,6 +8,8 @@ import {browserHistory} from 'utils/browser_history.jsx';
 
 import ChannelIdentifierRouter from './channel_identifier_router';
 
+jest.useFakeTimers();
+
 describe('components/channel_layout/CenterChannel', () => {
     const baseProps = {
 
@@ -69,7 +71,6 @@ describe('components/channel_layout/CenterChannel', () => {
                 url: '/team/channel/identifier/abcd',
             },
         };
-        jest.useFakeTimers();
         browserHistory.replace = jest.fn();
         shallow(<ChannelIdentifierRouter {...props}/>);
         jest.runOnlyPendingTimers();
@@ -90,7 +91,6 @@ describe('components/channel_layout/CenterChannel', () => {
             },
         };
 
-        jest.useFakeTimers();
         browserHistory.replace = jest.fn();
         const wrapper = shallow(<ChannelIdentifierRouter {...baseProps}/>);
         wrapper.setProps(props);

--- a/components/edit_post_modal/edit_post_modal.test.jsx
+++ b/components/edit_post_modal/edit_post_modal.test.jsx
@@ -23,6 +23,8 @@ jest.mock('utils/user_agent', () => ({
     isMobile: jest.fn().mockReturnValue(false),
 }));
 
+jest.useFakeTimers();
+
 function createEditPost({canEditPost, canDeletePost, useChannelMentions, ctrlSend, config, license, editingPost, actions} = {canEditPost: true, canDeletePost: true}) { //eslint-disable-line react/prop-types
     const canEditPostProp = canEditPost === undefined ? true : canEditPost;
     const canDeletePostProp = canDeletePost === undefined ? true : canDeletePost;

--- a/components/suggestion/at_mention_provider/at_mention_provider.test.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_provider.test.jsx
@@ -5,6 +5,8 @@ import {Constants} from 'utils/constants';
 import AtMentionProvider from 'components/suggestion/at_mention_provider/at_mention_provider.jsx';
 import AtMentionSuggestion from 'components/suggestion/at_mention_provider/at_mention_suggestion.jsx';
 
+jest.useFakeTimers();
+
 describe('components/suggestion/at_mention_provider/AtMentionProvider', () => {
     const userid10 = {id: 'userid10', username: 'nicknamer', first_name: '', last_name: '', nickname: 'Z'};
     const userid3 = {id: 'userid3', username: 'other', first_name: 'X', last_name: 'Y', nickname: 'Z'};

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -13,8 +13,6 @@ global.fetch = jest.fn().mockResolvedValue({status: 200});
 
 configure({adapter: new Adapter()});
 
-jest.useFakeTimers();
-
 global.window = Object.create(window);
 Object.defineProperty(window, 'location', {
     value: {


### PR DESCRIPTION
Turning on fake timers for everything breaks a bunch of tests in mattermost-redux since those rely a lot more on async code and timeouts. Now we'll only use them on the specific test files that need them.