### PR TITLE
Fixing site_statistics_spec

### DIFF
--- a/e2e/cypress/integration/system_console/reporting/site_statistics_spec.js
+++ b/e2e/cypress/integration/system_console/reporting/site_statistics_spec.js
@@ -31,10 +31,10 @@ describe('System Console > Site Statistics', () => {
     it('MM-T903 - Site Statistics > Deactivating a user increments the Daily and Monthly Active Users counts down', () => {
         // # Post a message as testUser to make them daily/monthly active
         cy.getCurrentChannelId().then((channelId) => {
-            const message = "New Daily Message"
+            const message = 'New Daily Message';
             cy.postMessageAs({sender: testUser, message, channelId});
         });
-        
+
         // # Go to admin console
         goToAdminConsole();
 

--- a/e2e/cypress/integration/system_console/reporting/site_statistics_spec.js
+++ b/e2e/cypress/integration/system_console/reporting/site_statistics_spec.js
@@ -13,12 +13,6 @@ import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('System Console > Site Statistics', () => {
     let testUser;
-    let totalActiveUsersInitial;
-    let dailyActiveUsersInitial;
-    let monthlyActiveUsersInitial;
-    let totalActiveUsersFinal;
-    let dailyActiveUsersFinal;
-    let monthlyActiveUsersFinal;
 
     before(() => {
         cy.apiInitSetup().then(({team, user}) => {
@@ -26,14 +20,19 @@ describe('System Console > Site Statistics', () => {
             testUser = user;
             cy.apiLogin(testUser);
             cy.visit(`/${team.name}/channels/town-square`);
+
+            // # Post a message as testUser to make them daily/monthly active
+            cy.postMessage('New Daily Message');
         });
     });
+
     it('MM-T903 - Site Statistics > Deactivating a user increments the Daily and Monthly Active Users counts down', () => {
-        // # Post a message as testUser to make them daily/monthly active
-        cy.getCurrentChannelId().then((channelId) => {
-            const message = 'New Daily Message';
-            cy.postMessageAs({sender: testUser, message, channelId});
-        });
+        let totalActiveUsersInitial;
+        let dailyActiveUsersInitial;
+        let monthlyActiveUsersInitial;
+        let totalActiveUsersFinal;
+        let dailyActiveUsersFinal;
+        let monthlyActiveUsersFinal;
 
         // # Go to admin console
         goToAdminConsole();
@@ -45,35 +44,33 @@ describe('System Console > Site Statistics', () => {
         // # Get the number text and turn them into numbers
         cy.findByTestId('totalActiveUsers').invoke('text').then((totalActiveText) => {
             totalActiveUsersInitial = parseInt(totalActiveText, 10);
-            cy.findByTestId('dailyActiveUsers').invoke('text').then((dailyActiveText) => {
-                dailyActiveUsersInitial = parseInt(dailyActiveText, 10);
-                cy.findByTestId('monthlyActiveUsers').invoke('text').then((monthlyActiveText) => {
-                    monthlyActiveUsersInitial = parseInt(monthlyActiveText, 10);
+        });
+        cy.findByTestId('dailyActiveUsers').invoke('text').then((dailyActiveText) => {
+            dailyActiveUsersInitial = parseInt(dailyActiveText, 10);
+        });
+        cy.findByTestId('monthlyActiveUsers').invoke('text').then((monthlyActiveText) => {
+            monthlyActiveUsersInitial = parseInt(monthlyActiveText, 10);
 
-                    // # Deactivate user and reload page and then wait 2 seconds
-                    cy.externalActivateUser(testUser.id, false);
-                    cy.reload();
-                    cy.wait(TIMEOUTS.TWO_SEC);
+            // # Deactivate user and reload page and then wait 2 seconds
+            cy.externalActivateUser(testUser.id, false);
+            cy.reload();
+            cy.wait(TIMEOUTS.TWO_SEC);
+        });
 
-                    // # Get the numbers required again
-                    cy.findByTestId('totalActiveUsers').invoke('text').then((totalActiveFinalText) => {
-                        totalActiveUsersFinal = parseInt(totalActiveFinalText, 10);
+        // # Get the numbers required again
+        cy.findByTestId('totalActiveUsers').invoke('text').then((totalActiveFinalText) => {
+            totalActiveUsersFinal = parseInt(totalActiveFinalText, 10);
+        });
+        cy.findByTestId('dailyActiveUsers').invoke('text').then((dailyActiveFinalText) => {
+            dailyActiveUsersFinal = parseInt(dailyActiveFinalText, 10);
+        });
+        cy.findByTestId('monthlyActiveUsers').invoke('text').then((monthlyActiveFinalText) => {
+            monthlyActiveUsersFinal = parseInt(monthlyActiveFinalText, 10);
 
-                        cy.findByTestId('dailyActiveUsers').invoke('text').then((dailyActiveFinalText) => {
-                            dailyActiveUsersFinal = parseInt(dailyActiveFinalText, 10);
-
-                            cy.findByTestId('monthlyActiveUsers').invoke('text').then((monthlyActiveFinalText) => {
-                                monthlyActiveUsersFinal = parseInt(monthlyActiveFinalText, 10);
-
-                                // * Assert that the final number is the initial number minus one
-                                expect(totalActiveUsersFinal).equal(totalActiveUsersInitial - 1);
-                                expect(dailyActiveUsersFinal).equal(dailyActiveUsersInitial - 1);
-                                expect(monthlyActiveUsersFinal).equal(monthlyActiveUsersInitial - 1);
-                            });
-                        });
-                    });
-                });
-            });
+            // * Assert that the final number is the initial number minus one
+            expect(totalActiveUsersFinal).equal(totalActiveUsersInitial - 1);
+            expect(dailyActiveUsersFinal).equal(dailyActiveUsersInitial - 1);
+            expect(monthlyActiveUsersFinal).equal(monthlyActiveUsersInitial - 1);
         });
     });
 });

--- a/e2e/cypress/integration/system_console/reporting/site_statistics_spec.js
+++ b/e2e/cypress/integration/system_console/reporting/site_statistics_spec.js
@@ -12,56 +12,63 @@
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('System Console > Site Statistics', () => {
-    it('MM-T903 - Site Statistics > Deactivating a user increments the Daily and Monthly Active Users counts down', () => {
-        cy.apiInitSetup().then(({team, user}) => {
-            const testUser = user;
+    let testUser;
+    let totalActiveUsersInitial;
+    let dailyActiveUsersInitial;
+    let monthlyActiveUsersInitial;
+    let totalActiveUsersFinal;
+    let dailyActiveUsersFinal;
+    let monthlyActiveUsersFinal;
 
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
             // # Login as test user and visit town-square
+            testUser = user;
             cy.apiLogin(testUser);
             cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+    it('MM-T903 - Site Statistics > Deactivating a user increments the Daily and Monthly Active Users counts down', () => {
+        // # Post a message as testUser to make them daily/monthly active
+        cy.getCurrentChannelId().then((channelId) => {
+            const message = "New Daily Message"
+            cy.postMessageAs({sender: testUser, message, channelId});
+        });
+        
+        // # Go to admin console
+        goToAdminConsole();
 
-            // # Go to admin console
-            goToAdminConsole();
+        // # Go to system analytics
+        cy.findByTestId('reporting.system_analytics', {timeout: TIMEOUTS.ONE_MIN}).click();
+        cy.wait(TIMEOUTS.ONE_SEC);
 
-            // # Go to system analytics
-            cy.findByTestId('reporting.system_analytics', {timeout: TIMEOUTS.ONE_MIN}).click();
-            cy.wait(TIMEOUTS.ONE_SEC);
+        // # Get the number text and turn them into numbers
+        cy.findByTestId('totalActiveUsers').invoke('text').then((totalActiveText) => {
+            totalActiveUsersInitial = parseInt(totalActiveText, 10);
+            cy.findByTestId('dailyActiveUsers').invoke('text').then((dailyActiveText) => {
+                dailyActiveUsersInitial = parseInt(dailyActiveText, 10);
+                cy.findByTestId('monthlyActiveUsers').invoke('text').then((monthlyActiveText) => {
+                    monthlyActiveUsersInitial = parseInt(monthlyActiveText, 10);
 
-            let totalActiveUsersInitial;
-            let dailyActiveUsersInitial;
-            let monthlyActiveUsersInitial;
-            let totalActiveUsersFinal;
-            let dailyActiveUsersFinal;
-            let monthlyActiveUsersFinal;
+                    // # Deactivate user and reload page and then wait 2 seconds
+                    cy.externalActivateUser(testUser.id, false);
+                    cy.reload();
+                    cy.wait(TIMEOUTS.TWO_SEC);
 
-            // # Get the number and turn them into numbers
-            cy.findByTestId('totalActiveUsers').invoke('text').then((text) => {
-                totalActiveUsersInitial = parseInt(text, 10);
-                cy.findByTestId('dailyActiveUsers').invoke('text').then((text2) => {
-                    dailyActiveUsersInitial = parseInt(text2, 10);
-                    cy.findByTestId('monthlyActiveUsers').invoke('text').then((text3) => {
-                        monthlyActiveUsersInitial = parseInt(text3, 10);
+                    // # Get the numbers required again
+                    cy.findByTestId('totalActiveUsers').invoke('text').then((totalActiveFinalText) => {
+                        totalActiveUsersFinal = parseInt(totalActiveFinalText, 10);
 
-                        // # Deactivate user and reload page and then wait 2 seconds
-                        cy.externalActivateUser(testUser.id, false);
-                        cy.reload();
-                        cy.wait(TIMEOUTS.TWO_SEC);
+                        cy.findByTestId('dailyActiveUsers').invoke('text').then((dailyActiveFinalText) => {
+                            dailyActiveUsersFinal = parseInt(dailyActiveFinalText, 10);
 
-                        // # Get the numbers required again
-                        cy.findByTestId('totalActiveUsers').invoke('text').then((text4) => {
-                            totalActiveUsersFinal = parseInt(text4, 10);
+                            cy.findByTestId('monthlyActiveUsers').invoke('text').then((monthlyActiveFinalText) => {
+                                monthlyActiveUsersFinal = parseInt(monthlyActiveFinalText, 10);
 
-                            cy.findByTestId('dailyActiveUsers').invoke('text').then((text5) => {
-                                dailyActiveUsersFinal = parseInt(text5, 10);
-
-                                cy.findByTestId('monthlyActiveUsers').invoke('text').then((text6) => {
-                                    monthlyActiveUsersFinal = parseInt(text6, 10);
-
-                                    // * Assert that the final number is the initial number minus one
-                                    expect(totalActiveUsersFinal).equal(totalActiveUsersInitial - 1);
-                                    expect(dailyActiveUsersFinal).equal(dailyActiveUsersInitial - 1);
-                                    expect(monthlyActiveUsersFinal).equal(monthlyActiveUsersInitial - 1);
-                                });
+                                // * Assert that the final number is the initial number minus one
+                                expect(totalActiveUsersFinal).equal(totalActiveUsersInitial - 1);
+                                expect(dailyActiveUsersFinal).equal(dailyActiveUsersInitial - 1);
+                                expect(monthlyActiveUsersFinal).equal(monthlyActiveUsersInitial - 1);
                             });
                         });
                     });


### PR DESCRIPTION
This PR fixes the `site_statistics_spec` test that was failing in prod: the first run of the test was always failing because the testUser was not "active". Having the testUser post a message fixes this issue as that causes them to become an "active" daily and monthly user.

<img width="703" alt="Screen Shot 2021-03-16 at 7 46 18 PM" src="https://user-images.githubusercontent.com/691331/111414155-b6832400-869c-11eb-9a98-735385a79c26.png">
