### PR TITLE
Fix status dropdown

### DIFF
--- a/e2e/cypress/integration/menus/status_dropdown_spec.js
+++ b/e2e/cypress/integration/menus/status_dropdown_spec.js
@@ -10,6 +10,8 @@
 // Stage: @prod
 // Group: @menu
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 describe('Status dropdown menu', () => {
     before(() => {
         // # Login as test user and visit town-square
@@ -28,7 +30,7 @@ describe('Status dropdown menu', () => {
 
     it('Displays default menu when status icon is clicked', () => {
         // # Wait for posts to load
-        cy.get('#postListContent').should('be.visible');
+        cy.get('#postListContent', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Click status menu
         cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
@@ -171,6 +173,9 @@ describe('Status dropdown menu', () => {
         });
 
         it('MM-T2927_5 Verify "Set a Custom Header Status" is clickable', () => {
+            // # Enable Custom Status
+            cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+
             // # Wait for posts to load
             cy.get('#postListContent').should('be.visible');
 

--- a/e2e/cypress/integration/system_console/environment_spec.js
+++ b/e2e/cypress/integration/system_console/environment_spec.js
@@ -210,7 +210,7 @@ describe('Environment', () => {
         cy.findByTestId('minimumHashtagLengthinput').clear().type(minimumHashtagLength1);
 
         // # Click Save button to save the settings
-        cy.get('#saveSetting').click();
+        cy.get('#saveSetting').click({force: true});
 
         // Get config again
         cy.apiGetConfig().then(({config}) => {
@@ -221,7 +221,7 @@ describe('Environment', () => {
         cy.findByTestId('minimumHashtagLengthinput').clear().type(minimumHashtagLength2);
 
         // # Click Save button to save the settings
-        cy.get('#saveSetting').click();
+        cy.get('#saveSetting').click({force: true});
 
         // Get config again
         cy.apiGetConfig().then(({config}) => {


### PR DESCRIPTION
In this PR:
- fixing status dropdown failure by enabling custom status (1st screenshot below)
- fixing system_console/environment_spec failure by forcing a click on "Save" button (2nd screenshot below)

<img width="687" alt="Screen Shot 2021-03-18 at 4 45 26 PM" src="https://user-images.githubusercontent.com/691331/111715620-75f8e700-8811-11eb-9a48-2345cc4a448d.png">

<img width="695" alt="Screen Shot 2021-03-18 at 4 43 45 PM" src="https://user-images.githubusercontent.com/691331/111715638-7ee9b880-8811-11eb-9020-0ac10792d3ff.png">
