### PR TITLE
Updating status_dropdown_spec with missing test cases

### DIFF
--- a/e2e/cypress/fixtures/theme.json
+++ b/e2e/cypress/fixtures/theme.json
@@ -25,5 +25,32 @@
         "mentionHighlightLink":"#166de0",
         "codeTheme":"github",
         "mentionBg":"#ffffff"
+    },
+    "dark": {
+        "sidebarBg":"#171717",
+        "sidebarText":"#ffffff",
+        "sidebarUnreadText":"#ffffff",
+        "sidebarTextHoverBg":"#302e30",
+        "sidebarTextActiveBorder":"#196caf",
+        "sidebarTextActiveColor":"#ffffff",
+        "sidebarHeaderBg":"#1f1f1f",
+        "sidebarTeamBarBg": "#181818",
+        "sidebarHeaderTextColor":"#ffffff",
+        "onlineIndicator":"#399fff",
+        "awayIndicator":"#c1b966",
+        "dndIndicator":"#e81023",
+        "mentionBj":"#ffffff",
+        "mentionColor":"#ffffff",
+        "centerChannelBg":"#1f1f1f",
+        "centerChannelColor":"#dddddd",
+        "newMessageSeparator":"#cc992d",
+        "linkColor":"#0d93ff",
+        "buttonBg":"#0177e7",
+        "buttonColor":"#ffffff",
+        "errorTextColor":"#ff6461",
+        "mentionHighlightBg":"#784098",
+        "mentionHighlightLink":"#a4ffeb",
+        "codeTheme":"monokai",
+        "mentionBg":"#0177e7"
     }
 }

--- a/e2e/cypress/integration/menus/status_dropdown_spec.js
+++ b/e2e/cypress/integration/menus/status_dropdown_spec.js
@@ -8,9 +8,17 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @menu
+// Group: @menu @custom_status @status_menu
 
+import theme from '../../fixtures/theme.json';
 import * as TIMEOUTS from '../../fixtures/timeouts';
+
+const statusTestCases = [
+    {id: 'status-menu-online', icon: 'online--icon', text: 'Online'},
+    {id: 'status-menu-away', icon: 'away--icon', text: 'Away'},
+    {id: 'status-menu-dnd', icon: 'dnd--icon', text: 'Do Not Disturb', helpText: 'Disables all notifications'},
+    {id: 'status-menu-offline', text: 'Offline'},
+];
 
 describe('Status dropdown menu', () => {
     before(() => {
@@ -18,7 +26,6 @@ describe('Status dropdown menu', () => {
         cy.apiInitSetup().then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
         });
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: false}});
     });
 
     afterEach(() => {
@@ -28,163 +35,106 @@ describe('Status dropdown menu', () => {
         cy.reload();
     });
 
-    it('Displays default menu when status icon is clicked', () => {
-        // # Wait for posts to load
-        cy.get('#postListContent', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+    after(() => {
+        // # Reset to enable the custom status
+        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+    });
 
-        // # Click status menu
-        cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
+    it('MM-T2927_1 Should open status menu', () => {
+        // # Open status menu
+        openStatusMenu(TIMEOUTS.ONE_MIN);
 
-        // # Wait for status menu to transition in
+        // * Verify that the status dropdown opens and is visible
         cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
     });
 
-    it('Changes status icon to online when "Online" menu item is selected', () => {
-        // # Wait for posts to load
-        cy.get('#postListContent').should('be.visible');
-
-        // # Set user status to away to ensure menu click changes status
-        cy.apiUpdateUserStatus('away').then(() => {
-            // # Click status menu
-            cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
-
-            // # Wait for status menu to transition in
-            cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
-
-            cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu #status-menu-online').click();
-
-            cy.get('.MenuWrapper.status-dropdown-menu > .status-wrapper > button.status > span > svg > path.online--icon').should('exist');
-        });
-    });
-
-    it('Changes status icon to away when "Away" menu item is selected', () => {
-        // # Wait for posts to load
-        cy.get('#postListContent').should('be.visible');
-
-        // # Click status menu
-        cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
+    it('MM-T2927_2 Should show all available statuses with their icons', () => {
+        // # Open status menu
+        openStatusMenu();
 
         // # Wait for status menu to transition in
         cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
 
-        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu #status-menu-away').click();
+        statusTestCases.forEach((tc) => {
+            // * Verify status text
+            cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id} span.MenuItem__primary-text`).should('have.text', tc.text).should('be.visible');
 
-        cy.get('.MenuWrapper.status-dropdown-menu > .status-wrapper > button.status > span > svg > path.away--icon').should('exist');
+            // * Verify status help text
+            if (tc.helpText) {
+                cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id} span.MenuItem__help-text`).should('have.text', tc.helpText).should('be.visible');
+            }
+
+            // * Verify status icon
+            if (tc.icon) {
+                cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id} span.icon span.${tc.icon}`).should('be.visible');
+            } else {
+                cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id} span.icon span:not([class])`).should('be.visible');
+            }
+        });
     });
 
-    it('Changes status icon to do not disturb when "Do Not Disturb" menu item is selected', () => {
-        // # Wait for posts to load
-        cy.get('#postListContent').should('be.visible');
+    it('MM-T2927_3 Should select each status, and have the user\'s active status change', () => {
+        // * Verify that all statuses get set correctly
+        stepThroughStatuses();
+    });
 
-        // # Click status menu
-        cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
+    it('MM-T2927_4 Icons are visible in dark mode', () => {
+        // #Change to dark mode
+        cy.apiSaveThemePreference(JSON.stringify(theme.dark));
 
-        // # Wait for status menu to transition in
+        // * Verify that all statuses get set correctly
+        stepThroughStatuses();
+
+        // # Reset the theme to default
+        cy.apiSaveThemePreference(JSON.stringify(theme.default));
+    });
+
+    it('MM-T2927_5 "Set a Custom Header Status" is clickable', () => {
+        // # Open status menu
+        openStatusMenu();
+
+        // * Verify "Set a Custom Status" header is clickable
+        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li:nth-child(3)').should('be.visible').
+            and('have.text', 'Set a Custom Status').and('have.css', 'cursor', 'pointer');
+    });
+
+    it('MM-T2927_6 When custom status is disabled, status menu is displayed when status icon is clicked', () => {
+        // # Disable custom statuses
+        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: false}});
+
+        // # Open status menu
+        openStatusMenu();
+
+        // * Verify that the status menu dropdown opens and is visible
         cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
-
-        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu #status-menu-dnd').click();
-
-        cy.get('.MenuWrapper.status-dropdown-menu > .status-wrapper > button.status > span > svg > path.dnd--icon').should('exist');
-    });
-
-    it('Changes status icon to offline when "Offline" menu item is selected', () => {
-        // # Wait for posts to load
-        cy.get('#postListContent').should('be.visible');
-
-        // # Click status menu
-        cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
-
-        // # Wait for status menu to transition in
-        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
-
-        // # Click "Offline" in menu
-        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu #status-menu-offline').click();
-
-        // * Check that icon is offline icon
-        cy.get('.MenuWrapper.status-dropdown-menu > .status-wrapper > button.status > span > svg.offline--icon').should('exist');
-    });
-
-    describe('MM-T2927 Set user status', () => {
-        const statusTestCases = [
-            {id: 'status-menu-online', icon: 'online--icon', text: 'Online'},
-            {id: 'status-menu-away', icon: 'away--icon', text: 'Away'},
-            {id: 'status-menu-dnd', icon: 'dnd--icon', text: 'Do Not Disturb', helpText: 'Disables all notifications'},
-            {id: 'status-menu-offline', text: 'Offline'},
-        ];
-
-        it('MM-T2927_1 should open status menu', () => {
-            // # Wait for posts to load
-            cy.get('#postListContent').should('be.visible');
-
-            // # Open status menu
-            cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
-
-            // # Wait for status menu to transition in
-            cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
-        });
-
-        it('MM-T2927_2 should show all available statuses with their icons', () => {
-            // # Wait for posts to load
-            cy.get('#postListContent').should('be.visible');
-
-            // # Open status menu
-            cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
-
-            // # Wait for status menu to transition in
-            cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
-
-            statusTestCases.forEach((tc) => {
-                // * Verify status text
-                cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id} span.MenuItem__primary-text`).should('have.text', tc.text);
-
-                // * Verify status help text
-                if (tc.helpText) {
-                    cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id} span.MenuItem__help-text`).should('have.text', tc.helpText);
-                }
-
-                // * Verify status icon
-                if (tc.icon) {
-                    cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id} span.icon span.${tc.icon}`).should('be.visible');
-                } else {
-                    cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id} span.icon span:not([class])`).should('be.visible');
-                }
-            });
-        });
-
-        it('MM-T2927_3 should select each status, and have the user\'s active status change', () => {
-            // # Wait for posts to load
-            cy.get('#postListContent').should('be.visible');
-
-            // * Verify all statuses will change the user's status icon
-            statusTestCases.forEach((tc) => {
-                // # Open status menu
-                cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
-
-                // # Wait for status menu to transition in
-                cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
-
-                // # Click status choice
-                cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id}`).should('be.visible').
-                    and('have.css', 'cursor', 'pointer').click();
-
-                // # Verify correct status icon is shown on user's profile picture
-                cy.get('.MenuWrapper.status-dropdown-menu svg').should('have.attr', 'aria-label', `${tc.text} Icon`);
-            });
-        });
-
-        it('MM-T2927_5 Verify "Set a Custom Header Status" is clickable', () => {
-            // # Enable Custom Status
-            cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
-
-            // # Wait for posts to load
-            cy.get('#postListContent').should('be.visible');
-
-            // # Open status menu
-            cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
-
-            // * Verify "Set a Custom Status" header is clickable
-            cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li:nth-child(3)').should('be.visible').
-                and('have.text', 'Set a Custom Status').and('have.css', 'cursor', 'pointer');
-        });
     });
 });
+
+function openStatusMenu(timeOut) {
+    // # Wait for posts to load
+    cy.get('#postListContent', {timeout: timeOut}).should('be.visible');
+
+    // # Click status menu
+    cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
+}
+
+function stepThroughStatuses() {
+    // # Wait for posts to load
+    cy.get('#postListContent').should('be.visible');
+
+    // * Verify the user's status icon changes correctly every time
+    statusTestCases.forEach((tc) => {
+        // # Open status menu
+        cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
+
+        // # Wait for status menu to transition in
+        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
+
+        // # Click status choice
+        cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id}`).should('be.visible').
+            and('have.css', 'cursor', 'pointer').click();
+
+        // # Verify correct status icon is shown on user's profile picture
+        cy.get('.MenuWrapper.status-dropdown-menu svg').should('have.attr', 'aria-label', `${tc.text} Icon`);
+    });
+}

--- a/e2e/cypress/integration/menus/status_dropdown_spec.js
+++ b/e2e/cypress/integration/menus/status_dropdown_spec.js
@@ -11,7 +11,6 @@
 // Group: @menu @custom_status @status_menu
 
 import theme from '../../fixtures/theme.json';
-import * as TIMEOUTS from '../../fixtures/timeouts';
 
 const statusTestCases = [
     {id: 'status-menu-online', icon: 'online--icon', text: 'Online'},
@@ -35,14 +34,9 @@ describe('Status dropdown menu', () => {
         cy.reload();
     });
 
-    after(() => {
-        // # Reset to enable the custom status
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
-    });
-
     it('MM-T2927_1 Should open status menu', () => {
         // # Open status menu
-        openStatusMenu(TIMEOUTS.ONE_MIN);
+        cy.uiOpenSetStatusMenu();
 
         // * Verify that the status dropdown opens and is visible
         cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
@@ -50,7 +44,7 @@ describe('Status dropdown menu', () => {
 
     it('MM-T2927_2 Should show all available statuses with their icons', () => {
         // # Open status menu
-        openStatusMenu();
+        cy.uiOpenSetStatusMenu();
 
         // # Wait for status menu to transition in
         cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
@@ -91,7 +85,7 @@ describe('Status dropdown menu', () => {
 
     it('MM-T2927_5 "Set a Custom Header Status" is clickable', () => {
         // # Open status menu
-        openStatusMenu();
+        cy.uiOpenSetStatusMenu();
 
         // * Verify "Set a Custom Status" header is clickable
         cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li:nth-child(3)').should('be.visible').
@@ -103,20 +97,12 @@ describe('Status dropdown menu', () => {
         cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: false}});
 
         // # Open status menu
-        openStatusMenu();
+        cy.uiOpenSetStatusMenu();
 
         // * Verify that the status menu dropdown opens and is visible
         cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
     });
 });
-
-function openStatusMenu(timeOut) {
-    // # Wait for posts to load
-    cy.get('#postListContent', {timeout: timeOut}).should('be.visible');
-
-    // # Click status menu
-    cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
-}
 
 function stepThroughStatuses() {
     // # Wait for posts to load
@@ -124,17 +110,10 @@ function stepThroughStatuses() {
 
     // * Verify the user's status icon changes correctly every time
     statusTestCases.forEach((tc) => {
-        // # Open status menu
-        cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
+        // # Step through all the status
+        cy.uiOpenSetStatusMenu(tc.text);
 
-        // # Wait for status menu to transition in
-        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
-
-        // # Click status choice
-        cy.get(`.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu li#${tc.id}`).should('be.visible').
-            and('have.css', 'cursor', 'pointer').click();
-
-        // # Verify correct status icon is shown on user's profile picture
+        // * Verify correct status icon is shown on user's profile picture
         cy.get('.MenuWrapper.status-dropdown-menu svg').should('have.attr', 'aria-label', `${tc.text} Icon`);
     });
 }

--- a/e2e/cypress/support/api/cloud_default_config.json
+++ b/e2e/cypress/support/api/cloud_default_config.json
@@ -37,6 +37,7 @@
         "EnableOpenServer": true,
         "EnableUserDeactivation": false,
         "RestrictCreationToDomains": "",
+        "EnableCustomUserStatuses": true,
         "EnableCustomBrand": false,
         "CustomBrandText": "",
         "CustomDescriptionText": "",

--- a/e2e/cypress/support/api/on_prem_default_config.json
+++ b/e2e/cypress/support/api/on_prem_default_config.json
@@ -92,6 +92,7 @@
         "EnableOpenServer": true,
         "EnableUserDeactivation": false,
         "RestrictCreationToDomains": "",
+        "EnableCustomUserStatuses": true,
         "EnableCustomBrand": false,
         "CustomBrandText": "",
         "CustomDescriptionText": "",


### PR DESCRIPTION
In this PR:

- Adding the missing test case T2927_4: verify that the status icons are visible in dark mode.
- Adding a test case T2927_6 (updated in Zephyr as well) to verify that the status menu opens as expected when custom status is disabled to make sure such regression is covered.
- Removed a few duplicate tests that were written a long time ago.
- Some cleanups.
<img width="688" alt="Screen Shot 2021-03-19 at 6 27 05 PM" src="https://user-images.githubusercontent.com/691331/111855207-b7a49300-88e0-11eb-8327-3277e0c0780b.png">
