### PR TITLE
[MM-33609] - Fix team icon coverage on firefox

### DIFF
--- a/components/widgets/team_icon/team_icon.scss
+++ b/components/widgets/team_icon/team_icon.scss
@@ -107,7 +107,7 @@
         @include clearfix;
         @include background-size(100% 100%);
         background-color: $white;
-        background-repeat: no-repeat;
+        background-repeat: unset;
         width: 100%;
         height: 100%;
 


### PR DESCRIPTION

#### Summary
Fix the background blend mode for team icon when the white background is peeking through in Firefox

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33609

