### PR TITLE
MM-25140 Fix unit tests which are broken on Node 14

### DIFF
--- a/components/add_groups_to_channel_modal/add_groups_to_channel_modal.tsx
+++ b/components/add_groups_to_channel_modal/add_groups_to_channel_modal.tsx
@@ -148,13 +148,13 @@ export default class AddGroupsToChannelModal extends React.PureComponent<Props, 
 
         this.setState({saving: true});
 
-        groupIDs.forEach(async (groupID) => {
+        await Promise.all(groupIDs.map(async (groupID) => {
             const {error} = await this.props.actions.linkGroupSyncable(groupID, this.props.currentChannelId, Groups.SYNCABLE_TYPE_CHANNEL, {auto_add: true});
             this.handleResponse(error);
             if (!error) {
                 this.handleHide();
             }
-        });
+        }));
     }
 
     addValue = (value: GroupValue) => {

--- a/components/add_groups_to_team_modal/add_groups_to_team_modal.tsx
+++ b/components/add_groups_to_team_modal/add_groups_to_team_modal.tsx
@@ -145,13 +145,13 @@ export default class AddGroupsToTeamModal extends React.PureComponent<Props, Sta
 
         this.setState({saving: true});
 
-        groupIDs.forEach(async (groupID) => {
+        await Promise.all(groupIDs.map(async (groupID) => {
             const {error} = await this.props.actions.linkGroupSyncable(groupID, this.props.currentTeamId, Groups.SYNCABLE_TYPE_TEAM, {auto_add: true, scheme_admin: false});
             this.handleResponse(error);
             if (!error) {
                 this.handleHide();
             }
-        });
+        }));
     }
 
     // public for tests

--- a/components/data_prefetch/data_prefetch.test.tsx
+++ b/components/data_prefetch/data_prefetch.test.tsx
@@ -12,6 +12,13 @@ import {TestHelper} from 'utils/test_helper';
 
 import DataPrefetch from './data_prefetch';
 
+const mockQueue: Array<() => Promise<void>> = [];
+
+jest.mock('p-queue', () => class PQueueMock {
+    add = (o: () => Promise<void>) => mockQueue.push(o);
+    clear = () => mockQueue.splice(0, mockQueue.length);
+});
+
 jest.mock('actions/user_actions.jsx', () => ({
     loadProfilesForSidebar: jest.fn(() => Promise.resolve({})),
 }));
@@ -24,8 +31,7 @@ describe('/components/data_prefetch', () => {
             trackDMGMOpenChannels: jest.fn(() => Promise.resolve()),
         },
         prefetchQueueObj: {
-            1: ['mentionChannel'],
-            2: ['unreadChannel'],
+            1: [],
         },
         prefetchRequestStatus: {},
         sidebarLoaded: true,
@@ -66,124 +72,212 @@ describe('/components/data_prefetch', () => {
         })],
     };
 
-    test('should call posts of current channel when it is set', async () => {
-        const wrapper = shallow<DataPrefetch>(
-            <DataPrefetch {...defaultProps}/>,
-        );
-        const instance = wrapper.instance();
-
-        instance.prefetchPosts = jest.fn();
-        wrapper.setProps({currentChannelId: 'currentChannelId'});
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('currentChannelId');
-        await loadProfilesForSidebar();
-        expect(defaultProps.actions.trackDMGMOpenChannels).toHaveBeenCalled();
+    beforeEach(() => {
+        mockQueue.splice(0, mockQueue.length);
     });
 
-    test('should call for LHS profiles and also call for posts based on prefetchQueueObj', async () => {
+    test('should fetch posts for current channel on first channel load', async () => {
+        const props = defaultProps;
         const wrapper = shallow<DataPrefetch>(
-            <DataPrefetch {...defaultProps}/>,
+            <DataPrefetch {...props}/>,
         );
+
         const instance = wrapper.instance();
         instance.prefetchPosts = jest.fn();
+
+        // Change channels and wait for async componentDidUpdate to resolve
         wrapper.setProps({currentChannelId: 'currentChannelId'});
+        await Promise.resolve(true);
+
+        expect(mockQueue).toHaveLength(1);
+        expect(instance.prefetchPosts).not.toHaveBeenCalled();
+
+        // Manually run queued tasks
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(1);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('currentChannelId');
+    });
+
+    test('should track opened DMs/GMs on first channel load', async () => {
+        const props = defaultProps;
+        const wrapper = shallow<DataPrefetch>(
+            <DataPrefetch {...props}/>,
+        );
+
+        expect(props.actions.trackDMGMOpenChannels).not.toHaveBeenCalled();
+
+        // Change channels
+        wrapper.setProps({currentChannelId: 'currentChannelId'});
+        await Promise.resolve(true);
+
+        expect(props.actions.trackDMGMOpenChannels).toHaveBeenCalledTimes(1);
+
+        // Change channels again
+        wrapper.setProps({currentChannelId: 'anotherChannelId'});
+        await Promise.resolve(true);
+
+        expect(props.actions.trackDMGMOpenChannels).toHaveBeenCalledTimes(1);
+    });
+
+    test('should fetch profiles for sidebar on first channel load', async () => {
+        const props = defaultProps;
+        const wrapper = shallow<DataPrefetch>(
+            <DataPrefetch {...props}/>,
+        );
+
+        expect(loadProfilesForSidebar).not.toHaveBeenCalled();
+
+        // Change channels
+        wrapper.setProps({currentChannelId: 'currentChannelId'});
+        await Promise.resolve(true);
 
         expect(loadProfilesForSidebar).toHaveBeenCalledTimes(1);
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('currentChannelId');
-        await loadProfilesForSidebar();
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel');
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('unreadChannel');
-        expect(instance.prefetchPosts).toHaveBeenCalledTimes(3);
+
+        // Change channels again
+        wrapper.setProps({currentChannelId: 'anotherChannelId'});
+        await Promise.resolve(true);
+
+        expect(loadProfilesForSidebar).toHaveBeenCalledTimes(1);
     });
 
-    test('Should call for posts based on prefetchQueueObj and obey concurrency', async () => {
+    test('should fetch channels in priority order', async () => {
         const props = {
             ...defaultProps,
             prefetchQueueObj: {
-                1: ['mentionChannel0', 'mentionChannel1', 'mentionChannel2', 'mentionChannel3'],
-                2: [],
+                1: ['mentionChannel0', 'mentionChannel1'],
+                2: ['unreadChannel0', 'unreadChannel1'],
                 3: [],
             },
         };
-
         const wrapper = shallow<DataPrefetch>(
             <DataPrefetch {...props}/>,
         );
+
         const instance = wrapper.instance();
-        instance.prefetchPosts = jest.fn(() => Promise.resolve({}));
+        instance.prefetchPosts = jest.fn();
 
         wrapper.setProps({currentChannelId: 'currentChannelId'});
+        await Promise.resolve(true);
+
+        expect(mockQueue).toHaveLength(5); // current channel, mentioned channels, unread channels
+        expect(instance.prefetchPosts).not.toHaveBeenCalled();
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(1);
         expect(instance.prefetchPosts).toHaveBeenCalledWith('currentChannelId');
-        await props.actions.prefetchChannelPosts();
 
-        await loadProfilesForSidebar();
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(2);
         expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel0');
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel1');
-        expect(instance.prefetchPosts).toHaveBeenCalledTimes(3);
 
-        await props.actions.prefetchChannelPosts();
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel2');
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel3');
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(3);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel1');
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(4);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('unreadChannel0');
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(5);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('unreadChannel1');
     });
 
-    test('Should call for new prefetchQueueObj channels on change of prop and cancel previous ones', async () => {
+    test('should cancel fetch and requeue channels when prefetch queue changes', async () => {
         const props = {
             ...defaultProps,
             prefetchQueueObj: {
-                1: ['mentionChannel0', 'mentionChannel1', 'mentionChannel2', 'mentionChannel3', 'mentionChannel4'],
-                2: [],
+                1: [],
+                2: ['unreadChannel0', 'unreadChannel1', 'unreadChannel2'],
             },
         };
-
-        const wrapper = shallow(
+        const wrapper = shallow<DataPrefetch>(
             <DataPrefetch {...props}/>,
         );
-        const instance = wrapper.instance() as DataPrefetch;
-        instance.prefetchPosts = jest.fn(() => Promise.resolve({}));
+
+        const instance = wrapper.instance();
+        instance.prefetchPosts = jest.fn();
 
         wrapper.setProps({currentChannelId: 'currentChannelId'});
+        await Promise.resolve(true);
 
-        await props.actions.prefetchChannelPosts();
-        await loadProfilesForSidebar();
-        expect(instance.prefetchPosts).toHaveBeenCalledTimes(3);
+        expect(mockQueue).toHaveLength(4);
+        expect(instance.prefetchPosts).not.toHaveBeenCalled();
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(1);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('currentChannelId');
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(2);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('unreadChannel0');
+
         wrapper.setProps({
             prefetchQueueObj: {
-                1: ['mentionChannel5', 'mentionChannel6'],
-                2: [],
-                3: [],
+                1: ['mentionChannel0', 'mentionChannel1'],
+                2: ['unreadChannel2', 'unreadChannel3'],
             },
         });
 
-        await props.actions.prefetchChannelPosts();
+        // Check queue has been cleared and wait for async componentDidUpdate to complete
+        expect(mockQueue).toHaveLength(0);
+        await Promise.resolve(true);
+
+        expect(mockQueue).toHaveLength(4);
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(3);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel0');
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(4);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel1');
+
+        mockQueue.shift()!();
         expect(instance.prefetchPosts).toHaveBeenCalledTimes(5);
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel5');
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel6');
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('unreadChannel2');
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(6);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('unreadChannel3');
     });
 
     test('should skip making request for posts if a request was made', async () => {
         const props = {
             ...defaultProps,
+            prefetchQueueObj: {
+                1: ['mentionChannel'],
+                2: ['unreadChannel'],
+            },
             prefetchRequestStatus: {
                 unreadChannel: 'success',
             },
         };
-
         const wrapper = shallow<DataPrefetch>(
             <DataPrefetch {...props}/>,
         );
+
         const instance = wrapper.instance();
         instance.prefetchPosts = jest.fn();
-        wrapper.setProps({currentChannelId: 'currentChannelId'});
 
-        expect(loadProfilesForSidebar).toHaveBeenCalledTimes(1);
+        wrapper.setProps({currentChannelId: 'currentChannelId'});
+        await Promise.resolve(true);
+
+        expect(mockQueue).toHaveLength(2);
+
+        mockQueue.shift()!();
+        expect(instance.prefetchPosts).toHaveBeenCalledTimes(1);
         expect(instance.prefetchPosts).toHaveBeenCalledWith('currentChannelId');
-        await loadProfilesForSidebar();
-        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel');
+
+        mockQueue.shift()!();
         expect(instance.prefetchPosts).toHaveBeenCalledTimes(2);
+        expect(instance.prefetchPosts).toHaveBeenCalledWith('mentionChannel');
     });
 
     test('should add delay if last post is made in last min', async () => {
         Date.now = jest.fn().mockReturnValue(12346);
         Math.random = jest.fn().mockReturnValue(0.5);
+
         const props = {
             ...defaultProps,
             prefetchQueueObj: {
@@ -208,20 +302,30 @@ describe('/components/data_prefetch', () => {
                 last_post_at: 12345,
             }],
         };
-
         const wrapper = shallow(
             <DataPrefetch {...props}/>,
         );
-        wrapper.setProps({currentChannelId: 'currentChannelId'});
 
+        wrapper.setProps({currentChannelId: 'currentChannelId'});
+        await Promise.resolve(true);
+
+        expect(mockQueue).toHaveLength(2);
+
+        // The first channel is loaded with no delay
+        mockQueue.shift()!();
+        expect(props.actions.prefetchChannelPosts).toHaveBeenCalledTimes(1);
         expect(props.actions.prefetchChannelPosts).toHaveBeenCalledWith('currentChannelId', undefined);
-        await loadProfilesForSidebar();
+
+        // And the second is loaded with a half second delay
+        mockQueue.shift()!();
+        expect(props.actions.prefetchChannelPosts).toHaveBeenCalledTimes(2);
         expect(props.actions.prefetchChannelPosts).toHaveBeenCalledWith('mentionChannel', 500);
     });
 
     test('should not add delay if channel is DM even if last post is made in last min', async () => {
         Date.now = jest.fn().mockReturnValue(12346);
         Math.random = jest.fn().mockReturnValue(0.5);
+
         const props = {
             ...defaultProps,
             prefetchQueueObj: {
@@ -246,14 +350,23 @@ describe('/components/data_prefetch', () => {
                 last_post_at: 12345,
             }],
         };
-
         const wrapper = shallow<DataPrefetch>(
             <DataPrefetch {...props}/>,
         );
-        wrapper.setProps({currentChannelId: 'currentChannelId'});
 
+        wrapper.setProps({currentChannelId: 'currentChannelId'});
+        await Promise.resolve(true);
+
+        expect(mockQueue).toHaveLength(2);
+
+        // The first channel is loaded with no delay
+        mockQueue.shift()!();
+        expect(props.actions.prefetchChannelPosts).toHaveBeenCalledTimes(1);
         expect(props.actions.prefetchChannelPosts).toHaveBeenCalledWith('currentChannelId', undefined);
-        await loadProfilesForSidebar();
+
+        // And the second is loaded with no delay either
+        mockQueue.shift()!();
+        expect(props.actions.prefetchChannelPosts).toHaveBeenCalledTimes(2);
         expect(props.actions.prefetchChannelPosts).toHaveBeenCalledWith('mentionChannel', undefined);
     });
 


### PR DESCRIPTION
These tests are broken on Node 14 due to it running some async code differently. I fixed it by having the modals' `handleSubmit` methods actually wait for their results (which shouldn't affect the UI since it doesn't await on `handleSubmit`) and by figuring out how to properly mock the `PQueue` used by the `DataPrefetch` component. That one was a lot trickier since the tests did a lot of bizarre stuff like waiting on functions they'd mocked which didn't do anything other than letting other awaited calls proceed. With the mock, we can now manually pop and run queued tasks instead of having them run asynchronously at poorly-defined times.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25140

#### Related Pull Requests