### PR TITLE
MM-25140 Update build Docker image to Node 14

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:10.22
+FROM node:14.16
 RUN apt-get update && apt-get install -y make gcc nasm libpng-dev
 CMD [ "node" ]


### PR DESCRIPTION
Once https://github.com/mattermost/mattermost-webapp/pull/7741 is merged, we'll be able to run everything on Node 14, but we have to prep to push a new build image first.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25140

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/7741