### PR TITLE
[MM-34094] Hide bindings for system messages

### DIFF
--- a/components/dot_menu/index.ts
+++ b/components/dot_menu/index.ts
@@ -10,6 +10,8 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId, getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {appsEnabled, makeAppBindingsSelector} from 'mattermost-redux/selectors/entities/apps';
 import {AppBindingLocations} from 'mattermost-redux/constants/apps';
+import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
+import {isCombinedUserActivityPost} from 'mattermost-redux/utils/post_list';
 
 import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
 
@@ -62,7 +64,8 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
     const currentTeamUrl = `${getSiteURL()}/${currentTeam.name}`;
 
     const apps = appsEnabled(state);
-    const appBindings = getPostMenuBindings(state);
+    const showBindings = apps && !isSystemMessage(post) && !isCombinedUserActivityPost(post.id);
+    const appBindings = showBindings ? getPostMenuBindings(state) : undefined;
 
     return {
         channelIsArchived: isArchivedChannel(channel),


### PR DESCRIPTION
#### Summary

This PR takes into account whether the selected post is a system message, and hides the bindings if this is the case.

The `DotMenu` component receives an empty array of bindings in this case. The `appsEnabled` prop has been removed from the `DotMenu` component. 0/5 on if we should still explicitly check in the child component for this boolean.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-34094