### PR TITLE
MM-34001 Cypress/E2E: Fix for members with bots

### DIFF
--- a/e2e/cypress/integration/bot_accounts/in_lists_2_spec.js
+++ b/e2e/cypress/integration/bot_accounts/in_lists_2_spec.js
@@ -9,8 +9,6 @@
 
 // Group: @bot_accounts
 
-import {zip, sortBy} from 'lodash';
-
 import {createBotPatch} from '../../support/api/bots';
 import {generateRandomUser} from '../../support/api/user';
 
@@ -18,8 +16,6 @@ describe('Bots in lists', () => {
     let team;
     let channel;
     let testUser;
-    let bots;
-    let createdUsers;
 
     const STATUS_PRIORITY = {
         online: 0,
@@ -43,14 +39,14 @@ describe('Bots in lists', () => {
 
         cy.makeClient().then(async (client) => {
             // # Create bots
-            bots = await Promise.all([
+            const bots = await Promise.all([
                 client.createBot(createBotPatch()),
                 client.createBot(createBotPatch()),
                 client.createBot(createBotPatch()),
             ]);
 
             // # Create users
-            createdUsers = await Promise.all([
+            const createdUsers = await Promise.all([
                 client.createUser(generateRandomUser()),
                 client.createUser(generateRandomUser()),
             ]);
@@ -80,15 +76,15 @@ describe('Bots in lists', () => {
 
             cy.get('#member-list-popover .more-modal__row .more-modal__name').then(async ($query) => {
                 // # Extract usernames from jQuery collection
-                const usernames = $query.toArray().map(({innerText}) => innerText);
+                const usernames = $query.toArray().map(({innerText}) => innerText.split('\n')[0]);
 
                 // # Get users
                 const profiles = await client.getProfilesByUsernames(usernames);
                 const statuses = await client.getStatusesByIds(profiles.map((user) => user.id));
-                const users = zip(profiles, statuses).map(([profile, status]) => ({...profile, ...status}));
+                const users = Cypress._.zip(profiles, statuses).map(([profile, status]) => ({...profile, ...status}));
 
                 // # Sort 'em
-                const sortedUsers = sortBy(users, [
+                const sortedUsers = Cypress._.sortBy(users, [
                     ({is_bot: isBot}) => (isBot ? 1 : 0), // users first
                     ({status}) => STATUS_PRIORITY[status],
                     ({username}) => username,

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -24,7 +24,6 @@
     "lodash.mapkeys": "4.6.0",
     "lodash.without": "4.4.0",
     "lodash.xor": "4.5.0",
-    "lodash": "4.17.21",
     "mattermost-redux": "5.33.0",
     "mime": "2.5.2",
     "mime-types": "2.1.29",


### PR DESCRIPTION
#### Summary
Fix [MM-T1835](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T1835)

Others:
- removed `lodash` as explicit dependency in placed of using the bundled lodash by `Cypress._`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34001

#### Screenshot
![Screen Shot 2021-03-26 at 5 42 57 PM](https://user-images.githubusercontent.com/5334504/112613667-51c58780-8e5b-11eb-9dc5-da2a77c80f97.png)

