### PR TITLE
MM-34114 - grab users stats on demand to fix invite buttons logic

### DIFF
--- a/components/post_view/channel_intro_message/add_members_button.tsx
+++ b/components/post_view/channel_intro_message/add_members_button.tsx
@@ -30,13 +30,13 @@ export interface AddMembersButtonProps {
     channel: Channel;
     setHeader: React.ReactNode;
     theme: any;
-    showAddMemberButton: boolean;
 }
 
-const AddMembersButton: React.FC<AddMembersButtonProps> = ({totalUsers, usersLimit, channel, setHeader, theme, showAddMemberButton}: AddMembersButtonProps) => {
+const AddMembersButton: React.FC<AddMembersButtonProps> = ({totalUsers, usersLimit, channel, setHeader, theme}: AddMembersButtonProps) => {
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
     const inviteUsers = totalUsers < usersLimit;
-    if (!showAddMemberButton) {
+
+    if (!totalUsers) {
         return (<LoadingSpinner/>);
     }
     return (

--- a/components/post_view/channel_intro_message/add_members_button.tsx
+++ b/components/post_view/channel_intro_message/add_members_button.tsx
@@ -20,6 +20,8 @@ import * as Utils from 'utils/utils.jsx';
 
 import './add_members_button.scss';
 
+import LoadingSpinner from 'components/widgets/loading/loading_spinner';
+
 import MembersSvg from './members_illustration.svg';
 
 export interface AddMembersButtonProps {
@@ -28,12 +30,15 @@ export interface AddMembersButtonProps {
     channel: Channel;
     setHeader: React.ReactNode;
     theme: any;
+    showAddMemberButton: boolean;
 }
 
-const AddMembersButton: React.FC<AddMembersButtonProps> = ({totalUsers, usersLimit, channel, setHeader, theme}: AddMembersButtonProps) => {
+const AddMembersButton: React.FC<AddMembersButtonProps> = ({totalUsers, usersLimit, channel, setHeader, theme, showAddMemberButton}: AddMembersButtonProps) => {
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
     const inviteUsers = totalUsers < usersLimit;
-
+    if (!showAddMemberButton) {
+        return (<LoadingSpinner/>);
+    }
     return (
         inviteUsers && !isPrivate ? lessThanMaxFreeUsers(setHeader, theme) : moreThanMaxFreeUsers(channel, setHeader)
     );
@@ -133,4 +138,4 @@ const moreThanMaxFreeUsers = (channel: Channel, setHeader: React.ReactNode) => {
     );
 };
 
-export default AddMembersButton;
+export default React.memo(AddMembersButton);

--- a/components/post_view/channel_intro_message/channel_intro_message.tsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.tsx
@@ -50,7 +50,7 @@ type Props = {
 
 export default class ChannelIntroMessage extends React.PureComponent<Props> {
     componentDidMount() {
-        if (this.props.stats && !this.props.stats.total_users_count) {
+        if (!this.props.stats?.total_users_count) {
             this.props.actions.getTotalUsersStats();
         }
     }

--- a/components/post_view/channel_intro_message/channel_intro_message.tsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.tsx
@@ -43,9 +43,21 @@ type Props = {
     stats: any;
     theme: any;
     usersLimit: number;
+    actions: {
+        getTotalUsersStats: () => any;
+    };
 }
 
 export default class ChannelIntroMessage extends React.PureComponent<Props> {
+    showAddMemberButton = false;
+
+    componentDidMount() {
+        if (this.props.actions.getTotalUsersStats) {
+            this.props.actions.getTotalUsersStats().then(() => {
+                this.showAddMemberButton = true;
+            });
+        }
+    }
     render() {
         const {
             currentUserId,
@@ -74,11 +86,11 @@ export default class ChannelIntroMessage extends React.PureComponent<Props> {
         } else if (channel.type === Constants.GM_CHANNEL) {
             return createGMIntroMessage(channel, centeredIntro, channelProfiles, currentUserId);
         } else if (channel.name === Constants.DEFAULT_CHANNEL) {
-            return createDefaultIntroMessage(channel, centeredIntro, stats, usersLimit, theme, enableUserCreation, isReadOnly, teamIsGroupConstrained);
+            return createDefaultIntroMessage(channel, centeredIntro, stats, usersLimit, theme, this.showAddMemberButton, enableUserCreation, isReadOnly, teamIsGroupConstrained);
         } else if (channel.name === Constants.OFFTOPIC_CHANNEL) {
-            return createOffTopicIntroMessage(channel, centeredIntro, stats, usersLimit, theme);
+            return createOffTopicIntroMessage(channel, centeredIntro, stats, usersLimit, theme, this.showAddMemberButton);
         } else if (channel.type === Constants.OPEN_CHANNEL || channel.type === Constants.PRIVATE_CHANNEL) {
-            return createStandardIntroMessage(channel, centeredIntro, theme, stats, usersLimit, locale, creatorName);
+            return createStandardIntroMessage(channel, centeredIntro, theme, this.showAddMemberButton, stats, usersLimit, locale, creatorName);
         }
         return null;
     }
@@ -190,12 +202,12 @@ function createDMIntroMessage(channel: Channel, centeredIntro: string, teammate:
     );
 }
 
-function createOffTopicIntroMessage(channel: Channel, centeredIntro: string, stats: any, usersLimit: number, theme: any) {
+function createOffTopicIntroMessage(channel: Channel, centeredIntro: string, stats: any, usersLimit: number, theme: any, showAddMemberButton: boolean) {
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
     const children = createSetHeaderButton(channel);
     let totalUsers = 0;
-    if (stats && (typeof stats.TOTAL_USERS === 'number')) {
-        totalUsers = stats.TOTAL_USERS;
+    if (stats && (typeof stats.total_users_count === 'number')) {
+        totalUsers = stats.total_users_count;
     }
     let setHeaderButton = null;
     if (children) {
@@ -217,6 +229,7 @@ function createOffTopicIntroMessage(channel: Channel, centeredIntro: string, sta
             usersLimit={usersLimit}
             channel={channel}
             theme={theme}
+            showAddMemberButton={showAddMemberButton}
         />
     );
 
@@ -254,14 +267,15 @@ export function createDefaultIntroMessage(
     stats: any,
     usersLimit: number,
     theme: any,
+    showAddMemberButton: boolean,
     enableUserCreation?: boolean,
     isReadOnly?: boolean,
     teamIsGroupConstrained?: boolean,
 ) {
     let teamInviteLink = null;
     let totalUsers = 0;
-    if (stats && (typeof stats.TOTAL_USERS === 'number')) {
-        totalUsers = stats.TOTAL_USERS;
+    if (stats && (typeof stats.total_users_count === 'number')) {
+        totalUsers = stats.total_users_count;
     }
 
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
@@ -299,6 +313,7 @@ export function createDefaultIntroMessage(
                             usersLimit={usersLimit}
                             channel={channel}
                             theme={theme}
+                            showAddMemberButton={showAddMemberButton}
                         />
                     }
                     {teamIsGroupConstrained &&
@@ -370,14 +385,14 @@ export function createDefaultIntroMessage(
     );
 }
 
-function createStandardIntroMessage(channel: Channel, centeredIntro: string, theme: any, stats: any, usersLimit: number, locale: string, creatorName: string) {
+function createStandardIntroMessage(channel: Channel, centeredIntro: string, theme: any, showAddMemberButton: boolean, stats: any, usersLimit: number, locale: string, creatorName: string) {
     const uiName = channel.display_name;
     let memberMessage;
     const channelIsArchived = channel.delete_at !== 0;
 
     let totalUsers = 0;
-    if (stats && (typeof stats.TOTAL_USERS === 'number')) {
-        totalUsers = stats.TOTAL_USERS;
+    if (stats && (typeof stats.total_users_count === 'number')) {
+        totalUsers = stats.total_users_count;
     }
 
     if (channelIsArchived) {
@@ -503,6 +518,7 @@ function createStandardIntroMessage(channel: Channel, centeredIntro: string, the
             channel={channel}
             setHeader={setHeaderButton}
             theme={theme}
+            showAddMemberButton={showAddMemberButton}
         />
     );
 

--- a/components/post_view/channel_intro_message/channel_intro_message.tsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.tsx
@@ -49,13 +49,9 @@ type Props = {
 }
 
 export default class ChannelIntroMessage extends React.PureComponent<Props> {
-    showAddMemberButton = false;
-
     componentDidMount() {
-        if (this.props.actions.getTotalUsersStats) {
-            this.props.actions.getTotalUsersStats().then(() => {
-                this.showAddMemberButton = true;
-            });
+        if (this.props.stats && !this.props.stats.total_users_count) {
+            this.props.actions.getTotalUsersStats();
         }
     }
     render() {
@@ -86,11 +82,11 @@ export default class ChannelIntroMessage extends React.PureComponent<Props> {
         } else if (channel.type === Constants.GM_CHANNEL) {
             return createGMIntroMessage(channel, centeredIntro, channelProfiles, currentUserId);
         } else if (channel.name === Constants.DEFAULT_CHANNEL) {
-            return createDefaultIntroMessage(channel, centeredIntro, stats, usersLimit, theme, this.showAddMemberButton, enableUserCreation, isReadOnly, teamIsGroupConstrained);
+            return createDefaultIntroMessage(channel, centeredIntro, stats, usersLimit, theme, enableUserCreation, isReadOnly, teamIsGroupConstrained);
         } else if (channel.name === Constants.OFFTOPIC_CHANNEL) {
-            return createOffTopicIntroMessage(channel, centeredIntro, stats, usersLimit, theme, this.showAddMemberButton);
+            return createOffTopicIntroMessage(channel, centeredIntro, stats, usersLimit, theme);
         } else if (channel.type === Constants.OPEN_CHANNEL || channel.type === Constants.PRIVATE_CHANNEL) {
-            return createStandardIntroMessage(channel, centeredIntro, theme, this.showAddMemberButton, stats, usersLimit, locale, creatorName);
+            return createStandardIntroMessage(channel, centeredIntro, theme, stats, usersLimit, locale, creatorName);
         }
         return null;
     }
@@ -202,13 +198,11 @@ function createDMIntroMessage(channel: Channel, centeredIntro: string, teammate:
     );
 }
 
-function createOffTopicIntroMessage(channel: Channel, centeredIntro: string, stats: any, usersLimit: number, theme: any, showAddMemberButton: boolean) {
+function createOffTopicIntroMessage(channel: Channel, centeredIntro: string, stats: any, usersLimit: number, theme: any) {
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
     const children = createSetHeaderButton(channel);
-    let totalUsers = 0;
-    if (stats && (typeof stats.total_users_count === 'number')) {
-        totalUsers = stats.total_users_count;
-    }
+    const totalUsers = stats.total_users_count;
+
     let setHeaderButton = null;
     if (children) {
         setHeaderButton = (
@@ -229,7 +223,6 @@ function createOffTopicIntroMessage(channel: Channel, centeredIntro: string, sta
             usersLimit={usersLimit}
             channel={channel}
             theme={theme}
-            showAddMemberButton={showAddMemberButton}
         />
     );
 
@@ -267,17 +260,12 @@ export function createDefaultIntroMessage(
     stats: any,
     usersLimit: number,
     theme: any,
-    showAddMemberButton: boolean,
     enableUserCreation?: boolean,
     isReadOnly?: boolean,
     teamIsGroupConstrained?: boolean,
 ) {
     let teamInviteLink = null;
-    let totalUsers = 0;
-    if (stats && (typeof stats.total_users_count === 'number')) {
-        totalUsers = stats.total_users_count;
-    }
-
+    const totalUsers = stats.total_users_count;
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
 
     let setHeaderButton = null;
@@ -313,7 +301,6 @@ export function createDefaultIntroMessage(
                             usersLimit={usersLimit}
                             channel={channel}
                             theme={theme}
-                            showAddMemberButton={showAddMemberButton}
                         />
                     }
                     {teamIsGroupConstrained &&
@@ -385,15 +372,11 @@ export function createDefaultIntroMessage(
     );
 }
 
-function createStandardIntroMessage(channel: Channel, centeredIntro: string, theme: any, showAddMemberButton: boolean, stats: any, usersLimit: number, locale: string, creatorName: string) {
+function createStandardIntroMessage(channel: Channel, centeredIntro: string, theme: any, stats: any, usersLimit: number, locale: string, creatorName: string) {
     const uiName = channel.display_name;
     let memberMessage;
     const channelIsArchived = channel.delete_at !== 0;
-
-    let totalUsers = 0;
-    if (stats && (typeof stats.total_users_count === 'number')) {
-        totalUsers = stats.total_users_count;
-    }
+    const totalUsers = stats.total_users_count;
 
     if (channelIsArchived) {
         memberMessage = '';
@@ -518,7 +501,6 @@ function createStandardIntroMessage(channel: Channel, centeredIntro: string, the
             channel={channel}
             setHeader={setHeaderButton}
             theme={theme}
-            showAddMemberButton={showAddMemberButton}
         />
     );
 

--- a/components/post_view/channel_intro_message/index.ts
+++ b/components/post_view/channel_intro_message/index.ts
@@ -3,12 +3,15 @@
 
 import {connect} from 'react-redux';
 
+import {bindActionCreators, Dispatch} from 'redux';
+
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getAdminAnalytics} from 'mattermost-redux/selectors/entities/admin';
 import {isCurrentChannelReadOnly, getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
-import {getProfilesInCurrentChannel, getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
+import {getProfilesInCurrentChannel, getCurrentUserId, getUser, getTotalUsersStats as getTotalUsersStatsSelector} from 'mattermost-redux/selectors/entities/users';
 import {get, getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import {getTotalUsersStats} from 'mattermost-redux/actions/users';
 
 import {UserProfile} from 'mattermost-redux/types/users';
 
@@ -17,6 +20,8 @@ import {getDirectTeammate, getDisplayNameByUser} from 'utils/utils.jsx';
 import {getCurrentLocale} from 'selectors/i18n';
 
 import {GlobalState} from 'types/store';
+
+import {GenericAction} from 'mattermost-redux/types/actions';
 
 import ChannelIntroMessage from './channel_intro_message';
 
@@ -34,6 +39,8 @@ function mapStateToProps(state: GlobalState) {
         usersLimit = 10;
     }
 
+    const stats = getTotalUsersStatsSelector(state) || {total_users_count: 0};
+
     return {
         currentUserId: getCurrentUserId(state),
         channel,
@@ -46,10 +53,18 @@ function mapStateToProps(state: GlobalState) {
         creatorName: getDisplayNameByUser(state, creator),
         teammate,
         teammateName: getDisplayNameByUser(state, teammate),
-        stats: getAdminAnalytics(state),
+        stats,
         usersLimit,
         theme: getTheme(state),
     };
 }
 
-export default connect(mapStateToProps)(ChannelIntroMessage);
+function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+    return {
+        actions: bindActionCreators({
+            getTotalUsersStats,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ChannelIntroMessage);


### PR DESCRIPTION
#### Summary
A bug was found in the logic for when to show the invite people to workspace or show the invite members to workspace. The problem was the in the initial implementation, the state.entities.admin.analytics.TOTAL_USER value was used, and it worked fine, but just for admins. This pull requests fixes that fetching on demand the total_users using the redux getTotalUsersStats action function.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34114

#### Screenshots

The totalUsers shown for an admin user:
<img width="1433" alt="Captura de pantalla 2021-03-26 a las 16 10 25" src="https://user-images.githubusercontent.com/10082627/112664944-d06df500-8e5a-11eb-8b16-16918fafa460.png">

The totalUsers shown for a NON admin user:
<img width="1760" alt="Captura de pantalla 2021-03-26 a las 16 11 01" src="https://user-images.githubusercontent.com/10082627/112664963-d368e580-8e5a-11eb-815a-a47951312320.png">


After Adding more users than the usersLimit, now the button changes:
<img width="1745" alt="Captura de pantalla 2021-03-26 a las 16 26 52" src="https://user-images.githubusercontent.com/10082627/112664969-d49a1280-8e5a-11eb-98fa-ed1ae2ad05a2.png">

Same behavior for a NON admin user:
<img width="1373" alt="Captura de pantalla 2021-03-26 a las 16 57 42" src="https://user-images.githubusercontent.com/10082627/112664970-d532a900-8e5a-11eb-969e-a3bae726c427.png">
