### PR TITLE
Fix error when root post has been deleted

### DIFF
--- a/components/rhs_thread/rhs_thread.test.tsx
+++ b/components/rhs_thread/rhs_thread.test.tsx
@@ -9,17 +9,8 @@ import {UserProfile} from 'mattermost-redux/types/users';
 import {Post} from 'mattermost-redux/types/posts';
 
 import {TestHelper} from 'utils/test_helper';
-import * as Utils from 'utils/utils.jsx';
 
 import RhsThread from './rhs_thread';
-
-jest.mock('utils/utils', () => {
-    const original = jest.requireActual('utils/utils');
-    return {
-        ...original,
-        getRootPost: jest.fn().mockImplementation(original.getRootPost),
-    };
-});
 
 describe('components/RhsThread', () => {
     const post: Post = TestHelper.getPostMock({
@@ -144,10 +135,13 @@ describe('components/RhsThread', () => {
     });
 
     test('should not break if root post is missing', () => {
-        (Utils.getRootPost as any).mockImplementation(() => undefined);
+        const props = {
+            ...baseProps,
+            posts: [{...baseProps.posts[0], root_id: 'something'}],
+        };
 
         shallow(
-            <RhsThread {...baseProps}/>,
+            <RhsThread {...props}/>,
         );
     });
 });

--- a/components/rhs_thread/rhs_thread.test.tsx
+++ b/components/rhs_thread/rhs_thread.test.tsx
@@ -12,6 +12,14 @@ import {TestHelper} from 'utils/test_helper';
 
 import RhsThread from './rhs_thread';
 
+jest.mock('utils/utils', () => {
+    const original = jest.requireActual('utils/utils');
+    return {
+        ...original,
+        getRootPost: jest.fn().mockReturnValue(undefined),
+    };
+});
+
 describe('components/RhsThread', () => {
     const post: Post = TestHelper.getPostMock({
         channel_id: 'channel_id',
@@ -132,5 +140,11 @@ describe('components/RhsThread', () => {
         });
 
         expect(scrollToBottom).not.toHaveBeenCalled();
+    });
+
+    test('should not break if root post is missing', () => {
+        shallow(
+            <RhsThread {...baseProps}/>,
+        );
     });
 });

--- a/components/rhs_thread/rhs_thread.test.tsx
+++ b/components/rhs_thread/rhs_thread.test.tsx
@@ -9,6 +9,7 @@ import {UserProfile} from 'mattermost-redux/types/users';
 import {Post} from 'mattermost-redux/types/posts';
 
 import {TestHelper} from 'utils/test_helper';
+import * as Utils from 'utils/utils.jsx';
 
 import RhsThread from './rhs_thread';
 
@@ -16,7 +17,7 @@ jest.mock('utils/utils', () => {
     const original = jest.requireActual('utils/utils');
     return {
         ...original,
-        getRootPost: jest.fn().mockReturnValue(undefined),
+        getRootPost: jest.fn().mockImplementation(original.getRootPost),
     };
 });
 
@@ -143,6 +144,8 @@ describe('components/RhsThread', () => {
     });
 
     test('should not break if root post is missing', () => {
+        (Utils.getRootPost as any).mockImplementation(() => undefined);
+
         shallow(
             <RhsThread {...baseProps}/>,
         );

--- a/components/rhs_thread/rhs_thread.tsx
+++ b/components/rhs_thread/rhs_thread.tsx
@@ -132,7 +132,8 @@ export default class RhsThread extends React.Component<Props, State> {
         this.scrollToBottom();
         this.resizeRhsPostList();
         window.addEventListener('resize', this.handleResize);
-        if (this.props.posts.length < (Utils.getRootPost(this.props.posts).reply_count + 1)) {
+        const rootPost = Utils.getRootPost(this.props.posts);
+        if (rootPost && this.props.posts.length < (rootPost.reply_count + 1)) {
             this.props.actions.getPostThread(this.props.selected.id, true);
         }
     }


### PR DESCRIPTION
#### Summary
When posts were deleted in bulk there may be posts whose root post doesn't exist anymore. I believe this usually happens when posts are deleted due to an EE data retention policy.

This caused a JS error when clicking the reply button on the remaining post from the thread because it tried to get the `reply_count` from a `null` (or `undefined`, I don't remember).

#### Ticket Link
[MM-34310](https://mattermost.atlassian.net/browse/MM-34310)