### PR TITLE
Create app call response posts as bot

### DIFF
--- a/actions/command.ts
+++ b/actions/command.ts
@@ -128,7 +128,7 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
                     switch (callResp.type) {
                     case AppCallResponseTypes.OK:
                         if (callResp.markdown) {
-                            GlobalActions.sendEphemeralPost(callResp.markdown, args.channel_id, args.parent_id);
+                            GlobalActions.sendEphemeralPost(callResp.markdown, args.channel_id, args.parent_id, callResp.app_metadata?.bot_user_id);
                         }
                         return {data: true};
                     case AppCallResponseTypes.ERROR:

--- a/actions/global_actions.tsx
+++ b/actions/global_actions.tsx
@@ -186,11 +186,11 @@ export function showMobileSubMenuModal(elements: any[]) { // TODO Use more speci
     dispatch(openModal(submenuModalData));
 }
 
-export function sendEphemeralPost(message: string, channelId?: string, parentId?: string): void {
+export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): void {
     const timestamp = Utils.getTimestamp();
     const post = {
         id: Utils.generateId(),
-        user_id: '0',
+        user_id: userId || '0',
         channel_id: channelId || getCurrentChannelId(getState()),
         message,
         type: PostTypes.EPHEMERAL,

--- a/components/apps_form/apps_form_container.tsx
+++ b/components/apps_form/apps_form_container.tsx
@@ -66,7 +66,7 @@ class AppsFormContainer extends React.PureComponent<Props, State> {
         switch (callResp.type) {
         case AppCallResponseTypes.OK:
             if (callResp.markdown) {
-                sendEphemeralPost(callResp.markdown);
+                sendEphemeralPost(callResp.markdown, call.context.channel_id, call.context.root_id || call.context.post_id, callResp.app_metadata?.bot_user_id);
             }
             break;
         case AppCallResponseTypes.FORM:

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -300,7 +300,7 @@ class DotMenu extends React.PureComponent<Props, State> {
         const res = await this.props.actions?.doAppCall(call, AppCallTypes.SUBMIT, this.props.intl);
 
         const callResp = (res as {data: AppCallResponse}).data;
-        const ephemeral = (message: string) => sendEphemeralPost(message, this.props.post.channel_id, this.props.post.root_id);
+        const ephemeral = (message: string) => sendEphemeralPost(message, this.props.post.channel_id, this.props.post.root_id, callResp.app_metadata?.bot_user_id);
         switch (callResp.type) {
         case AppCallResponseTypes.OK:
             if (callResp.markdown) {

--- a/components/post_view/embedded_bindings/button_binding/button_binding.test.tsx
+++ b/components/post_view/embedded_bindings/button_binding/button_binding.test.tsx
@@ -36,6 +36,9 @@ describe('components/post_view/embedded_bindings/button_binding/', () => {
                 data: {
                     type: 'ok',
                     markdown: 'Nice job!',
+                    app_metadata: {
+                        bot_user_id: 'botuserid',
+                    },
                 },
             }),
             getChannel: jest.fn().mockResolvedValue({
@@ -81,7 +84,7 @@ describe('components/post_view/embedded_bindings/button_binding/', () => {
             values: undefined,
         }, 'submit', {});
 
-        expect(baseProps.sendEphemeralPost).toHaveBeenCalledWith('Nice job!', 'some_channel_id', 'some_root_id');
+        expect(baseProps.sendEphemeralPost).toHaveBeenCalledWith('Nice job!', 'some_channel_id', 'some_root_id', 'botuserid');
     });
 
     test('should handle error call response', async () => {
@@ -92,6 +95,9 @@ describe('components/post_view/embedded_bindings/button_binding/', () => {
                     data: {
                         type: 'error',
                         error: 'The error',
+                        app_metadata: {
+                            bot_user_id: 'botuserid',
+                        },
                     },
                 }),
                 getChannel: jest.fn().mockResolvedValue({
@@ -108,6 +114,6 @@ describe('components/post_view/embedded_bindings/button_binding/', () => {
         const wrapper = shallow<ButtonBindingUnwrapped>(<ButtonBindingUnwrapped {...props}/>);
         await wrapper.instance().handleClick();
 
-        expect(props.sendEphemeralPost).toHaveBeenCalledWith('The error', 'some_channel_id', 'some_root_id');
+        expect(props.sendEphemeralPost).toHaveBeenCalledWith('The error', 'some_channel_id', 'some_root_id', 'botuserid');
     });
 });

--- a/components/post_view/embedded_bindings/button_binding/button_binding.tsx
+++ b/components/post_view/embedded_bindings/button_binding/button_binding.tsx
@@ -23,7 +23,7 @@ type Props = {
         doAppCall: (call: AppCallRequest, type: AppCallType, intl: IntlShape) => Promise<ActionResult>;
         getChannel: (channelId: string) => Promise<ActionResult>;
     };
-    sendEphemeralPost: (message: string, channelID?: string, rootID?: string) => void;
+    sendEphemeralPost: (message: string, channelID?: string, rootID?: string, userID?: string) => void;
 }
 
 type State = {
@@ -69,7 +69,7 @@ export class ButtonBinding extends React.PureComponent<Props, State> {
 
         this.setState({executing: false});
         const callResp = (res as {data: AppCallResponse}).data;
-        const ephemeral = (message: string) => this.props.sendEphemeralPost(message, this.props.post.channel_id, this.props.post.root_id);
+        const ephemeral = (message: string) => this.props.sendEphemeralPost(message, this.props.post.channel_id, this.props.post.root_id, callResp.app_metadata?.bot_user_id);
         switch (callResp.type) {
         case AppCallResponseTypes.OK:
             if (callResp.markdown) {

--- a/components/post_view/embedded_bindings/select_binding/select_binding.test.tsx
+++ b/components/post_view/embedded_bindings/select_binding/select_binding.test.tsx
@@ -80,6 +80,9 @@ describe('components/post_view/embedded_bindings/select_binding', () => {
                         data: {
                             type: 'ok',
                             markdown: 'Nice job!',
+                            app_metadata: {
+                                bot_user_id: 'botuserid',
+                            },
                         },
                     }),
                     getChannel: jest.fn().mockResolvedValue({
@@ -120,7 +123,7 @@ describe('components/post_view/embedded_bindings/select_binding', () => {
                 values: undefined,
             }, 'submit', {});
 
-            expect(props.sendEphemeralPost).toHaveBeenCalledWith('Nice job!', 'some_channel_id', 'some_root_id');
+            expect(props.sendEphemeralPost).toHaveBeenCalledWith('Nice job!', 'some_channel_id', 'some_root_id', 'botuserid');
         });
     });
 
@@ -132,6 +135,9 @@ describe('components/post_view/embedded_bindings/select_binding', () => {
                     data: {
                         type: 'error',
                         error: 'The error',
+                        app_metadata: {
+                            bot_user_id: 'botuserid',
+                        },
                     },
                 }),
                 getChannel: jest.fn().mockResolvedValue({
@@ -152,6 +158,6 @@ describe('components/post_view/embedded_bindings/select_binding', () => {
             value: 'option1',
         });
 
-        expect(props.sendEphemeralPost).toHaveBeenCalledWith('The error', 'some_channel_id', 'some_root_id');
+        expect(props.sendEphemeralPost).toHaveBeenCalledWith('The error', 'some_channel_id', 'some_root_id', 'botuserid');
     });
 });

--- a/components/post_view/embedded_bindings/select_binding/select_binding.tsx
+++ b/components/post_view/embedded_bindings/select_binding/select_binding.tsx
@@ -33,7 +33,7 @@ type Props = {
         doAppCall: (call: AppCallRequest, type: AppCallType, intl: IntlShape) => Promise<ActionResult>;
         getChannel: (channelId: string) => Promise<ActionResult>;
     };
-    sendEphemeralPost: (message: string, channelID?: string, rootID?: string) => void;
+    sendEphemeralPost: (message: string, channelID?: string, rootID?: string, userID?: string) => void;
 };
 
 type State = {
@@ -99,7 +99,7 @@ export class SelectBinding extends React.PureComponent<Props, State> {
 
         const res = await this.props.actions.doAppCall(call, AppCallTypes.SUBMIT, this.props.intl);
         const callResp = (res as {data: AppCallResponse}).data;
-        const ephemeral = (message: string) => this.props.sendEphemeralPost(message, this.props.post.channel_id, this.props.post.root_id);
+        const ephemeral = (message: string) => this.props.sendEphemeralPost(message, this.props.post.channel_id, this.props.post.root_id, callResp.app_metadata?.bot_user_id);
         switch (callResp.type) {
         case AppCallResponseTypes.OK:
             if (callResp.markdown) {

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
@@ -912,7 +912,7 @@ export class AppCommandParser {
         if (err.message) {
             errStr = err.message;
         }
-        displayError(errStr);
+        displayError(errStr, this.channelID, this.rootPostID);
     }
 
     // getSuggestionsForSubCommands returns suggestions for a subcommand's name

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
@@ -79,8 +79,8 @@ export const getExecuteSuggestion = (parsed: ParsedCommand): AutocompleteSuggest
     };
 };
 
-export const displayError = (err: string) => {
-    sendEphemeralPost(err);
+export const displayError = (err: string, channelID: string, rootID?: string) => {
+    sendEphemeralPost(err, channelID, rootID);
 };
 
 // Shim of mobile-version intl

--- a/packages/mattermost-redux/src/types/apps.ts
+++ b/packages/mattermost-redux/src/types/apps.ts
@@ -85,7 +85,13 @@ export type AppCallResponse<Res = unknown> = {
     use_external_browser?: boolean;
     call?: AppCall;
     form?: AppForm;
+    app_metadata?: AppMetadataForClient;
 };
+
+export type AppMetadataForClient = {
+    bot_user_id: string;
+    bot_username: string;
+}
 
 export type AppContext = {
     app_id: string;

--- a/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.tsx
@@ -167,7 +167,7 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
         const res = await this.props.actions.doAppCall(call, AppCallTypes.SUBMIT, this.props.intl);
 
         const callResp = (res as {data: AppCallResponse}).data;
-        const ephemeral = (message: string) => sendEphemeralPost(message, this.props.channel.id);
+        const ephemeral = (message: string) => sendEphemeralPost(message, this.props.channel.id, '', callResp.app_metadata?.bot_user_id);
         switch (callResp.type) {
         case AppCallResponseTypes.OK:
             if (callResp.markdown) {


### PR DESCRIPTION
#### Summary

This PR changes `sendEphemeralPost` to support an optional `userID` argument, to create the ephemeral post with a specific user.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-31083

#### Related Pull Requests

https://github.com/mattermost/mattermost-plugin-apps/pull/119