### PR TITLE
MM-34371: handle undefined status in switcher

### DIFF
--- a/sass/components/_mentions.scss
+++ b/sass/components/_mentions.scss
@@ -63,7 +63,6 @@
 
     .status {
         width: auto;
-        margin: 0 8px;
         display: block;
         top: 1px;
 
@@ -71,6 +70,12 @@
             width: 12px;
             height: 12px;
         }
+    }
+
+    // .mentions__name is way too multi-purpose. This rule targets its use in
+    // SwitchChannelSuggestion, applying margin in a way that handles null elements correctly.
+    .status, .mentions__fullname {
+        margin: 0 0 0 8px;
     }
 
     .fa-user {


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-webapp/pull/6609 introduced the display of user statuses in the channel switcher, but without loading the status for users not already known to the client.

This PR works around that limitation by correctly rendering an undefined status. It does not attempt to load the status for these users at this time.

Instead of:
<img width="615" alt="image" src="https://user-images.githubusercontent.com/1023171/113034844-f0f2c380-9168-11eb-8e34-cec8cfd263c6.png">

We now show:
<img width="621" alt="image" src="https://user-images.githubusercontent.com/1023171/113034735-d587b880-9168-11eb-880a-5a9a7b28aca2.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34371