### PR TITLE
chore : Fixed typo in babel plugin for object, rest, spread

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -27,7 +27,7 @@ const config = {
     plugins: [
         'lodash',
         '@babel/plugin-proposal-class-properties',
-        '@babel/proposal-object-rest-spread',
+        '@babel/plugin-proposal-object-rest-spread',
         'react-hot-loader/babel',
         'babel-plugin-typescript-to-proptypes',
     ],


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The installed `@babel/plugin-proposal-object-rest-spread` should be added in the babel config as [correct config](https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread#usage), there was a small typo.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
As discussed in [Community](https://community.mattermost.com/core/pl/dj1tpwmuxpf87by67p8tawo51h)

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
N/A