### PR TITLE
make totalUsers optional

### DIFF
--- a/components/post_view/channel_intro_message/add_members_button.tsx
+++ b/components/post_view/channel_intro_message/add_members_button.tsx
@@ -25,7 +25,7 @@ import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 import MembersSvg from './members_illustration.svg';
 
 export interface AddMembersButtonProps {
-    totalUsers: number;
+    totalUsers?: number;
     usersLimit: number;
     channel: Channel;
     setHeader: React.ReactNode;
@@ -33,12 +33,13 @@ export interface AddMembersButtonProps {
 }
 
 const AddMembersButton: React.FC<AddMembersButtonProps> = ({totalUsers, usersLimit, channel, setHeader, theme}: AddMembersButtonProps) => {
-    const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
-    const inviteUsers = totalUsers < usersLimit;
-
     if (!totalUsers) {
         return (<LoadingSpinner/>);
     }
+
+    const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
+    const inviteUsers = totalUsers < usersLimit;
+
     return (
         inviteUsers && !isPrivate ? lessThanMaxFreeUsers(setHeader, theme) : moreThanMaxFreeUsers(channel, setHeader)
     );


### PR DESCRIPTION
#### Summary
The `totalUsers` prop expected by `AddMembersButton` isn't actually required, since the component has code to handle when the prop is falsy.  The property itself isn't available until after the background stats have loaded.

This removes a warning during development:
<img width="901" alt="image" src="https://user-images.githubusercontent.com/1023171/113052597-b5aebf80-917d-11eb-8806-19454a95a613.png">

#### Ticket Link
None.