### PR TITLE
make actorId optional

### DIFF
--- a/components/post_view/combined_system_message/combined_system_message.tsx
+++ b/components/post_view/combined_system_message/combined_system_message.tsx
@@ -174,7 +174,7 @@ export type Props = {
     currentUsername: string;
     intl: IntlShape;
     messageData: Array<{
-        actorId: string;
+        actorId?: string;
         postType: string;
         userIds: string[];
     }>;
@@ -264,7 +264,7 @@ export class CombinedSystemMessage extends React.PureComponent<Props> {
         return usernames;
     }
 
-    renderFormattedMessage(postType: string, userIds: string[], actorId: string): JSX.Element {
+    renderFormattedMessage(postType: string, userIds: string[], actorId?: string): JSX.Element {
         const {formatMessage} = this.props.intl;
         const {currentUserId, currentUsername} = this.props;
         const usernames = this.getUsernamesByIds(userIds);
@@ -320,7 +320,7 @@ export class CombinedSystemMessage extends React.PureComponent<Props> {
         );
     }
 
-    renderMessage(postType: string, userIds: string[], actorId: string): JSX.Element {
+    renderMessage(postType: string, userIds: string[], actorId?: string): JSX.Element {
         return (
             <React.Fragment key={postType + actorId}>
                 {this.renderFormattedMessage(postType, userIds, actorId)}


### PR DESCRIPTION
#### Summary
The combined system message component assembles a message from a set of system posts, but the TypeScript definition assumes that all system messages have actors. Some do not, including the opening system messages of `Town Square`, for which the join message is initiated by the server and not a user.

This eliminates the following console error:
<img width="987" alt="image" src="https://user-images.githubusercontent.com/1023171/113054320-a761a300-917f-11eb-88e2-b561a9a355b5.png">

#### Ticket Link
None.