### PR TITLE
Cypress/E2E: Fix test key extraction

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/authentication_method_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/authentication_method_spec.js
@@ -73,7 +73,7 @@ describe('Settings', () => {
             });
     });
 
-    it('MM-T953: Verify correct authentication method', () => {
+    it('MM-T953 Verify correct authentication method', () => {
         cy.visit('/admin_console/user_management/users');
 
         const adminUsername = getAdminAccount().username;

--- a/e2e/cypress/integration/messaging/markdown_spec.js
+++ b/e2e/cypress/integration/messaging/markdown_spec.js
@@ -50,7 +50,7 @@ describe('Markdown', () => {
         });
     });
 
-    it('MM-T2241: Markdown basics', () => {
+    it('MM-T2241 Markdown basics', () => {
         // # Post markdown message
         cy.postMessage('/test url test-markdown-basics.md').wait(TIMEOUTS.ONE_SEC);
 
@@ -69,7 +69,7 @@ describe('Markdown', () => {
         });
     });
 
-    it('MM-T2242: Markdown lists', () => {
+    it('MM-T2242 Markdown lists', () => {
         // # Post markdown message
         cy.postMessage('/test url test-markdown-lists.md').wait(TIMEOUTS.ONE_SEC);
 
@@ -88,7 +88,7 @@ describe('Markdown', () => {
         });
     });
 
-    it('MM-T1744: Markdown tables', () => {
+    it('MM-T2244 Markdown tables', () => {
         // # Post markdown message
         cy.postMessage('/test url test-tables.md').wait(TIMEOUTS.ONE_SEC);
 
@@ -107,7 +107,7 @@ describe('Markdown', () => {
         });
     });
 
-    it('MM-T2246: Markdown code syntax', () => {
+    it('MM-T2246 Markdown code syntax', () => {
         // # Post markdown message
         cy.postMessage('/test url test-syntax-highlighting').wait(TIMEOUTS.ONE_SEC);
 

--- a/e2e/cypress/integration/system_console/mobile_settings_spec.js
+++ b/e2e/cypress/integration/system_console/mobile_settings_spec.js
@@ -14,7 +14,7 @@ describe('Settings', () => {
         cy.shouldRunOnTeamEdition();
     });
 
-    it('MM-T1149: Hide mobile-specific settings', () => {
+    it('MM-T1149 Hide mobile-specific settings', () => {
         cy.visit('/admin_console/site_config/file_sharing_downloads');
 
         // * Check buttons

--- a/e2e/utils/test_cases.js
+++ b/e2e/utils/test_cases.js
@@ -55,7 +55,8 @@ function getTM4JTestCases(report) {
             };
         }).
         reduce((acc, item) => {
-            const key = item.title.split(' ')[0].split('_')[0];
+            // Extract the key to exactly match with "MM-T[0-9]+"
+            const key = item.title.match(/(MM-T\d+)/)[0];
 
             if (acc[key]) {
                 acc[key].push(item);


### PR DESCRIPTION
#### Summary
Fix test key extraction.

Typical error in CI:
<img width="701" alt="Screen Shot 2021-03-31 at 6 48 07 PM" src="https://user-images.githubusercontent.com/5334504/113132938-b2850380-9251-11eb-940c-c082ca1c7c5a.png">


#### Ticket Link
none but failed on daily Cypress run during saving test execution.
