### PR TITLE
MM-34553: profile popover, fix channel admin badge in channel header mentions

### DIFF
--- a/components/profile_popover/index.js
+++ b/components/profile_popover/index.js
@@ -13,6 +13,7 @@ import {
 import {
     getChannelMembersInChannels,
     canManageAnyChannelMembersInCurrentTeam,
+    getCurrentChannelId,
 } from 'mattermost-redux/selectors/entities/channels';
 
 import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
@@ -20,13 +21,18 @@ import {getMembershipForCurrentEntities} from 'actions/views/profile_popover';
 import {closeModal, openModal} from 'actions/views/modals';
 
 import {areTimezonesEnabledAndSupported} from 'selectors/general';
-import {getRhsState} from 'selectors/rhs';
+import {getRhsState, getSelectedPost} from 'selectors/rhs';
 
 import {makeGetCustomStatus, isCustomStatusEnabled} from 'selectors/views/custom_status';
 
 import ProfilePopover from './profile_popover.jsx';
 
-function mapStateToProps(state, {userId, channelId}) {
+function getDefaultChannelId(state) {
+    const selectedPost = getSelectedPost(state);
+    return selectedPost.exists ? selectedPost.channel_id : getCurrentChannelId(state);
+}
+
+function mapStateToProps(state, {userId, channelId = getDefaultChannelId(state)}) {
     const team = getCurrentTeam(state);
     const teamMember = getTeamMember(state, team.id, userId);
     const getCustomStatus = makeGetCustomStatus();
@@ -57,6 +63,7 @@ function mapStateToProps(state, {userId, channelId}) {
         modals: state.views.modals.modalState,
         customStatus: getCustomStatus(state, userId),
         isCustomStatusEnabled: isCustomStatusEnabled(state),
+        channelId,
     };
 }
 


### PR DESCRIPTION
#### Summary
#7744 refactored Profile Popover and a number of callsites to rely on explicit channelId's. Some codepaths (see `markdown.tsx`/`messageHtmlToComponent`/`at_mention.jsx`) do not provide an explicit channel Id and instead Profile Popover was responsible for getting it's own channelId via `selectedPost.channel_id` or `getCurrentChannelId`.

This PR restores that auto channelId retrieval, fixing regression [MM-34553](https://mattermost.atlassian.net/browse/MM-34553)

Previous implementation: https://github.com/mattermost/mattermost-webapp/blob/cb98b4f9488ed537861d502b53ac8d70dab5f169/components/profile_popover/index.js#L41-L48

#### Ticket Link

- https://mattermost.atlassian.net/browse/MM-34553

#### Screenshots
<img width="279" alt="CleanShot 2021-03-31 at 21 45 15@2x" src="https://user-images.githubusercontent.com/11724372/113237915-5cbe5480-926d-11eb-8034-00f3a64ea0a4.png">
<img width="284" alt="CleanShot 2021-03-31 at 21 44 32@2x" src="https://user-images.githubusercontent.com/11724372/113237919-60ea7200-926d-11eb-8951-79acb76f02e0.png">
