### PR TITLE
[MM-34346] Migrate 'components/toast' and associated tests to TypeScript

### DIFF
--- a/components/channel_header/__snapshots__/channel_header.test.jsx.snap
+++ b/components/channel_header/__snapshots__/channel_header.test.jsx.snap
@@ -159,7 +159,7 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
         </div>
       </div>
     </div>
-    <Connect(ChannelHeaderPlug)
+    <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
           "delete_at": 0,
@@ -1156,7 +1156,7 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
         </div>
       </div>
     </div>
-    <Connect(ChannelHeaderPlug)
+    <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
           "delete_at": 0,

--- a/components/toast/__snapshots__/toast.test.tsx.snap
+++ b/components/toast/__snapshots__/toast.test.tsx.snap
@@ -239,7 +239,6 @@ exports[`components/Toast should match snapshot to not have actions 1`] = `
 >
   <div
     className="toast__message"
-    onClick={null}
   >
     <span>
       child

--- a/components/toast/toast.test.tsx
+++ b/components/toast/toast.test.tsx
@@ -3,15 +3,15 @@
 
 import React from 'react';
 
-import {shallow} from 'enzyme';
+import {shallow, ReactWrapper} from 'enzyme';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
-import * as Utils from 'utils/utils.jsx';
+import * as Utils from 'utils/utils';
 
-import Toast from './toast.jsx';
+import Toast, {Props} from './toast';
 
 describe('components/Toast', () => {
-    const defaultProps = {
+    const defaultProps: Props = {
         onClick: jest.fn(),
         show: true,
         showActions: true,
@@ -20,23 +20,23 @@ describe('components/Toast', () => {
     };
 
     test('should match snapshot for showing toast', () => {
-        const wrapper = shallow(<Toast {...defaultProps}><span>{'child'}</span></Toast>);
+        const wrapper = shallow<Toast>(<Toast {...defaultProps}><span>{'child'}</span></Toast>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for hiding toast', () => {
-        const wrapper = shallow(<Toast {...{...defaultProps, show: false}}><span>{'child'}</span></Toast>);
+        const wrapper = shallow<Toast>(<Toast {...{...defaultProps, show: false}}><span>{'child'}</span></Toast>);
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find('.toast__visible').length).toBe(0);
     });
 
     test('should match snapshot for toast width less than 780px', () => {
-        const wrapper = shallow(<Toast {...{...defaultProps, width: 779}}><span>{'child'}</span></Toast>);
+        const wrapper = shallow<Toast>(<Toast {...{...defaultProps, width: 779}}><span>{'child'}</span></Toast>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot to not have actions', () => {
-        const wrapper = shallow(<Toast {...{...defaultProps, showActions: false}}><span>{'child'}</span></Toast>);
+        const wrapper = shallow<Toast>(<Toast {...{...defaultProps, showActions: false}}><span>{'child'}</span></Toast>);
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find('.toast__pointer').length).toBe(0);
     });
@@ -44,15 +44,17 @@ describe('components/Toast', () => {
     test('should dismiss', () => {
         defaultProps.onDismiss = jest.fn();
 
-        const wrapper = mountWithIntl(<Toast {... defaultProps}><span>{'child'}</span></Toast>);
+        const wrapper: ReactWrapper<any, any, React.Component> = mountWithIntl(<Toast {... defaultProps}><span>{'child'}</span></Toast>);
         const toast = wrapper.find(Toast).instance();
 
-        toast.handleDismiss();
+        if (toast instanceof Toast) {
+            toast.handleDismiss();
+        }
         expect(defaultProps.onDismiss).toHaveBeenCalledTimes(1);
     });
 
     test('should match snapshot to have extraClasses', () => {
-        const wrapper = shallow(<Toast {...{...defaultProps, extraClasses: 'extraClasses'}}><span>{'child'}</span></Toast>);
+        const wrapper = shallow<Toast>(<Toast {...{...defaultProps, extraClasses: 'extraClasses'}}><span>{'child'}</span></Toast>);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/components/toast/toast.tsx
+++ b/components/toast/toast.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, {ReactNode, MouseEventHandler} from 'react';
 
 import {FormattedMessage} from 'react-intl';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
@@ -13,17 +12,19 @@ import Constants from 'utils/constants';
 
 import './toast.scss';
 
-export default class Toast extends React.PureComponent {
-    static propTypes = {
-        onClick: PropTypes.func,
-        onClickMessage: PropTypes.string,
-        onDismiss: PropTypes.func,
-        children: PropTypes.element,
-        show: PropTypes.bool.isRequired,
-        showActions: PropTypes.bool, //used for showing jump actions
-        width: PropTypes.number,
-        extraClasses: PropTypes.string,
-    }
+export type Props = {
+    onClick?: MouseEventHandler<HTMLDivElement>;
+    onClickMessage?: string;
+    onDismiss?: () => void;
+    children?: ReactNode;
+    show: boolean;
+    showActions?: boolean; //used for showing jump actions
+    width: number;
+    extraClasses?: string;
+}
+
+export default class Toast extends React.PureComponent<Props> {
+    private mounted!: boolean;
 
     componentDidMount() {
         this.mounted = true;
@@ -88,7 +89,7 @@ export default class Toast extends React.PureComponent {
             <div className={toastClass}>
                 <div
                     className={toastActionClass}
-                    onClick={showActions ? this.props.onClick : null}
+                    onClick={showActions ? this.props.onClick : undefined}
                 >
                     {showActions && jumpSection()}
                     {this.props.children}


### PR DESCRIPTION
#### Summary
Migrates 'components/toast' and associated tests to TypeScript

#### Ticket Link
Fixes [#17227](https://github.com/mattermost/mattermost-server/issues/17277)
JIRA ticket: [MM-34346](https://mattermost.atlassian.net/browse/MM-34346)