### PR TITLE
Fix emoticons not being case indepent

### DIFF
--- a/components/suggestion/emoticon_provider.jsx
+++ b/components/suggestion/emoticon_provider.jsx
@@ -60,7 +60,7 @@ export default class EmoticonProvider extends Provider {
     }
     handlePretextChanged(pretext, resultsCallback) {
         // Look for the potential emoticons at the start of the text, after whitespace, and at the start of emoji reaction commands
-        const captured = (/(^|\s|^\+|^-)(:([^:\s]*))$/g).exec(pretext);
+        const captured = (/(^|\s|^\+|^-)(:([^:\s]*))$/g).exec(pretext.toLowerCase());
         if (!captured) {
             return false;
         }


### PR DESCRIPTION
#### Summary
Lowercase pretext to ensure case independency

#### Ticket Link
None
