### PR TITLE
[MM-34491] Respect slash command root label

### DIFF
--- a/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
@@ -595,8 +595,9 @@ export class AppCommandParser {
         const result: AutocompleteSuggestion[] = [];
 
         const bindings = this.getCommandBindings();
+
         for (const binding of bindings) {
-            let base = binding.app_id;
+            let base = binding.label;
             if (!base) {
                 continue;
             }
@@ -604,10 +605,11 @@ export class AppCommandParser {
             if (base[0] !== '/') {
                 base = '/' + base;
             }
+
             if (base.startsWith(command)) {
                 result.push({
+                    Complete: binding.label,
                     Suggestion: base,
-                    Complete: base.substring(1),
                     Description: binding.description || '',
                     Hint: binding.hint || '',
                     IconData: binding.icon || '',
@@ -811,7 +813,7 @@ export class AppCommandParser {
     isAppCommand = (pretext: string): boolean => {
         const command = pretext.toLowerCase();
         for (const binding of this.getCommandBindings()) {
-            let base = binding.app_id;
+            let base = binding.label;
             if (!base) {
                 continue;
             }


### PR DESCRIPTION
#### Summary
Instead of using the appID as the root command trigger, respect the label send by the app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34491

#### Related Pull Requests
- Has Apps plugin changes: https://github.com/mattermost/mattermost-plugin-apps/pull/131
- Has mobile changes: https://github.com/mattermost/mattermost-mobile/pull/5278