### PR TITLE
[MM-34580] - Truncate image name when text is too long

### DIFF
--- a/components/single_image_view/__snapshots__/single_image_view.test.tsx.snap
+++ b/components/single_image_view/__snapshots__/single_image_view.test.tsx.snap
@@ -8,13 +8,17 @@ exports[`components/SingleImageView should match snapshot 1`] = `
     className="file__image"
   >
     <div
-      className="image-name"
-      data-testid="image-name"
+      className="image-header"
     >
       <div
-        onClick={[Function]}
+        className="image-name"
+        data-testid="image-name"
       >
-        name
+        <div
+          onClick={[Function]}
+        >
+          name
+        </div>
       </div>
       <button
         aria-label="Toggle Embed Visibility"
@@ -77,13 +81,17 @@ exports[`components/SingleImageView should match snapshot 2`] = `
     className="file__image"
   >
     <div
-      className="image-name"
-      data-testid="image-name"
+      className="image-header"
     >
       <div
-        onClick={[Function]}
+        className="image-name"
+        data-testid="image-name"
       >
-        name
+        <div
+          onClick={[Function]}
+        >
+          name
+        </div>
       </div>
       <button
         aria-label="Toggle Embed Visibility"
@@ -170,13 +178,17 @@ exports[`components/SingleImageView should match snapshot, SVG image 1`] = `
     className="file__image"
   >
     <div
-      className="image-name"
-      data-testid="image-name"
+      className="image-header"
     >
       <div
-        onClick={[Function]}
+        className="image-name"
+        data-testid="image-name"
       >
-        name_svg
+        <div
+          onClick={[Function]}
+        >
+          name_svg
+        </div>
       </div>
       <button
         aria-label="Toggle Embed Visibility"
@@ -243,13 +255,17 @@ exports[`components/SingleImageView should match snapshot, SVG image 2`] = `
     className="file__image"
   >
     <div
-      className="image-name"
-      data-testid="image-name"
+      className="image-header"
     >
       <div
-        onClick={[Function]}
+        className="image-name"
+        data-testid="image-name"
       >
-        name_svg
+        <div
+          onClick={[Function]}
+        >
+          name_svg
+        </div>
       </div>
       <button
         aria-label="Toggle Embed Visibility"
@@ -340,13 +356,17 @@ exports[`components/SingleImageView should set loaded state on callback of onIma
     className="file__image"
   >
     <div
-      className="image-name"
-      data-testid="image-name"
+      className="image-header"
     >
       <div
-        onClick={[Function]}
+        className="image-name"
+        data-testid="image-name"
       >
-        name
+        <div
+          onClick={[Function]}
+        >
+          name
+        </div>
       </div>
       <button
         aria-label="Toggle Embed Visibility"

--- a/components/single_image_view/single_image_view.tsx
+++ b/components/single_image_view/single_image_view.tsx
@@ -144,14 +144,16 @@ export default class SingleImageView extends React.PureComponent<Props, State> {
         }
 
         const fileHeader = (
-            <div
-                data-testid='image-name'
-                className={imageNameClass}
-            >
+            <div className='image-header'>
                 <div
-                    onClick={this.handleImageClick}
+                    data-testid='image-name'
+                    className={imageNameClass}
                 >
-                    {fileInfo.name}
+                    <div
+                        onClick={this.handleImageClick}
+                    >
+                        {fileInfo.name}
+                    </div>
                 </div>
                 {toggle}
             </div>

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -148,6 +148,11 @@
     .file__image {
         @include legacy-pie-clearfix;
 
+        .image-header {
+            display: flex;
+            align-items: baseline;
+        }
+
         .image-name {
             cursor: pointer;
             font-size: 12px;


### PR DESCRIPTION
#### Summary
Fixes long file names not being truncated and expand/collapse chevron being hidden

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34580

#### Screenshots
Long file name: 
<img width="545" alt="Screenshot 2021-04-07 at 15 28 15" src="https://user-images.githubusercontent.com/16692883/113835262-034aae00-97b6-11eb-93e6-8cd43d97c929.png">

Short file name: 
<img width="574" alt="Screenshot 2021-04-07 at 15 28 22" src="https://user-images.githubusercontent.com/16692883/113835271-06de3500-97b6-11eb-9e1b-2a216c8ad48a.png">
