### PR TITLE
Cypress/E2E: Fix MM-T1635 Channel listing is displayed correctly with proper team name

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/settings_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/settings_spec.js
@@ -87,8 +87,7 @@ describe('Settings', () => {
         // # Get the team name
         cy.get('#channels .DataGrid .DataGrid_rows > :nth-child(1)').
             within(() => {
-                cy.get('.DataGrid_cell').
-                    contains('Team').
+                cy.get('.DataGrid_cell:nth-of-type(2)').
                     invoke('text').
                     then((name) => {
                         teamName = name;


### PR DESCRIPTION
#### Summary
- Fixed team name selector

#### Ticket Link
NA

![Screen Shot 2021-04-07 at 8 31 18 AM](https://user-images.githubusercontent.com/487991/113893461-e7c2b180-977b-11eb-96ae-c67c02d42360.png)
