### PR TITLE
Cypress/E2E: Fix MM-T1665_1 Deactivated user is not shown in Direct Messages modal when no previous conversation

### DIFF
--- a/e2e/cypress/integration/messaging/dm_list_of_users_spec.js
+++ b/e2e/cypress/integration/messaging/dm_list_of_users_spec.js
@@ -42,7 +42,7 @@ describe('Messaging', () => {
 
             // # Search for the deactivated user
             cy.findByRole('dialog', {name: 'Direct Messages'}).should('be.visible').wait(TIMEOUTS.ONE_SEC);
-            cy.findByRole('textbox', {name: 'Search for people'}).should('have.focused').type(deactivatedUser.email);
+            cy.findByRole('textbox', {name: 'Search for people'}).click({force: true}).type(deactivatedUser.email);
 
             // * Verify that the inactive user is not found
             cy.get('.no-channel-message').should('be.visible').and('contain', 'No results found matching');


### PR DESCRIPTION
#### Summary
- Fixed clicking on search box

#### Ticket Link
NA

![Screen Shot 2021-04-07 at 8 55 43 AM](https://user-images.githubusercontent.com/487991/113896726-0eceb280-977f-11eb-9c49-6d11c2171326.png)

