### PR TITLE
MM-34502 Fix help text being invisible for empty gif picker

### DIFF
--- a/components/gif_picker/components/SearchGrid/SearchGrid.scss
+++ b/components/gif_picker/components/SearchGrid/SearchGrid.scss
@@ -2,7 +2,6 @@
   position: relative;
   width: 100%;
   margin: 0 auto;
-  font-size: 0;
   overflow-x: hidden;
   height: 336px;
 }


### PR DESCRIPTION
The placeholder added in #7501 was missing its help text because the entire search results component for the gif picker had font-size set to 0. The "No results" line was still visible because it had its own font size set, but the help text was invisible because of that.

I don't think setting a font size for the rest of that component seems to have an effect. I can't find anything in the original PR relating to that line, so I think it might've been left over code.
![Screen Shot 2021-04-08 at 11 48 26 AM](https://user-images.githubusercontent.com/3277310/114057238-642ec080-9860-11eb-9f02-b1912177ae9d.png)
![Screen Shot 2021-04-08 at 11 48 34 AM](https://user-images.githubusercontent.com/3277310/114057246-65f88400-9860-11eb-9004-823bb0fde8a8.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34502

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/7501