### PR TITLE
MM-34699-fix oauth check in admin_definition

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -178,7 +178,7 @@ export const it = {
     stateIsFalse: (key) => (config, state) => !state[key],
     configIsTrue: (group, setting) => (config) => Boolean(config[group][setting]),
     configIsFalse: (group, setting) => (config) => !config[group][setting],
-    configContains: (group, setting, word) => (config) => Boolean(config[group][setting].includes(word)),
+    configContains: (group, setting, word) => (config) => Boolean(config[group][setting]?.includes(word)),
     enterpriseReady: (config, state, license, enterpriseReady) => enterpriseReady,
     licensed: (config, state, license) => license.IsLicensed === 'true',
     licensedForFeature: (feature) => (config, state, license) => license.IsLicensed && license[feature] === 'true',
@@ -195,7 +195,7 @@ export const it = {
 };
 
 const usesLegacyOauth = (config, state, license, enterpriseReady, consoleAccess, cloud) => {
-    if (!config.GITLAB_SERVICE || !config.GOOGLE_SERVICE || !config.OFFICE365_SERVICE) {
+    if (!config.GitLabSettings || !config.GoogleSettings || !config.Office365Settings) {
         return false;
     }
 

--- a/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
+++ b/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
@@ -1904,6 +1904,25 @@ exports[`components/AdminSidebar should match snapshot, with license (with all f
               }
             />
             <AdminSidebarSection
+              definitionKey="authentication.oauth"
+              key="authentication.oauth"
+              name="authentication/oauth"
+              parentLink=""
+              subsection={false}
+              tag={
+                <FormattedMessage
+                  defaultMessage="deprecated"
+                  id="admin.sidebar.oauth.tag"
+                />
+              }
+              title={
+                <FormattedMessage
+                  defaultMessage="OAuth 2.0"
+                  id="admin.sidebar.oauth"
+                />
+              }
+            />
+            <AdminSidebarSection
               definitionKey="authentication.openid"
               key="authentication.openid"
               name="authentication/openid"


### PR DESCRIPTION
#### Summary
OAuth is no longer being displayed on the System Console sidebar when it should be, even with System Admin. The wrong Config Group was being checked. This was added to handle a system role that did not contain that permission. This PR checks for the correct Groups and also checks the Setting for null.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34699

#### Screenshots
![Screen Shot 2021-04-08 at 11 51 13 AM](https://user-images.githubusercontent.com/12704875/114073639-bd96ef80-9860-11eb-9e0b-cabd8243ca82.png)
