### PR TITLE
Cypress/E2E: Fix reporting and save environment details to dashboard

### DIFF
--- a/e2e/generate_test_cycle.js
+++ b/e2e/generate_test_cycle.js
@@ -49,35 +49,19 @@
 
 const os = require('os');
 const chalk = require('chalk');
-const axios = require('axios');
 
+const {createAndStartCycle} = require('./utils/dashboard');
 const {getSortedTestFiles} = require('./utils/file');
 
 require('dotenv').config();
 
 const {
-    AUTOMATION_DASHBOARD_URL,
-    AUTOMATION_DASHBOARD_TOKEN,
     BRANCH,
     BROWSER,
     BUILD_ID,
     HEADLESS,
     REPO,
 } = process.env;
-
-async function createAndStartCycle(data) {
-    const response = await axios({
-        url: `${AUTOMATION_DASHBOARD_URL}/cycles/start`,
-        headers: {
-            Authorization: `Bearer ${AUTOMATION_DASHBOARD_TOKEN}`,
-        },
-        method: 'post',
-        timeout: 10000,
-        data,
-    });
-
-    return response.data;
-}
 
 async function main() {
     const browser = BROWSER || 'chrome';

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -5635,36 +5635,6 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
-    "reportportal-client": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/reportportal-client/-/reportportal-client-5.5.0.tgz",
-      "integrity": "sha512-VtzdJbYkm15l0A1XVVviWJZKhaYdIAZim682lQEew7wBg5RsOna/ZsePGb3MLCuNZVBv2GNnldzCNW6B4cbKTg==",
-      "dev": true,
-      "requires": {
-        "axios": "^0.18.1",
-        "axios-retry": "^3.1.2",
-        "glob": "^7.1.4",
-        "uniqid": "^5.0.3"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.18.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
-      }
-    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -6762,12 +6732,6 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
-    },
-    "uniqid": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.2.0.tgz",
-      "integrity": "sha512-LH8zsvwJ/GL6YtNfSOmMCrI9piraAUjBfw2MCvleNE6a4pVKJwXjG2+HWhkVeFcSg+nmaPKbMrMOoxwQluZ1Mg==",
-      "dev": true
     },
     "universalify": {
       "version": "2.0.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -39,7 +39,6 @@
     "path": "0.12.7",
     "pg": "8.5.1",
     "recursive-readdir": "2.2.2",
-    "reportportal-client": "5.5.0",
     "shelljs": "0.8.4",
     "start-server-and-test": "1.12.1",
     "uuid": "8.3.2",

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -135,13 +135,13 @@ async function runTests() {
         // Write test environment details once only
         if (i === 0) {
             const environment = {
-                cypressVersion: result.cypressVersion,
-                browserName: result.browserName,
-                browserVersion: result.browserVersion,
+                cypress_version: result.cypressVersion,
+                browser_name: result.browserName,
+                browser_version: result.browserVersion,
                 headless,
-                osName: result.osName,
-                osVersion: result.osVersion,
-                nodeVersion: process.version,
+                os_name: result.osName,
+                os_version: result.osVersion,
+                node_version: process.version,
             };
 
             writeJsonToFile(environment, 'environment.json', RESULTS_DIR);

--- a/e2e/save_report.js
+++ b/e2e/save_report.js
@@ -12,8 +12,6 @@
  * Environment variables:
  *   For saving artifacts to AWS S3
  *      - AWS_S3_BUCKET, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
- *   For saving reports to Automation dashboard
- *      - DASHBOARD_ENABLE, DASHBOARD_ENDPOINT and DASHBOARD_TOKEN
  *   For saving test cases to Test Management
  *      - TM4J_ENABLE=true|false
  *      - TM4J_API_KEY=[api_key]
@@ -40,7 +38,6 @@ const {
 } = require('./utils/report');
 const {saveArtifacts} = require('./utils/artifacts');
 const {MOCHAWESOME_REPORT_DIR, RESULTS_DIR} = require('./utils/constants');
-const {saveDashboard} = require('./utils/dashboard');
 const {createTestCycle, createTestExecutions} = require('./utils/test_cases');
 
 require('dotenv').config();
@@ -50,7 +47,6 @@ const saveReport = async () => {
         BRANCH,
         BUILD_ID,
         BUILD_TAG,
-        DASHBOARD_ENABLE,
         DIAGNOSTIC_WEBHOOK_URL,
         DIAGNOSTIC_USER_ID,
         DIAGNOSTIC_TEAM_ID,
@@ -105,11 +101,6 @@ const saveReport = async () => {
     if (TYPE === 'RELEASE' && DIAGNOSTIC_WEBHOOK_URL && DIAGNOSTIC_USER_ID && DIAGNOSTIC_TEAM_ID) {
         const data = generateDiagnosticReport(summary, {userId: DIAGNOSTIC_USER_ID, teamId: DIAGNOSTIC_TEAM_ID});
         await sendReport('test info for diagnostic analysis', DIAGNOSTIC_WEBHOOK_URL, data);
-    }
-
-    // Save data to automation dashboard
-    if (DASHBOARD_ENABLE === 'true') {
-        await saveDashboard(jsonReport, BRANCH);
     }
 
     // Save test cases to Test Management

--- a/e2e/utils/dashboard.js
+++ b/e2e/utils/dashboard.js
@@ -5,118 +5,118 @@
 
 /*
  * Environment:
- *   DASHBOARD_ENDPOINT=[url]
- *   DASHBOARD_TOKEN=[token]
+ *   AUTOMATION_DASHBOARD_URL=[url]
+ *   AUTOMATION_DASHBOARD_TOKEN=[token]
  */
 
-const RPClient = require('reportportal-client');
+const axios = require('axios');
+const axiosRetry = require('axios-retry');
+const chalk = require('chalk');
 
-const {getAllTests} = require('./report');
+require('dotenv').config();
+axiosRetry(axios, {
+    retries: 5,
+    retryDelay: axiosRetry.exponentialDelay,
+});
 
-// See reference: https://github.com/reportportal/client-javascript#starttestitem
-const testItemTypes = {
-    SUITE: 'SUITE',
-    TEST: 'TEST',
-};
+const {
+    AUTOMATION_DASHBOARD_URL,
+    AUTOMATION_DASHBOARD_TOKEN,
+} = process.env;
 
-// See reference: https://github.com/reportportal/client-javascript#finishtestitem
-const testItemStatus = {
-    PASSED: 'PASSED',
-    FAILED: 'FAILED',
-    SKIPPED: 'SKIPPED',
-};
+const connectionErrors = ['ECONNABORTED', 'ECONNREFUSED'];
 
-function saveDashboard(report, branch) {
-    const {
-        DASHBOARD_ENDPOINT,
-        DASHBOARD_TOKEN,
-    } = process.env;
-
-    const reporterOptions = {
-        endpoint: DASHBOARD_ENDPOINT,
-        token: DASHBOARD_TOKEN,
-        project: 'Webapp',
-        description: 'Mattermost UI Automation with Cypress',
-    };
-
-    const rpClient = new RPClient(reporterOptions);
-
-    rpClient.checkConnect().then(() => {
-        console.log('You have successfully connected to the automation dashboard server.');
-    }, (error) => {
-        console.log('Error connecting to automation dashboard server');
-        console.dir(error);
+async function createAndStartCycle(data) {
+    const response = await axios({
+        url: `${AUTOMATION_DASHBOARD_URL}/cycles/start`,
+        headers: {
+            Authorization: `Bearer ${AUTOMATION_DASHBOARD_TOKEN}`,
+        },
+        method: 'post',
+        timeout: 10000,
+        data,
     });
 
-    // Start Launch
-    const launchObj = rpClient.startLaunch({
-        name: `Cypress Test ${branch} branch`,
-        startTime: report.stats.start,
-        description: `Cypress test report with ${branch} branch`,
-    });
-
-    const startDate = new Date(report.stats.start);
-    let startTime = 0;
-
-    // Save each Suite and Test
-    report.results.forEach((suite, index) => {
-        if (index === 0) {
-            startTime = startDate.getTime();
-        }
-
-        const suiteData = {
-            description: suite.fullFile,
-            name: suite.suites[0].title,
-            startTime,
-            type: testItemTypes.SUITE,
-        };
-
-        const suiteObj = rpClient.startTestItem(suiteData, launchObj.tempId);
-        const tests = getAllTests(suite.suites);
-        tests.forEach((test) => {
-            let status;
-            if (test.pass) {
-                status = testItemStatus.PASSED;
-            } else if (test.fail) {
-                status = testItemStatus.FAILED;
-            } else {
-                status = testItemStatus.SKIPPED;
-            }
-
-            const testData = {
-                description: test.title + (test.fail ? test.err.estack : ''),
-                name: test.fullTitle,
-                startTime,
-                type: testItemTypes.TEST,
-            };
-
-            const itemObj = rpClient.startTestItem(testData, launchObj.tempId, suiteObj.tempId);
-            startTime += test.duration;
-            rpClient.finishTestItem(itemObj.tempId, {
-                status,
-                endTime: startTime,
-            });
-
-            if (test.fail) {
-                rpClient.sendLog(itemObj.tempId, {
-                    level: 'INFO',
-                    message: test.err.message,
-                    time: startTime,
-                });
-            }
-        });
-
-        rpClient.finishTestItem(suiteObj.tempId, {endTime: startTime});
-    });
-
-    const finished = rpClient.finishLaunch(launchObj.tempId, {endTime: startTime});
-    return finished.promise.then(() => {
-        console.log('Successfully sent automation dashboard data.');
-        return {success: true};
-    }, (error) => {
-        console.log('Encountered error while sending automation dashboard data.', error);
-        return {error};
-    });
+    return response.data;
 }
 
-module.exports = {saveDashboard};
+async function getSpecToTest({repo, branch, build, server}) {
+    try {
+        const response = await axios({
+            url: `${AUTOMATION_DASHBOARD_URL}/executions/specs/start?repo=${repo}&branch=${branch}&build=${build}`,
+            headers: {
+                Authorization: `Bearer ${AUTOMATION_DASHBOARD_TOKEN}`,
+            },
+            method: 'post',
+            timeout: 10000,
+            data: {server},
+        });
+
+        return response.data;
+    } catch (err) {
+        console.log(chalk.red('Failed to get spec to test'));
+        if (connectionErrors.includes(err.code) || !err.response) {
+            console.log(chalk.red(`Error code: ${err.code}`));
+            return {code: err.code};
+        }
+
+        return err.response && err.response.data;
+    }
+}
+
+async function recordSpecResult(specId, spec, tests) {
+    try {
+        const response = await axios({
+            url: `${AUTOMATION_DASHBOARD_URL}/executions/specs/end?id=${specId}`,
+            headers: {
+                Authorization: `Bearer ${AUTOMATION_DASHBOARD_TOKEN}`,
+            },
+            method: 'post',
+            timeout: 10000,
+            data: {spec, tests},
+        });
+
+        console.log(chalk.green('Successfully recorded!'));
+        return response.data;
+    } catch (err) {
+        console.log(chalk.red('Failed to record spec result'));
+        if (connectionErrors.includes(err.code) || !err.response) {
+            console.log(chalk.red(`Error code: ${err.code}`));
+            return {code: err.code};
+        }
+
+        return err.response && err.response.data;
+    }
+}
+
+async function updateCycle(id, cyclePatch) {
+    try {
+        const response = await axios({
+            url: `${AUTOMATION_DASHBOARD_URL}/cycles/${id}`,
+            headers: {
+                Authorization: `Bearer ${AUTOMATION_DASHBOARD_TOKEN}`,
+            },
+            method: 'put',
+            timeout: 10000,
+            data: cyclePatch,
+        });
+
+        console.log(chalk.green('Successfully updated the cycle with test environment data!'));
+        return response.data;
+    } catch (err) {
+        console.log(chalk.red('Failed to update cycle'));
+        if (connectionErrors.includes(err.code) || !err.response) {
+            console.log(chalk.red(`Error code: ${err.code}`));
+            return {code: err.code};
+        }
+
+        return err.response && err.response.data;
+    }
+}
+
+module.exports = {
+    createAndStartCycle,
+    getSpecToTest,
+    recordSpecResult,
+    updateCycle,
+};

--- a/e2e/utils/report.js
+++ b/e2e/utils/report.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable no-console */
+/* eslint-disable no-console, camelcase */
 
 const axios = require('axios');
 const fse = require('fs-extra');
@@ -111,13 +111,13 @@ function generateTestReport(summary, isUploadedToS3, reportLink, environment, te
     } = process.env;
     const {statsFieldValue, stats} = summary;
     const {
-        cypressVersion,
-        browserName,
-        browserVersion,
+        cypress_version,
+        browser_name,
+        browser_version,
         headless,
-        osName,
-        osVersion,
-        nodeVersion,
+        os_name,
+        os_version,
+        node_version,
     } = environment;
 
     let testResult;
@@ -129,7 +129,7 @@ function generateTestReport(summary, isUploadedToS3, reportLink, environment, te
     }
 
     const title = generateTitle();
-    const envValue = `cypress@${cypressVersion} | node@${nodeVersion} | ${browserName}@${browserVersion}${headless ? ' (headless)' : ''} | ${osName}@${osVersion}`;
+    const envValue = `cypress@${cypress_version} | node@${node_version} | ${browser_name}@${browser_version}${headless ? ' (headless)' : ''} | ${os_name}@${os_version}`;
 
     if (FULL_REPORT === 'true') {
         let reportField;


### PR DESCRIPTION
#### Summary
- Fix reporting and save environment details to dashboard (see latest test run in automation channel)
- Save environment details to dashboard (see attached screenshot)

Others:
- replace dashboard logic from old dashboard (using reportportal) to the new one.

#### Ticket Link
none, getting `undefined` in daily Cypress run instead of the test environment data


#### Screenshots
![Screen Shot 2021-04-12 at 10 38 35 PM](https://user-images.githubusercontent.com/5334504/114413888-f4faf880-9be0-11eb-8850-2b0305f039c6.png)
