### PR TITLE
Cypress/E2E: Update tests and keys of search date filters

### DIFF
--- a/e2e/cypress/integration/search_filter/after_spec.js
+++ b/e2e/cypress/integration/search_filter/after_spec.js
@@ -18,7 +18,7 @@ import {
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - after', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
@@ -34,23 +34,26 @@ describe('SF15699 Search Date Filter - after', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });
 
-    it('omits results before and on target date', () => {
+    it('MM-T587 after: omits results before and on target date', () => {
         searchAndValidate(`after:${firstDateEarly.query} ${commonText}`, [todayMessage, secondOffTopicMessage, secondMessage]);
     });
 
-    it('can be used in conjunction with "in:"', () => {
+    it('MM-T592_1 after: can be used in conjunction with in:', () => {
         searchAndValidate(`after:${firstDateEarly.query} in:town-square ${commonText}`, [todayMessage, secondMessage]);
     });
 
-    it('can be used in conjunction with "from:"', () => {
+    it('MM-T592_2 after: can be used in conjunction with from:', () => {
         searchAndValidate(`after:${firstDateEarly.query} from:${anotherAdmin.username} ${commonText}`, [secondOffTopicMessage]);
     });
 
-    it('using a date from the future shows no results', () => {
-        searchAndValidate(`after:2099-7-15 ${commonText}`);
+    it('MM-T592_3 after: re-add "in:" in conjunction with "from:"', () => {
+        searchAndValidate(`after:${firstDateEarly.query} in:town-square ${commonText} from:${anotherAdmin.username} ${commonText}`);
     });
 });

--- a/e2e/cypress/integration/search_filter/before_spec.js
+++ b/e2e/cypress/integration/search_filter/before_spec.js
@@ -18,11 +18,10 @@ import {
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - before', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
-        allMessagesInOrder,
         secondDateEarly,
         firstMessage,
         firstOffTopicMessage,
@@ -34,23 +33,26 @@ describe('SF15699 Search Date Filter - before', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });
 
-    it('omits results on and after target date', () => {
+    it('MM-T586 before: omits results on and after target date', () => {
         searchAndValidate(`before:${secondDateEarly.query} ${commonText}`, [firstOffTopicMessage, firstMessage]);
     });
 
-    it('can be used in conjunction with "in:"', () => {
-        searchAndValidate(`before:${secondDateEarly.query} in:town-square ${commonText}`, [firstMessage]);
+    it('MM-T591_1 before: can be used in conjunction with "in:"', () => {
+        searchAndValidate(`before:${secondDateEarly.query} in:off-topic ${commonText}`, [firstOffTopicMessage]);
     });
 
-    it('can be used in conjunction with "from:"', () => {
+    it('MM-T591_2 before: can be used in conjunction with "from:"', () => {
         searchAndValidate(`before:${secondDateEarly.query} from:${anotherAdmin.username} ${commonText}`, [firstMessage]);
     });
 
-    it('using a date from the future shows results', () => {
-        searchAndValidate(`before:2099-7-15 ${commonText}`, allMessagesInOrder);
+    it('MM-T591_3 before: re-add "in:" in conjunction with "from:"', () => {
+        searchAndValidate(`before:${secondDateEarly.query} in:off-topic from:${anotherAdmin.username} ${commonText}`);
     });
 });

--- a/e2e/cypress/integration/search_filter/edit_spec.js
+++ b/e2e/cypress/integration/search_filter/edit_spec.js
@@ -19,25 +19,25 @@ import {
     setupTestData,
 } from './helpers';
 
-function changeTimezone(timezone) {
-    cy.apiPatchMe({timezone: {automaticTimezone: '', manualTimezone: timezone, useAutomaticTimezone: 'false'}});
-}
-
-describe('SF15699 Search Date Filter - edit', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const admin = getAdminAccount();
-
+    let teamName;
     let anotherAdmin;
 
     before(() => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
+            teamName = team.name;
+
+            // # Visit town-square
+            cy.visit(`/${teamName}/channels/town-square`);
 
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });
 
-    it('with calendar picker and results update', () => {
+    it('MM-T599 Edit date and search again', () => {
         // # Create expected data
         const targetMessage = 'calendarUpdate' + Date.now();
         const targetDate = getMsAndQueryForDate(Date.UTC(2019, 0, 15, 9, 30));
@@ -47,9 +47,9 @@ describe('SF15699 Search Date Filter - edit', () => {
             cy.postMessageAs({sender: admin, message: targetMessage, channelId, createAt: targetDate.ms});
         });
 
-        // # Set clock to custom date, reload page for it to take effect
+        // # Set clock to custom date and visit town-square like reloading a page to take effect
         cy.clock(targetDate.ms, ['Date']);
-        cy.reload();
+        cy.visit(`/${teamName}/channels/town-square`);
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Type on: into search field
@@ -80,7 +80,8 @@ describe('SF15699 Search Date Filter - edit', () => {
             find('.post-message').
             should('have.text', targetMessage);
 
-        cy.reload();
+        // # Visit town-square to reload a page
+        cy.visit(`/${teamName}/channels/town-square`);
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Back space right after the date to bring up date picker again
@@ -110,7 +111,7 @@ describe('SF15699 Search Date Filter - edit', () => {
         cy.findAllByTestId('search-item-container').should('have.length', 0);
     });
 
-    it('changing timezone changes day search results appears', () => {
+    it('MM-T595 Changing timezone changes day search results appears', () => {
         const identifier = 'timezone' + Date.now();
 
         const target = getMsAndQueryForDate(Date.UTC(2018, 9, 31, 23, 59));
@@ -132,3 +133,7 @@ describe('SF15699 Search Date Filter - edit', () => {
         searchAndValidate(`on:${target.query} ${identifier}`);
     });
 });
+
+function changeTimezone(timezone) {
+    cy.apiPatchMe({timezone: {automaticTimezone: '', manualTimezone: timezone, useAutomaticTimezone: 'false'}});
+}

--- a/e2e/cypress/integration/search_filter/future_date_spec.js
+++ b/e2e/cypress/integration/search_filter/future_date_spec.js
@@ -13,18 +13,16 @@
 import {getAdminAccount} from '../../support/env';
 
 import {
-    getTestMessages,
     searchAndValidate,
+    getTestMessages,
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - mixed', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
-        firstDateEarly,
-        secondMessage,
-        secondOffTopicMessage,
+        allMessagesInOrder,
     } = testData;
     const admin = getAdminAccount();
     let anotherAdmin;
@@ -40,11 +38,15 @@ describe('SF15699 Search Date Filter - mixed', () => {
         });
     });
 
-    it('"before:" and "after:" can be used together', () => {
-        searchAndValidate(`before:${Cypress.moment().format('YYYY-MM-DD')} after:${firstDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
+    it('MM-T605_1 before: using a date from the future shows results', () => {
+        searchAndValidate(`before:2099-7-15 ${commonText}`, allMessagesInOrder);
     });
 
-    it('"before:", "after:", "from:", and "in:" can be used in one search', () => {
-        searchAndValidate(`before:${Cypress.moment().format('YYYY-MM-DD')} after:${firstDateEarly.query} from:${anotherAdmin.username} in:off-topic ${commonText}`, [secondOffTopicMessage]);
+    it('MM-T605_2 on: using a date from the future shows no results', () => {
+        searchAndValidate(`on:2099-7-15 ${commonText}`);
+    });
+
+    it('MM-T605_3 after: using a date from the future shows no results', () => {
+        searchAndValidate(`after:2099-7-15 ${commonText}`);
     });
 });

--- a/e2e/cypress/integration/search_filter/helpers.js
+++ b/e2e/cypress/integration/search_filter/helpers.js
@@ -95,9 +95,6 @@ export function setupTestData(data, {team, admin, anotherAdmin}) {
     const baseUrl = Cypress.config('baseUrl');
     cy.externalRequest({user: admin, method: 'put', baseUrl, path: `users/${anotherAdmin.id}/roles`, data: {roles: 'system_user system_admin'}});
 
-    // # Visit town-square
-    cy.visit(`/${team.name}/channels/town-square`);
-
     // # Create a post from today
     cy.get('#postListContent', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible');
     cy.postMessage(todayMessage).wait(TIMEOUTS.ONE_SEC);

--- a/e2e/cypress/integration/search_filter/input_spec.js
+++ b/e2e/cypress/integration/search_filter/input_spec.js
@@ -34,6 +34,9 @@ describe('SF15699 Search Date Filter - input', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });

--- a/e2e/cypress/integration/search_filter/invalid_spec.js
+++ b/e2e/cypress/integration/search_filter/invalid_spec.js
@@ -28,6 +28,9 @@ describe('SF15699 Search Date Filter - invalid', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });

--- a/e2e/cypress/integration/search_filter/on_spec.js
+++ b/e2e/cypress/integration/search_filter/on_spec.js
@@ -19,7 +19,7 @@ import {
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - on', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
@@ -35,31 +35,38 @@ describe('SF15699 Search Date Filter - on', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });
 
-    it('omits results before and after target date', () => {
+    it('MM-T588 on: omits results before and after target date', () => {
         searchAndValidate(`on:${secondDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
     });
 
-    it('takes precedence over "after:" and "before:"', () => {
+    it('MM-T590_1 on: takes precedence over "before:"', () => {
         searchAndValidate(`before:${Cypress.moment().format('YYYY-MM-DD')} on:${secondDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
     });
 
-    it('takes precedence over "after:"', () => {
+    it('MM-T590_2 on: takes precedence over "after:"', () => {
         searchAndValidate(`after:${firstDateEarly.query} on:${secondDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
     });
 
-    it('can be used in conjunction with "in:"', () => {
+    it('MM-T3994_1 on: can be used in conjunction with "in:"', () => {
         searchAndValidate(`on:${secondDateEarly.query} in:town-square ${commonText}`, [secondMessage]);
     });
 
-    it('can be used in conjunction with "from:"', () => {
+    it('MM-T3994_2 on: can be used in conjunction with "from:"', () => {
         searchAndValidate(`on:${secondDateEarly.query} from:${anotherAdmin.username} ${commonText}`, [secondOffTopicMessage]);
     });
 
-    it('works from 12:00am to 11:59pm', () => {
+    it('MM-T3994_3 on: re-add "in:" in conjunction with "from:"', () => {
+        searchAndValidate(`on:${secondDateEarly.query} in:town-square from:${anotherAdmin.username} ${commonText}`);
+    });
+
+    it('MM-T604 Use "on:" to return only results from today', () => {
         // create posts on a day at 11:59 the previous day, 12:00am the main day, 11:59pm the main day, and 12:00 the next day
         const identifier = 'christmas' + Date.now();
 
@@ -81,9 +88,5 @@ describe('SF15699 Search Date Filter - on', () => {
 
         // * Verify we only see messages from the expected date, and not outside of it
         searchAndValidate(`on:${targetAM.query} ${identifier}`, [targetPMMessage, targetAMMessage]);
-    });
-
-    it('using a date from the future shows no results', () => {
-        searchAndValidate(`on:2099-7-15 ${commonText}`);
     });
 });


### PR DESCRIPTION
#### Summary
Update tests and keys of search date filters for the following test cases:

`"on:"`
- MM-T588
- MM-T590
- MM-T3994
- MM-T604

`"after:"`
- MM-T587
- MM-T592

`"before:"`
- MM-T586
- MM-T591

Edited
- MM-T599
- MM-T595

Future date
- MM-T605

#### Screenshots
![Screen Shot 2021-04-13 at 8 49 01 PM](https://user-images.githubusercontent.com/5334504/114554831-b4ab8100-9c99-11eb-907e-9b804d724938.png)
![Screen Shot 2021-04-13 at 8 34 13 PM](https://user-images.githubusercontent.com/5334504/114554183-03a4e680-9c99-11eb-8c34-cd27dfa8d6d8.png)
![Screen Shot 2021-04-13 at 8 35 40 PM](https://user-images.githubusercontent.com/5334504/114554186-043d7d00-9c99-11eb-9f62-abaa60ab6c40.png)
![Screen Shot 2021-04-13 at 8 47 15 PM](https://user-images.githubusercontent.com/5334504/114554591-7b731100-9c99-11eb-9a92-80e57c9c06d2.png)
![Screen Shot 2021-04-13 at 8 50 12 PM](https://user-images.githubusercontent.com/5334504/114554989-de64a800-9c99-11eb-8082-c16047088c4b.png)
