### PR TITLE
Cypress/E2E: Update tests and keys of search date filters (remaining)

### DIFF
--- a/e2e/cypress/integration/search_filter/after_spec.js
+++ b/e2e/cypress/integration/search_filter/after_spec.js
@@ -18,7 +18,7 @@ import {
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - after', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
@@ -34,23 +34,26 @@ describe('SF15699 Search Date Filter - after', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });
 
-    it('omits results before and on target date', () => {
+    it('MM-T587 after: omits results before and on target date', () => {
         searchAndValidate(`after:${firstDateEarly.query} ${commonText}`, [todayMessage, secondOffTopicMessage, secondMessage]);
     });
 
-    it('can be used in conjunction with "in:"', () => {
+    it('MM-T592_1 after: can be used in conjunction with in:', () => {
         searchAndValidate(`after:${firstDateEarly.query} in:town-square ${commonText}`, [todayMessage, secondMessage]);
     });
 
-    it('can be used in conjunction with "from:"', () => {
+    it('MM-T592_2 after: can be used in conjunction with from:', () => {
         searchAndValidate(`after:${firstDateEarly.query} from:${anotherAdmin.username} ${commonText}`, [secondOffTopicMessage]);
     });
 
-    it('using a date from the future shows no results', () => {
-        searchAndValidate(`after:2099-7-15 ${commonText}`);
+    it('MM-T592_3 after: re-add "in:" in conjunction with "from:"', () => {
+        searchAndValidate(`after:${firstDateEarly.query} in:town-square ${commonText} from:${anotherAdmin.username} ${commonText}`);
     });
 });

--- a/e2e/cypress/integration/search_filter/before_spec.js
+++ b/e2e/cypress/integration/search_filter/before_spec.js
@@ -18,11 +18,10 @@ import {
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - before', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
-        allMessagesInOrder,
         secondDateEarly,
         firstMessage,
         firstOffTopicMessage,
@@ -34,23 +33,26 @@ describe('SF15699 Search Date Filter - before', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });
 
-    it('omits results on and after target date', () => {
+    it('MM-T586 before: omits results on and after target date', () => {
         searchAndValidate(`before:${secondDateEarly.query} ${commonText}`, [firstOffTopicMessage, firstMessage]);
     });
 
-    it('can be used in conjunction with "in:"', () => {
-        searchAndValidate(`before:${secondDateEarly.query} in:town-square ${commonText}`, [firstMessage]);
+    it('MM-T591_1 before: can be used in conjunction with "in:"', () => {
+        searchAndValidate(`before:${secondDateEarly.query} in:off-topic ${commonText}`, [firstOffTopicMessage]);
     });
 
-    it('can be used in conjunction with "from:"', () => {
+    it('MM-T591_2 before: can be used in conjunction with "from:"', () => {
         searchAndValidate(`before:${secondDateEarly.query} from:${anotherAdmin.username} ${commonText}`, [firstMessage]);
     });
 
-    it('using a date from the future shows results', () => {
-        searchAndValidate(`before:2099-7-15 ${commonText}`, allMessagesInOrder);
+    it('MM-T591_3 before: re-add "in:" in conjunction with "from:"', () => {
+        searchAndValidate(`before:${secondDateEarly.query} in:off-topic from:${anotherAdmin.username} ${commonText}`);
     });
 });

--- a/e2e/cypress/integration/search_filter/edit_spec.js
+++ b/e2e/cypress/integration/search_filter/edit_spec.js
@@ -19,25 +19,25 @@ import {
     setupTestData,
 } from './helpers';
 
-function changeTimezone(timezone) {
-    cy.apiPatchMe({timezone: {automaticTimezone: '', manualTimezone: timezone, useAutomaticTimezone: 'false'}});
-}
-
-describe('SF15699 Search Date Filter - edit', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const admin = getAdminAccount();
-
+    let teamName;
     let anotherAdmin;
 
     before(() => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
+            teamName = team.name;
+
+            // # Visit town-square
+            cy.visit(`/${teamName}/channels/town-square`);
 
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });
 
-    it('with calendar picker and results update', () => {
+    it('MM-T599 Edit date and search again', () => {
         // # Create expected data
         const targetMessage = 'calendarUpdate' + Date.now();
         const targetDate = getMsAndQueryForDate(Date.UTC(2019, 0, 15, 9, 30));
@@ -47,9 +47,9 @@ describe('SF15699 Search Date Filter - edit', () => {
             cy.postMessageAs({sender: admin, message: targetMessage, channelId, createAt: targetDate.ms});
         });
 
-        // # Set clock to custom date, reload page for it to take effect
+        // # Set clock to custom date and visit town-square like reloading a page to take effect
         cy.clock(targetDate.ms, ['Date']);
-        cy.reload();
+        cy.visit(`/${teamName}/channels/town-square`);
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Type on: into search field
@@ -80,7 +80,8 @@ describe('SF15699 Search Date Filter - edit', () => {
             find('.post-message').
             should('have.text', targetMessage);
 
-        cy.reload();
+        // # Visit town-square to reload a page
+        cy.visit(`/${teamName}/channels/town-square`);
         cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
 
         // # Back space right after the date to bring up date picker again
@@ -110,7 +111,7 @@ describe('SF15699 Search Date Filter - edit', () => {
         cy.findAllByTestId('search-item-container').should('have.length', 0);
     });
 
-    it('changing timezone changes day search results appears', () => {
+    it('MM-T595 Changing timezone changes day search results appears', () => {
         const identifier = 'timezone' + Date.now();
 
         const target = getMsAndQueryForDate(Date.UTC(2018, 9, 31, 23, 59));
@@ -132,3 +133,7 @@ describe('SF15699 Search Date Filter - edit', () => {
         searchAndValidate(`on:${target.query} ${identifier}`);
     });
 });
+
+function changeTimezone(timezone) {
+    cy.apiPatchMe({timezone: {automaticTimezone: '', manualTimezone: timezone, useAutomaticTimezone: 'false'}});
+}

--- a/e2e/cypress/integration/search_filter/future_date_spec.js
+++ b/e2e/cypress/integration/search_filter/future_date_spec.js
@@ -13,18 +13,16 @@
 import {getAdminAccount} from '../../support/env';
 
 import {
-    getTestMessages,
     searchAndValidate,
+    getTestMessages,
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - mixed', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
-        firstDateEarly,
-        secondMessage,
-        secondOffTopicMessage,
+        allMessagesInOrder,
     } = testData;
     const admin = getAdminAccount();
     let anotherAdmin;
@@ -40,11 +38,15 @@ describe('SF15699 Search Date Filter - mixed', () => {
         });
     });
 
-    it('"before:" and "after:" can be used together', () => {
-        searchAndValidate(`before:${Cypress.moment().format('YYYY-MM-DD')} after:${firstDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
+    it('MM-T605_1 before: using a date from the future shows results', () => {
+        searchAndValidate(`before:2099-7-15 ${commonText}`, allMessagesInOrder);
     });
 
-    it('"before:", "after:", "from:", and "in:" can be used in one search', () => {
-        searchAndValidate(`before:${Cypress.moment().format('YYYY-MM-DD')} after:${firstDateEarly.query} from:${anotherAdmin.username} in:off-topic ${commonText}`, [secondOffTopicMessage]);
+    it('MM-T605_2 on: using a date from the future shows no results', () => {
+        searchAndValidate(`on:2099-7-15 ${commonText}`);
+    });
+
+    it('MM-T605_3 after: using a date from the future shows no results', () => {
+        searchAndValidate(`after:2099-7-15 ${commonText}`);
     });
 });

--- a/e2e/cypress/integration/search_filter/helpers.js
+++ b/e2e/cypress/integration/search_filter/helpers.js
@@ -95,9 +95,6 @@ export function setupTestData(data, {team, admin, anotherAdmin}) {
     const baseUrl = Cypress.config('baseUrl');
     cy.externalRequest({user: admin, method: 'put', baseUrl, path: `users/${anotherAdmin.id}/roles`, data: {roles: 'system_user system_admin'}});
 
-    // # Visit town-square
-    cy.visit(`/${team.name}/channels/town-square`);
-
     // # Create a post from today
     cy.get('#postListContent', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible');
     cy.postMessage(todayMessage).wait(TIMEOUTS.ONE_SEC);

--- a/e2e/cypress/integration/search_filter/input_spec.js
+++ b/e2e/cypress/integration/search_filter/input_spec.js
@@ -19,7 +19,7 @@ import {
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - input', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
@@ -41,15 +41,15 @@ describe('SF15699 Search Date Filter - input', () => {
         });
     });
 
-    it('can search for single post without adding a date filter', () => {
-        searchAndValidate(todayMessage, [todayMessage]);
-    });
-
-    it('can search for posts sharing text', () => {
+    it('MM-T585_1 Unfiltered search for all posts is not affected', () => {
         searchAndValidate(commonText, allMessagesInOrder);
     });
 
-    it('with calendar picker to set date', () => {
+    it('MM-T585_2 Unfiltered search for recent post is not affected', () => {
+        searchAndValidate(todayMessage, [todayMessage]);
+    });
+
+    it('MM-T596 Use calendar picker to set date', () => {
         const today = Cypress.moment().format('YYYY-MM-DD');
 
         // # Type before: in search field
@@ -68,15 +68,21 @@ describe('SF15699 Search Date Filter - input', () => {
 
         // * Verify date picker output gets put into field as expected date
         cy.get('#searchBox').should('have.value', `before:${today} `);
+
+        // # Click "x" to the right of the search term
+        cy.get('#searchFormContainer').find('.input-clear-x').click({force: true});
+
+        // * The "x" to clear the search query has disappeared
+        cy.get('#searchBox').should('have.value', '');
     });
 
-    it('backspace after last character of filter makes calendar reappear', () => {
+    it('MM-T3997 Backspace after last character of filter makes calendar reappear', () => {
         const today = Cypress.moment().format('YYYY-MM-DD');
 
         // # Type before: in search field
         cy.get('#searchBox').clear().type('before:');
 
-        // * Day picker should be visible
+        // * Date picker should be visible
         cy.get('.DayPicker').
             as('dayPicker').
             should('be.visible');
@@ -85,7 +91,7 @@ describe('SF15699 Search Date Filter - input', () => {
         cy.get('@dayPicker').
             find('.DayPicker-Day--today').click();
 
-        // * Day picker should disappear
+        // * Date picker should disappear
         cy.get('@dayPicker').should('not.exist');
 
         // # Hit backspace with focus right after the date
@@ -98,41 +104,36 @@ describe('SF15699 Search Date Filter - input', () => {
         cy.get('@dayPicker').should('be.visible');
     });
 
-    describe('works without leading 0 in', () => {
+    it('MM-T598 Dates work without leading 0 for date and month', () => {
         // These must match the date of the firstMessage, only altering leading zeroes
-        const tests = [
+        const testCases = [
             {name: 'day', date: '2018-06-5'},
             {name: 'month', date: '2018-6-05'},
             {name: 'month and date', date: '2018-6-5'},
         ];
 
-        before(() => {
+        testCases.forEach((test) => {
             cy.reload();
-        });
-
-        tests.forEach((test) => {
-            it(test.name, () => {
-                searchAndValidate(`on:${test.date} "${firstMessage}"`, [firstMessage]);
-            });
+            searchAndValidate(`on:${test.date} "${firstMessage}"`, [firstMessage]);
         });
     });
 
-    describe('query string can be removed with', () => {
+    it('MM-T601 Remove date filter with keyboard', () => {
         const queryString = `on:${Cypress.moment().format('YYYY-MM-DD')} ${commonText}`;
 
-        it('with keyboard', () => {
-            cy.get('#searchBox').
-                clear().
-                wait(TIMEOUTS.HALF_SEC).
-                type(queryString).
-                type('{backspace}'.repeat(queryString.length)).
-                should('have.value', '');
-        });
+        // * Filter can be removed with keyboard
+        cy.get('#searchBox').
+            clear().
+            wait(TIMEOUTS.HALF_SEC).
+            type(queryString).
+            type('{backspace}'.repeat(queryString.length)).
+            should('have.value', '');
 
-        it('with "x"', () => {
-            cy.get('#searchBox').clear().wait(TIMEOUTS.HALF_SEC).type(queryString);
-            cy.get('#searchFormContainer').find('.input-clear-x').click({force: true});
-            cy.get('#searchBox').should('have.value', '');
-        });
+        // # Enter query to search box and then click "x" to the right of the search term
+        cy.get('#searchBox').clear().wait(TIMEOUTS.HALF_SEC).type(queryString);
+        cy.get('#searchFormContainer').find('.input-clear-x').click({force: true});
+
+        // * The "x" to clear the search query has disappeared
+        cy.get('#searchBox').should('have.value', '');
     });
 });

--- a/e2e/cypress/integration/search_filter/input_spec.js
+++ b/e2e/cypress/integration/search_filter/input_spec.js
@@ -34,6 +34,9 @@ describe('SF15699 Search Date Filter - input', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });

--- a/e2e/cypress/integration/search_filter/invalid_spec.js
+++ b/e2e/cypress/integration/search_filter/invalid_spec.js
@@ -18,7 +18,7 @@ import {
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - invalid', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {commonText} = testData;
     const admin = getAdminAccount();
@@ -35,19 +35,19 @@ describe('SF15699 Search Date Filter - invalid', () => {
         });
     });
 
-    it('wrong format returns no results', () => {
+    it('MM-T602_1 wrong format returns no results', () => {
         searchAndValidate(`before:123-456-789 ${commonText}`);
     });
 
-    it('correct format, invalid date returns no results', () => {
+    it('MM-T602_2 correct format, invalid date returns no results', () => {
         searchAndValidate(`before:2099-15-45 ${commonText}`);
     });
 
-    it('invalid leap year returns no results', () => {
+    it('MM-T602_3 invalid leap year returns no results', () => {
         searchAndValidate(`after:2018-02-29 ${commonText}`);
     });
 
-    it('using invalid string for date returns no results', () => {
+    it('MM-T602_4 using invalid string for date returns no results', () => {
         searchAndValidate(`before:banana ${commonText}`);
     });
 });

--- a/e2e/cypress/integration/search_filter/invalid_spec.js
+++ b/e2e/cypress/integration/search_filter/invalid_spec.js
@@ -28,6 +28,9 @@ describe('SF15699 Search Date Filter - invalid', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });

--- a/e2e/cypress/integration/search_filter/mixed_spec.js
+++ b/e2e/cypress/integration/search_filter/mixed_spec.js
@@ -40,11 +40,11 @@ describe('SF15699 Search Date Filter - mixed', () => {
         });
     });
 
-    it('"before:" and "after:" can be used together', () => {
+    it('MM-T589 "before:" and "after:" can be used together', () => {
         searchAndValidate(`before:${Cypress.moment().format('YYYY-MM-DD')} after:${firstDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
     });
 
-    it('"before:", "after:", "from:", and "in:" can be used in one search', () => {
+    it('MM-T593 "before:", "after:", "from:", and "in:" can be used in one search', () => {
         searchAndValidate(`before:${Cypress.moment().format('YYYY-MM-DD')} after:${firstDateEarly.query} from:${anotherAdmin.username} in:off-topic ${commonText}`, [secondOffTopicMessage]);
     });
 });

--- a/e2e/cypress/integration/search_filter/negative_spec.js
+++ b/e2e/cypress/integration/search_filter/negative_spec.js
@@ -14,33 +14,6 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('Negative search filters will omit results', () => {
     const message = 'negative' + Date.now();
-
-    function search(query) {
-        cy.reload();
-        cy.get('#searchBox').clear().wait(TIMEOUTS.HALF_SEC).type(query).wait(TIMEOUTS.HALF_SEC).type('{enter}');
-
-        cy.get('#loadingSpinner').should('not.exist');
-        cy.get('#search-items-container', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-    }
-
-    function searchAndVerify(query) {
-        search(query);
-
-        // * Verify the amount of results matches the amount of our expected results
-        cy.findAllByTestId('search-item-container').should('have.length', 1).then((results) => {
-            // * Verify text of each result
-            cy.wrap(results).first().find('.post-message').should('have.text', message);
-        });
-
-        search(`-${query}`);
-
-        // * If we expect no results, verify results message
-        cy.get('.no-results__title').should('be.visible').and('have.text', `No results for "-${query}"`);
-
-        cy.get('#searchResultsCloseButton').click();
-        cy.get('.search-item__container').should('not.exist');
-    }
-
     let testUser;
 
     before(() => {
@@ -56,35 +29,61 @@ describe('Negative search filters will omit results', () => {
         });
     });
 
-    it('just search query', () => {
-        searchAndVerify(message);
+    it('MM-T607 Negative search term', () => {
+        searchAndVerify(message, message);
     });
 
-    it('-before:', () => {
+    it('MM-T608 Negative before: filter', () => {
         const tomorrow = Cypress.moment().add(1, 'days').format('YYYY-MM-DD');
         const query = `before:${tomorrow} ${message}`;
-        searchAndVerify(query);
+        searchAndVerify(query, message);
     });
 
-    it('-after:', () => {
+    it('MM-T609 Negative after: filter', () => {
         const yesterday = Cypress.moment().subtract(1, 'days').format('YYYY-MM-DD');
         const query = `after:${yesterday} ${message}`;
-        searchAndVerify(query);
+        searchAndVerify(query, message);
     });
 
-    it('-on:', () => {
+    it('MM-T611 Negative on: filter', () => {
         const today = Cypress.moment().format('YYYY-MM-DD');
         const query = `on:${today} ${message}`;
-        searchAndVerify(query);
+        searchAndVerify(query, message);
     });
 
-    it('-in:', () => {
+    it('MM-T3996 Negative in: filter', () => {
         const query = `in:town-square ${message}`;
-        searchAndVerify(query);
+        searchAndVerify(query, message);
     });
 
-    it('-from:', () => {
+    it('MM-T610 Negative from: filter', () => {
         const query = `from:${testUser.username} ${message}`;
-        searchAndVerify(query);
+        searchAndVerify(query, message);
     });
 });
+
+function search(query) {
+    cy.reload();
+    cy.get('#searchBox').clear().wait(TIMEOUTS.HALF_SEC).type(query).wait(TIMEOUTS.HALF_SEC).type('{enter}');
+
+    cy.get('#loadingSpinner').should('not.exist');
+    cy.get('#search-items-container', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+}
+
+function searchAndVerify(query, expectedMessage) {
+    search(query);
+
+    // * Verify the amount of results matches the amount of our expected results
+    cy.findAllByTestId('search-item-container').should('have.length', 1).then((results) => {
+        // * Verify text of each result
+        cy.wrap(results).first().find('.post-message').should('have.text', expectedMessage);
+    });
+
+    search(`-${query}`);
+
+    // * If we expect no results, verify results message
+    cy.get('.no-results__title').should('be.visible').and('have.text', `No results for "-${query}"`);
+
+    cy.get('#searchResultsCloseButton').click();
+    cy.get('.search-item__container').should('not.exist');
+}

--- a/e2e/cypress/integration/search_filter/on_spec.js
+++ b/e2e/cypress/integration/search_filter/on_spec.js
@@ -19,7 +19,7 @@ import {
     setupTestData,
 } from './helpers';
 
-describe('SF15699 Search Date Filter - on', () => {
+describe('Search Date Filter', () => {
     const testData = getTestMessages();
     const {
         commonText,
@@ -35,31 +35,38 @@ describe('SF15699 Search Date Filter - on', () => {
         cy.apiInitSetup({userPrefix: 'other-admin'}).then(({team, user}) => {
             anotherAdmin = user;
 
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+
             setupTestData(testData, {team, admin, anotherAdmin});
         });
     });
 
-    it('omits results before and after target date', () => {
+    it('MM-T588 on: omits results before and after target date', () => {
         searchAndValidate(`on:${secondDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
     });
 
-    it('takes precedence over "after:" and "before:"', () => {
+    it('MM-T590_1 on: takes precedence over "before:"', () => {
         searchAndValidate(`before:${Cypress.moment().format('YYYY-MM-DD')} on:${secondDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
     });
 
-    it('takes precedence over "after:"', () => {
+    it('MM-T590_2 on: takes precedence over "after:"', () => {
         searchAndValidate(`after:${firstDateEarly.query} on:${secondDateEarly.query} ${commonText}`, [secondOffTopicMessage, secondMessage]);
     });
 
-    it('can be used in conjunction with "in:"', () => {
+    it('MM-T3994_1 on: can be used in conjunction with "in:"', () => {
         searchAndValidate(`on:${secondDateEarly.query} in:town-square ${commonText}`, [secondMessage]);
     });
 
-    it('can be used in conjunction with "from:"', () => {
+    it('MM-T3994_2 on: can be used in conjunction with "from:"', () => {
         searchAndValidate(`on:${secondDateEarly.query} from:${anotherAdmin.username} ${commonText}`, [secondOffTopicMessage]);
     });
 
-    it('works from 12:00am to 11:59pm', () => {
+    it('MM-T3994_3 on: re-add "in:" in conjunction with "from:"', () => {
+        searchAndValidate(`on:${secondDateEarly.query} in:town-square from:${anotherAdmin.username} ${commonText}`);
+    });
+
+    it('MM-T604 Use "on:" to return only results from today', () => {
         // create posts on a day at 11:59 the previous day, 12:00am the main day, 11:59pm the main day, and 12:00 the next day
         const identifier = 'christmas' + Date.now();
 
@@ -81,9 +88,5 @@ describe('SF15699 Search Date Filter - on', () => {
 
         // * Verify we only see messages from the expected date, and not outside of it
         searchAndValidate(`on:${targetAM.query} ${identifier}`, [targetPMMessage, targetAMMessage]);
-    });
-
-    it('using a date from the future shows no results', () => {
-        searchAndValidate(`on:2099-7-15 ${commonText}`);
     });
 });


### PR DESCRIPTION
#### Summary
Note: Submitted on top of https://github.com/mattermost/mattermost-webapp/pull/7893 for ease of review. See https://github.com/mattermost/mattermost-webapp/commit/727c194c99a021f2622cdadd9c7c383ebe64fd68 for related change on this PR.

Updated tests and keys of search date filters for the following test cases:

Invalid date
- MM-T602

Mixed
- MM-T589
- MM-T593

Negative filter
- MM-T607
- MM-T608
- MM-T609
- MM-T611
- MM-T3996
- MM-T610

Input
- MM-T585
- MM-T596
- MM-3997
- MM-T598
- MM-T601

#### Screenshots
![Screen Shot 2021-04-13 at 9 03 27 PM](https://user-images.githubusercontent.com/5334504/114568807-0a3a5a80-9ca7-11eb-823f-bf96a77da717.png)
![Screen Shot 2021-04-13 at 9 07 14 PM](https://user-images.githubusercontent.com/5334504/114568814-0c041e00-9ca7-11eb-8c31-a502d21d6468.png)
![Screen Shot 2021-04-13 at 9 53 43 PM](https://user-images.githubusercontent.com/5334504/114568816-0c9cb480-9ca7-11eb-88e4-796b746853df.png)
![Screen Shot 2021-04-13 at 10 21 31 PM](https://user-images.githubusercontent.com/5334504/114568818-0dcde180-9ca7-11eb-8778-c192c4a18205.png)
