### PR TITLE
Cypress/E2E: Add @mfa metadata to specs accordingly

### DIFF
--- a/e2e/cypress/integration/accessibility/accessibility_account_settings_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_account_settings_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @accessibility
+// Group: @accessibility @mfa
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import accountSettingSections from '../../fixtures/account_setting_sections.json';

--- a/e2e/cypress/integration/auth_sso/authentication_2_spec.js
+++ b/e2e/cypress/integration/auth_sso/authentication_2_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @system_console @authentication
+// Group: @system_console @authentication @mfa
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
@@ -71,7 +71,7 @@ describe('Authentication', () => {
 
         cy.findByText('Create Account').click();
 
-        // * Assert that we are not shown a MFA scren and instead a Teams You Can join page
+        // * Assert that we are not shown an MFA screen and instead a Teams You Can join page
         cy.findByText('Teams you can join:', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
     });
 

--- a/e2e/cypress/integration/bot_accounts/bot_api_spec.js
+++ b/e2e/cypress/integration/bot_accounts/bot_api_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @bot_accounts
+// Group: @bot_accounts @mfa
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @not_cloud @enterprise @guest_account
+// Group: @not_cloud @enterprise @guest_account @mfa
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/enterprise/guest_accounts/system_console_guest_access_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/system_console_guest_access_ui_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @guest_account
+// Group: @enterprise @guest_account @mfa
 
 /**
  * Note: This test requires Enterprise license to be uploaded

--- a/e2e/cypress/integration/signin_authentication/authentication_spec.js
+++ b/e2e/cypress/integration/signin_authentication/authentication_spec.js
@@ -1,19 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getEmailUrl} from '../../utils';
-import {getAdminAccount} from '../../support/env';
-import timeouts from '../../fixtures/timeouts';
-
-const authenticator = require('authenticator');
-
 // ***************************************************************
 // - [#] indicates a test step (e.g. # Go to a page)
 // - [*] indicates an assertion (e.g. * Check the title)
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @signin_authentication
+// Group: @signin_authentication @mfa
+
+import {getEmailUrl} from '../../utils';
+import {getAdminAccount} from '../../support/env';
+import timeouts from '../../fixtures/timeouts';
+
+const authenticator = require('authenticator');
 
 describe('Authentication', () => {
     let testTeam;


### PR DESCRIPTION
#### Summary
Add @mfa metadata to specs accordingly which will be used to sort specs to last and lessen/avoid potential cascading side-effects to succeeding tests whenever unrecoverable MFA setup occurred.

Such filter would be used like:
```
node generate_test_cycle.js --stage="@prod" --sortLast="@elasticsearch,@ldap,@saml,@keycloak,@mfa"
```

#### Ticket Link
none, failing on daily
