### PR TITLE
Make sendEphemeralPost into a proper action

### DIFF
--- a/actions/apps.ts
+++ b/actions/apps.ts
@@ -98,53 +98,45 @@ export function openAppsModal(form: AppForm, call: AppCallRequest): Action {
 }
 
 export function postEphemeralCallResponseForPost(response: AppCallResponse, message: string, post: Post): ActionFunc {
-    return () => {
-        sendEphemeralPost(
+    return (dispatch: DispatchFunc) => {
+        return dispatch(sendEphemeralPost(
             message,
             post.channel_id,
             post.root_id || post.id,
             response.app_metadata?.bot_user_id,
-        );
-
-        return {data: true};
+        ));
     };
 }
 
 export function postEphemeralCallResponseForChannel(response: AppCallResponse, message: string, channelID: string): ActionFunc {
-    return () => {
-        sendEphemeralPost(
+    return (dispatch: DispatchFunc) => {
+        return dispatch(sendEphemeralPost(
             message,
             channelID,
             '',
             response.app_metadata?.bot_user_id,
-        );
-
-        return {data: true};
+        ));
     };
 }
 
 export function postEphemeralCallResponseForContext(response: AppCallResponse, message: string, context: AppContext): ActionFunc {
-    return () => {
-        sendEphemeralPost(
+    return (dispatch: DispatchFunc) => {
+        return dispatch(sendEphemeralPost(
             message,
             context.channel_id,
             context.root_id || context.post_id,
             response.app_metadata?.bot_user_id,
-        );
-
-        return {data: true};
+        ));
     };
 }
 
 export function postEphemeralCallResponseForCommandArgs(response: AppCallResponse, message: string, args: CommandArgs): ActionFunc {
-    return () => {
-        sendEphemeralPost(
+    return (dispatch: DispatchFunc) => {
+        return dispatch(sendEphemeralPost(
             message,
             args.channel_id,
             args.root_id,
             response.app_metadata?.bot_user_id,
-        );
-
-        return {data: true};
+        ));
     };
 }

--- a/actions/apps.ts
+++ b/actions/apps.ts
@@ -98,45 +98,37 @@ export function openAppsModal(form: AppForm, call: AppCallRequest): Action {
 }
 
 export function postEphemeralCallResponseForPost(response: AppCallResponse, message: string, post: Post): ActionFunc {
-    return (dispatch: DispatchFunc) => {
-        return dispatch(sendEphemeralPost(
-            message,
-            post.channel_id,
-            post.root_id || post.id,
-            response.app_metadata?.bot_user_id,
-        ));
-    };
+    return sendEphemeralPost(
+        message,
+        post.channel_id,
+        post.root_id || post.id,
+        response.app_metadata?.bot_user_id,
+    );
 }
 
 export function postEphemeralCallResponseForChannel(response: AppCallResponse, message: string, channelID: string): ActionFunc {
-    return (dispatch: DispatchFunc) => {
-        return dispatch(sendEphemeralPost(
-            message,
-            channelID,
-            '',
-            response.app_metadata?.bot_user_id,
-        ));
-    };
+    return sendEphemeralPost(
+        message,
+        channelID,
+        '',
+        response.app_metadata?.bot_user_id,
+    );
 }
 
 export function postEphemeralCallResponseForContext(response: AppCallResponse, message: string, context: AppContext): ActionFunc {
-    return (dispatch: DispatchFunc) => {
-        return dispatch(sendEphemeralPost(
-            message,
-            context.channel_id,
-            context.root_id || context.post_id,
-            response.app_metadata?.bot_user_id,
-        ));
-    };
+    return sendEphemeralPost(
+        message,
+        context.channel_id,
+        context.root_id || context.post_id,
+        response.app_metadata?.bot_user_id,
+    );
 }
 
 export function postEphemeralCallResponseForCommandArgs(response: AppCallResponse, message: string, args: CommandArgs): ActionFunc {
-    return (dispatch: DispatchFunc) => {
-        return dispatch(sendEphemeralPost(
-            message,
-            args.channel_id,
-            args.root_id,
-            response.app_metadata?.bot_user_id,
-        ));
-    };
+    return sendEphemeralPost(
+        message,
+        args.channel_id,
+        args.root_id,
+        response.app_metadata?.bot_user_id,
+    );
 }

--- a/actions/command.test.js
+++ b/actions/command.test.js
@@ -189,7 +189,7 @@ describe('executeCommand', () => {
 
     describe('leave', () => {
         test('should send message when command typed in reply threads', async () => {
-            GlobalActions.sendEphemeralPost = jest.fn();
+            GlobalActions.sendEphemeralPost = jest.fn().mockReturnValue({type: 'someaction'});
 
             const result = await store.dispatch(executeCommand('/leave', {channel_id: 'channel_id', parent_id: 'parent_id'}));
 

--- a/actions/command.ts
+++ b/actions/command.ts
@@ -64,7 +64,7 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
         case '/leave': {
             // /leave command not supported in reply threads.
             if (args.channel_id && (args.root_id || args.parent_id)) {
-                GlobalActions.sendEphemeralPost('/leave is not supported in reply threads. Use it in the center channel instead.', args.channel_id, args.parent_id);
+                dispatch(GlobalActions.sendEphemeralPost('/leave is not supported in reply threads. Use it in the center channel instead.', args.channel_id, args.parent_id));
                 return {data: true};
             }
             const channel = getCurrentChannel(state) || {};

--- a/actions/global_actions.tsx
+++ b/actions/global_actions.tsx
@@ -208,7 +208,7 @@ export function sendEphemeralPost(message: string, channelId?: string, parentId?
         };
 
         return doDispatch(handleNewPost(post));
-    }
+    };
 }
 
 export function sendAddToChannelEphemeralPost(user: UserProfile, addedUsername: string, addedUserId: string, channelId: string, postRootId = '', timestamp: number) {

--- a/actions/global_actions.tsx
+++ b/actions/global_actions.tsx
@@ -20,7 +20,7 @@ import {ChannelTypes} from 'mattermost-redux/action_types';
 import {fetchAppBindings} from 'mattermost-redux/actions/apps';
 import {Channel, ChannelMembership} from 'mattermost-redux/types/channels';
 import {UserProfile} from 'mattermost-redux/types/users';
-import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import {Team} from 'mattermost-redux/types/teams';
 
 import {browserHistory} from 'utils/browser_history';
@@ -191,22 +191,24 @@ export function showMobileSubMenuModal(elements: any[]) { // TODO Use more speci
     dispatch(openModal(submenuModalData));
 }
 
-export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): void {
-    const timestamp = Utils.getTimestamp();
-    const post = {
-        id: Utils.generateId(),
-        user_id: userId || '0',
-        channel_id: channelId || getCurrentChannelId(getState()),
-        message,
-        type: PostTypes.EPHEMERAL,
-        create_at: timestamp,
-        update_at: timestamp,
-        root_id: parentId,
-        parent_id: parentId,
-        props: {},
-    };
+export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): ActionFunc {
+    return (doDispatch: DispatchFunc) => {
+        const timestamp = Utils.getTimestamp();
+        const post = {
+            id: Utils.generateId(),
+            user_id: userId || '0',
+            channel_id: channelId || getCurrentChannelId(getState()),
+            message,
+            type: PostTypes.EPHEMERAL,
+            create_at: timestamp,
+            update_at: timestamp,
+            root_id: parentId,
+            parent_id: parentId,
+            props: {},
+        };
 
-    dispatch(handleNewPost(post));
+        return doDispatch(handleNewPost(post));
+    }
 }
 
 export function sendAddToChannelEphemeralPost(user: UserProfile, addedUsername: string, addedUserId: string, channelId: string, postRootId = '', timestamp: number) {

--- a/actions/global_actions.tsx
+++ b/actions/global_actions.tsx
@@ -192,12 +192,12 @@ export function showMobileSubMenuModal(elements: any[]) { // TODO Use more speci
 }
 
 export function sendEphemeralPost(message: string, channelId?: string, parentId?: string, userId?: string): ActionFunc {
-    return (doDispatch: DispatchFunc) => {
+    return (doDispatch: DispatchFunc, doGetState: GetStateFunc) => {
         const timestamp = Utils.getTimestamp();
         const post = {
             id: Utils.generateId(),
             user_id: userId || '0',
-            channel_id: channelId || getCurrentChannelId(getState()),
+            channel_id: channelId || getCurrentChannelId(doGetState()),
             message,
             type: PostTypes.EPHEMERAL,
             create_at: timestamp,

--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -51,6 +51,8 @@ export function handleNewPost(post, msg) {
                 dispatch(loadNewGMIfNeeded(post.channel_id));
             }
         }
+
+        return {data: true};
     };
 }
 

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
@@ -85,7 +85,7 @@ export const getExecuteSuggestion = (parsed: ParsedCommand): AutocompleteSuggest
 };
 
 export const displayError = (err: string, channelID: string, rootID?: string) => {
-    sendEphemeralPost(err, channelID, rootID);
+    Store.dispatch(sendEphemeralPost(err, channelID, rootID));
 };
 
 // Shim of mobile-version intl


### PR DESCRIPTION
#### Summary

I'm adding some actions that call `sendEphemeralPost` in https://github.com/mattermost/mattermost-webapp/pull/7827, and I want to be able to have them `dispatch` the call to `sendEphemeralPost`. I'm making this a separate PR to be clear about this change.

#### Ticket Link

