### PR TITLE
Prod test fixes

### DIFF
--- a/e2e/cypress/integration/integrations/incoming_webhook/inapp_username_profile_override_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/inapp_username_profile_override_spec.js
@@ -64,7 +64,7 @@ describe('Incoming webhook', () => {
         cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
 
         // # Click test channel on sidebar
-        cy.get(`#sidebarItem_${testChannel.name}`).should('be.visible').click();
+        cy.get(`#sidebarItem_${testChannel.name}`).should('be.visible').click({force: true});
 
         // # Wait for the webhook message to get posted
         cy.waitUntil(() => cy.getLastPost().then((el) => {
@@ -82,7 +82,7 @@ describe('Incoming webhook', () => {
         cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
 
         // # Click test channel on sidebar
-        cy.get(`#sidebarItem_${testChannel.name}`).should('be.visible').click();
+        cy.get(`#sidebarItem_${testChannel.name}`).should('be.visible').click({force: true});
 
         // # Wait for the webhook message to get posted
         cy.waitUntil(() => cy.getLastPost().then((el) => {

--- a/e2e/cypress/integration/integrations/incoming_webhook/setting_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/setting_spec.js
@@ -72,7 +72,7 @@ describe('Incoming webhook', () => {
 
 function switchToChannel(teamName, channelName) {
     cy.visit(`/${teamName}/channels/town-square`);
-    cy.get(`#sidebarItem_${channelName}`, {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click();
+    cy.get(`#sidebarItem_${channelName}`, {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click({force: true});
 }
 
 function editIncomingWebhook(incomingWebhookId, teamName, lockToChannel) {

--- a/e2e/cypress/integration/integrations/incoming_webhook/slack_formatting_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/slack_formatting_spec.js
@@ -173,7 +173,7 @@ describe('Incoming webhook', () => {
         cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
 
         cy.get(`#sidebarItem_${testChannel.name}`).find('#unreadMentions').should('have.text', '1');
-        cy.get(`#sidebarItem_${testChannel.name}`).click();
+        cy.get(`#sidebarItem_${testChannel.name}`).click({force: true});
 
         cy.getLastPost().within(() => {
             cy.get('.attachment__thumb-pretext').should('contain', id);
@@ -209,7 +209,7 @@ describe('Incoming webhook', () => {
         cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
 
         cy.get(`#sidebarItem_${testChannel.name}`).find('#unreadMentions').should('have.text', '1');
-        cy.get(`#sidebarItem_${testChannel.name}`).click();
+        cy.get(`#sidebarItem_${testChannel.name}`).click({force: true});
 
         cy.getLastPost().within(() => {
             cy.get('.attachment__thumb-pretext').should('contain', id);

--- a/e2e/cypress/integration/messaging/message_reply_gm_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_gm_spec.js
@@ -11,6 +11,7 @@
 // Group: @messaging
 
 import {getRandomId} from '../../utils';
+import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('Reply in existing GM', () => {
     let testUser;
@@ -69,6 +70,7 @@ describe('Reply in existing GM', () => {
                 cy.postMessageReplyInRHS(replyMessage);
                 cy.getLastPostId().then((replyId) => {
                     // * Verify that the reply is in the RHS with matching text
+                    cy.wait(TIMEOUTS.TWO_SEC);
                     cy.get(`#rhsPostMessageText_${replyId}`).should('be.visible').and('have.text', replyMessage);
 
                     // * Verify that the reply is in the center channel with matching text


### PR DESCRIPTION
Fixing the incoming webhook and gm reply tests:
- Looks like the incoming webhook tests need forced clicks on the channel names.
- The gm reply test looks like is looking for the reply sooner than it's available.

<img width="689" alt="Screen Shot 2021-04-14 at 4 43 21 PM" src="https://user-images.githubusercontent.com/691331/114794076-92207300-9d40-11eb-8a4c-c9ab92f7d612.png">
<img width="689" alt="Screen Shot 2021-04-14 at 4 40 23 PM" src="https://user-images.githubusercontent.com/691331/114794082-95b3fa00-9d40-11eb-91cd-f7934559340f.png">
<img width="689" alt="Screen Shot 2021-04-14 at 4 39 03 PM" src="https://user-images.githubusercontent.com/691331/114794090-99e01780-9d40-11eb-890d-895be6ddce7c.png">
<img width="690" alt="Screen Shot 2021-04-14 at 4 38 06 PM" src="https://user-images.githubusercontent.com/691331/114794099-9d739e80-9d40-11eb-90e5-ea001df418ec.png">
