### PR TITLE
Cypress/E2E: Fix test on LDAP groups, code theme and incoming webhook

### DIFF
--- a/e2e/cypress/integration/account_settings/display/code_theme_colors_spec.js
+++ b/e2e/cypress/integration/account_settings/display/code_theme_colors_spec.js
@@ -10,6 +10,8 @@
 // Stage: @prod
 // Group: @account_setting
 
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
 describe('Account Settings', () => {
     before(() => {
         // # Login as new user, visit town-square and post a message
@@ -42,9 +44,8 @@ describe('Account Settings', () => {
             verifyLastPostStyle(theme);
 
             // # Save and close settings modal
-            cy.get('#saveSetting').click();
-            cy.get('#accountSettingsHeader > .close').click();
-            cy.get('#accountSettingsHeader').should('be.hidden');
+            cy.get('#saveSetting').click().wait(TIMEOUTS.HALF_SEC);
+            cy.uiClose();
 
             // * Verify that the styles remain after saving and closing modal
             verifyLastPostStyle(theme);
@@ -71,9 +72,7 @@ function verifyLastPostStyle(codeTheme) {
 
 function navigateToThemeSettings() {
     // Change theme to desired theme (keeps settings modal open)
-    cy.toAccountSettingsModal();
-    cy.get('#displayButton').click();
-    cy.get('#displaySettingsTitle').should('exist');
+    cy.uiOpenAccountSettingsModal('Display');
 
     // Open edit theme
     cy.get('#themeTitle').should('be.visible');

--- a/e2e/cypress/integration/enterprise/integrations/incoming_webhook_spec.js
+++ b/e2e/cypress/integration/enterprise/integrations/incoming_webhook_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @enterprise @incoming_webhook @not_cloud
+// Group: @enterprise @elasticsearch @incoming_webhook @not_cloud
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 import {

--- a/e2e/cypress/integration/enterprise/ldap_group/channel_modes_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/channel_modes_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @enterprise @ldap_group
 
-describe('Test channel public/private toggle', () => {
+describe('LDAP Group Sync - Test channel public/private toggle', () => {
     let testTeam;
 
     before(() => {
@@ -20,10 +20,10 @@ describe('Test channel public/private toggle', () => {
         // Enable LDAP and LDAP group sync
         cy.apiUpdateConfig({LdapSettings: {Enable: true}});
 
-        // # Check and run LDAP Sync job
-        if (Cypress.env('runLDAPSync')) {
-            cy.checkRunLDAPSync();
-        }
+        // # Test LDAP configuration and server connection
+        // # Synchronize user attributes
+        cy.apiLDAPTest();
+        cy.apiLDAPSync();
 
         // # Init test setup
         cy.apiInitSetup().then(({team}) => {
@@ -31,7 +31,7 @@ describe('Test channel public/private toggle', () => {
         });
     });
 
-    it('Verify that System Admin can change channel privacy using toggle', () => {
+    it('MM-T4003_1 Verify that System Admin can change channel privacy using toggle', () => {
         cy.apiCreateChannel(testTeam.id, 'test-channel', 'Test Channel').then(({channel}) => {
             assert(channel.type === 'O');
             cy.visit(`/admin_console/user_management/channels/${channel.id}`);
@@ -53,7 +53,7 @@ describe('Test channel public/private toggle', () => {
         });
     });
 
-    it('Verify that resetting sync toggle doesn\'t alter channel privacy toggle', () => {
+    it('MM-T4003_2 Verify that resetting sync toggle doesn\'t alter channel privacy toggle', () => {
         cy.apiCreateChannel(testTeam.id, 'test-channel', 'Test Channel').then(({channel}) => {
             assert(channel.type === 'O');
             cy.visit(`/admin_console/user_management/channels/${channel.id}`);
@@ -68,7 +68,7 @@ describe('Test channel public/private toggle', () => {
         });
     });
 
-    it('Verify that toggles are disabled for default channel', () => {
+    it('MM-T4003_3 Verify that toggles are disabled for default channel', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
         cy.getCurrentChannelId().then((id) => {
             cy.visit(`/admin_console/user_management/channels/${id}`);

--- a/e2e/cypress/integration/enterprise/ldap_group/groups_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/groups_assign_roles_spec.js
@@ -48,7 +48,7 @@ const getChannelsAssociatedToGroupAndUnlink = (groupId) => {
     });
 };
 
-describe('System Console', () => {
+describe('LDAP Group Sync', () => {
     before(() => {
         // * Check if server has license for LDAP Groups
         cy.apiRequireLicenseForFeature('LDAPGroups');
@@ -56,13 +56,13 @@ describe('System Console', () => {
         // Enable LDAP
         cy.apiUpdateConfig({LdapSettings: {Enable: true}});
 
-        // # Check and run LDAP Sync job
-        if (Cypress.env('runLDAPSync')) {
-            cy.checkRunLDAPSync();
-        }
+        // # Test LDAP configuration and server connection
+        // # Synchronize user attributes
+        cy.apiLDAPTest();
+        cy.apiLDAPSync();
     });
 
-    it('MM-20058 - System Admin can map roles to teams and channels via group configuration page', () => {
+    it('MM-T2668 Team admin role can be set and saved', () => {
         // # Go to system admin page and to team configuration page
         cy.visit('/admin_console/user_management/groups');
         cy.get('#developers_group').then((el) => {


### PR DESCRIPTION
#### Summary
a. LDAP Groups
- changed the LDAP sync via API since LDAP config is already set
- created new Zephyr test cases - MM-T4003
- added existing test key - MM-T2668 

b. Code theme
- used `cy.uiClose()` to close the Account Settings

c. Incoming webhook
- failed due to timeout error during reindex. Add `@elasticsearch` metadata so it will test first where data is not yet huge.

#### Ticket Link
none, failing on daily Cypress prod

#### Screenshots
<img width="636" alt="Screen Shot 2021-04-15 at 8 42 23 AM" src="https://user-images.githubusercontent.com/5334504/114798464-f9cdd100-9dc7-11eb-982e-53e1f3eae6c9.png">
<img width="634" alt="Screen Shot 2021-04-15 at 8 43 22 AM" src="https://user-images.githubusercontent.com/5334504/114798470-fc302b00-9dc7-11eb-91c9-79740e73a6f7.png">
<img width="633" alt="Screen Shot 2021-04-15 at 8 44 42 AM" src="https://user-images.githubusercontent.com/5334504/114798474-fd615800-9dc7-11eb-886b-cd05238c0e57.png">
<img width="637" alt="Screen Shot 2021-04-15 at 8 45 56 AM" src="https://user-images.githubusercontent.com/5334504/114798475-fd615800-9dc7-11eb-928d-3c1b3d6f61d6.png">
