### PR TITLE
Adding missing Zephyr keys to existing E2E tests

### DIFF
--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -12,6 +12,25 @@
 
 import {getRandomId} from '../../../utils';
 
+describe('Account Settings', () => {
+    before(() => {
+        // # Login as new user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+
+    it('MM-T103_1 Compact view: Line breaks remain intact after editing', () => {
+        // * Verify line breaks do not change and blank line is still there in compact view.
+        verifyLineBreaksRemainIntact('COMPACT');
+    });
+
+    it('MM-T103_2 Standard view: Line breaks remain intact after editing', () => {
+        // * Verify line breaks do not change and blank line is still there in standard view.
+        verifyLineBreaksRemainIntact('STANDARD');
+    });
+});
+
 function verifyLineBreaksRemainIntact(display) {
     cy.uiChangeMessageDisplaySetting(display);
 
@@ -53,22 +72,3 @@ function verifyLineBreaksRemainIntact(display) {
             should('contain', '(edited)');
     });
 }
-
-describe('Account Settings', () => {
-    before(() => {
-        // # Login as new user and visit town-square
-        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
-            cy.visit(`/${team.name}/channels/town-square`);
-        });
-    });
-
-    it('MM-T103_1 Compact view: Line breaks remain intact after editing', () => {
-        // * Verify line breaks do not change and blank line is still there in compact view.
-        verifyLineBreaksRemainIntact('COMPACT');
-    });
-
-    it('MM-T103_2 Standard view: Line breaks remain intact after editing', () => {
-        // * Verify line breaks do not change and blank line is still there in standard view.
-        verifyLineBreaksRemainIntact('STANDARD');
-    });
-});

--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -12,7 +12,7 @@
 
 import {getRandomId} from '../../../utils';
 
-describe('Account Settings > Display > Message Display', () => {
+describe('Messaging', () => {
     before(() => {
         // # Login as new user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
@@ -20,47 +20,45 @@ describe('Account Settings > Display > Message Display', () => {
         });
     });
 
-    ['COMPACT', 'STANDARD'].forEach((display) => {
-        it(`M14283 ${display} view: Line breaks remain intact after editing`, () => {
-            cy.uiChangeMessageDisplaySetting(display);
+    it('MM-T103 Compact view: Line breaks remain intact after editing', () => {
+        cy.uiChangeMessageDisplaySetting('COMPACT');
 
-            const firstLine = `First line ${getRandomId()}`;
-            const secondLine = `Text after ${getRandomId()}`;
+        const firstLine = `First line ${getRandomId()}`;
+        const secondLine = `Text after ${getRandomId()}`;
 
-            // # Enter in text
-            cy.get('#post_textbox').
-                clear().
-                type(firstLine).
-                type('{shift}{enter}{enter}').
-                type(`${secondLine}{enter}`);
+        // # Enter in text
+        cy.get('#post_textbox').
+            clear().
+            type(firstLine).
+            type('{shift}{enter}{enter}').
+            type(`${secondLine}{enter}`);
 
-            // # Get last postId
-            cy.getLastPostId().then((postId) => {
-                const postMessageTextId = `#postMessageText_${postId}`;
+        // # Get last postId
+        cy.getLastPostId().then((postId) => {
+            const postMessageTextId = `#postMessageText_${postId}`;
 
-                // * Verify HTML still includes new line
-                cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine}</p>`);
+            // * Verify HTML still includes new line
+            cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine}</p>`);
 
-                // # click dot menu button
-                cy.clickPostDotMenu(postId);
+            // # click dot menu button
+            cy.clickPostDotMenu(postId);
 
-                // # click edit post
-                cy.get(`#edit_post_${postId}`).scrollIntoView().should('be.visible').click();
+            // # click edit post
+            cy.get(`#edit_post_${postId}`).scrollIntoView().should('be.visible').click();
 
-                // # Add ",edited" to the text
-                cy.get('#edit_textbox').type(',edited');
+            // # Add ",edited" to the text
+            cy.get('#edit_textbox').type(',edited');
 
-                // # Save
-                cy.get('#editButton').click();
+            // # Save
+            cy.get('#editButton').click();
 
-                // * Verify HTML includes newline and the edit
-                cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine},edited</p>`);
+            // * Verify HTML includes newline and the edit
+            cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine},edited</p>`);
 
-                // * Post should have (edited)
-                cy.get(`#postEdited_${postId}`).
-                    should('be.visible').
-                    should('contain', '(edited)');
-            });
+            // * Post should have (edited)
+            cy.get(`#postEdited_${postId}`).
+                should('be.visible').
+                should('contain', '(edited)');
         });
     });
 });

--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -63,10 +63,12 @@ describe('Account Settings', () => {
     });
 
     it('MM-T103_1 Compact view: Line breaks remain intact after editing', () => {
+        // * Verify line breaks do not change and blank line is still there in compact view.
         verifyLineBreaksRemainIntact('COMPACT');
     });
 
     it('MM-T103_2 Standard view: Line breaks remain intact after editing', () => {
+        // * Verify line breaks do not change and blank line is still there in standard view.
         verifyLineBreaksRemainIntact('STANDARD');
     });
 });

--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -12,7 +12,49 @@
 
 import {getRandomId} from '../../../utils';
 
-describe('Messaging', () => {
+function verifyLineBreaksRemainIntact(display) {
+    cy.uiChangeMessageDisplaySetting(display);
+
+    const firstLine = `First line ${getRandomId()}`;
+    const secondLine = `Text after ${getRandomId()}`;
+
+    // # Enter in text
+    cy.get('#post_textbox').
+        clear().
+        type(firstLine).
+        type('{shift}{enter}{enter}').
+        type(`${secondLine}{enter}`);
+
+    // # Get last postId
+    cy.getLastPostId().then((postId) => {
+        const postMessageTextId = `#postMessageText_${postId}`;
+
+        // * Verify HTML still includes new line
+        cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine}</p>`);
+
+        // # click dot menu button
+        cy.clickPostDotMenu(postId);
+
+        // # click edit post
+        cy.get(`#edit_post_${postId}`).scrollIntoView().should('be.visible').click();
+
+        // # Add ",edited" to the text
+        cy.get('#edit_textbox').type(',edited');
+
+        // # Save
+        cy.get('#editButton').click();
+
+        // * Verify HTML includes newline and the edit
+        cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine},edited</p>`);
+
+        // * Post should have (edited)
+        cy.get(`#postEdited_${postId}`).
+            should('be.visible').
+            should('contain', '(edited)');
+    });
+}
+
+describe('Account Settings', () => {
     before(() => {
         // # Login as new user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
@@ -20,45 +62,11 @@ describe('Messaging', () => {
         });
     });
 
-    it('MM-T103 Compact view: Line breaks remain intact after editing', () => {
-        cy.uiChangeMessageDisplaySetting('COMPACT');
+    it('MM-T103_1 Compact view: Line breaks remain intact after editing', () => {
+        verifyLineBreaksRemainIntact('COMPACT');
+    });
 
-        const firstLine = `First line ${getRandomId()}`;
-        const secondLine = `Text after ${getRandomId()}`;
-
-        // # Enter in text
-        cy.get('#post_textbox').
-            clear().
-            type(firstLine).
-            type('{shift}{enter}{enter}').
-            type(`${secondLine}{enter}`);
-
-        // # Get last postId
-        cy.getLastPostId().then((postId) => {
-            const postMessageTextId = `#postMessageText_${postId}`;
-
-            // * Verify HTML still includes new line
-            cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine}</p>`);
-
-            // # click dot menu button
-            cy.clickPostDotMenu(postId);
-
-            // # click edit post
-            cy.get(`#edit_post_${postId}`).scrollIntoView().should('be.visible').click();
-
-            // # Add ",edited" to the text
-            cy.get('#edit_textbox').type(',edited');
-
-            // # Save
-            cy.get('#editButton').click();
-
-            // * Verify HTML includes newline and the edit
-            cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine},edited</p>`);
-
-            // * Post should have (edited)
-            cy.get(`#postEdited_${postId}`).
-                should('be.visible').
-                should('contain', '(edited)');
-        });
+    it('MM-T103_2 Standard view: Line breaks remain intact after editing', () => {
+        verifyLineBreaksRemainIntact('STANDARD');
     });
 });

--- a/e2e/cypress/integration/messaging/long_post_attachments_spec.js
+++ b/e2e/cypress/integration/messaging/long_post_attachments_spec.js
@@ -39,7 +39,7 @@ function postAttachments() {
     });
 }
 
-describe('MM-T105 Long post with mutiple attachments', () => {
+describe('Messaging', () => {
     let testTeam;
 
     beforeEach(() => {
@@ -53,7 +53,8 @@ describe('MM-T105 Long post with mutiple attachments', () => {
         });
     });
 
-    it('Attachment previews/thumbnails display as expected, when viewing full or partial post', () => {
+    it('MM-T105 Long post with mutiple attachments', () => {
+        // * Attachment previews/thumbnails display as expected, when viewing full or partial post':
         // # Post attachments
         postAttachments();
 
@@ -73,9 +74,8 @@ describe('MM-T105 Long post with mutiple attachments', () => {
                     find('.post-image__name').contains('small-image.png').should('exist');
             });
         });
-    });
 
-    it('Can click one of the attachments and cycle through the multiple attachment previews as usual', () => {
+        // * Can click one of the attachments and cycle through the multiple attachment previews as usual:
         // # Post attachments
         postAttachments();
 

--- a/e2e/cypress/integration/messaging/message_edit_post_with_attachment_spec.js
+++ b/e2e/cypress/integration/messaging/message_edit_post_with_attachment_spec.js
@@ -12,7 +12,7 @@
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-describe('MM-13697 Edit Post with attachment', () => {
+describe('Messaging', () => {
     let townsquareLink;
 
     before(() => {
@@ -23,7 +23,7 @@ describe('MM-13697 Edit Post with attachment', () => {
         });
     });
 
-    it('Pasted text should be pasted where the cursor is', () => {
+    it('MM-T99 Edit Post with attachment, paste text in middle', () => {
         // # Got to a test channel on the side bar
         cy.get('#sidebarItem_town-square').click({force: true});
 


### PR DESCRIPTION
Adding missing Zephyr keys to the following E2E tests:
- message_display_mode_spec.js
- long_post_attachments_spec.js
- message_edit_post_with_attachment_spec.js
<img width="691" alt="Screen Shot 2021-04-14 at 5 44 45 PM" src="https://user-images.githubusercontent.com/691331/114800277-470d5c80-9d4e-11eb-978f-122620f71535.png">
<img width="692" alt="Screen Shot 2021-04-14 at 5 39 48 PM" src="https://user-images.githubusercontent.com/691331/114800288-4c6aa700-9d4e-11eb-819c-19492b640a4f.png">
<img width="691" alt="Screen Shot 2021-04-14 at 5 43 24 PM" src="https://user-images.githubusercontent.com/691331/114800296-512f5b00-9d4e-11eb-98e7-cf2fc44ab9ad.png">
