### PR TITLE
Fixing keys in Cypress

### DIFF
--- a/e2e/cypress/integration/messaging/header_spec.js
+++ b/e2e/cypress/integration/messaging/header_spec.js
@@ -65,35 +65,6 @@ describe('Header', () => {
 
         cy.apiSaveMessageDisplayPreference('clean');
     });
-
-    it('S13483 - Cleared search term should not reappear as RHS is opened and closed', () => {
-        // # Place the focus on the search box and search for something
-        cy.get('#searchFormContainer').click();
-        cy.get('#searchBox').should('be.visible').
-            type('London{enter}').
-            wait(TIMEOUTS.ONE_SEC).
-            clear();
-        cy.get('#searchbar-help-popup').should('be.visible');
-        cy.get('#searchFormContainer').type('{esc}');
-
-        // # Verify the Search side bar opens up
-        cy.get('#sidebar-right').should('be.visible').and('contain', 'Search Results');
-
-        // # Close the search side bar
-        // * Verify the Search side bar is closed
-        cy.get('#searchResultsCloseButton').should('be.visible').click();
-        cy.get('#sidebar-right').should('not.be.visible');
-
-        // # Verify that the cleared search text does not appear on the search box
-        cy.get('#searchBox').should('be.visible').and('be.empty');
-
-        // # Click the pin icon to open the pinned posts RHS
-        cy.get('#channelHeaderPinButton').should('be.visible').click();
-        cy.get('#sidebar-right').should('be.visible').and('contain', 'Pinned Posts');
-
-        // # Verify that the Search term input box is still cleared and search term does not reappear when RHS opens
-        cy.get('#searchBox').should('have.attr', 'value', '').and('be.empty');
-    });
 });
 
 function updateAndVerifyChannelHeader(prefix, header) {

--- a/e2e/cypress/integration/onboarding/existing_email_adress_spec.js
+++ b/e2e/cypress/integration/onboarding/existing_email_adress_spec.js
@@ -34,7 +34,7 @@ function signupWithEmail(name, pw) {
     cy.get('#createAccountButton').click();
 }
 
-describe('Email Address', () => {
+describe('Cloud Onboarding', () => {
     before(() => {
         // # Set EnableOpenServer to true and disable other auth options
         const newSettings = {
@@ -46,7 +46,7 @@ describe('Email Address', () => {
         cy.apiLogout();
     });
 
-    it('On14634 Email address already exists', () => {
+    it('MM-T403 Email address already exists', () => {
         // # Signup a new user with an email address and user generated in signupWithEmail
         signupWithEmail('unique.' + uniqueUserId, 'unique1pw');
 

--- a/e2e/cypress/integration/onboarding/tutorial_navigation_and_links_spec.js
+++ b/e2e/cypress/integration/onboarding/tutorial_navigation_and_links_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @onboarding @smoke @not_cloud
 
-describe('Test Tutorial Navigation', () => {
+describe('Cloud Onboarding', () => {
     let testUser;
     let otherUser;
     let testTeam;
@@ -42,7 +42,7 @@ describe('Test Tutorial Navigation', () => {
         });
     });
 
-    it('On13989 - Tutorial Navigation and Links', () => {
+    it('MM-T401 - Tutorial Navigation and Links', () => {
         // * Check that step one displays after new user signs in.
         checkStepOne();
 

--- a/e2e/cypress/integration/search/cleared_search_term_spec.js
+++ b/e2e/cypress/integration/search/cleared_search_term_spec.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @search
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('Search', () => {
+    before(() => {
+        // # Login as test user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+
+    it('MM-T352 - Cleared search term should not reappear as RHS is opened and closed', () => {
+        // # Place the focus on the search box and search for something
+        cy.get('#searchFormContainer').click();
+        cy.get('#searchBox').should('be.visible').
+            type('London{enter}').
+            wait(TIMEOUTS.ONE_SEC).
+            clear();
+        cy.get('#searchbar-help-popup').should('be.visible');
+        cy.get('#searchFormContainer').type('{esc}');
+
+        // # Verify the Search side bar opens up
+        cy.get('#sidebar-right').should('be.visible').and('contain', 'Search Results');
+
+        // # Close the search side bar
+        // * Verify the Search side bar is closed
+        cy.get('#searchResultsCloseButton').should('be.visible').click();
+        cy.get('#sidebar-right').should('not.be.visible');
+
+        // # Verify that the cleared search text does not appear on the search box
+        cy.get('#searchBox').should('be.visible').and('be.empty');
+
+        // # Click the pin icon to open the pinned posts RHS
+        cy.get('#channelHeaderPinButton').should('be.visible').click();
+        cy.get('#sidebar-right').should('be.visible').and('contain', 'Pinned Posts');
+
+        // # Verify that the Search term input box is still cleared and search term does not reappear when RHS opens
+        cy.get('#searchBox').should('have.attr', 'value', '').and('be.empty');
+    });
+});

--- a/e2e/cypress/integration/search/post_search_display_spec.js
+++ b/e2e/cypress/integration/search/post_search_display_spec.js
@@ -12,7 +12,7 @@
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-describe('Post search display', () => {
+describe('Search', () => {
     let testTeam;
     let testUser;
     let mmConfig;
@@ -35,7 +35,7 @@ describe('Post search display', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
     });
 
-    it('S14252 After clearing search query, search options display', () => {
+    it('MM-T353 After clearing search query, search options display', () => {
         const searchWord = 'Hello';
 
         // # Post a message

--- a/e2e/cypress/integration/search/results_post_comment_spec.js
+++ b/e2e/cypress/integration/search/results_post_comment_spec.js
@@ -25,7 +25,7 @@ describe('Search', () => {
         });
     });
 
-    it('S14548 Search results Right-Hand-Side: Post a comment', () => {
+    it('MM-T373 Search results Right-Hand-Side: Post a comment', () => {
         const message = `asparagus${getRandomId()}`;
         const comment = 'Replying to asparagus';
 


### PR DESCRIPTION
Next round of fixing missing Zephyr keys:
- `cleared_search_term_spec.js`: MM-T352 -- test was in `search` folder hence moved test from header_spec.js to this spec file. Also the test was already running in prod, hence added the `prod` tag
- `existing_email_adress_spec.js`: MM-T403
- `tutorial_navigation_and_links_spec.js`: MM-T401
- `post_search_display_spec.js`: MM-T353
- `results_post_comment_spec.js`: MM-T373
<img width="492" alt="Screen Shot 2021-04-15 at 7 02 18 PM" src="https://user-images.githubusercontent.com/691331/114962911-77253000-9e20-11eb-967a-ddb9365f4da5.png">
<img width="503" alt="Screen Shot 2021-04-15 at 7 12 58 PM" src="https://user-images.githubusercontent.com/691331/114962932-81dfc500-9e20-11eb-976f-31dcacb22492.png">
<img width="497" alt="Screen Shot 2021-04-15 at 7 09 48 PM" src="https://user-images.githubusercontent.com/691331/114962936-860be280-9e20-11eb-92c8-6b71133b9d09.png">
<img width="501" alt="Screen Shot 2021-04-15 at 7 04 33 PM" src="https://user-images.githubusercontent.com/691331/114962952-8c9a5a00-9e20-11eb-85c5-34b6287f8dd3.png">
<img width="498" alt="Screen Shot 2021-04-15 at 7 05 32 PM" src="https://user-images.githubusercontent.com/691331/114962961-90c67780-9e20-11eb-9ede-46ed3b9f041a.png">
