### PR TITLE
MM-35021: Only display overflow names in Avatars tooltip

### DIFF
--- a/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
+++ b/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
@@ -428,7 +428,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
         </UserAvatar>
         <SimpleTooltip
           animation={true}
-          content="first.last1, first.last2, first.last3, first.last4, first.last5"
+          content="first.last4, first.last5"
           id="names-overflow"
           onEntered={[Function]}
         >
@@ -444,7 +444,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
                 id="names-overflow"
                 placement="top"
               >
-                first.last1, first.last2, first.last3, first.last4, first.last5
+                first.last4, first.last5
               </Tooltip>
             }
             placement="top"
@@ -500,7 +500,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
                   }
                   placement="top"
                 >
-                  first.last1, first.last2, first.last3, first.last4, first.last5
+                  first.last4, first.last5
                 </OverlayWrapper>
               }
               placement="top"
@@ -1289,7 +1289,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
         </UserAvatar>
         <SimpleTooltip
           animation={true}
-          content="first.last1, first.last2, first.last3, first.last4, first.last5"
+          content="first.last4, first.last5"
           id="names-overflow"
           onEntered={[Function]}
         >
@@ -1305,7 +1305,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
                 id="names-overflow"
                 placement="top"
               >
-                first.last1, first.last2, first.last3, first.last4, first.last5
+                first.last4, first.last5
               </Tooltip>
             }
             placement="top"
@@ -1361,7 +1361,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
                   }
                   placement="top"
                 >
-                  first.last1, first.last2, first.last3, first.last4, first.last5
+                  first.last4, first.last5
                 </OverlayWrapper>
               }
               placement="top"

--- a/components/widgets/users/avatars/__snapshots__/avatars.test.tsx.snap
+++ b/components/widgets/users/avatars/__snapshots__/avatars.test.tsx.snap
@@ -391,7 +391,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
     </UserAvatar>
     <SimpleTooltip
       animation={true}
-      content="first.last1, first.last2, first.last3, first.last4, first.last5"
+      content="first.last4, first.last5"
       id="names-overflow"
       onEntered={[Function]}
     >
@@ -407,7 +407,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
             id="names-overflow"
             placement="top"
           >
-            first.last1, first.last2, first.last3, first.last4, first.last5
+            first.last4, first.last5
           </Tooltip>
         }
         placement="top"
@@ -463,7 +463,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
               }
               placement="top"
             >
-              first.last1, first.last2, first.last3, first.last4, first.last5
+              first.last4, first.last5
             </OverlayWrapper>
           }
           placement="top"

--- a/components/widgets/users/avatars/avatars.test.tsx
+++ b/components/widgets/users/avatars/avatars.test.tsx
@@ -5,9 +5,11 @@ import React from 'react';
 
 import {mount} from 'enzyme';
 
-import Avatar from '../avatar';
-
 import {mockStore} from 'tests/test_store';
+
+import SimpleTooltip from 'components/widgets/simple_tooltip';
+
+import Avatar from '../avatar';
 
 import Avatars from './avatars';
 
@@ -109,5 +111,27 @@ describe('components/widgets/users/Avatars', () => {
         expect(wrapper.find(Avatar).find({url: '/api/v4/users/3/image?_=0'}).exists()).toBe(true);
         expect(wrapper.find(Avatar).find({url: '/api/v4/users/4/image?_=0'}).exists()).toBe(false);
         expect(wrapper.find(Avatar).find({url: '/api/v4/users/5/image?_=0'}).exists()).toBe(false);
+
+        expect(wrapper.find(Avatar).find({text: '+2'}).exists()).toBe(true);
+    });
+
+    test('should not duplicate displayed users in overflow tooltip', () => {
+        const {mountOptions} = mockStore(state);
+
+        const wrapper = mount(
+            <Avatars
+                size='xl'
+                userIds={[
+                    '1',
+                    '2',
+                    '3',
+                    '4',
+                    '5',
+                ]}
+            />,
+            mountOptions,
+        );
+
+        expect(wrapper.find(SimpleTooltip).find({id: 'names-overflow'}).prop('content')).toBe('first.last4, first.last5');
     });
 });

--- a/components/widgets/users/avatars/avatars.tsx
+++ b/components/widgets/users/avatars/avatars.tsx
@@ -81,7 +81,7 @@ function Avatars({
     const [overlayProps, setImmediate] = useSynchronizedImmediate();
     const [displayUserIds, overflowUserIds, {overflowUnnamedCount, nonDisplayCount}] = countMeta(userIds, totalUsers);
     const overflowNames = useSelector((state: GlobalState) => {
-        return userIds.map((userId) => displayNameGetter(state, true)(selectUser(state, userId))).join(', ');
+        return overflowUserIds.map((userId) => displayNameGetter(state, true)(selectUser(state, userId))).join(', ');
     });
 
     return (


### PR DESCRIPTION
`Avatars` overflow tooltip should only display users represented by '+N'. This corrects a prior refactoring var-typo.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35021

#### Screenshots
<img width="221" alt="CleanShot 2021-04-19 at 17 42 45@2x" src="https://user-images.githubusercontent.com/11724372/115312432-ef4c6800-a136-11eb-9358-5b51d18d84a4.png">
<img width="224" alt="CleanShot 2021-04-19 at 17 34 49@2x" src="https://user-images.githubusercontent.com/11724372/115312457-f96e6680-a136-11eb-8b83-d0e9786e40e5.png">
