### PR TITLE
[MM-34838] Remove Ancillary Permissions That Are Purposefully Being Remove

### DIFF
--- a/components/admin_console/system_roles/system_role/system_role.tsx
+++ b/components/admin_console/system_roles/system_role/system_role.tsx
@@ -6,6 +6,7 @@ import {FormattedMessage} from 'react-intl';
 import {uniq, difference} from 'lodash';
 
 import {Role} from 'mattermost-redux/types/roles';
+import {Client4} from 'mattermost-redux/client';
 
 import {UserProfile} from 'mattermost-redux/types/users';
 import {Dictionary} from 'mattermost-redux/types/utilities';
@@ -124,9 +125,11 @@ export default class SystemRole extends React.PureComponent<Props, State> {
 
         // Do not update permissions if sysadmin or if roles have not been updated (to prevent overrwiting roles with no permissions)
         if (role.name !== Constants.PERMISSIONS_SYSTEM_ADMIN && Object.keys(permissionsToUpdate).length > 0) {
+            const rolePermissionsWithAncillaryPermssions = await Client4.getAncillaryPermisisons(updatedRolePermissions)
+
             const newRole: Role = {
                 ...role,
-                permissions: updatedRolePermissions,
+                permissions: rolePermissionsWithAncillaryPermssions,
             };
             const result = await editRole(newRole);
             if (isError(result)) {

--- a/components/admin_console/system_roles/system_role/system_role.tsx
+++ b/components/admin_console/system_roles/system_role/system_role.tsx
@@ -125,7 +125,7 @@ export default class SystemRole extends React.PureComponent<Props, State> {
 
         // Do not update permissions if sysadmin or if roles have not been updated (to prevent overrwiting roles with no permissions)
         if (role.name !== Constants.PERMISSIONS_SYSTEM_ADMIN && Object.keys(permissionsToUpdate).length > 0) {
-            const rolePermissionsWithAncillaryPermssions = await Client4.getAncillaryPermissions(updatedRolePermissions)
+            const rolePermissionsWithAncillaryPermssions = await Client4.getAncillaryPermissions(updatedRolePermissions);
 
             const newRole: Role = {
                 ...role,

--- a/components/admin_console/system_roles/system_role/system_role.tsx
+++ b/components/admin_console/system_roles/system_role/system_role.tsx
@@ -125,7 +125,7 @@ export default class SystemRole extends React.PureComponent<Props, State> {
 
         // Do not update permissions if sysadmin or if roles have not been updated (to prevent overrwiting roles with no permissions)
         if (role.name !== Constants.PERMISSIONS_SYSTEM_ADMIN && Object.keys(permissionsToUpdate).length > 0) {
-            const rolePermissionsWithAncillaryPermssions = await Client4.getAncillaryPermisisons(updatedRolePermissions)
+            const rolePermissionsWithAncillaryPermssions = await Client4.getAncillaryPermissions(updatedRolePermissions)
 
             const newRole: Role = {
                 ...role,

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -422,6 +422,10 @@ export default class Client4 {
         return `${this.getBaseRoute()}/cloud`;
     }
 
+    getPermissionsRoute() {
+        return `${this.getBaseRoute()}/permissions`;
+    }
+
     getUserThreadsRoute(userID: string, teamID: string): string {
         return `${this.getUserRoute(userID)}/teams/${teamID}/threads`;
     }
@@ -3699,6 +3703,13 @@ export default class Client4 {
         return this.doFetch<StatusOK>(
             `${this.getCloudRoute()}/subscription/limitreached/join`,
             {method: 'post'},
+        );
+    }
+
+    getAncillaryPermisisons = (subsectionPermissions: string[]) => {
+        return this.doFetch<string[]>(
+            `${this.getPermissionsRoute()}/ancillary_permissions?subsection_permissions=${subsectionPermissions.join(',')}`,
+            {method: 'get'},
         );
     }
 

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -3708,7 +3708,7 @@ export default class Client4 {
 
     getAncillaryPermissions = (subsectionPermissions: string[]) => {
         return this.doFetch<string[]>(
-            `${this.getPermissionsRoute()}/ancillary_permissions?subsection_permissions=${subsectionPermissions.join(',')}`,
+            `${this.getPermissionsRoute()}/ancillary?subsection_permissions=${subsectionPermissions.join(',')}`,
             {method: 'get'},
         );
     }

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -3706,7 +3706,7 @@ export default class Client4 {
         );
     }
 
-    getAncillaryPermisisons = (subsectionPermissions: string[]) => {
+    getAncillaryPermissions = (subsectionPermissions: string[]) => {
         return this.doFetch<string[]>(
             `${this.getPermissionsRoute()}/ancillary_permissions?subsection_permissions=${subsectionPermissions.join(',')}`,
             {method: 'get'},


### PR DESCRIPTION
Summary
If I have a section permission that gives me ancillary permissions, I cannot remove an ancillary permission individually via MMCTL anymore. This PR aims to resolve this issue.

For example.
I have SYSCONSOLE_XXXX_WRITE which gives me manage_team permission, if I try to remove manage_team, it will always keep being re-added.

Ticket Link
https://mattermost.atlassian.net/browse/MM-34838


Server Changes: https://github.com/mattermost/mattermost-server/pull/17466

```release-note
NONE
```