### PR TITLE
Cypress/E2E: Fix cloud onboarding tests

### DIFF
--- a/e2e/cypress/integration/enterprise/cloud/onboarding/invite_member_by_email_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/invite_member_by_email_spec.js
@@ -1,0 +1,144 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @onboarding @cloud_only
+
+describe('Cloud Onboarding - Sysadmin invite members by email', () => {
+    let teamId;
+    let townSquarePage;
+    let sysadmin;
+
+    before(() => {
+        cy.apiRequireLicenseForFeature('Cloud');
+
+        cy.apiInitSetup().then(({team}) => {
+            teamId = team.id;
+            townSquarePage = `/${team.name}/channels/town-square`;
+        });
+
+        cy.apiAdminLogin().then((res) => {
+            sysadmin = res.user;
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as sysadmin and set all steps to false
+        const preference = {
+            user_id: sysadmin.id,
+            category: 'recommended_next_steps',
+            value: 'false',
+        };
+        const adminSteps = [
+            'complete_profile',
+            'notification_setup',
+            'team_setup',
+            'invite_members',
+            'hide',
+            'skip',
+        ];
+
+        cy.apiSaveUserPreference(adminSteps.map((step) => ({...preference, name: step})));
+        cy.visit(townSquarePage);
+    });
+
+    it('MM-T3332_3 Invite more than user limit', () => {
+        cy.intercept('GET', '/api/v4/cloud/subscription/stats', {
+            statusCode: 200,
+            body: {
+                remaining_seats: 10,
+                is_paid_tier: 'false',
+                is_free_trial: 'true',
+            },
+        });
+
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Click Invite members to the team header
+        cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .InviteMembersStep').should('be.visible');
+
+        // # Enter email addresses
+        cy.get('#MultiInput_InviteMembersStep__membersListInput input').should('be.visible').type('a@b.c,b@c.d,c@d.e,d@e.f,e@f.g,f@g.h,g@h.i,h@i.j,i@j.k,j@k.l,k@l.m,', {force: true});
+
+        cy.apiGetConfig().then(({config}) => {
+            cy.get('.InviteMembersStep__invitationResults').should('contain', `The free tier is limited to ${config.ExperimentalSettings.CloudUserLimit} members.`);
+        });
+
+        // * Verify that Send button is disabled until only 10 emails remain
+        cy.findByTestId('InviteMembersStep__sendButton').should('be.disabled');
+
+        // # Remove the last email
+        cy.get('#MultiInput_InviteMembersStep__membersListInput input').should('be.visible').type('{backspace}');
+
+        // * Verify that Send button is now enabled
+        cy.findByTestId('InviteMembersStep__sendButton').should('not.be.disabled');
+    });
+
+    it('MM-T3332_1 Invite with valid email', () => {
+        const emails = [
+            'bill.s.preston@wyldstallyns.com',
+            'theodore.logan@wyldstallyns.com',
+            'joanna.preston@wyldstallyns.com',
+            'elizabeth.logan@wyldstallyns.com',
+        ];
+
+        cy.intercept(`/api/v4/teams/${teamId}/invite/email?graceful=true`, (req) => {
+            req.continue((res) => {
+                // # Mock the response if email rate limit is exceeded
+                if (res.body.id === 'app.email.rate_limit_exceeded.app_error') {
+                    res.send(200, emails.map((email) => ({email})));
+                }
+            });
+        });
+
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Click Invite members to the team header
+        cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .InviteMembersStep').should('be.visible');
+
+        // * Verify that Send button is disabled until emails are entered
+        cy.findByTestId('InviteMembersStep__sendButton').should('be.disabled');
+
+        // # Enter email addresses
+        cy.get('#MultiInput_InviteMembersStep__membersListInput input').should('be.visible').type(emails.join(','), {force: true});
+
+        // # Click Send
+        cy.findByTestId('InviteMembersStep__sendButton').should('not.be.disabled').click();
+
+        // * Verify that 4 invitations were sent
+        cy.get('.InviteMembersStep__invitationResults').should('contain', `${emails.length} invitations sent`);
+    });
+
+    it('MM-T3332_2 Invite with invalid emails', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Click Invite members to the team header
+        cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .InviteMembersStep').should('be.visible');
+
+        // # Enter email addresses
+        cy.get('#MultiInput_InviteMembersStep__membersListInput input').should('be.visible').type('bill.s.preston@wyldstallyns.com,theodoreloganwyldstallynscom,', {force: true});
+
+        // # Click Send
+        cy.findByTestId('InviteMembersStep__sendButton').should('not.be.disabled').click();
+
+        // * Verify that the error message shows
+        cy.get('.InviteMembersStep__invitationResults').should('contain', 'One or more email addresses are invalid');
+    });
+});

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/set_profile_and_team_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/set_profile_and_team_spec.js
@@ -1,0 +1,173 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @onboarding @cloud_only
+
+describe('Cloud Onboarding - Sysadmin', () => {
+    let townSquarePage;
+    let sysadmin;
+
+    before(() => {
+        cy.apiRequireLicenseForFeature('Cloud');
+
+        cy.apiInitSetup().then(({team}) => {
+            townSquarePage = `/${team.name}/channels/town-square`;
+        });
+
+        cy.apiAdminLogin().then((res) => {
+            sysadmin = res.user;
+        });
+    });
+
+    beforeEach(() => {
+        // # Login as sysadmin and set all steps to false
+        const preference = {
+            user_id: sysadmin.id,
+            category: 'recommended_next_steps',
+            value: 'false',
+        };
+        const adminSteps = [
+            'complete_profile',
+            'notification_setup',
+            'team_setup',
+            'invite_members',
+            'hide',
+            'skip',
+        ];
+
+        cy.apiSaveUserPreference(adminSteps.map((step) => ({...preference, name: step})));
+        cy.visit(townSquarePage);
+    });
+
+    it('MM-T3330_1 Sysadmin - Set full name and profile image', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Clear full name
+        cy.apiPatchUser(sysadmin.id, {first_name: '', last_name: ''}).then(() => {
+            // * Check to make sure card is expanded
+            cy.get('.Card__body.expanded .CompleteProfileStep').should('be.visible');
+
+            // # Clear full name input
+            cy.get('#input_fullName').should('be.visible').clear();
+
+            // * Save profile should be disabled
+            cy.findByTestId('CompleteProfileStep__saveProfileButton').should('be.disabled');
+
+            // # Enter full name
+            cy.get('#input_fullName').should('be.visible').clear().type('Theodore Logan');
+
+            // # Select profile picture
+            cy.findByTestId('PictureSelector__input-CompleteProfileStep__profilePicture').attachFile('mattermost-icon.png');
+
+            // # Click Save profile button
+            cy.findByTestId('CompleteProfileStep__saveProfileButton').should('be.visible').and('not.be.disabled').click();
+
+            // * Check to make sure card is collapsed and step is complete
+            cy.get('.Card.complete .CompleteProfileStep').should('exist');
+
+            // * Step counter should increment
+            cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '1 / 4 steps complete');
+        });
+    });
+
+    it('MM-T3330_2 Sysadmin - Set full name and profile image - no name provided', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .CompleteProfileStep').should('be.visible');
+
+        // # Clear full name box
+        cy.get('#input_fullName').should('be.visible').type('Theodore Logan').clear();
+
+        // * Verify error message is displayed
+        cy.get('.CompleteProfileStep__fullName .Input___error span').should('contain', 'Your name cannot be blank');
+
+        // * Save profile should be disabled
+        cy.findByTestId('CompleteProfileStep__saveProfileButton').should('be.disabled');
+    });
+
+    it('MM-T3330_3 Sysadmin - Set full name and profile image - upload file of wrong type', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .CompleteProfileStep').should('be.visible');
+
+        // # Upload file
+        cy.findByTestId('PictureSelector__input-CompleteProfileStep__profilePicture').attachFile('saml_users.json');
+
+        // * Verify error message is displayed
+        cy.get('.CompleteProfileStep__pictureError').should('contain', 'Photos must be in BMP, JPG or PNG format. Maximum file size is 50MB.');
+    });
+
+    it('MM-T3331_1 Sysadmin - Set team name and team icon', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Click Name your team header
+        cy.get('button.NextStepsView__cardHeader:contains(Name your team)').should('be.visible').click();
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .TeamProfileStep').should('be.visible');
+
+        // # Enter team name
+        cy.get('#input_teamName').should('be.visible').clear().type('Wyld Stallyns');
+
+        // # Select profile picture
+        cy.findByTestId('PictureSelector__input-TeamProfileStep__teamIcon').attachFile('mattermost-icon.png');
+
+        // # Click Save team button
+        cy.findByTestId('TeamProfileStep__saveTeamButton').should('be.visible').and('not.be.disabled').click();
+
+        // * Check to make sure card is collapsed and step is complete
+        cy.get('.Card.complete .TeamProfileStep').should('exist');
+
+        // * Step counter should increment
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '1 / 4 steps complete');
+    });
+
+    it('MM-T3331_2 Sysadmin - Set team name and team icon - no name provided', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Click Name your team header
+        cy.get('button.NextStepsView__cardHeader:contains(Name your team)').should('be.visible').click();
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .TeamProfileStep').should('be.visible');
+
+        // # Clear team name box
+        cy.get('#input_teamName').should('be.visible').type('Wyld Stallyns').clear();
+
+        // * Verify error message is displayed
+        cy.get('.TeamProfileStep__textInputs .Input___error span').should('contain', 'Team name cannot be blank');
+
+        // * Save team should be disabled
+        cy.findByTestId('TeamProfileStep__saveTeamButton').should('be.disabled');
+    });
+
+    it('MM-T3331_3 Sysadmin - Set team name and team icon - upload file of wrong type', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Click Name your team header
+        cy.get('button.NextStepsView__cardHeader:contains(Name your team)').should('be.visible').click();
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .TeamProfileStep').should('be.visible');
+
+        // # Upload file
+        cy.findByTestId('PictureSelector__input-TeamProfileStep__teamIcon').attachFile('saml_users.json');
+
+        // * Verify error message is displayed
+        cy.get('.TeamProfileStep__pictureError').should('contain', 'Photos must be in BMP, JPG or PNG format. Maximum file size is 50MB.');
+    });
+});


### PR DESCRIPTION
#### Summary
- updated onboarding process with the last change related to notification setup
- separated specs into 3 files since other tests require mocking to response. Also, it makes it easier for test maintenance and promotion.
- added `@cloud_only` metadata so it can be filtered for Cloud tests only.

#### Ticket Link
failed on daily Cypress run

#### Screenshots
![Screen Shot 2021-04-21 at 2 14 49 PM](https://user-images.githubusercontent.com/5334504/115506438-6f94d980-a2ad-11eb-92da-59427eae03e7.png)
![Screen Shot 2021-04-21 at 2 15 28 PM](https://user-images.githubusercontent.com/5334504/115506448-715e9d00-a2ad-11eb-8778-b3b0e272c369.png)
![Screen Shot 2021-04-21 at 2 18 27 PM](https://user-images.githubusercontent.com/5334504/115506451-71f73380-a2ad-11eb-9fab-b02b63d53865.png)
