### PR TITLE
MM-35074: short circuit slash command hooks

### DIFF
--- a/actions/hooks.js
+++ b/actions/hooks.js
@@ -50,6 +50,12 @@ export function runSlashCommandWillBePostedHooks(originalMessage, originalArgs) 
 
                 message = result.message;
                 args = result.args;
+
+                // The first plugin to consume the slash command by returning an empty object
+                // should terminate the processing by subsequent plugins.
+                if (Object.keys(result).length === 0) {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
#### Summary
When the Confluence plugin consumes a slash command for client-side processing (i.e. `/confluence subscribe`), it signals this by returning an empty object as per the required interface.

However, the webapp passes this empty object through all other registered slash command hooks. When the Confluence and Incident Collaboration plugins are installed (and Incident Collaboration "registers last"), Incident Collaboration receives this empty object and [mistakenly initializes](https://github.com/mattermost/mattermost-plugin-incident-collaboration/blob/98c01d6a3e76bfa48d9dd4860136d4f9a7dbde85/webapp/src/slash_command.ts#L9-L11) the `undefined` args parameter in testing whether it should process the slash command. The final result consumed by the webapp is now partially initialized, leading to a JavaScript exception and a create post component that won't process slash commands until it mounts afresh.

While we can address this in Incident Collaboration, it's unexpected that the webapp would notify plugins at all in this case, given there is literally no metadata on which to try to do anything meaningful. Short-circuit in this case, avoiding the original report altogether.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-35074

#### Release Note
```release-note
Short-circuit slash command hooks when a plugin consumes one for client-side processing.
```