### PR TITLE
MM-35127 CRT: Marking thread as unread doesn't set the timestamp correctly

### DIFF
--- a/components/threading/global_threads/thread_item/thread_item.test.tsx
+++ b/components/threading/global_threads/thread_item/thread_item.test.tsx
@@ -103,6 +103,7 @@ describe('components/threading/global_threads/thread_item', () => {
                 edit_at: 1611786714912,
             },
         });
+        set(mockState, 'entities.posts.postsInThread', {'1y8hpek81byspd4enyk9mp1ncw': []});
         set(mockState, 'entities.channels.channels', {
             pnzsh7kwt7rmzgj8yb479sc9yw: {
                 id: 'pnzsh7kwt7rmzgj8yb479sc9yw',

--- a/components/threading/global_threads/thread_menu/thread_menu.tsx
+++ b/components/threading/global_threads/thread_menu/thread_menu.tsx
@@ -110,7 +110,7 @@ function ThreadMenu({
                     })}
                     onClick={useCallback(() => {
                         dispatch(updateThreadRead(currentUserId, currentTeamId, threadId, hasUnreads ? Date.now() : unreadTimestamp));
-                    }, [currentUserId, currentTeamId, threadId, hasUnreads, updateThreadRead])}
+                    }, [currentUserId, currentTeamId, threadId, hasUnreads, updateThreadRead, unreadTimestamp])}
                 />
 
                 <Menu.ItemAction

--- a/components/threading/global_threads/thread_pane/thread_pane.test.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.test.tsx
@@ -73,6 +73,7 @@ describe('components/threading/global_threads/thread_pane', () => {
                     myPreferences: {},
                 },
                 posts: {
+                    postsInThread: {'1y8hpek81byspd4enyk9mp1ncw': []},
                     posts: {
                         '1y8hpek81byspd4enyk9mp1ncw': {
                             id: '1y8hpek81byspd4enyk9mp1ncw',

--- a/components/threading/global_threads/thread_pane/thread_pane.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.tsx
@@ -9,7 +9,7 @@ import {UserThread} from 'mattermost-redux/types/threads';
 import {setThreadFollow} from 'mattermost-redux/actions/threads';
 
 import {makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getPost, makeGetPostsForThread} from 'mattermost-redux/selectors/entities/posts';
 
 import {t} from 'utils/i18n';
 
@@ -24,6 +24,7 @@ import {useThreadRouting} from '../../hooks';
 import './thread_pane.scss';
 
 const getChannel = makeGetChannel();
+const getPostsForThread = makeGetPostsForThread();
 
 type Props = {
     thread: UserThread;
@@ -53,9 +54,15 @@ const ThreadPane = ({
 
     const channel = useSelector((state: GlobalState) => getChannel(state, {id: channelId}));
     const post = useSelector((state: GlobalState) => getPost(state, thread.id));
-
+    const postsInThread = useSelector((state: GlobalState) => getPostsForThread(state, {rootId: post.id}));
     const selectHandler = useCallback(() => select(), []);
+    let unreadTimestamp = post.edit_at || post.create_at;
 
+    // if we have the whole thread, get the posts in it, sorted. First post - root post, second post - oldest reply. Use that timestamp
+    if (postsInThread.length > 1) {
+        const p = postsInThread[postsInThread.length - 2];
+        unreadTimestamp = p.edit_at || p.create_at;
+    }
     const goToInChannelHandler = useCallback(() => {
         goToInChannel(threadId);
     }, [goToInChannel, threadId]);
@@ -104,7 +111,7 @@ const ThreadPane = ({
                             threadId={threadId}
                             isFollowing={isFollowing}
                             hasUnreads={Boolean(thread.unread_replies || thread.unread_mentions)}
-                            unreadTimestamp={post.edit_at || post.create_at}
+                            unreadTimestamp={unreadTimestamp}
                         >
                             <SimpleTooltip
                                 id='threadActionMenu'

--- a/components/threading/global_threads/thread_pane/thread_pane.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.tsx
@@ -58,7 +58,8 @@ const ThreadPane = ({
     const selectHandler = useCallback(() => select(), []);
     let unreadTimestamp = post.edit_at || post.create_at;
 
-    // if we have the whole thread, get the posts in it, sorted. First post - root post, second post - oldest reply. Use that timestamp
+    // if we have the whole thread, get the posts in it, sorted from newest to oldest.
+    // Last post - root post, second to last post - oldest reply. Use that timestamp
     if (postsInThread.length > 1) {
         const p = postsInThread[postsInThread.length - 2];
         unreadTimestamp = p.edit_at || p.create_at;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
pass correct timestamp on 'mark as unread'
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-35127
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
https://github.com/mattermost/mattermost-server/pull/17507
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
