### PR TITLE
MM-33540 Remove sticky headings from sidebar to fix nesting errors

### DIFF
--- a/components/sidebar/sidebar_category_header.tsx
+++ b/components/sidebar/sidebar_category_header.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {DraggableProvidedDragHandleProps} from 'react-beautiful-dnd';
 
 import {wrapEmojis} from 'utils/emoji_utils';
-import * as UserAgent from 'utils/user_agent';
 
 type StaticProps = {
     children?: React.ReactNode;
@@ -15,11 +14,7 @@ type StaticProps = {
 
 export const SidebarCategoryHeaderStatic = React.forwardRef((props: StaticProps, ref?: React.Ref<HTMLDivElement>) => {
     return (
-        <div
-            className={classNames('SidebarChannelGroupHeader SidebarChannelGroupHeader--static', {
-                'SidebarChannelGroupHeader--sticky': supportsStickyHeaders(),
-            })}
-        >
+        <div className='SidebarChannelGroupHeader SidebarChannelGroupHeader--static'>
             <div
                 ref={ref}
                 className='SidebarChannelGroupHeader_groupButton'
@@ -48,7 +43,6 @@ export const SidebarCategoryHeader = React.forwardRef((props: Props, ref?: React
     return (
         <div
             className={classNames('SidebarChannelGroupHeader', {
-                'SidebarChannelGroupHeader--sticky': supportsStickyHeaders(),
                 muted: props.muted,
             })}
         >
@@ -83,7 +77,3 @@ SidebarCategoryHeader.defaultProps = {
     isDraggingOver: false,
 };
 SidebarCategoryHeader.displayName = 'SidebarCategoryHeader';
-
-function supportsStickyHeaders() {
-    return !UserAgent.isFirefox() && !UserAgent.isSafari();
-}

--- a/components/sidebar/sidebar_category_header.tsx
+++ b/components/sidebar/sidebar_category_header.tsx
@@ -66,8 +66,8 @@ export const SidebarCategoryHeader = React.forwardRef((props: Props, ref?: React
                 >
                     {wrapEmojis(props.displayName)}
                 </div>
-                {props.children}
             </button>
+            {props.children}
         </div>
     );
 });

--- a/components/sidebar/unread_channel_indicator/__snapshots__/unread_channel_indicator.test.tsx.snap
+++ b/components/sidebar/unread_channel_indicator/__snapshots__/unread_channel_indicator.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`UnreadChannelIndicator should match snapshot 1`] = `
 <div
-  className="nav-pills__unread-indicator withStickyHeaders"
+  className="nav-pills__unread-indicator"
   id="unreadIndicatorundefined"
   onClick={[MockFunction]}
 >
@@ -14,7 +14,7 @@ exports[`UnreadChannelIndicator should match snapshot 1`] = `
 
 exports[`UnreadChannelIndicator should match snapshot when content is an element 1`] = `
 <div
-  className="nav-pills__unread-indicator nav-pills__unread-indicator--visible withStickyHeaders"
+  className="nav-pills__unread-indicator nav-pills__unread-indicator--visible"
   id="unreadIndicatorundefined"
   onClick={[MockFunction]}
 >
@@ -29,7 +29,7 @@ exports[`UnreadChannelIndicator should match snapshot when content is an element
 
 exports[`UnreadChannelIndicator should match snapshot when content is text 1`] = `
 <div
-  className="nav-pills__unread-indicator nav-pills__unread-indicator--visible withStickyHeaders"
+  className="nav-pills__unread-indicator nav-pills__unread-indicator--visible"
   id="unreadIndicatorundefined"
   onClick={[MockFunction]}
 >
@@ -42,7 +42,7 @@ exports[`UnreadChannelIndicator should match snapshot when content is text 1`] =
 
 exports[`UnreadChannelIndicator should match snapshot when show is set 1`] = `
 <div
-  className="nav-pills__unread-indicator nav-pills__unread-indicator--visible withStickyHeaders"
+  className="nav-pills__unread-indicator nav-pills__unread-indicator--visible"
   id="unreadIndicatorundefined"
   onClick={[MockFunction]}
 >

--- a/components/sidebar/unread_channel_indicator/unread_channel_indicator.scss
+++ b/components/sidebar/unread_channel_indicator/unread_channel_indicator.scss
@@ -46,10 +46,6 @@
     &-top {
         top: 16px;
 
-        &.withStickyHeaders {
-            top: 32px;
-        }
-
         .icon {
             svg {
                 transform: rotate(180deg);

--- a/components/sidebar/unread_channel_indicator/unread_channel_indicator.tsx
+++ b/components/sidebar/unread_channel_indicator/unread_channel_indicator.tsx
@@ -4,14 +4,9 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import * as UserAgent from 'utils/user_agent';
 import UnreadBelowIcon from 'components/widgets/icons/unread_below_icon';
 
 import './unread_channel_indicator.scss';
-
-function supportsStickyHeaders() {
-    return !UserAgent.isFirefox() && !UserAgent.isSafari();
-}
 
 type Props = {
 
@@ -47,7 +42,6 @@ function UnreadChannelIndicator(props: Props) {
             id={'unreadIndicator' + props.name}
             className={classNames('nav-pills__unread-indicator', {
                 'nav-pills__unread-indicator--visible': props.show,
-                withStickyHeaders: supportsStickyHeaders(),
             }, props.extraClass)}
             onClick={props.onClick}
         >

--- a/e2e/cypress/integration/channel_sidebar/category_sorting_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/category_sorting_spec.js
@@ -14,16 +14,14 @@ import {getRandomId} from '../../utils';
 
 let testTeam;
 let testUser;
-let testChannel;
 
 describe('Category sorting', () => {
     beforeEach(() => {
         // # Login as test user and visit town-square
         cy.apiAdminLogin();
-        cy.apiInitSetup({loginAfter: true}).then(({team, user, channel}) => {
+        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
             testTeam = team;
             testUser = user;
-            testChannel = channel;
             cy.visit(`/${team.name}/channels/town-square`);
         });
     });
@@ -165,48 +163,49 @@ describe('Category sorting', () => {
         cy.findByLabelText('abcdefghijklmnopqrstuv').should('be.visible');
     });
 
-    it('MM-T3864 Sticky category headers', () => {
-        const categoryName = createCategoryFromSidebarMenu();
+    // // Commented out since we've had to disable sticky headings because of issues with the menu components
+    // it('MM-T3864 Sticky category headers', () => {
+    //     const categoryName = createCategoryFromSidebarMenu();
 
-        // # Move test channel to Favourites
-        cy.get(`#sidebarItem_${testChannel.name}`).parent().then((element) => {
-            // # Get id of the channel
-            const id = element[0].getAttribute('data-rbd-draggable-id');
-            cy.get(`#sidebarItem_${testChannel.name}`).parent('li').within(() => {
-                // # Open dropdown next to channel name
-                cy.get('.SidebarMenu').invoke('show').get('.SidebarMenu_menuButton').should('be.visible').click({force: true});
+    //     // # Move test channel to Favourites
+    //     cy.get(`#sidebarItem_${testChannel.name}`).parent().then((element) => {
+    //         // # Get id of the channel
+    //         const id = element[0].getAttribute('data-rbd-draggable-id');
+    //         cy.get(`#sidebarItem_${testChannel.name}`).parent('li').within(() => {
+    //             // # Open dropdown next to channel name
+    //             cy.get('.SidebarMenu').invoke('show').get('.SidebarMenu_menuButton').should('be.visible').click({force: true});
 
-                // # Favourite the channel
-                cy.get(`#favorite-${id} button`).should('be.visible').click({force: true});
-            });
-        });
+    //             // # Favourite the channel
+    //             cy.get(`#favorite-${id} button`).should('be.visible').click({force: true});
+    //         });
+    //     });
 
-        // # Create 15 channels and add them to a custom category
-        for (let i = 0; i < 15; i++) {
-            createChannelAndAddToCategory(categoryName);
-            cy.get('#SidebarContainer .scrollbar--view').scrollTo('bottom', {ensureScrollable: false});
-        }
+    //     // # Create 15 channels and add them to a custom category
+    //     for (let i = 0; i < 15; i++) {
+    //         createChannelAndAddToCategory(categoryName);
+    //         cy.get('#SidebarContainer .scrollbar--view').scrollTo('bottom', {ensureScrollable: false});
+    //     }
 
-        // # Create 10 channels and add them to Favourites
-        for (let i = 0; i < 10; i++) {
-            createChannelAndAddToFavourites();
-            cy.get('#SidebarContainer .scrollbar--view').scrollTo('bottom', {ensureScrollable: false});
-        }
+    //     // # Create 10 channels and add them to Favourites
+    //     for (let i = 0; i < 10; i++) {
+    //         createChannelAndAddToFavourites();
+    //         cy.get('#SidebarContainer .scrollbar--view').scrollTo('bottom', {ensureScrollable: false});
+    //     }
 
-        // # Scroll to the center of the channel list
-        cy.get('#SidebarContainer .scrollbar--view').scrollTo('center', {ensureScrollable: false});
+    //     // # Scroll to the center of the channel list
+    //     cy.get('#SidebarContainer .scrollbar--view').scrollTo('center', {ensureScrollable: false});
 
-        // * Verify that both the 'More Unreads' label and the category header are visible
-        cy.get('#unreadIndicatorTop').should('be.visible');
-        cy.get('#SidebarContainer .SidebarChannelGroupHeader:contains(FAVORITES)').should('be.visible');
+    //     // * Verify that both the 'More Unreads' label and the category header are visible
+    //     cy.get('#unreadIndicatorTop').should('be.visible');
+    //     cy.get('#SidebarContainer .SidebarChannelGroupHeader:contains(FAVORITES)').should('be.visible');
 
-        // # Scroll to the bottom of the list
-        cy.get('#SidebarContainer .scrollbar--view').scrollTo('bottom', {ensureScrollable: false});
+    //     // # Scroll to the bottom of the list
+    //     cy.get('#SidebarContainer .scrollbar--view').scrollTo('bottom', {ensureScrollable: false});
 
-        // * Verify that the 'More Unreads' label is still visible but the category is not
-        cy.get('#unreadIndicatorTop').should('be.visible');
-        cy.get('#SidebarContainer .SidebarChannelGroupHeader:contains(FAVORITES)').should('not.be.visible');
-    });
+    //     // * Verify that the 'More Unreads' label is still visible but the category is not
+    //     cy.get('#unreadIndicatorTop').should('be.visible');
+    //     cy.get('#SidebarContainer .SidebarChannelGroupHeader:contains(FAVORITES)').should('not.be.visible');
+    // });
 });
 
 function createChannelAndAddToCategory(categoryName) {
@@ -239,26 +238,27 @@ function createChannelAndAddToCategory(categoryName) {
     return channelName;
 }
 
-function createChannelAndAddToFavourites() {
-    const userId = testUser.id;
-    cy.apiCreateChannel(testTeam.id, `channel-${getRandomId()}`, 'New Test Channel').then(({channel}) => {
-        // # Add the user to the channel
-        cy.apiAddUserToChannel(channel.id, userId).then(() => {
-            // # Move to a new category
-            cy.get(`#sidebarItem_${channel.name}`).parent().then((element) => {
-                // # Get id of the channel
-                const id = element[0].getAttribute('data-rbd-draggable-id');
-                cy.get(`#sidebarItem_${channel.name}`).parent('li').within(() => {
-                    // # Open dropdown next to channel name
-                    cy.get('.SidebarMenu').invoke('show').get('.SidebarMenu_menuButton').should('be.visible').click({force: true});
+// // Commented out since we've had to disable sticky headings because of issues with the menu components
+// function createChannelAndAddToFavourites() {
+//     const userId = testUser.id;
+//     cy.apiCreateChannel(testTeam.id, `channel-${getRandomId()}`, 'New Test Channel').then(({channel}) => {
+//         // # Add the user to the channel
+//         cy.apiAddUserToChannel(channel.id, userId).then(() => {
+//             // # Move to a new category
+//             cy.get(`#sidebarItem_${channel.name}`).parent().then((element) => {
+//                 // # Get id of the channel
+//                 const id = element[0].getAttribute('data-rbd-draggable-id');
+//                 cy.get(`#sidebarItem_${channel.name}`).parent('li').within(() => {
+//                     // # Open dropdown next to channel name
+//                     cy.get('.SidebarMenu').invoke('show').get('.SidebarMenu_menuButton').should('be.visible').click({force: true});
 
-                    // # Favourite the channel
-                    cy.get(`#favorite-${id} button`).should('be.visible').click({force: true});
-                });
-            });
-        });
-    });
-}
+//                     // # Favourite the channel
+//                     cy.get(`#favorite-${id} button`).should('be.visible').click({force: true});
+//                 });
+//             });
+//         });
+//     });
+// }
 
 function verifyAlphabeticalSortingOrder(categoryName, length) {
     // # Go through each channel to get its name

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -574,12 +574,14 @@
     }
 
     .SidebarChannelGroup .SidebarChannelGroupHeader {
+        align-items: center;
         height: 32px;
         font-family: 'Open Sans', sans-serif;
         text-transform: uppercase;
         text-overflow: ellipsis;
         text-align: left;
         border: none;
+        background-color: var(--sidebar-bg);
         color: rgba(var(--sidebar-text-rgb), 0.6);
         top: 0;
         box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.33);

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -605,10 +605,6 @@
             display: none;
         }
 
-        &.SidebarChannelGroupHeader--sticky {
-            position: sticky;
-        }
-
         &.muted {
             .icon-chevron-down, .SidebarChannelGroupHeader_text {
                 opacity: 0.4;


### PR DESCRIPTION
As in #7708, this fixes the nesting issues in the sidebar that caused some warning spam and likely caused navigation issues for accessibility tools, but to do that, we had to give up sticky category headings on browsers that support it. Once the menu components are rewritten to change how the menus themselves are nested, sticky headings can be re-added, but we can't have both at once due to some weird browser-specific interactions between `position: sticky`, z-indices, and overflows.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33540

#### Release Note
```release-note
Removed sticky sidebar headings in favor of fixing nesting errors
```