### PR TITLE
Cypress/E2E: Fix guest identification ui, post search display, new messages toast specs

### DIFF
--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
@@ -210,7 +210,7 @@ describe('MM-18045 Verify Guest User Identification in different screens', () =>
         // * Verify Guest Badge in GM header
         cy.get('#channelHeaderTitle').should('be.visible').find('.Badge').should('be.visible').and('have.text', 'GUEST');
         cy.get('#channelHeaderDescription').within(($el) => {
-            cy.wrap($el).find('.has-guest-header').should('be.visible').and('have.text', 'This channel has guests');
+            cy.wrap($el).find('.has-guest-header').should('be.visible').and('have.text', 'This group message has guests');
         });
     });
 

--- a/e2e/cypress/integration/search/post_search_display_spec.js
+++ b/e2e/cypress/integration/search/post_search_display_spec.js
@@ -48,7 +48,7 @@ describe('Search', () => {
         cy.get('#searchbarContainer').should('be.visible').within(() => {
             cy.get('#searchFormContainer').find('.input-clear-x').click({force: true});
             cy.get('#searchbar-help-popup').should('be.visible');
-            cy.get('#searchFormContainer').type('{esc}');
+            cy.get('#searchBox').type('{esc}');
         });
 
         // # RHS should be visible with search results

--- a/e2e/cypress/integration/toast/new_messages_toast_spec.js
+++ b/e2e/cypress/integration/toast/new_messages_toast_spec.js
@@ -76,10 +76,10 @@ describe('Toast', () => {
         scrollDown();
 
         // * Should hide the scroll to new message button as it is at the bottom
-        cy.get('div.toast__jump').should('not.be.visible');
+        cy.get('div.toast__jump').should('not.exist');
 
         // * As time elapsed the toast should be hidden
-        cy.get('div.toast').should('not.be.visible');
+        cy.get('div.toast').should('not.exist');
     });
 
     it('MM-T1784_2 should see a toast with number of unread messages in the toast if the bottom is not in view', () => {
@@ -121,7 +121,7 @@ describe('Toast', () => {
 
     it('MM-T1784_4 marking a channel as unread should reappear new message toast', () => {
         visitTownSquareAndWaitForPageToLoad();
-        cy.get('div.toast').should('not.be.visible');
+        cy.get('div.toast').should('not.exist');
 
         // # Scroll up so bottom is not visible
         scrollUp();
@@ -170,7 +170,7 @@ describe('Toast', () => {
         cy.get('div.toast').findByText('Jump to recents').should('be.visible').click();
 
         // * Verify toast is not visible
-        cy.get('div.toast__jump').should('not.be.visible');
+        cy.get('div.toast__jump').should('not.exist');
 
         // # Scroll up on the channel
         scrollUp();
@@ -188,6 +188,6 @@ describe('Toast', () => {
         scrollDown();
 
         // * Verify toast is not visible
-        cy.get('div.toast').should('not.be.visible');
+        cy.get('div.toast').should('not.exist');
     });
 });


### PR DESCRIPTION
#### Summary
 - Fix `guest_identification_ui_spec`
 - Fix `post_search_display_spec`
 - Fix `new_messages_toast_spec`

#### Ticket Link
NA

#### Release Note
```release-note
NONE
```

![Screen Shot 2021-04-27 at 8 42 30 AM](https://user-images.githubusercontent.com/487991/116277270-27a50500-a73a-11eb-9461-189a80bed90c.png)
![Screen Shot 2021-04-27 at 9 24 27 AM](https://user-images.githubusercontent.com/487991/116277503-63d86580-a73a-11eb-88b9-1eee1d586332.png)
![Screen Shot 2021-04-27 at 9 44 26 AM](https://user-images.githubusercontent.com/487991/116280214-51136000-a73d-11eb-87c3-3986cc6fae5d.png)
