### PR TITLE
[MM-35062] Increase specificity of GenericModal CSS to override existing styles

### DIFF
--- a/components/generic_modal.scss
+++ b/components/generic_modal.scss
@@ -1,6 +1,6 @@
 @charset 'UTF-8';
 
-.GenericModal {
+.app__body .modal .GenericModal {
     &.modal-dialog {
         margin-top: calc(50vh - 240px);
     }


### PR DESCRIPTION
#### Summary
The `GenericModal` styles were being overridden by more specific styles used by existing modals. I've increased the specificity of the `GenericModal` styles so that they aren't overridden.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35062

#### Release Note
```release-note
NONE
```
