### PR TITLE
[MM-34343] Migrate 'components/suggestion/search_channel_suggestion' and associated tests to TypeScript

### DIFF
--- a/components/suggestion/search_channel_suggestion/__snapshots__/search_channel_suggestion.test.tsx.snap
+++ b/components/suggestion/search_channel_suggestion/__snapshots__/search_channel_suggestion.test.tsx.snap
@@ -1,0 +1,232 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/suggestion/search_channel_suggestion should match snapshot 1`] = `
+<div
+  className="search-autocomplete__item"
+  onClick={[Function]}
+  onMouseMove={[Function]}
+  role="button"
+  tabIndex={-1}
+>
+  <span
+    className="search-autocomplete__name"
+    data-testid="listItem"
+  >
+    <div
+      className="search-autocomplete__icon"
+    >
+      <i
+        className="icon light icon--standard icon--no-spacing icon-globe"
+      />
+    </div>
+    <span
+      className="ml-3"
+    >
+      name
+    </span>
+    <span
+      className="ml-2 light"
+    >
+      ~
+      DN
+    </span>
+  </span>
+</div>
+`;
+
+exports[`components/suggestion/search_channel_suggestion should match snapshot, channel type DM_CHANNEL 1`] = `
+<div
+  className="search-autocomplete__item selected a11y--focused"
+  onClick={[Function]}
+  onMouseMove={[Function]}
+  role="button"
+  tabIndex={-1}
+>
+  <span
+    className="search-autocomplete__name"
+    data-testid="listItem"
+  >
+    <Memo(Avatar)
+      size="sm"
+      url="/api/v4/users/DN/image?_=0"
+    />
+    <span
+      className="ml-3"
+    >
+      @
+      name
+    </span>
+  </span>
+  <BotBadge
+    className="badge-popoverlist"
+    show={false}
+  />
+</div>
+`;
+
+exports[`components/suggestion/search_channel_suggestion should match snapshot, channel type GM_CHANNEL 1`] = `
+<div
+  className="search-autocomplete__item selected a11y--focused"
+  onClick={[Function]}
+  onMouseMove={[Function]}
+  role="button"
+  tabIndex={-1}
+>
+  <span
+    className="search-autocomplete__name"
+    data-testid="listItem"
+  >
+    <div
+      className="search-autocomplete__icon"
+    >
+      <div
+        className="status status--group"
+      >
+        G
+      </div>
+    </div>
+    <span
+      className="ml-3"
+    >
+      @
+      name
+    </span>
+  </span>
+</div>
+`;
+
+exports[`components/suggestion/search_channel_suggestion should match snapshot, channel type OPEN_CHANNEL 1`] = `
+<div
+  className="search-autocomplete__item selected a11y--focused"
+  onClick={[Function]}
+  onMouseMove={[Function]}
+  role="button"
+  tabIndex={-1}
+>
+  <span
+    className="search-autocomplete__name"
+    data-testid="listItem"
+  >
+    <div
+      className="search-autocomplete__icon"
+    >
+      <i
+        className="icon light icon--standard icon--no-spacing icon-globe"
+      />
+    </div>
+    <span
+      className="ml-3"
+    >
+      name
+    </span>
+    <span
+      className="ml-2 light"
+    >
+      ~
+      DN
+    </span>
+  </span>
+</div>
+`;
+
+exports[`components/suggestion/search_channel_suggestion should match snapshot, channel type PRIVATE_CHANNEL 1`] = `
+<div
+  className="search-autocomplete__item selected a11y--focused"
+  onClick={[Function]}
+  onMouseMove={[Function]}
+  role="button"
+  tabIndex={-1}
+>
+  <span
+    className="search-autocomplete__name"
+    data-testid="listItem"
+  >
+    <div
+      className="search-autocomplete__icon"
+    >
+      <i
+        className="icon light icon--standard icon--no-spacing icon-lock-outline"
+      />
+    </div>
+    <span
+      className="ml-3"
+    >
+      name
+    </span>
+    <span
+      className="ml-2 light"
+    >
+      ~
+      DN
+    </span>
+  </span>
+</div>
+`;
+
+exports[`components/suggestion/search_channel_suggestion should match snapshot, isSelection is false 1`] = `
+<div
+  className="search-autocomplete__item"
+  onClick={[Function]}
+  onMouseMove={[Function]}
+  role="button"
+  tabIndex={-1}
+>
+  <span
+    className="search-autocomplete__name"
+    data-testid="listItem"
+  >
+    <div
+      className="search-autocomplete__icon"
+    >
+      <i
+        className="icon light icon--standard icon--no-spacing icon-globe"
+      />
+    </div>
+    <span
+      className="ml-3"
+    >
+      name
+    </span>
+    <span
+      className="ml-2 light"
+    >
+      ~
+      DN
+    </span>
+  </span>
+</div>
+`;
+
+exports[`components/suggestion/search_channel_suggestion should match snapshot, isSelection is true 1`] = `
+<div
+  className="search-autocomplete__item selected a11y--focused"
+  onClick={[Function]}
+  onMouseMove={[Function]}
+  role="button"
+  tabIndex={-1}
+>
+  <span
+    className="search-autocomplete__name"
+    data-testid="listItem"
+  >
+    <div
+      className="search-autocomplete__icon"
+    >
+      <i
+        className="icon light icon--standard icon--no-spacing icon-globe"
+      />
+    </div>
+    <span
+      className="ml-3"
+    >
+      name
+    </span>
+    <span
+      className="ml-2 light"
+    >
+      ~
+      DN
+    </span>
+  </span>
+</div>
+`;

--- a/components/suggestion/search_channel_suggestion/index.ts
+++ b/components/suggestion/search_channel_suggestion/index.ts
@@ -5,10 +5,17 @@ import {connect} from 'react-redux';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {getDirectTeammate} from 'utils/utils';
+import {GlobalState} from 'types/store';
 
 import SearchChannelSuggestion from './search_channel_suggestion';
 
-const mapStateToProps = (state, ownProps) => {
+type OwnProps = {
+    item: {
+        id: string;
+    };
+}
+
+const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
     return {
         teammate: getDirectTeammate(state, ownProps.item.id),
         currentUser: getCurrentUserId(state),

--- a/components/suggestion/search_channel_suggestion/search_channel_suggestion.test.tsx
+++ b/components/suggestion/search_channel_suggestion/search_channel_suggestion.test.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {TestHelper} from 'utils/test_helper';
+
+import SearchChannelSuggestion from './search_channel_suggestion';
+
+describe('components/suggestion/search_channel_suggestion', () => {
+    const mockChannel = TestHelper.getChannelMock();
+    const mockTeamMate = TestHelper.getUserMock();
+
+    const baseProps = {
+        item: mockChannel,
+        isSelection: false,
+        teammate: mockTeamMate,
+        currentUser: 'userid1',
+        term: '',
+        matchedPretext: '',
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <SearchChannelSuggestion {...baseProps}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, isSelection is false', () => {
+        const props = {...baseProps, isSelection: false};
+        const wrapper = shallow(
+            <SearchChannelSuggestion {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, isSelection is true', () => {
+        const props = {...baseProps, isSelection: true};
+        const wrapper = shallow(
+            <SearchChannelSuggestion {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, channel type DM_CHANNEL', () => {
+        mockChannel.type = 'D';
+        const props = {...baseProps, item: mockChannel, isSelection: true};
+        const wrapper = shallow(
+            <SearchChannelSuggestion {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, channel type GM_CHANNEL', () => {
+        mockChannel.type = 'G';
+        const props = {...baseProps, item: mockChannel, isSelection: true};
+        const wrapper = shallow(
+            <SearchChannelSuggestion {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, channel type OPEN_CHANNEL', () => {
+        mockChannel.type = 'O';
+        const props = {...baseProps, item: mockChannel, isSelection: true};
+        const wrapper = shallow(
+            <SearchChannelSuggestion {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, channel type PRIVATE_CHANNEL', () => {
+        mockChannel.type = 'P';
+        const props = {...baseProps, item: mockChannel, isSelection: true};
+        const wrapper = shallow(
+            <SearchChannelSuggestion {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/suggestion/search_channel_suggestion/search_channel_suggestion.tsx
+++ b/components/suggestion/search_channel_suggestion/search_channel_suggestion.tsx
@@ -3,15 +3,13 @@
 import React from 'react';
 
 import {getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
-
 import {imageURLForUser} from 'utils/utils.jsx';
 import Constants from 'utils/constants';
 import Avatar from 'components/widgets/users/avatar';
 import BotBadge from 'components/widgets/badges/bot_badge';
+import Suggestion from '../suggestion';
 
-import Suggestion from '../suggestion.jsx';
-
-function itemToName(item, currentUser) {
+function itemToName(item: any, currentUser: string) {
     let itemMarkup = (item);
 
     if (item.type === Constants.DM_CHANNEL) {
@@ -70,7 +68,9 @@ function itemToName(item, currentUser) {
 }
 
 export default class SearchChannelSuggestion extends Suggestion {
-    render() {
+    private node = React.createRef<HTMLDivElement>();
+
+    render(): JSX.Element {
         const {item, isSelection, teammate, currentUser} = this.props;
 
         let className = 'search-autocomplete__item';
@@ -95,9 +95,7 @@ export default class SearchChannelSuggestion extends Suggestion {
                 onClick={this.handleClick}
                 onMouseMove={this.handleMouseMove}
                 className={className}
-                ref={(node) => {
-                    this.node = node;
-                }}
+                ref={this.node}
                 {...Suggestion.baseProps}
             >
                 <span


### PR DESCRIPTION
Summary
This code migrate "components/suggestion/search_channel_suggestion" component to TypeScript.

Ticket Link
Jira card: https://mattermost.atlassian.net/browse/MM-34343
Github issue: https://github.com/mattermost/mattermost-server/issues/17280

```release-note
Release Note
- Refactor component to typescript, no changes in UI
```