### PR TITLE
move e2e specs to cypress directory

### DIFF
--- a/e2e/cypress/integration/widgets/badges_spec.js
+++ b/e2e/cypress/integration/widgets/badges_spec.js
@@ -19,7 +19,7 @@ describe('Widgets - Badges', () => {
         cy.requireStorybookServer();
 
         // # Go to widget story and verify that it renders regular badge
-        cy.toWidgetStory('/story/badges--regular-badge');
+        cy.toWidgetStory('/story/widgets-badges--regular-badge');
         cy.get('.sidebar-container').should('be.visible').within(() => {
             cy.findByText('regular badge').should('exist');
         });
@@ -75,7 +75,7 @@ describe('Widgets - Badges', () => {
             cy.get('.Badge').should('be.visible');
         });
 
-        cy.openStoryPanel('Knobs').then(() => {
+        cy.openStoryPanel('Knobs (2)').then(() => {
             // # Uncheck "Show" and verify that the badge is hidden
             cy.get('#Show').uncheck().should('be.not.checked');
             cy.get('@iframeRoot').should('be.visible').within(() => {

--- a/e2e/cypress/integration/widgets/popover_spec.js
+++ b/e2e/cypress/integration/widgets/popover_spec.js
@@ -19,7 +19,7 @@ describe('Widgets - Popover', () => {
         cy.requireStorybookServer();
 
         // # Go to widget story and verify that it renders regular popup
-        cy.toWidgetStory('/story/popover--basic-popover');
+        cy.toWidgetStory('/story/widgets-popover--basic-popover');
         cy.get('.sidebar-container').should('be.visible').within(() => {
             cy.findByText('basic popover').should('exist');
         });


### PR DESCRIPTION
#### Summary
Using `npm run cypress:run` at `mattermost-webapp/e2e` folder ended with error:
```
Error: Webpack Compilation Error
../packages/mattermost-redux/src/utils/user_utils.ts 202:107
Module parse failed: Unexpected token (202:107)
File was processed with these loaders:
 * ../../../Library/Caches/Cypress/7.1.0/Cypress.app/Contents/Resources/app/packages/server/node_modules/ts-loader/index.js
You may need an additional loader to handle the result of these loaders.
|         role !== constants_1.General.SYSTEM_USER_ROLE)) || (
|     // If user is a system admin or a system guest then ignore team and channel memberships
>     !isSystemRole && userIsNotAdminOrGuest && ((role === constants_1.General.TEAM_ADMIN_ROLE && membership?.scheme_admin) ||
|         (role === constants_1.General.CHANNEL_ADMIN_ROLE && membership?.scheme_admin) ||
```
Same error was occurring when `npm run cypress:open` and running `badges_spec` or `popover_spec` through gui. Problem was only with these two specs.
Moving them to cypress directory solves the problem (after several days of debugging I've no idea why 😀 - maybe it's related with fact that cypress uses its own js/ts processor)
These two specs was also skipped on CI (example test report https://mm-cypress-report.s3.amazonaws.com/4749-master-e20-prod-mattermost-enterprise-edition:master/mochawesome.html not shows them). I've made minor update because they weren't passing.

#### Ticket Link
n/a

