### PR TITLE
Automated cherry pick of #7917

### DIFF
--- a/components/announcement_bar/configuration_bar/configuration_bar.tsx
+++ b/components/announcement_bar/configuration_bar/configuration_bar.tsx
@@ -220,7 +220,7 @@ const ConfigurationAnnouncementBar: React.FC<Props> = (props: Props) => {
         }
 
         const daysUntilLicenseExpires = daysToLicenseExpire(props.license);
-        if (isTrialLicense(props.license) && daysUntilLicenseExpires && daysUntilLicenseExpires <= 14 && !props.dismissedExpiringTrialLicense) {
+        if (isTrialLicense(props.license) && typeof daysUntilLicenseExpires !== 'undefined' && daysUntilLicenseExpires <= 14 && !props.dismissedExpiringTrialLicense) {
             const purchaseLicense = (
                 <PurchaseLink
                     buttonTextElement={
@@ -250,7 +250,7 @@ const ConfigurationAnnouncementBar: React.FC<Props> = (props: Props) => {
 
             let announcementBarType = AnnouncementBarTypes.ANNOUNCEMENT;
 
-            if (daysUntilLicenseExpires <= 1) {
+            if (daysUntilLicenseExpires < 1) {
                 message = (
                     <>
                         <img

--- a/utils/license_utils.jsx
+++ b/utils/license_utils.jsx
@@ -28,7 +28,8 @@ export function isLicenseExpired(license) {
         return false;
     }
 
-    const timeDiff = parseInt(license.ExpiresAt, 10) - Date.now();
+    const endDate = new Date(parseInt(license?.ExpiresAt, 10));
+    const timeDiff = moment(endDate).startOf('day').diff(moment().startOf('day'), 'days');
     return timeDiff < 0;
 }
 


### PR DESCRIPTION
Cherry pick of #7917 on release-5.35.
```release-note
Fixed an issue with trial licenses where the banner end date did not match the trial card end date.
```

/cc  @BenCookie95