### PR TITLE
remove URL slug for GMs in channel switcher

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -191,6 +191,9 @@ class SwitchChannelSuggestion extends Suggestion {
                     </React.Fragment>
                 );
             }
+        } else if (channel.type === Constants.GM_CHANNEL) {
+            // remove the slug from the option
+            displayName = channel.display_name;
         }
 
         let sharedIcon = null;


### PR DESCRIPTION
#### Summary
removes the URL "slug" information for GM's in the channel switcher

#### Ticket Link
[MM-35085](https://mattermost.atlassian.net/browse/MM-35085)

#### Screenshots
|**before**|**after**|
|-----------|--------|
|<img width="619" alt="Screenshot 2021-04-28 at 16 45 55" src="https://user-images.githubusercontent.com/32863416/116423804-4c37d480-a841-11eb-93e3-856692c1346a.png">|<img width="620" alt="Screenshot 2021-04-28 at 16 43 20" src="https://user-images.githubusercontent.com/32863416/116423471-024eee80-a841-11eb-8bb6-c5a0bd09da72.png">|


#### Release Note
```release-note
removes the URL "slug" information for GM's in the channel switcher
```
