### PR TITLE
[MM-35301] Fixed incorrect cursor on search hint dismiss button

### DIFF
--- a/components/hint-toast/hint_toast.scss
+++ b/components/hint-toast/hint_toast.scss
@@ -45,6 +45,8 @@
 
       .close-btn {
           line-height: normal;
+
+          cursor: pointer;
       }
   }
 }


### PR DESCRIPTION
#### Summary
Cursor now correctly switches to "Pointer" (hand) appearance on hover of search channel hint dismiss button.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35301

#### Related Pull Requests
Fixes a bug introduced in https://github.com/mattermost/mattermost-webapp/pull/6896

#### Screenshots
No drastic UI changes here.

#### Release Note
```release-note
Fixed incorrect cursor hover appearance on search hint dismiss button
```