### PR TITLE
[MM-34340] Migrated RhsCardHeader component to TypeScript

### DIFF
--- a/components/rhs_card_header/index.tsx
+++ b/components/rhs_card_header/index.tsx
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {AnyAction, bindActionCreators, Dispatch} from 'redux';
 
-import {GlobalState} from 'types/store/index.js';
+import {GlobalState} from 'types/store';
 
 import {
     showMentions,

--- a/components/rhs_card_header/index.tsx
+++ b/components/rhs_card_header/index.tsx
@@ -2,7 +2,9 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
+import {AnyAction, bindActionCreators, Dispatch} from 'redux';
+
+import {GlobalState} from 'types/store/index.js';
 
 import {
     showMentions,
@@ -14,15 +16,15 @@ import {
 } from 'actions/views/rhs';
 import {getIsRhsExpanded} from 'selectors/rhs';
 
-import RhsCardHeader from './rhs_card_header.jsx';
+import RhsCardHeader from './rhs_card_header';
 
-function mapStateToProps(state) {
+function mapStateToProps(state: GlobalState) {
     return {
         isExpanded: getIsRhsExpanded(state),
     };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
     return {
         actions: bindActionCreators({
             showMentions,

--- a/components/rhs_card_header/rhs_card_header.tsx
+++ b/components/rhs_card_header/rhs_card_header.tsx
@@ -8,9 +8,10 @@ import {FormattedMessage} from 'react-intl';
 import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants, {RHSStates} from 'utils/constants';
+import {RhsState} from 'types/store/rhs';
 
 type Props = {
-    previousRhsState: string;
+    previousRhsState: RhsState;
     isExpanded: boolean;
     actions: {
         showMentions: () => void;

--- a/components/rhs_card_header/rhs_card_header.tsx
+++ b/components/rhs_card_header/rhs_card_header.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 export default class RhsCardHeader extends React.PureComponent<Props> {
-    handleBack = (e: { preventDefault: () => void }): void => {
+    handleBack = (e: React.MouseEvent<HTMLAnchorElement>): void => {
         e.preventDefault();
 
         switch (this.props.previousRhsState) {

--- a/components/rhs_card_header/rhs_card_header.tsx
+++ b/components/rhs_card_header/rhs_card_header.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
 import React from 'react';
 import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
@@ -10,21 +9,21 @@ import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants, {RHSStates} from 'utils/constants';
 
-export default class RhsCardHeader extends React.PureComponent {
-    static propTypes = {
-        previousRhsState: PropTypes.oneOf(Object.values(RHSStates)),
-        isExpanded: PropTypes.bool.isRequired,
-        actions: PropTypes.shape({
-            showMentions: PropTypes.func,
-            showSearchResults: PropTypes.func,
-            showFlaggedPosts: PropTypes.func,
-            showPinnedPosts: PropTypes.func,
-            closeRightHandSide: PropTypes.func,
-            toggleRhsExpanded: PropTypes.func.isRequired,
-        }),
+type Props = {
+    previousRhsState: string;
+    isExpanded: boolean;
+    actions: {
+        showMentions: () => void;
+        showSearchResults: () => void;
+        showFlaggedPosts: () => void;
+        showPinnedPosts: () => void;
+        closeRightHandSide: () => void;
+        toggleRhsExpanded: () => void;
     };
+};
 
-    handleBack = (e) => {
+export default class RhsCardHeader extends React.PureComponent<Props> {
+    handleBack = (e: { preventDefault: () => void }): void => {
         e.preventDefault();
 
         switch (this.props.previousRhsState) {
@@ -48,7 +47,7 @@ export default class RhsCardHeader extends React.PureComponent {
         }
     }
 
-    render() {
+    render(): React.ReactNode {
         let back;
         let backToResultsTooltip;
 
@@ -129,7 +128,7 @@ export default class RhsCardHeader extends React.PureComponent {
                             id='generic_icons.back'
                             defaultMessage='Back Icon'
                         >
-                            {(ariaLabel) => (
+                            {(ariaLabel?: string) => (
                                 <i
                                     className='icon icon-arrow-back-ios'
                                     aria-label={ariaLabel}
@@ -166,7 +165,7 @@ export default class RhsCardHeader extends React.PureComponent {
                                 id='rhs_header.expandSidebarTooltip.icon'
                                 defaultMessage='Expand Sidebar Icon'
                             >
-                                {(ariaLabel) => (
+                                {(ariaLabel?: string) => (
                                     <i
                                         className='icon icon-arrow-expand'
                                         aria-label={ariaLabel}
@@ -177,7 +176,7 @@ export default class RhsCardHeader extends React.PureComponent {
                                 id='rhs_header.collapseSidebarTooltip.icon'
                                 defaultMessage='Collapse Sidebar Icon'
                             >
-                                {(ariaLabel) => (
+                                {(ariaLabel?: string) => (
                                     <i
                                         className='icon icon-arrow-collapse'
                                         aria-label={ariaLabel}
@@ -201,7 +200,7 @@ export default class RhsCardHeader extends React.PureComponent {
                                 id='rhs_header.closeTooltip.icon'
                                 defaultMessage='Close Sidebar Icon'
                             >
-                                {(ariaLabel) => (
+                                {(ariaLabel?: string) => (
                                     <i
                                         className='icon icon-close'
                                         aria-label={ariaLabel}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Migrated RhsCardHeader component to TypeScript

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/17263
JIRA: https://mattermost.atlassian.net/browse/MM-34340

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
