### PR TITLE
MM-34909: Marking as unread from the post menu should mark the thread as unread

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -4,9 +4,12 @@
 import {SearchTypes} from 'mattermost-redux/action_types';
 import {getMyChannelMember} from 'mattermost-redux/actions/channels';
 import {getChannel, getMyChannelMember as getMyChannelMemberSelector} from 'mattermost-redux/selectors/entities/channels';
+import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import * as ThreadActions from 'mattermost-redux/actions/threads';
 import * as PostActions from 'mattermost-redux/actions/posts';
 import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {canEditPost, comparePosts} from 'mattermost-redux/utils/post_utils';
 
 import {addRecentEmoji} from 'actions/emoji_actions';
@@ -232,11 +235,20 @@ export function setEditingPost(postId = '', commentCount = 0, refocusId = '', ti
     };
 }
 
-export function markPostAsUnread(post) {
+export function markPostAsUnread(post, location) {
     return async (dispatch, getState) => {
         const state = getState();
         const userId = getCurrentUserId(state);
-        await dispatch(PostActions.setUnreadPost(userId, post.id));
+        const currentTeamId = getCurrentTeamId(state);
+
+        // if CRT:ON and this is from within ThreadViewer (e.g. post dot-menu), mark the thread as unread
+        if (isCollapsedThreadsEnabled(state) && (location === 'RHS_ROOT' || location === 'RHS_COMMENT')) {
+            await dispatch(ThreadActions.updateThreadRead(userId, currentTeamId, post.root_id || post.id, post.create_at));
+        } else {
+            // use normal channel unread system
+            await dispatch(PostActions.setUnreadPost(userId, post.id));
+        }
+
         return {data: true};
     };
 }

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -94,7 +94,7 @@ type Props = {
         /**
          * Function to set the unread mark at given post
          */
-        markPostAsUnread: (post: Post) => void;
+        markPostAsUnread: (post: Post, location?: 'CENTER' | 'RHS_ROOT' | 'RHS_COMMENT' | string) => void;
 
         /**
          * Function to perform an app call
@@ -206,7 +206,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
 
     handleUnreadMenuItemActivated = (e: React.MouseEvent) => {
         e.preventDefault();
-        this.props.actions.markPostAsUnread(this.props.post);
+        this.props.actions.markPostAsUnread(this.props.post, this.props.location);
     }
 
     handleDeleteMenuItemActivated = (e: React.MouseEvent) => {

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -190,7 +190,7 @@ class Post extends React.PureComponent {
         }
 
         if (e.altKey) {
-            this.props.actions.markPostAsUnread(post);
+            this.props.actions.markPostAsUnread(post, 'CENTER');
         }
     }
 

--- a/components/post_view/post/post.test.js
+++ b/components/post_view/post/post.test.js
@@ -45,7 +45,7 @@ describe('Post', () => {
 
         wrapper.find(`#post_${baseProps.post.id}`).simulate('click', {altKey: true});
 
-        expect(baseProps.actions.markPostAsUnread).toHaveBeenCalledWith(baseProps.post);
+        expect(baseProps.actions.markPostAsUnread).toHaveBeenCalledWith(baseProps.post, 'CENTER');
     });
 
     test('should not mark post as unread on click when channel is archived', () => {

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -280,7 +280,7 @@ class RhsComment extends React.PureComponent {
         }
 
         if (e.altKey) {
-            this.props.actions.markPostAsUnread(this.props.post);
+            this.props.actions.markPostAsUnread(this.props.post, 'RHS_COMMENT');
         }
     }
 

--- a/components/rhs_comment/rhs_comment.test.jsx
+++ b/components/rhs_comment/rhs_comment.test.jsx
@@ -156,7 +156,7 @@ describe('components/RhsComment', () => {
 
         wrapper.simulate('click', {altKey: true});
 
-        expect(baseProps.actions.markPostAsUnread).toHaveBeenCalledWith(baseProps.post);
+        expect(baseProps.actions.markPostAsUnread).toHaveBeenCalledWith(baseProps.post, 'RHS_COMMENT');
     });
 
     test('should not call markPostAsUnread when post is alt+clicked on when channel is archived', () => {

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -215,7 +215,7 @@ class RhsRootPost extends React.PureComponent {
         }
 
         if (e.altKey) {
-            this.props.actions.markPostAsUnread(this.props.post);
+            this.props.actions.markPostAsUnread(this.props.post, 'RHS_ROOT');
         }
     }
 


### PR DESCRIPTION
#### Summary
Via post dot-menu or alt/opt-click:
- Marking a post as unread **in a thread** should mark the **thread** as unread.
- Marking a post as unread **in a channel** should mark the **channel** as unread.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34909

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
