### PR TITLE
[MM-35445] Fix Spelling Mistake for Custom Terms of Service

### DIFF
--- a/packages/mattermost-redux/src/constants/permissions.ts
+++ b/packages/mattermost-redux/src/constants/permissions.ts
@@ -210,7 +210,7 @@ const values = {
     SYSCONSOLE_READ_COMPLIANCE_COMPLIANCE_MONITORING: 'sysconsole_read_compliance_compliance_monitoring',
     SYSCONSOLE_WRITE_COMPLIANCE_COMPLIANCE_MONITORING: 'sysconsole_write_compliance_compliance_monitoring',
     SYSCONSOLE_READ_COMPLIANCE_CUSTOM_TERMS_OF_SERVICE: 'sysconsole_read_compliance_custom_terms_of_service',
-    SYSCONSOLE_WRITE_COMPLIANCE_CUSTOM_TERMS_OF_SERVICE: 'sysconsole_read_compliance_custom_terms_of_service',
+    SYSCONSOLE_WRITE_COMPLIANCE_CUSTOM_TERMS_OF_SERVICE: 'sysconsole_write_compliance_custom_terms_of_service',
     SYSCONSOLE_READ_EXPERIMENTAL_FEATURES: 'sysconsole_read_experimental_features',
     SYSCONSOLE_WRITE_EXPERIMENTAL_FEATURES: 'sysconsole_write_experimental_features',
     SYSCONSOLE_READ_EXPERIMENTAL_FEATURE_FLAGS: 'sysconsole_read_experimental_feature_flags',


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
I was contacted by QA that custom terms of service is always read-only state regardless of what you do.
Noticed a small typo in redux permissions.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-35445


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Fixes bug where custom terms of service in system console is always in read-only state.
```
