### PR TITLE
MM-35319 - last day message inconsistencies

### DIFF
--- a/components/admin_console/billing/billing_summary/billing_summary.tsx
+++ b/components/admin_console/billing/billing_summary/billing_summary.tsx
@@ -21,7 +21,6 @@ import {Client4} from 'mattermost-redux/client';
 enum TrialPeriodDays {
     TRIAL_14_DAYS = 14,
     TRIAL_3_DAYS = 3,
-    TRIAL_2_DAYS = 2,
     TRIAL_1_DAY = 1,
     TRIAL_0_DAYS = 0
 }
@@ -116,14 +115,14 @@ export const freeTrial = (onUpgradeMattermostCloud: () => void, daysLeftOnTrial:
                     values={{daysLeftOnTrial}}
                 />
             }
-            {(daysLeftOnTrial > TrialPeriodDays.TRIAL_0_DAYS && daysLeftOnTrial <= TrialPeriodDays.TRIAL_3_DAYS) &&
+            {(daysLeftOnTrial > TrialPeriodDays.TRIAL_1_DAY && daysLeftOnTrial <= TrialPeriodDays.TRIAL_3_DAYS) &&
                 <FormattedMarkdownMessage
                     id='admin.billing.subscription.freeTrial.lessThan3Days.description'
                     defaultMessage='Your free trial will end in {daysLeftOnTrial, number} {daysLeftOnTrial, plural, one {day} other {days}}. Add payment information to continue enjoying the benefits of Cloud Professional.'
                     values={{daysLeftOnTrial}}
                 />
             }
-            {(daysLeftOnTrial === TrialPeriodDays.TRIAL_0_DAYS) &&
+            {(daysLeftOnTrial === TrialPeriodDays.TRIAL_1_DAY) &&
                 <FormattedMarkdownMessage
                     id='admin.billing.subscription.freeTrial.lastDay.description'
                     defaultMessage='Your free trial has ended. Add payment information to continue enjoying the benefits of Cloud Professional.'

--- a/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
@@ -50,8 +50,7 @@ enum TrialPeriodDays {
     TRIAL_14_DAYS = 14,
     TRIAL_3_DAYS = 3,
     TRIAL_2_DAYS = 2,
-    TRIAL_1_DAY = 1,
-    TRIAL_0_DAYS = 0
+    TRIAL_1_DAY = 1
 }
 
 class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
@@ -80,9 +79,9 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
         const {daysLeftOnTrial} = this.props;
         let dismissValue = '';
         if (daysLeftOnTrial > TrialPeriodDays.TRIAL_3_DAYS) {
-            dismissValue = '14_days_banner1';
-        } else if (daysLeftOnTrial <= TrialPeriodDays.TRIAL_3_DAYS && daysLeftOnTrial > TrialPeriodDays.TRIAL_0_DAYS) {
-            dismissValue = '3_days_banner1';
+            dismissValue = '14_days_banner';
+        } else if (daysLeftOnTrial <= TrialPeriodDays.TRIAL_3_DAYS && daysLeftOnTrial >= TrialPeriodDays.TRIAL_1_DAY) {
+            dismissValue = '3_days_banner';
         }
         trackEvent(
             TELEMETRY_CATEGORIES.CLOUD_ADMIN,
@@ -142,9 +141,9 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
             return null;
         }
 
-        if ((preferences.some((pref) => pref.name === CloudBanners.TRIAL && pref.value === '14_days_banner1') && daysLeftOnTrial > TrialPeriodDays.TRIAL_3_DAYS) ||
-            ((daysLeftOnTrial <= TrialPeriodDays.TRIAL_3_DAYS && daysLeftOnTrial > TrialPeriodDays.TRIAL_0_DAYS) &&
-            preferences.some((pref) => pref.name === CloudBanners.TRIAL && pref.value === '3_days_banner1'))) {
+        if ((preferences.some((pref) => pref.name === CloudBanners.TRIAL && pref.value === '14_days_banner') && daysLeftOnTrial > TrialPeriodDays.TRIAL_3_DAYS) ||
+            ((daysLeftOnTrial <= TrialPeriodDays.TRIAL_3_DAYS && daysLeftOnTrial >= TrialPeriodDays.TRIAL_1_DAY) &&
+            preferences.some((pref) => pref.name === CloudBanners.TRIAL && pref.value === '3_days_banner'))) {
             return null;
         }
 


### PR DESCRIPTION
#### Summary
Show the last day expiring trial messages in a consistent way so all of them specifies that the last trial day says "end today"

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35319

#### Screenshots
<img width="1569" alt="Captura de pantalla 2021-05-06 a las 12 33 22" src="https://user-images.githubusercontent.com/10082627/117285243-1c538700-ae68-11eb-95f8-4263ce15d777.png">

#### Release Note
```release-note
NONE
```