### PR TITLE
Cypress/e2e:fixed custom status test case

### DIFF
--- a/e2e/cypress/integration/custom_status/custom_status_3_spec.js
+++ b/e2e/cypress/integration/custom_status/custom_status_3_spec.js
@@ -54,7 +54,7 @@ describe('Custom Status - Setting Your Own Custom Status', () => {
         cy.get('#emojiPicker').should('exist');
 
         // # Select the emoji from the emoji picker overlay
-        cy.get(`#emojiPicker .emoji-picker-items__container .emoji-picker__item img[data-testid="${customStatus.emoji}"]`).click({force :true});    
+        cy.get(`#emojiPicker .emoji-picker-items__container .emoji-picker__item img[data-testid="${customStatus.emoji}"]`).click({force: true});
 
         // * Emoji picker should be closed
         cy.get('#emojiPicker').should('not.exist');

--- a/e2e/cypress/integration/custom_status/custom_status_3_spec.js
+++ b/e2e/cypress/integration/custom_status/custom_status_3_spec.js
@@ -54,7 +54,7 @@ describe('Custom Status - Setting Your Own Custom Status', () => {
         cy.get('#emojiPicker').should('exist');
 
         // # Select the emoji from the emoji picker overlay
-        cy.get(`#emojiPicker .emoji-picker-items__container .emoji-picker__item img[data-testid="${customStatus.emoji}"]`).click();
+        cy.get(`#emojiPicker .emoji-picker-items__container .emoji-picker__item img[data-testid="${customStatus.emoji}"]`).click({force :true});    
 
         // * Emoji picker should be closed
         cy.get('#emojiPicker').should('not.exist');


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fixed custom status cases 
This small change fixed 5 test cases
<!--

-->

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->


<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![image](https://user-images.githubusercontent.com/6909890/117372789-1b3a4e00-ae98-11eb-8c42-0043715aecc4.png)


<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
