### PR TITLE
[Re: MM-34523] Fix failing test

### DIFF
--- a/components/admin_console/license_settings/license_settings.test.jsx
+++ b/components/admin_console/license_settings/license_settings.test.jsx
@@ -4,11 +4,23 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
+import {fakeDate} from 'tests/helpers/date';
+
 import LicenseSettings from './license_settings.jsx';
 
 const flushPromises = () => new Promise(setImmediate);
 
 describe('components/admin_console/license_settings/LicenseSettings', () => {
+    let resetFakeDate;
+
+    beforeAll(() => {
+        resetFakeDate = fakeDate(new Date('2021-04-14T12:00:00Z'));
+    });
+
+    afterAll(() => {
+        resetFakeDate();
+    });
+
     const defaultProps = {
         isDisabled: false,
         license: {


### PR DESCRIPTION
#### Summary
Freeze time for `Date.now`-sensitive unit test (possibly updated in #7826).

This may need to be cherry-picked as-needed. Most CI runs after `2021-05-06T21:10:43.65Z` will likely produce https://app.circleci.com/pipelines/github/mattermost/mattermost-webapp/37978/workflows/f0324801-b613-49d2-90ba-a3da562caa44/jobs/258653.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
