### PR TITLE
MM-35431: fixes save post disabled when opened from threads

### DIFF
--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -27,14 +27,14 @@ function mapStateToProps(state) {
     const config = getConfig(state);
     const editingPost = getEditingPost(state);
     const currentUserId = getCurrentUserId(state);
-    const channelId = getCurrentChannelId(state);
+    const channelId = getCurrentChannelId(state) || editingPost?.post?.channel_id;
     const teamId = getCurrentTeamId(state);
     let canDeletePost = false;
     let canEditPost = false;
 
     if (editingPost && editingPost.post && editingPost.post.user_id === currentUserId) {
-        canDeletePost = haveIChannelPermission(state, {channel: editingPost.post.channel_id, team: teamId, permission: Permissions.DELETE_POST});
-        canEditPost = haveIChannelPermission(state, {channel: editingPost.post.channel_id, team: teamId, permission: Permissions.EDIT_POST});
+        canDeletePost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.DELETE_POST});
+        canEditPost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.EDIT_POST});
     } else {
         canDeletePost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.DELETE_OTHERS_POSTS});
         canEditPost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.EDIT_OTHERS_POSTS});

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -31,9 +31,10 @@ function mapStateToProps(state) {
     const teamId = getCurrentTeamId(state);
     let canDeletePost = false;
     let canEditPost = false;
+
     if (editingPost && editingPost.post && editingPost.post.user_id === currentUserId) {
-        canDeletePost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.DELETE_POST});
-        canEditPost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.EDIT_POST});
+        canDeletePost = haveIChannelPermission(state, {channel: editingPost.post.channel_id, team: teamId, permission: Permissions.DELETE_POST});
+        canEditPost = haveIChannelPermission(state, {channel: editingPost.post.channel_id, team: teamId, permission: Permissions.EDIT_POST});
     } else {
         canDeletePost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.DELETE_OTHERS_POSTS});
         canEditPost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.EDIT_OTHERS_POSTS});

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -27,7 +27,7 @@ function mapStateToProps(state) {
     const config = getConfig(state);
     const editingPost = getEditingPost(state);
     const currentUserId = getCurrentUserId(state);
-    const channelId = getCurrentChannelId(state) || editingPost?.post?.channel_id;
+    const channelId = editingPost?.post?.channel_id || getCurrentChannelId(state);
     const teamId = getCurrentTeamId(state);
     let canDeletePost = false;
     let canEditPost = false;


### PR DESCRIPTION
#### Summary

In the context of threads there is no current channel, so it appeared as
the user never had permissions to edit owned post.
This commit fixes that by using **not** the current channel's id but the
editing post's channel id to get permissions.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35431

#### Release Note

```release-note
NONE
```