### PR TITLE
MM-35332 Cypress/E2E: Not extending session when setting is disabled

### DIFF
--- a/e2e/cypress/integration/enterprise/extend_session/not_extended_when_disabled/helpers.js
+++ b/e2e/cypress/integration/enterprise/extend_session/not_extended_when_disabled/helpers.js
@@ -1,0 +1,129 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getAdminAccount} from '../../../../support/env';
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
+
+const admin = getAdminAccount();
+const oneDay = 24 * 60 * 60 * 1000;
+const twentySeconds = 20 * 1000;
+
+export function verifyExtendedSession(testUser, sessionLengthInDays, loginTestUser) {
+    // # Login as test user and visit default channel
+    loginTestUser();
+    cy.visit('/');
+
+    // # Get active user sessions as baseline reference
+    cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: initialSessions}) => {
+        expect(initialSessions.length).to.equal(1);
+        const initialSession = initialSessions[0];
+
+        // # Post a message to a channel
+        const now = Date.now();
+        cy.postMessage(now);
+
+        // # Update user session which is to expire 20 sec from now
+        const soonToExpire = getExpirationFromNow(twentySeconds);
+        cy.dbUpdateUserSession({
+            userId: initialSession.userid,
+            sessionId: initialSession.id,
+            fieldsToUpdate: {expiresat: soonToExpire},
+        }).then(({session: updatedSession}) => {
+            // * Verify that the session is updated
+            expect(parseInt(updatedSession.expiresat, 10)).to.equal(soonToExpire);
+
+            // # Invalidate cache and reload to take effect the soon to expire session
+            cy.externalRequest({user: admin, method: 'POST', path: 'caches/invalidate'});
+            cy.reload();
+
+            // # Visit default channel
+            cy.visit('/');
+
+            // # Get active session of test user
+            cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: extendedSessions}) => {
+                expect(extendedSessions.length).to.equal(1);
+                const extendedSession = extendedSessions[0];
+
+                // * Verify that the session has been extended depending on session length (in days) setting
+                expect(extendedSession.id).to.equal(updatedSession.id);
+                expect(parseInt(extendedSession.expiresat, 10)).to.be.greaterThan(parseInt(updatedSession.expiresat, 10));
+                expect(parseInt(extendedSession.expiresat, 10)).to.be.greaterThan(parseInt(initialSession.expiresat, 10));
+
+                expect(parseInt(extendedSession.expiresat, 10)).to.be.closeTo(now + (sessionLengthInDays * oneDay), twentySeconds);
+            });
+
+            // # Post multiple times to check that the session continues and doesn't redirect to login page
+            Cypress._.times(20, (i) => {
+                cy.postMessage(i);
+            });
+        });
+    });
+}
+
+export function verifyNotExtendedSession(testUser, loginTestUser) {
+    // # Login as test user and visit default channel
+    loginTestUser();
+    cy.visit('/');
+
+    // # Get active user sessions as baseline reference
+    cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: initialSessions}) => {
+        expect(initialSessions.length).to.equal(1);
+        const initialSession = initialSessions[0];
+        expect(parseInt(initialSession.expiresat, 10)).to.be.greaterThan(0);
+
+        // # Post a message to a channel
+        const now = Date.now();
+        cy.postMessage(`now: ${now}`);
+
+        // # Update user session which is to expire 20 sec from now
+        const soonToExpire = getExpirationFromNow(twentySeconds);
+        cy.dbUpdateUserSession({
+            userId: initialSession.userid,
+            sessionId: initialSession.id,
+            fieldsToUpdate: {expiresat: soonToExpire},
+        }).then(({session: updatedSession}) => {
+            // * Verify that the session is updated
+            expect(parseInt(updatedSession.expiresat, 10)).to.equal(soonToExpire);
+
+            // # Invalidate cache and reload to take effect the soon to expire session
+            cy.externalRequest({user: admin, method: 'POST', path: 'caches/invalidate'});
+            cy.reload();
+
+            // # Visit default channel
+            cy.visit('/');
+
+            // # Get active session of test user
+            cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: soonToExpireSessions}) => {
+                // * Verify that the session was not extended
+                expect(soonToExpireSessions.length).to.equal(1);
+                expect(soonToExpireSessions[0].id).to.equal(updatedSession.id);
+                expect(parseInt(soonToExpireSessions[0].expiresat, 10)).to.equal(parseInt(updatedSession.expiresat, 10));
+
+                // * Verify that it redirects to login page due to expired session
+                cy.waitUntil(() => {
+                    return cy.url().then((url) => {
+                        return url.includes('/login');
+                    });
+                }, {
+                    timeout: TIMEOUTS.TWO_MIN,
+                    interval: TIMEOUTS.TWO_SEC,
+                });
+
+                // * Verify that user has no active session
+                cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: activeSessions}) => {
+                    expect(activeSessions.length).to.equal(0);
+                });
+
+                // * Verify that the session has not been extended
+                cy.dbGetUserSession({sessionId: initialSession.id}).then(({session: unExtendedSession}) => {
+                    expect(parseInt(unExtendedSession.expiresat, 10)).to.equal(soonToExpire);
+                    expect(parseInt(unExtendedSession.expiresat, 10)).to.be.lessThan(Date.now());
+                });
+            });
+        });
+    });
+}
+
+function getExpirationFromNow(duration = 0) {
+    return Date.now() + duration;
+}

--- a/e2e/cypress/integration/enterprise/extend_session/not_extended_when_disabled/with_email_login_spec.js
+++ b/e2e/cypress/integration/enterprise/extend_session/not_extended_when_disabled/with_email_login_spec.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @not_cloud @extend_session
+
+import {verifyExtendedSession, verifyNotExtendedSession} from './helpers';
+
+describe('Extended Session Length', () => {
+    const sessionLengthInDays = 1;
+    const setting = {
+        ServiceSettings: {
+            SessionLengthWebInDays: sessionLengthInDays,
+        },
+    };
+    let emailUser;
+
+    before(() => {
+        cy.shouldNotRunOnCloudEdition();
+        cy.apiRequireLicense();
+
+        // * Server database should match with the DB client and config at "cypress.json"
+        cy.apiRequireServerDBToMatch();
+
+        cy.apiInitSetup().then(({user}) => {
+            emailUser = user;
+        });
+    });
+
+    beforeEach(() => {
+        cy.apiAdminLogin();
+        cy.apiRevokeUserSessions(emailUser.id);
+    });
+
+    it('MM-T4045_1 Email user session should have extended due to user activity when enabled', () => {
+        // # Enable ExtendSessionLengthWithActivity
+        setting.ServiceSettings.ExtendSessionLengthWithActivity = true;
+        cy.apiUpdateConfig(setting);
+
+        verifyExtendedSession(emailUser, sessionLengthInDays, () => cy.apiLogin(emailUser));
+    });
+
+    it('MM-T4045_2 Email user session should not extend even with user activity when disabled', () => {
+        // # Disable ExtendSessionLengthWithActivity
+        setting.ServiceSettings.ExtendSessionLengthWithActivity = false;
+        cy.apiUpdateConfig(setting);
+
+        verifyNotExtendedSession(emailUser, () => cy.apiLogin(emailUser));
+    });
+});

--- a/e2e/cypress/integration/enterprise/extend_session/not_extended_when_disabled/with_ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/extend_session/not_extended_when_disabled/with_ldap_login_spec.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @not_cloud @extend_session @ldap
+
+import ldapUsers from '../../../../fixtures/ldap_users.json';
+
+import {verifyExtendedSession, verifyNotExtendedSession} from './helpers';
+
+describe('Extended Session Length', () => {
+    const sessionLengthInDays = 1;
+    const setting = {
+        ServiceSettings: {
+            SessionLengthWebInDays: sessionLengthInDays,
+        },
+    };
+    let ldapUser;
+
+    before(() => {
+        cy.shouldNotRunOnCloudEdition();
+        cy.apiRequireLicense();
+
+        // * Server database should match with the DB client and config at "cypress.json"
+        cy.apiRequireServerDBToMatch();
+
+        // # Test LDAP connection and synchronize user
+        cy.apiLDAPTest();
+        cy.apiLDAPSync();
+
+        const ldapUserTest1 = ldapUsers['test-1'];
+        cy.apiLogin(ldapUserTest1).then(({user}) => {
+            cy.apiSaveTutorialStep(user.id, '999');
+            ldapUser = {...user, password: ldapUserTest1.password};
+
+            cy.apiAdminLogin();
+            cy.apiInitSetup().then(({team}) => {
+                cy.apiAddUserToTeam(team.id, user.id);
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.apiAdminLogin();
+        cy.apiRevokeUserSessions(ldapUser.id);
+    });
+
+    it('MM-T4046_1 LDAP user session should have extended due to user activity when enabled', () => {
+        // # Enable ExtendSessionLengthWithActivity
+        setting.ServiceSettings.ExtendSessionLengthWithActivity = true;
+        cy.apiUpdateConfig(setting);
+
+        verifyExtendedSession(ldapUser, sessionLengthInDays, () => cy.apiLogin(ldapUser));
+    });
+
+    it('MM-T4046_2 LDAP user session should not extend even with user activity when disabled', () => {
+        // # Disable ExtendSessionLengthWithActivity
+        setting.ServiceSettings.ExtendSessionLengthWithActivity = false;
+        cy.apiUpdateConfig(setting);
+
+        verifyNotExtendedSession(ldapUser, () => cy.apiLogin(ldapUser));
+    });
+});

--- a/e2e/cypress/integration/enterprise/extend_session/not_extended_when_disabled/with_saml_login_spec.js
+++ b/e2e/cypress/integration/enterprise/extend_session/not_extended_when_disabled/with_saml_login_spec.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Requires openldap and keycloak running
+// Requires keycloak certificate at fixtures folder
+// - copy ./mattermost-server/build/docker/keycloak/keycloak.crt to ./mattermost-webapp/e2e/cypress/fixtures/keycloak.crt
+// Requires Cypress' chromeWebSecurity to be false
+
+// Group: @enterprise @not_cloud @extend_session @ldap @saml @keycloak
+
+import testusers from '../../../../fixtures/saml_ldap_users.json';
+import {getRandomId} from '../../../../utils';
+
+import {verifyExtendedSession, verifyNotExtendedSession} from './helpers';
+
+describe('Extended Session Length', () => {
+    const sessionLengthInDays = 1;
+    const baseUrl = Cypress.config('baseUrl');
+    const {keycloakBaseUrl, keycloakAppName} = Cypress.env();
+    const idpUrl = `${keycloakBaseUrl}/auth/realms/${keycloakAppName}/protocol/saml`;
+    const idpDescriptorUrl = `${keycloakBaseUrl}/auth/realms/${keycloakAppName}`;
+
+    const samlConfig = {
+        SamlSettings: {
+            Enable: true,
+            Encrypt: false,
+            IdpUrl: idpUrl,
+            IdpDescriptorUrl: idpDescriptorUrl,
+            ServiceProviderIdentifier: `${baseUrl}/login/sso/saml`,
+            AssertionConsumerServiceURL: `${baseUrl}/login/sso/saml`,
+            SignatureAlgorithm: 'RSAwithSHA256',
+            PublicCertificateFile: '',
+            PrivateKeyFile: '',
+            FirstNameAttribute: 'firstName',
+            LastNameAttribute: 'lastName',
+            EmailAttribute: 'email',
+            UsernameAttribute: 'username',
+            EnableSyncWithLdap: true,
+            EnableSyncWithLdapIncludeAuth: true,
+            IdAttribute: 'username',
+        },
+        LdapSettings: {
+            EnableSync: true,
+            BaseDN: 'ou=e2etest,dc=mm,dc=test,dc=com',
+        },
+    };
+
+    const sessionConfig = {
+        ServiceSettings: {
+            SessionLengthSSOInDays: sessionLengthInDays,
+        },
+    };
+
+    let samlUser;
+    let testSettings;
+
+    before(() => {
+        cy.shouldNotRunOnCloudEdition();
+        cy.apiRequireLicenseForFeature('LDAP', 'SAML');
+
+        // * Server database should match with the DB client and config at "cypress.json"
+        cy.apiRequireServerDBToMatch();
+
+        cy.apiUpdateConfig(samlConfig).then(({config}) => {
+            // # Require keycloak with realm setup
+            cy.apiRequireKeycloak();
+
+            // # Upload certificate, overwrite existing
+            cy.apiUploadSAMLIDPCert('keycloak.crt');
+
+            // # Reset keycloak user
+            const samlTestUser1 = testusers.user1;
+            cy.keycloakResetUsers([samlTestUser1]);
+
+            // # Test LDAP connection and add/reset LDAP/SAML test users
+            cy.apiLDAPTest();
+            cy.resetLDAPUsers();
+
+            cy.apiGetUserByEmail(samlTestUser1.email, false).then(({user}) => {
+                cy.apiSaveTutorialStep(user.id, '999');
+                samlUser = {...user, password: samlTestUser1.password};
+
+                testSettings = {
+                    loginButtonText: 'SAML',
+                    siteName: config.TeamSettings.SiteName,
+                    siteUrl: config.ServiceSettings.SiteURL,
+                    teamName: '',
+                    user: samlUser,
+                };
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.apiAdminLogin();
+        cy.apiRevokeUserSessions(samlUser.id);
+    });
+
+    it('MM-T4047_1 SAML/SSO user session should have extended due to user activity when enabled', () => {
+        // # Enable ExtendSessionLengthWithActivity
+        sessionConfig.ServiceSettings.ExtendSessionLengthWithActivity = true;
+        cy.apiUpdateConfig({...samlConfig, ...sessionConfig});
+
+        verifyExtendedSession(samlUser, sessionLengthInDays, () => doSamlAndKeycloakLogin(testSettings));
+    });
+
+    it('MM-T4047_2 SAML/SSO user session should not extend even with user activity when disabled', () => {
+        // # Disable ExtendSessionLengthWithActivity
+        sessionConfig.ServiceSettings.ExtendSessionLengthWithActivity = false;
+        cy.apiUpdateConfig({...samlConfig, ...sessionConfig});
+
+        verifyNotExtendedSession(samlUser, () => doSamlAndKeycloakLogin(testSettings));
+    });
+});
+
+function doSamlAndKeycloakLogin(testSettings) {
+    // # Mattermost user login via SAML
+    cy.doSamlLogin(testSettings);
+
+    // # User login to Keycloak
+    cy.doKeycloakLogin(testSettings.user);
+
+    // # Create team if no membership
+    cy.skipOrCreateTeam(testSettings, getRandomId());
+}


### PR DESCRIPTION
#### Summary
Related PR - https://github.com/mattermost/mattermost-server/pull/17581

Test cases:
- [MM-T4045](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4045) - session via Email login
- [MM-T4046](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4046) - session via LDAP login
- [MM-T4047](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4047) - session via SAML login

Note:
- Separated into its own spec file since they require different auth mechanism and to make it easier to move individually into production test.
- Test will fail if your server doesn't include the recent fix - https://github.com/mattermost/mattermost-server/commit/a668479992047548e6d40eed4e5cc1d408161447

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35332

#### Screenshots
![Screen Shot 2021-05-08 at 6 44 54 AM](https://user-images.githubusercontent.com/5334504/117515793-ddd5dd80-afc9-11eb-8807-1dfdcefad2dc.png)
<img width="653" alt="Screen Shot 2021-05-08 at 6 53 27 AM" src="https://user-images.githubusercontent.com/5334504/117515880-2097b580-afca-11eb-9188-13866ff85031.png">
<img width="653" alt="Screen Shot 2021-05-08 at 6 58 10 AM" src="https://user-images.githubusercontent.com/5334504/117516160-e37ff300-afca-11eb-9d3d-123229b784c3.png">


#### Release Note
```release-note
NONE
```
