### PR TITLE
MM-35509 Do not use getDerivedStateFromProps to determine picker placement and instead use memoization

### DIFF
--- a/components/emoji_picker/emoji_picker_overlay.jsx
+++ b/components/emoji_picker/emoji_picker_overlay.jsx
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Overlay} from 'react-bootstrap';
+import memoize from 'memoize-one';
 
 import {popOverOverlayPosition} from 'utils/position_utils.tsx';
 import {Constants} from 'utils/constants';
@@ -44,56 +45,46 @@ export default class EmojiPickerOverlay extends React.PureComponent {
         enableGifPicker: false,
     };
 
-    constructor(props) {
-        super(props);
-        this.state = {};
-    }
-
-    static emojiPickerPosition(props) {
-        const emojiTrigger = props.target();
-
-        if (typeof props.rightOffset !== 'undefined') {
-            return props.rightOffset;
+    emojiPickerPosition = memoize((emojiTrigger, rightOffset) => {
+        if (typeof rightOffset !== 'undefined') {
+            return rightOffset;
         }
 
-        let rightOffset = Constants.DEFAULT_EMOJI_PICKER_RIGHT_OFFSET;
+        let calculatedRightOffset = Constants.DEFAULT_EMOJI_PICKER_RIGHT_OFFSET;
         if (emojiTrigger) {
-            rightOffset = window.innerWidth - emojiTrigger.getBoundingClientRect().left - Constants.DEFAULT_EMOJI_PICKER_LEFT_OFFSET;
+            calculatedRightOffset = window.innerWidth - emojiTrigger.getBoundingClientRect().left - Constants.DEFAULT_EMOJI_PICKER_LEFT_OFFSET;
 
-            if (rightOffset < Constants.DEFAULT_EMOJI_PICKER_RIGHT_OFFSET) {
-                rightOffset = Constants.DEFAULT_EMOJI_PICKER_RIGHT_OFFSET;
+            if (calculatedRightOffset < Constants.DEFAULT_EMOJI_PICKER_RIGHT_OFFSET) {
+                calculatedRightOffset = Constants.DEFAULT_EMOJI_PICKER_RIGHT_OFFSET;
             }
         }
 
-        return rightOffset;
-    }
+        return calculatedRightOffset;
+    });
 
-    static getPlacement(props) {
-        const target = props.target();
+    getPlacement = memoize((target, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition) => {
         if (target) {
             const targetBounds = target.getBoundingClientRect();
-            return popOverOverlayPosition(targetBounds, window.innerHeight, props.spaceRequiredAbove, props.spaceRequiredBelow, props.defaultHorizontalPosition);
+            return popOverOverlayPosition(targetBounds, window.innerHeight, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition);
         }
 
         return 'top';
-    }
-
-    static getDerivedStateFromProps(props) {
-        return {
-            placement: EmojiPickerOverlay.getPlacement(props),
-            rightOffset: EmojiPickerOverlay.emojiPickerPosition(props),
-        };
-    }
+    });
 
     render() {
+        const {target, rightOffset, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition} = this.props;
+
+        const calculatedRightOffset = this.emojiPickerPosition(target(), rightOffset);
+        const placement = this.getPlacement(target(), spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition);
+
         return (
             <Overlay
                 show={this.props.show}
-                placement={this.state.placement}
+                placement={placement}
                 rootClose={true}
                 container={this.props.container}
                 onHide={this.props.onHide}
-                target={this.props.target}
+                target={target}
                 animation={false}
             >
                 <EmojiPickerTabs
@@ -101,7 +92,7 @@ export default class EmojiPickerOverlay extends React.PureComponent {
                     onEmojiClose={this.props.onHide}
                     onEmojiClick={this.props.onEmojiClick}
                     onGifClick={this.props.onGifClick}
-                    rightOffset={this.state.rightOffset}
+                    rightOffset={calculatedRightOffset}
                     topOffset={this.props.topOffset}
                     leftOffset={this.props.leftOffset}
                 />

--- a/components/emoji_picker/emoji_picker_overlay.jsx
+++ b/components/emoji_picker/emoji_picker_overlay.jsx
@@ -45,11 +45,7 @@ export default class EmojiPickerOverlay extends React.PureComponent {
         enableGifPicker: false,
     };
 
-    emojiPickerPosition = memoize((emojiTrigger, rightOffset) => {
-        if (typeof rightOffset !== 'undefined') {
-            return rightOffset;
-        }
-
+    emojiPickerPosition = memoize((emojiTrigger) => {
         let calculatedRightOffset = Constants.DEFAULT_EMOJI_PICKER_RIGHT_OFFSET;
         if (emojiTrigger) {
             calculatedRightOffset = window.innerWidth - emojiTrigger.getBoundingClientRect().left - Constants.DEFAULT_EMOJI_PICKER_LEFT_OFFSET;
@@ -74,7 +70,7 @@ export default class EmojiPickerOverlay extends React.PureComponent {
     render() {
         const {target, rightOffset, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition} = this.props;
 
-        const calculatedRightOffset = typeof rightOffset !== 'undefined' ? rightOffset : emojiPickerPosition(target())
+        const calculatedRightOffset = typeof rightOffset === 'undefined' ? this.emojiPickerPosition(target()) : rightOffset;
         const placement = this.getPlacement(target(), spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition);
 
         return (

--- a/components/emoji_picker/emoji_picker_overlay.jsx
+++ b/components/emoji_picker/emoji_picker_overlay.jsx
@@ -74,7 +74,7 @@ export default class EmojiPickerOverlay extends React.PureComponent {
     render() {
         const {target, rightOffset, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition} = this.props;
 
-        const calculatedRightOffset = this.emojiPickerPosition(target(), rightOffset);
+        const calculatedRightOffset = typeof rightOffset !== 'undefined' ? rightOffset : emojiPickerPosition(target())
         const placement = this.getPlacement(target(), spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition);
 
         return (


### PR DESCRIPTION
#### Summary
A customer is experiencing slow typing issues. A JS profile showed the following:

<img width="432" alt="Screen Shot 2021-05-10 at 9 18 51 PM" src="https://user-images.githubusercontent.com/2672098/117744079-f9adcf00-b1d5-11eb-8bf9-ee68e9637505.png">

A very significant amount of time is spent on "Recalculate Style" and the primary trigger for this seems to be the `getBoundingClientRect` function calls inside the EmojiPickerOverlay component. After some brief investigation it was apparent that on every single character typed into the textbox `getBoundingClientRect` was being called twice due to improper use of `getDerivedStateFromProps`. I have used memoization to properly implement the functionality in a much more performant way.

Unfortunately, I was unable to reproduce the exact slow typing issue the customer is experiencing so I'm not sure how much effect this will have or if this is the root cause of the issues or not.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35509

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Performance improvement to emoji picker overlay that should improve typing performance.
```
