### PR TITLE
Cypress/E2E: Fix flaky test on MM-T1776

### DIFF
--- a/e2e/cypress/integration/auth_sso/authentication_not_cloud_spec.js
+++ b/e2e/cypress/integration/auth_sso/authentication_not_cloud_spec.js
@@ -56,7 +56,7 @@ describe('Authentication', () => {
 
         cy.findByPlaceholderText('E.g.: "10"', {timeout: TIMEOUTS.ONE_MIN}).clear().type('2');
 
-        cy.findByRole('button', {name: 'Save'}).click();
+        cy.uiSaveConfig();
 
         // * Ensure error appears when saving a password outside of the limits
         cy.findByPlaceholderText('E.g.: "10"').invoke('val').should('equal', '2');


### PR DESCRIPTION
#### Summary
Use `cy.uiSaveConfig` for it has guaranteed saving wait mechanism before doing verification.

![Screen Shot 2021-05-11 at 9 31 01 PM](https://user-images.githubusercontent.com/5334504/117830129-eb2ee880-b2a5-11eb-8565-cf43bdc87a33.png)

#### Ticket Link
failed on release test

#### Release Note
```release-note
NONE
```