### PR TITLE
[MM-35310] Only show channels not in a team attached to the current policy

### DIFF
--- a/components/admin_console/data_retention_settings/custom_policy_form/custom_policy_form.tsx
+++ b/components/admin_console/data_retention_settings/custom_policy_form/custom_policy_form.tsx
@@ -33,6 +33,7 @@ import './custom_policy_form.scss';
 type Props = {
     policyId?: string;
     policy?: DataRetentionCustomPolicy | null;
+    teams?: Team[];
     actions: {
         fetchPolicy: (id: string) => Promise<{ data: DataRetentionCustomPolicy; error?: Error }>;
         fetchPolicyTeams: (id: string, page: number, perPage: number) => Promise<{ data: Team[]; error?: Error }>;
@@ -190,6 +191,23 @@ export default class CustomPolicyForm extends React.PureComponent<Props, State> 
         }
         this.setState({removedChannels: {...removedChannels}, newChannels: {...newChannels}, removedChannelsCount, saveNeeded: true});
         this.props.actions.setNavigationBlocked(true);
+    }
+
+    getTeamsToExclude = () => {
+        const {teams} = this.props;
+        const {newTeams, removedTeams} = this.state;
+
+        let teamsToDisplay = teams?.map(function(team) {
+            return team['id'];
+          });;
+        const includeTeamsList = Object.keys(newTeams);
+
+        // Remove teams to remove and add teams to add
+        if (teamsToDisplay) {
+            teamsToDisplay = teamsToDisplay?.filter((id) => !removedTeams[id]);
+            teamsToDisplay = [...includeTeamsList, ...teamsToDisplay];
+        }
+        return teamsToDisplay;
     }
     handleSubmit = async () => {
         const {policyName, messageRetentionInputValue, messageRetentionDropdownValue, newTeams, removedTeams, newChannels, removedChannels} = this.state;
@@ -424,6 +442,7 @@ export default class CustomPolicyForm extends React.PureComponent<Props, State> 
                                 groupID={''}
                                 alreadySelected={Object.keys(this.state.newChannels)}
                                 excludePolicyConstrained={true}
+                                excludeTeamIds={this.getTeamsToExclude()}
                             />
                         }
                         <Card

--- a/components/admin_console/data_retention_settings/custom_policy_form/custom_policy_form.tsx
+++ b/components/admin_console/data_retention_settings/custom_policy_form/custom_policy_form.tsx
@@ -197,9 +197,9 @@ export default class CustomPolicyForm extends React.PureComponent<Props, State> 
         const {teams} = this.props;
         const {newTeams, removedTeams} = this.state;
 
-        let teamsToDisplay = teams?.map(function(team) {
-            return team['id'];
-          });;
+        let teamsToDisplay = teams?.map((team) => {
+            return team.id;
+        });
         const includeTeamsList = Object.keys(newTeams);
 
         // Remove teams to remove and add teams to add

--- a/components/admin_console/data_retention_settings/custom_policy_form/index.ts
+++ b/components/admin_console/data_retention_settings/custom_policy_form/index.ts
@@ -30,6 +30,7 @@ import {GlobalState} from 'types/store';
 import {setNavigationBlocked} from 'actions/admin_actions.jsx';
 
 import CustomPolicyForm from './custom_policy_form';
+import {getTeamsInPolicy} from 'mattermost-redux/selectors/entities/teams';
 
 type Actions = {
     fetchPolicy: (id: string) => Promise<{ data: DataRetentionCustomPolicy }>;
@@ -52,12 +53,15 @@ type OwnProps = {
 }
 
 function mapStateToProps() {
+    const getPolicyTeams = getTeamsInPolicy();
     return (state: GlobalState, ownProps: OwnProps) => {
         const policyId = ownProps.match.params.policy_id;
         const policy = getDataRetentionCustomPolicy(state, policyId);
+        const teams = policyId ? getPolicyTeams(state, {policyId}) : [];
         return {
             policyId,
             policy,
+            teams,
         };
     };
 }

--- a/components/admin_console/data_retention_settings/custom_policy_form/index.ts
+++ b/components/admin_console/data_retention_settings/custom_policy_form/index.ts
@@ -29,8 +29,9 @@ import {GlobalState} from 'types/store';
 
 import {setNavigationBlocked} from 'actions/admin_actions.jsx';
 
-import CustomPolicyForm from './custom_policy_form';
 import {getTeamsInPolicy} from 'mattermost-redux/selectors/entities/teams';
+
+import CustomPolicyForm from './custom_policy_form';
 
 type Actions = {
     fetchPolicy: (id: string) => Promise<{ data: DataRetentionCustomPolicy }>;

--- a/components/channel_selector_modal/__snapshots__/channel_selector_modal.test.tsx.snap
+++ b/components/channel_selector_modal/__snapshots__/channel_selector_modal.test.tsx.snap
@@ -1,5 +1,117 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/ChannelSelectorModal exclude already selected 1`] = `
+<Modal
+  animation={true}
+  aria-labelledby="channelSelectorModalLabel"
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="a11y__modal more-modal more-direct-channels channel-selector-modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onExited={[Function]}
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  role="dialog"
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h1"
+      id="channelSelectorModalLabel"
+    >
+      <injectIntl(FormattedMarkdownMessage)
+        defaultMessage="Add Channels to **Channel Selection** List"
+        id="add_channels_to_scheme.title"
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <MultiSelect
+      ariaLabelRenderer={[Function]}
+      buttonSubmitText="Add"
+      handleAdd={[Function]}
+      handleDelete={[Function]}
+      handleInput={[Function]}
+      handlePageChange={[Function]}
+      handleSubmit={[Function]}
+      key="addChannelsToSchemeKey"
+      loading={true}
+      numRemainingText={
+        <FormattedMessage
+          defaultMessage="Use ↑↓ to browse, ↵ to select."
+          id="multiselect.selectChannels"
+        />
+      }
+      optionRenderer={[Function]}
+      options={
+        Array [
+          Object {
+            "create_at": 0,
+            "creator_id": "id",
+            "delete_at": 0,
+            "display_name": "name",
+            "extra_update_at": 0,
+            "group_constrained": false,
+            "header": "header",
+            "id": "channel-3",
+            "label": "name",
+            "last_post_at": 0,
+            "name": "DN",
+            "purpose": "purpose",
+            "scheme_id": "id",
+            "team_display_name": "teamDisplayName",
+            "team_id": "teamid1",
+            "team_name": "teamName",
+            "team_update_at": 0,
+            "total_msg_count": 0,
+            "total_msg_count_root": 0,
+            "type": "O",
+            "update_at": 0,
+            "value": "channel-3",
+          },
+        ]
+      }
+      perPage={50}
+      placeholderText="Search and add channels"
+      saveButtonPosition="top"
+      saving={false}
+      selectedItemRef={
+        Object {
+          "current": null,
+        }
+      }
+      valueRenderer={[Function]}
+      valueWithImage={false}
+      values={Array []}
+    />
+  </ModalBody>
+</Modal>
+`;
+
 exports[`components/ChannelSelectorModal should match snapshot 1`] = `
 <Modal
   animation={true}
@@ -67,7 +179,58 @@ exports[`components/ChannelSelectorModal should match snapshot 1`] = `
         />
       }
       optionRenderer={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "create_at": 0,
+            "creator_id": "id",
+            "delete_at": 0,
+            "display_name": "name",
+            "extra_update_at": 0,
+            "group_constrained": false,
+            "header": "header",
+            "id": "channel-2",
+            "label": "name",
+            "last_post_at": 0,
+            "name": "DN",
+            "purpose": "purpose",
+            "scheme_id": "id",
+            "team_display_name": "teamDisplayName",
+            "team_id": "teamid2",
+            "team_name": "teamName",
+            "team_update_at": 0,
+            "total_msg_count": 0,
+            "total_msg_count_root": 0,
+            "type": "O",
+            "update_at": 0,
+            "value": "channel-2",
+          },
+          Object {
+            "create_at": 0,
+            "creator_id": "id",
+            "delete_at": 0,
+            "display_name": "name",
+            "extra_update_at": 0,
+            "group_constrained": false,
+            "header": "header",
+            "id": "channel-3",
+            "label": "name",
+            "last_post_at": 0,
+            "name": "DN",
+            "purpose": "purpose",
+            "scheme_id": "id",
+            "team_display_name": "teamDisplayName",
+            "team_id": "teamid1",
+            "team_name": "teamName",
+            "team_update_at": 0,
+            "total_msg_count": 0,
+            "total_msg_count_root": 0,
+            "type": "O",
+            "update_at": 0,
+            "value": "channel-3",
+          },
+        ]
+      }
       perPage={50}
       placeholderText="Search and add channels"
       saveButtonPosition="top"

--- a/components/channel_selector_modal/channel_selector_modal.test.tsx
+++ b/components/channel_selector_modal/channel_selector_modal.test.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import ChannelSelectorModal from 'components/channel_selector_modal/channel_selector_modal';
-import { ChannelWithTeamData } from 'mattermost-redux/types/channels';
-import { TestHelper } from 'utils/test_helper';
+import {ChannelWithTeamData} from 'mattermost-redux/types/channels';
+import {TestHelper} from 'utils/test_helper';
 
 describe('components/ChannelSelectorModal', () => {
     const channel1: ChannelWithTeamData = Object.assign(TestHelper.getChannelWithTeamDataMock({id: 'channel-1', team_id: 'teamid1'}));
@@ -45,10 +45,10 @@ describe('components/ChannelSelectorModal', () => {
 
     test('exclude already selected', () => {
         const wrapper = shallow(
-            <ChannelSelectorModal 
+            <ChannelSelectorModal
                 {...defaultProps}
                 excludeTeamIds={['teamid2']}
-            />
+            />,
         );
         wrapper.setState({channels: [
             channel1,

--- a/components/channel_selector_modal/channel_selector_modal.test.tsx
+++ b/components/channel_selector_modal/channel_selector_modal.test.tsx
@@ -5,48 +5,28 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import ChannelSelectorModal from 'components/channel_selector_modal/channel_selector_modal';
+import { ChannelWithTeamData } from 'mattermost-redux/types/channels';
+import { TestHelper } from 'utils/test_helper';
 
 describe('components/ChannelSelectorModal', () => {
+    const channel1: ChannelWithTeamData = Object.assign(TestHelper.getChannelWithTeamDataMock({id: 'channel-1', team_id: 'teamid1'}));
+    const channel2: ChannelWithTeamData = Object.assign(TestHelper.getChannelWithTeamDataMock({id: 'channel-2', team_id: 'teamid2'}));
+    const channel3: ChannelWithTeamData = Object.assign(TestHelper.getChannelWithTeamDataMock({id: 'channel-3', team_id: 'teamid1'}));
+
     const defaultProps = {
         excludeNames: [],
         currentSchemeId: 'xxx',
-        alreadySelected: ['id1'],
+        alreadySelected: ['channel-1'],
         searchTerm: '',
-        channels: [
-            {
-                id: 'id1',
-                delete_at: 0,
-                scheme_id: '',
-                display_name: 'Channel 1',
-                team_display_name: 'Team 1',
-            },
-            {
-                id: 'id2',
-                delete_at: 123,
-                scheme_id: '',
-                display_name: 'Channel 2',
-                team_display_name: 'Team 2',
-            },
-            {
-                id: 'id3',
-                delete_at: 0,
-                scheme_id: 'test',
-                display_name: 'Channel 3',
-                team_display_name: 'Team 3',
-            },
-            {
-                id: 'id4',
-                delete_at: 0,
-                scheme_id: '',
-                display_name: 'Channel 4',
-                team_display_name: 'Team 4',
-            },
-        ],
         onModalDismissed: jest.fn(),
         onChannelsSelected: jest.fn(),
         groupID: '',
         actions: {
-            loadChannels: jest.fn(() => Promise.resolve({data: []})),
+            loadChannels: jest.fn().mockResolvedValue({data: [
+                channel1,
+                channel2,
+                channel3,
+            ]}),
             setModalSearchTerm: jest.fn(),
             searchChannels: jest.fn(() => Promise.resolve({data: []})),
             searchAllChannels: jest.fn(() => Promise.resolve({data: []})),
@@ -55,6 +35,26 @@ describe('components/ChannelSelectorModal', () => {
 
     test('should match snapshot', () => {
         const wrapper = shallow(<ChannelSelectorModal {...defaultProps}/>);
+        wrapper.setState({channels: [
+            channel1,
+            channel2,
+            channel3,
+        ]});
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('exclude already selected', () => {
+        const wrapper = shallow(
+            <ChannelSelectorModal 
+                {...defaultProps}
+                excludeTeamIds={['teamid2']}
+            />
+        );
+        wrapper.setState({channels: [
+            channel1,
+            channel2,
+            channel3,
+        ]});
 
         expect(wrapper).toMatchSnapshot();
     });

--- a/components/channel_selector_modal/channel_selector_modal.tsx
+++ b/components/channel_selector_modal/channel_selector_modal.tsx
@@ -30,6 +30,7 @@ type Props = {
     };
     alreadySelected?: string[];
     excludePolicyConstrained?: boolean;
+    excludeTeamIds?: string[];
 }
 
 type State = {
@@ -211,6 +212,9 @@ export default class ChannelSelectorModal extends React.PureComponent<Props, Sta
         }
         if (this.props.excludePolicyConstrained) {
             options = options.filter((channel) => channel.policy_id === null);
+        }
+        if (this.props.excludeTeamIds) {
+            options = options.filter((channel) => this.props.excludeTeamIds?.indexOf(channel.team_id) === -1);
         }
         const values = this.state.values.map((i): ChannelWithTeamDataValue => ({...i, label: i.display_name, value: i.id}));
 

--- a/utils/test_helper.ts
+++ b/utils/test_helper.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {Channel, ChannelMembership, ChannelNotifyProps} from 'mattermost-redux/types/channels';
+import {Channel, ChannelMembership, ChannelNotifyProps, ChannelWithTeamData} from 'mattermost-redux/types/channels';
 import {Bot} from 'mattermost-redux/types/bots';
 import {Role} from 'mattermost-redux/types/roles';
 import {UserProfile, UserAccessToken} from 'mattermost-redux/types/users';
@@ -105,6 +105,32 @@ export class TestHelper {
             creator_id: 'id',
             scheme_id: 'id',
             group_constrained: false,
+        };
+        return Object.assign({}, defaultChannel, override);
+    }
+
+    public static getChannelWithTeamDataMock(override?: Partial<ChannelWithTeamData>): Channel {
+        const defaultChannel: ChannelWithTeamData = {
+            id: 'channel_id',
+            create_at: 0,
+            update_at: 0,
+            delete_at: 0,
+            team_id: 'team_id',
+            type: 'O',
+            display_name: 'name',
+            name: 'DN',
+            header: 'header',
+            purpose: 'purpose',
+            last_post_at: 0,
+            total_msg_count: 0,
+            total_msg_count_root: 0,
+            extra_update_at: 0,
+            creator_id: 'id',
+            scheme_id: 'id',
+            group_constrained: false,
+            team_display_name: 'teamDisplayName',
+            team_name: 'teamName',
+            team_update_at: 0,
         };
         return Object.assign({}, defaultChannel, override);
     }

--- a/utils/test_helper.ts
+++ b/utils/test_helper.ts
@@ -109,7 +109,7 @@ export class TestHelper {
         return Object.assign({}, defaultChannel, override);
     }
 
-    public static getChannelWithTeamDataMock(override?: Partial<ChannelWithTeamData>): Channel {
+    public static getChannelWithTeamDataMock(override?: Partial<ChannelWithTeamData>): ChannelWithTeamData {
         const defaultChannel: ChannelWithTeamData = {
             id: 'channel_id',
             create_at: 0,


### PR DESCRIPTION
#### Summary
When selecting channels for a policy, you should only see channels that are not related to a team in the current policy

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35310

#### Release Note
```release-note
NONE
```
