### PR TITLE
Cypress/E2E: Fix failed tests related to emoji picker

### DIFF
--- a/e2e/cypress/integration/archived_channel/archive_channel_add_reaction_spec.js
+++ b/e2e/cypress/integration/archived_channel/archive_channel_add_reaction_spec.js
@@ -39,9 +39,9 @@ describe('Archived channels', () => {
             cy.clickPostReactionIcon(postId);
 
             // # Choose "slightly_frowning_face" emoji
-            // delaying 500ms in case of lag
-            // eslint-disable-next-line cypress/no-unnecessary-waiting
-            cy.get('.emoji-picker__items #emoji-1f641').wait(500).click();
+            cy.findByTestId('slightly_frowning_face').
+                should('exist').
+                click({force: true});
 
             // * Should have added the reaction with count
             cy.get(`#postReaction-${postId}-slightly_frowning_face .Reaction__number--display`).should('have.text', '1');

--- a/e2e/cypress/integration/emoji/custom_emoji_1_spec.js
+++ b/e2e/cypress/integration/emoji/custom_emoji_1_spec.js
@@ -65,7 +65,7 @@ describe('Custom emojis', () => {
         // # Type emoji name and click on save
         cy.get('#name').type('croissant');
         cy.get('.backstage-form__footer').within(($form) => {
-            cy.findByText('Save').click();
+            cy.findByText('Save').click().wait(TIMEOUTS.FIVE_SEC);
 
             // * Check for error saying that the emoji icon is a system one
             cy.wrap($form).find('.has-error').should('be.visible').and('have.text', 'This name is already in use by a system emoji. Please choose another name.');
@@ -126,6 +126,7 @@ describe('Custom emojis', () => {
 
         // # Click on Save
         cy.get('.backstage-form__footer').findByText('Save').click().wait(TIMEOUTS.FIVE_SEC);
+        cy.findByText('Add Custom Emoji').should('be.visible');
 
         // # Go back to home channel
         cy.findByText('Back to Mattermost').should('exist').and('be.visible').click().wait(TIMEOUTS.FIVE_SEC);
@@ -182,6 +183,7 @@ describe('Custom emojis', () => {
 
         // # Click on Save
         cy.get('.backstage-form__footer').findByText('Save').click().wait(TIMEOUTS.FIVE_SEC);
+        cy.findByText('Add Custom Emoji').should('be.visible');
 
         // # Go back to home channel
         cy.findByText('Back to Mattermost').should('exist').and('be.visible').click().wait(TIMEOUTS.FIVE_SEC);

--- a/e2e/cypress/integration/emoji/sorted_emojis_spec.js
+++ b/e2e/cypress/integration/emoji/sorted_emojis_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @emoji
 
-describe('MM-T157 Filtered emojis are sorted by recency, then begins with, then contains (alphabetically within each)', () => {
+describe('Emoji sorting', () => {
     before(() => {
         // # Login as test user and visit town-square
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
@@ -18,43 +18,42 @@ describe('MM-T157 Filtered emojis are sorted by recency, then begins with, then 
         });
     });
 
-    it('By recency', () => {
-        // #Post a dog emoji
+    it('MM-T157 Filtered emojis are sorted by recency, then begins with, then contains (alphabetically within each)', () => {
+        // # Post a dog emoji
         cy.postMessage(':dog:');
 
-        // #Post a cat emoji
+        // # Post a cat emoji
         cy.postMessage(':cat:');
 
-        // #Open emoji picker
+        // # Open emoji picker
         cy.get('#emojiPickerButton').click();
 
-        // #Assert first recently used emoji has the data-test-id value of 'cat' which was the last one we sent
-        cy.findAllByTestId('emojiItem').first().within(($el) => {
-            cy.wrap($el).findByTestId('cat').should('be.visible');
-        });
-    });
+        // # Assert first recently used emoji has the data-test-id value of 'cat' which was the last one we sent
+        cy.findAllByTestId('emojiItem').
+            findByRole('button', {name: 'cat emoji'}).
+            should('exist').
+            click({force: true});
 
-    it('By recently used emoji first in alphabetical order, Followed by emoji that contain "word" in alphabetical', () => {
         const emojiList = [];
 
-        // #Post a guardsman emoji
+        // # Post a guardsman emoji
         cy.postMessage(':guardsman:');
 
-        // #Post a white small square emoji
+        // # Post a white small square emoji
         cy.postMessage(':white_small_square:');
 
-        // #Open emoji picker
+        // # Open emoji picker
         cy.get('#emojiPickerButton').click();
 
-        //#Search sma text in emoji searching input
+        // # Search sma text in emoji searching input
         cy.findByTestId('emojiInputSearch').should('be.visible').type('sma');
 
-        // #Get list of recent emojis based on search text
+        // # Get list of recent emojis based on search text
         cy.findAllByTestId('emojiItem').children('img').each(($el) => {
             const emojiName = $el.get(0);
             emojiList.push(emojiName.dataset.testid);
         }).then(() => {
-            // #Comparing list of emojis obtained from search above and making sure order is same as requirement describes
+            // # Comparing list of emojis obtained from search above and making sure order is same as requirement describes
             expect(emojiList).to.deep.equal(['guardsman', 'white_small_square', 'small_airplane', 'small_blue_diamond', 'small_orange_diamond', 'small_red_triangle', 'small_red_triangle_down', 'arrow_down_small', 'arrow_up_small', 'black_medium_small_square', 'black_small_square', 'sun_behind_small_cloud', 'white_medium_small_square']);
         });
     });

--- a/e2e/cypress/integration/messaging/emoji_insert_position_spec.js
+++ b/e2e/cypress/integration/messaging/emoji_insert_position_spec.js
@@ -27,7 +27,10 @@ describe('Messaging', () => {
 
         // # Select the grinning emoji from the emoji picker.
         cy.get('#emojiPickerButton').click();
-        cy.get('img[data-testid="grinning"]').should('be.visible').click({force: true});
+        cy.findAllByTestId('emojiItem').
+            findByRole('button', {name: 'grinning emoji'}).
+            should('exist').
+            click({force: true});
 
         // * The emoji should be inserted where the cursor is at the time of selection.
         cy.get('#post_textbox').should('have.value', 'Hello :grinning: World!');

--- a/e2e/cypress/integration/messaging/message_reaction_gm_spec.js
+++ b/e2e/cypress/integration/messaging/message_reaction_gm_spec.js
@@ -50,8 +50,9 @@ describe('Emoji reactions to posts/messages in GM channels', () => {
             cy.clickPostReactionIcon(postId);
 
             // # Choose "slightly_frowning_face" emoji
-            // delaying 500ms in case of lag
-            cy.get('.emoji-picker__items #emoji-1f641').wait(500).click(); // eslint-disable-line cypress/no-unnecessary-waiting
+            cy.findByTestId('slightly_frowning_face').
+                should('exist').
+                click({force: true});
 
             // * The number shown on the reaction is incremented by 1
             cy.get(`#postReaction-${postId}-slightly_frowning_face .Reaction__number--display`).
@@ -59,7 +60,7 @@ describe('Emoji reactions to posts/messages in GM channels', () => {
                 should('be.visible');
         });
 
-        // * Verify that the Add a Reaction button is visible at the right times
+        // * Verify that the Add Reaction button is visible at the right times
         cy.getLastPostId().then((postId) => {
             // * Verify that the Add Reaction button isn't visible
             cy.findByLabelText('Add a reaction').should('not.be.visible');
@@ -67,7 +68,7 @@ describe('Emoji reactions to posts/messages in GM channels', () => {
             // # Focus on the post since we can't hover with Cypress
             cy.get(`#post_${postId}`).focus().tab().tab();
 
-            // * Verify that the Add Reaction button is 1now visible
+            // * Verify that the Add Reaction button is now visible
             cy.findByLabelText('Add a reaction').should('be.visible');
 
             // # Click somewhere to clear the focus

--- a/e2e/cypress/integration/messaging/message_reaction_spec.js
+++ b/e2e/cypress/integration/messaging/message_reaction_spec.js
@@ -44,9 +44,9 @@ describe('Emoji reactions to posts/messages', () => {
             cy.clickPostReactionIcon(postId);
 
             // # Choose "slightly_frowning_face" emoji
-            // delaying 500ms in case of lag
-            // eslint-disable-next-line cypress/no-unnecessary-waiting
-            cy.get('.emoji-picker__items #emoji-1f641').wait(500).click();
+            cy.findByTestId('slightly_frowning_face').
+                should('exist').
+                click({force: true});
 
             // * The number shown on the reaction is incremented by 1
             cy.get(`#postReaction-${postId}-slightly_frowning_face .Reaction__number--display`).
@@ -117,9 +117,9 @@ describe('Emoji reactions to posts/messages', () => {
             cy.get('#emojiPicker').should('be.visible');
 
             // # Select the "sweat_smile" emoji
-            // delaying 500ms in case of lag
-            // eslint-disable-next-line cypress/no-unnecessary-waiting
-            cy.get('.emoji-picker__items #emoji-1f605').wait(500).click();
+            cy.findByTestId('sweat_smile').
+                should('exist').
+                click({force: true});
 
             // * The emoji picker is no longer open
             cy.get('#emojiPicker').should('not.exist');

--- a/e2e/cypress/integration/messaging/reactions_spec.js
+++ b/e2e/cypress/integration/messaging/reactions_spec.js
@@ -51,13 +51,19 @@ describe('Messaging', () => {
             cy.clickPostReactionIcon(postId);
 
             // # Add a reaction to the post
-            cy.get('.emoji-picker__items #emoji-1f631').wait(TIMEOUTS.HALF_SEC).click();
+            // cy.get('.emoji-picker__items #emoji-1f631').wait(TIMEOUTS.HALF_SEC).click();
+            cy.findByTestId('smiley').
+                should('exist').
+                click({force: true});
 
             // # Click the `+` button next to the existing reactions (visible on hover)
             cy.get(`#addReaction-${postId}`).should('exist').click({force: true});
 
             // # Click to select an emoji from the picker
-            cy.get('.emoji-picker__items #emoji-1f643').wait(TIMEOUTS.HALF_SEC).click();
+            // cy.get('.emoji-picker__items #emoji-1f643').wait(TIMEOUTS.HALF_SEC).click();
+            cy.findByTestId('upside_down_face').
+                should('exist').
+                click({force: true});
 
             // * Emoji reaction is added to the post
             cy.get(`#${postId}_message`).within(() => {
@@ -68,7 +74,7 @@ describe('Messaging', () => {
             // * Reaction appears in recently used section of emoji picker
             cy.get('#emojiPickerButton').click().then(() => {
                 cy.findAllByTestId('emojiItem').first().within(($el) => {
-                    cy.wrap($el).findByTestId('upside_down_face').should('be.visible');
+                    cy.wrap($el).findByTestId('upside_down_face').should('exist');
                 });
             });
         });
@@ -88,18 +94,24 @@ describe('Messaging', () => {
                 cy.get(`#RHS_ROOT_reaction_${postId}`).should('exist').click({force: true});
 
                 // # Click the emoji picker icon to react to the message, select a reaction
-                cy.get('.emoji-picker__items #emoji-1f631').wait(TIMEOUTS.HALF_SEC).click();
+                // cy.get('.emoji-picker__items #emoji-1f631').wait(TIMEOUTS.HALF_SEC).click();
+                cy.findByTestId('smiley').
+                    should('exist').
+                    click({force: true});
 
                 // # Hover over the post again and observe the `+` icon next to your reaction
                 cy.get(`#addReaction-${postId}`).should('exist').click({force: true});
 
                 // # Click the `+` icon and select a different reaction
-                cy.get('.emoji-picker__items #emoji-1f643').wait(TIMEOUTS.HALF_SEC).click();
+                // cy.get('.emoji-picker__items #emoji-1f643').wait(TIMEOUTS.HALF_SEC).click();
+                cy.findByTestId('upside_down_face').
+                    should('exist').
+                    click({force: true});
 
                 // * Two reactions are added to the message in the expanded RHS
                 cy.get(`#rhsPost_${postId}`).within(() => {
                     cy.findByLabelText('reactions').should('be.visible');
-                    cy.findByLabelText('remove reaction scream').should('be.visible');
+                    cy.findByLabelText('remove reaction smiley').should('be.visible');
                     cy.findByLabelText('remove reaction upside down face').should('be.visible');
                 });
 


### PR DESCRIPTION
#### Screenshots
![Screen Shot 2021-05-13 at 12 44 41 AM](https://user-images.githubusercontent.com/5334504/118014875-40dac200-b386-11eb-956d-0fdbf2c831af.png)
![Screen Shot 2021-05-13 at 12 47 23 AM](https://user-images.githubusercontent.com/5334504/118014881-42a48580-b386-11eb-93f4-5996c19e8a58.png)
![Screen Shot 2021-05-13 at 12 51 14 AM](https://user-images.githubusercontent.com/5334504/118014884-43d5b280-b386-11eb-92c1-6277db20f68d.png)
![Screen Shot 2021-05-13 at 12 52 10 AM](https://user-images.githubusercontent.com/5334504/118014887-446e4900-b386-11eb-8854-c79751ebaa1e.png)
![Screen Shot 2021-05-13 at 12 53 17 AM](https://user-images.githubusercontent.com/5334504/118014888-446e4900-b386-11eb-97ab-3bdd0a3f5e8e.png)
![Screen Shot 2021-05-13 at 12 54 20 AM](https://user-images.githubusercontent.com/5334504/118014890-4506df80-b386-11eb-987f-e50ac7078006.png)
![Screen Shot 2021-05-13 at 12 55 40 AM](https://user-images.githubusercontent.com/5334504/118014891-459f7600-b386-11eb-82a7-42e77edee8c3.png)

#### Release Note
```release-note
NONE
```
