### PR TITLE
migrate tutorial to typescript

### DIFF
--- a/components/tutorial/index.tsx
+++ b/components/tutorial/index.tsx
@@ -9,10 +9,11 @@ import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import Constants from 'utils/constants';
+import {GlobalState} from 'types/store';
 
-import TutorialView from './tutorial_view.jsx';
+import TutorialView from './tutorial_view';
 
-function mapStateToProps(state) {
+function mapStateToProps(state: GlobalState) {
     const license = getLicense(state);
     const config = getConfig(state);
 

--- a/components/tutorial/menu_tutorial_tip.tsx
+++ b/components/tutorial/menu_tutorial_tip.tsx
@@ -1,14 +1,18 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import React from 'react';
-import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 
-import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
+import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 import TutorialTip from './tutorial_tip';
 
-const MenuTutorialTip = ({toggleFunc, onBottom}) => {
+type Props = {
+    toggleFunc?: React.MouseEventHandler<HTMLDivElement>;
+    onBottom: boolean;
+}
+
+const MenuTutorialTip = ({toggleFunc, onBottom}: Props) => {
     const screens = [];
 
     screens.push(
@@ -59,11 +63,6 @@ const MenuTutorialTip = ({toggleFunc, onBottom}) => {
             />
         </div>
     );
-};
-
-MenuTutorialTip.propTypes = {
-    toggleFunc: PropTypes.func,
-    onBottom: PropTypes.bool.isRequired,
 };
 
 export default MenuTutorialTip;

--- a/components/tutorial/tutorial_tip/index.ts
+++ b/components/tutorial/tutorial_tip/index.ts
@@ -1,18 +1,20 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
+import {bindActionCreators, Dispatch} from 'redux';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {closeMenu as closeRhsMenu} from 'actions/views/rhs';
 import {Preferences} from 'utils/constants';
+import {GlobalState} from 'types/store';
 
 import TutorialTip from './tutorial_tip';
 
-function mapStateToProps(state) {
+function mapStateToProps(state: GlobalState) {
     const currentUserId = getCurrentUserId(state);
     return {
         currentUserId,
@@ -20,7 +22,7 @@ function mapStateToProps(state) {
     };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             closeRhsMenu,

--- a/components/tutorial/tutorial_view.tsx
+++ b/components/tutorial/tutorial_view.tsx
@@ -1,12 +1,23 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-
-import PropTypes from 'prop-types';
 import React from 'react';
 
 import TutorialIntroScreens from './tutorial_intro_screens';
 
-export default class TutorialView extends React.PureComponent {
+type Props = {
+    isRoot?: boolean;
+    townSquareDisplayName: string;
+    appDownloadLink?: string;
+    isLicensed: boolean;
+    restrictTeamInvite: boolean;
+    supportEmail?: string;
+}
+
+export default class TutorialView extends React.PureComponent<Props> {
+    static defaultProps: Partial<Props> = {
+        isRoot: true,
+    }
+
     componentDidMount() {
         if (this.props.isRoot) {
             document.body.classList.add('app__body');
@@ -36,16 +47,3 @@ export default class TutorialView extends React.PureComponent {
         );
     }
 }
-
-TutorialView.propTypes = {
-    isRoot: PropTypes.bool,
-    townSquareDisplayName: PropTypes.string.isRequired,
-    appDownloadLink: PropTypes.string,
-    isLicensed: PropTypes.bool.isRequired,
-    restrictTeamInvite: PropTypes.bool.isRequired,
-    supportEmail: PropTypes.string.isRequired,
-};
-
-TutorialView.defaultProps = {
-    isRoot: true,
-};


### PR DESCRIPTION
#### Summary

migrated tutorial to typescript. also found out that `index` of `tutorial_intro_screens` is not migrated to typescript. so i migrated that file too. 

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/17274

#### Release Note

```release-note
NONE
```