### PR TITLE
[MM-35555] file overlay should cover center channel input box

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -120,7 +120,7 @@
     text-align: center;
     top: 0;
     width: 100%;
-    z-index: 11;
+    z-index: 13;
 
     .overlay__indent {
         @include clearfix;


### PR DESCRIPTION

#### Summary

File overlay covers center channel's input box.

#### Ticket Link

[MM-35555](https://mattermost.atlassian.net/browse/MM-35555)

#### Screenshots

<img width="1205" alt="Screenshot 2021-05-17 at 12 49 35" src="https://user-images.githubusercontent.com/1515906/118476875-59443700-b70e-11eb-9b38-1c7533654cac.png">

#### Release Note

```release-note
input box is shadowed when uploading a file in center channel
```
