### PR TITLE
[MM-35653] Data Retention redux tests

### DIFF
--- a/packages/mattermost-redux/src/actions/admin.test.js
+++ b/packages/mattermost-redux/src/actions/admin.test.js
@@ -1269,4 +1269,291 @@ describe('Actions.Admin', () => {
 
         await Actions.sendWarnMetricAck(warnMetricAck.id, false)(store.dispatch, store.getState);
     });
+
+    it('getDataRetentionCustomPolicies', async () => {
+        const policies = {
+            policies: [
+                {
+                    id: 'id1',
+                    display_name: 'Test Policy',
+                    post_duration: 100,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+                {
+                    id: 'id2',
+                    display_name: 'Test Policy 2',
+                    post_duration: 365,
+                    team_count: 0,
+                    channel_count: 9,
+                },
+            ],
+            total_count: 2,
+        };
+        nock(Client4.getBaseRoute()).
+            get('/data_retention/policies?page=0&per_page=10').
+            reply(200, policies);
+
+        await Actions.getDataRetentionCustomPolicies()(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const policesState = state.entities.admin.dataRetentionCustomPolicies;
+        assert.ok(policesState);
+
+        assert.ok(policesState['id1'].id === 'id1');
+        assert.ok(policesState['id1'].display_name === 'Test Policy');
+        assert.ok(policesState['id1'].post_duration === 100);
+        assert.ok(policesState['id1'].team_count === 2);
+        assert.ok(policesState['id1'].channel_count === 1);
+
+        assert.ok(policesState['id2'].id === 'id2');
+        assert.ok(policesState['id2'].display_name === 'Test Policy 2');
+        assert.ok(policesState['id2'].post_duration === 365);
+        assert.ok(policesState['id2'].team_count === 0);
+        assert.ok(policesState['id2'].channel_count === 9);
+    });
+
+    it('getDataRetentionCustomPolicy', async () => {
+        const policy = {
+            id: 'id1',
+            display_name: 'Test Policy',
+            post_duration: 100,
+            team_count: 2,
+            channel_count: 1,
+        };
+        nock(Client4.getBaseRoute()).
+            get('/data_retention/policies/id1').
+            reply(200, policy);
+
+        await Actions.getDataRetentionCustomPolicy('id1')(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const policesState = state.entities.admin.dataRetentionCustomPolicies;
+        assert.ok(policesState);
+
+        assert.ok(policesState['id1'].id === 'id1');
+        assert.ok(policesState['id1'].display_name === 'Test Policy');
+        assert.ok(policesState['id1'].post_duration === 100);
+        assert.ok(policesState['id1'].team_count === 2);
+        assert.ok(policesState['id1'].channel_count === 1);
+    });
+
+    it('getDataRetentionCustomPolicyTeams', async () => {
+        const teams = [
+            {
+                ...TestHelper.fakeTeam(),
+                policy_id: 'id1',
+                id: 'teamId1',
+            },
+        ];
+        nock(Client4.getBaseRoute()).
+            get('/data_retention/policies/id1/teams?page=0&per_page=50').
+            reply(200, {
+                teams: teams,
+                total_count: 1,
+            });
+
+        await Actions.getDataRetentionCustomPolicyTeams('id1')(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const teamsState = state.entities.teams.teams;
+
+        assert.ok(teamsState);
+        assert.ok(teamsState['teamId1'].policy_id === 'id1');
+    });
+
+    it('getDataRetentionCustomPolicyChannels', async () => {
+        const channels = [
+            {
+                ...TestHelper.fakeChannel('teamId1'),
+                policy_id: 'id1',
+                id: 'channelId1',
+            },
+        ];
+        nock(Client4.getBaseRoute()).
+            get('/data_retention/policies/id1/channels?page=0&per_page=50').
+            reply(200, {
+                channels: channels,
+                total_count: 1,
+            });
+
+        await Actions.getDataRetentionCustomPolicyChannels('id1')(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const teamsState = state.entities.channels.channels;
+
+        assert.ok(teamsState);
+        assert.ok(teamsState['channelId1'].policy_id === 'id1');
+    });
+    
+    it('searchDataRetentionCustomPolicyTeams', async () => {
+        nock(Client4.getBaseRoute()).
+            post('/data_retention/policies/id1/teams/search').
+            reply(200, [TestHelper.basicTeam]);
+
+        const response = await store.dispatch(Actions.searchDataRetentionCustomPolicyTeams('id1', 'test'));
+
+        assert.ok(response.data.length === 1);
+    });
+
+    it('searchDataRetentionCustomPolicyChannels', async () => {
+        nock(Client4.getBaseRoute()).
+            post('/data_retention/policies/id1/channels/search').
+            reply(200, [TestHelper.basicChannel]);
+
+        const response = await store.dispatch(Actions.searchDataRetentionCustomPolicyChannels('id1', 'test'));
+
+        assert.ok(response.data.length === 1);
+    });
+
+    it('createDataRetentionCustomPolicy', async () => {
+        const policy = {
+            display_name: 'Test',
+            post_duration: 100,
+            channel_ids: ['channel1'],
+            team_ids: ['team1', 'team2'],
+        };
+        nock(Client4.getBaseRoute()).
+            post('/data_retention/policies').
+            reply(200, {
+                id: 'id1',
+                display_name: 'Test',
+                post_duration: 100,
+                team_count: 2,
+                channel_count: 1,
+            });
+        await Actions.createDataRetentionCustomPolicy(policy)(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const policesState = state.entities.admin.dataRetentionCustomPolicies;
+        assert.ok(policesState);
+
+        assert.ok(policesState['id1'].id === 'id1');
+        assert.ok(policesState['id1'].display_name === 'Test');
+        assert.ok(policesState['id1'].post_duration === 100);
+        assert.ok(policesState['id1'].team_count === 2);
+        assert.ok(policesState['id1'].channel_count === 1);
+    });
+
+    it('updateDataRetentionCustomPolicy', async () => {
+        nock(Client4.getBaseRoute()).
+            patch('/data_retention/policies/id1').
+            reply(200, {
+                id: 'id1',
+                display_name: 'Test123',
+                post_duration: 365,
+                team_count: 2,
+                channel_count: 1,
+            });
+        await Actions.updateDataRetentionCustomPolicy('id1', {display_name: 'Test123', post_duration: 365})(store.dispatch, store.getState);
+
+        const updateState = store.getState();
+        const policyState = updateState.entities.admin.dataRetentionCustomPolicies;
+        assert.ok(policyState);
+
+        assert.ok(policyState['id1'].id === 'id1');
+        assert.ok(policyState['id1'].display_name === 'Test123');
+        assert.ok(policyState['id1'].post_duration === 365);
+        assert.ok(policyState['id1'].team_count === 2);
+        assert.ok(policyState['id1'].channel_count === 1);
+    });
+    
+    it('createDataRetentionCustomPolicy', async () => {
+        const policy = {
+            display_name: 'Test',
+            post_duration: 100,
+            channel_ids: ['channel1'],
+            team_ids: ['team1', 'team2'],
+        };
+        nock(Client4.getBaseRoute()).
+            post('/data_retention/policies').
+            reply(200, {
+                id: 'id1',
+                display_name: 'Test',
+                post_duration: 100,
+                team_count: 2,
+                channel_count: 1,
+            });
+            await Actions.createDataRetentionCustomPolicy(policy)(store.dispatch, store.getState);
+
+            const state = store.getState();
+            const policesState = state.entities.admin.dataRetentionCustomPolicies;
+            assert.ok(policesState);
+
+            assert.ok(policesState['id1'].id === 'id1');
+            assert.ok(policesState['id1'].display_name === 'Test');
+            assert.ok(policesState['id1'].post_duration === 100);
+            assert.ok(policesState['id1'].team_count === 2);
+            assert.ok(policesState['id1'].channel_count === 1);
+    });
+
+    it('removeDataRetentionCustomPolicyTeams', async () => {
+        const teams = [
+            {
+                ...TestHelper.fakeTeam(),
+                policy_id: 'id1',
+                id: 'teamId1',
+            },
+            {
+                ...TestHelper.fakeTeam(),
+                policy_id: 'id1',
+                id: 'teamId2',
+            },
+        ];
+        nock(Client4.getBaseRoute()).
+            get('/data_retention/policies/id1/teams?page=0&per_page=50').
+            reply(200, {
+                teams: teams,
+                total_count: 2,
+            });
+
+        await Actions.getDataRetentionCustomPolicyTeams('id1')(store.dispatch, store.getState);
+
+        nock(Client4.getBaseRoute()).
+            delete('/data_retention/policies/id1/teams').
+            reply(200, OK_RESPONSE);
+
+        await Actions.removeDataRetentionCustomPolicyTeams('id1', ['teamId2'])(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const teamsState = state.entities.teams.teams;
+
+        assert.ok(teamsState);
+        assert.ok(teamsState['teamId2'].policy_id === null);
+    });
+
+    it('removeDataRetentionCustomPolicyChannels', async () => {
+        const channels = [
+            {
+                ...TestHelper.fakeChannel('teamId1'),
+                policy_id: 'id1',
+                id: 'channelId1',
+            },
+            {
+                ...TestHelper.fakeChannel('teamId1'),
+                policy_id: 'id1',
+                id: 'channelId2',
+            },
+        ];
+        nock(Client4.getBaseRoute()).
+            get('/data_retention/policies/id1/channels?page=0&per_page=50').
+            reply(200, {
+                channels: channels,
+                total_count: 1,
+            });
+
+        await Actions.getDataRetentionCustomPolicyChannels('id1')(store.dispatch, store.getState);
+
+        nock(Client4.getBaseRoute()).
+            delete('/data_retention/policies/id1/channels').
+            reply(200, OK_RESPONSE);
+
+        await Actions.removeDataRetentionCustomPolicyChannels('id1', ['channelId2'])(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const channelsState = state.entities.channels.channels;
+
+        assert.ok(channelsState);
+        assert.ok(channelsState['channelId2'].policy_id === null);
+    });
 });

--- a/packages/mattermost-redux/src/actions/admin.test.js
+++ b/packages/mattermost-redux/src/actions/admin.test.js
@@ -1300,17 +1300,17 @@ describe('Actions.Admin', () => {
         const policesState = state.entities.admin.dataRetentionCustomPolicies;
         assert.ok(policesState);
 
-        assert.ok(policesState['id1'].id === 'id1');
-        assert.ok(policesState['id1'].display_name === 'Test Policy');
-        assert.ok(policesState['id1'].post_duration === 100);
-        assert.ok(policesState['id1'].team_count === 2);
-        assert.ok(policesState['id1'].channel_count === 1);
+        assert.ok(policesState.id1.id === 'id1');
+        assert.ok(policesState.id1.display_name === 'Test Policy');
+        assert.ok(policesState.id1.post_duration === 100);
+        assert.ok(policesState.id1.team_count === 2);
+        assert.ok(policesState.id1.channel_count === 1);
 
-        assert.ok(policesState['id2'].id === 'id2');
-        assert.ok(policesState['id2'].display_name === 'Test Policy 2');
-        assert.ok(policesState['id2'].post_duration === 365);
-        assert.ok(policesState['id2'].team_count === 0);
-        assert.ok(policesState['id2'].channel_count === 9);
+        assert.ok(policesState.id2.id === 'id2');
+        assert.ok(policesState.id2.display_name === 'Test Policy 2');
+        assert.ok(policesState.id2.post_duration === 365);
+        assert.ok(policesState.id2.team_count === 0);
+        assert.ok(policesState.id2.channel_count === 9);
     });
 
     it('getDataRetentionCustomPolicy', async () => {
@@ -1331,11 +1331,11 @@ describe('Actions.Admin', () => {
         const policesState = state.entities.admin.dataRetentionCustomPolicies;
         assert.ok(policesState);
 
-        assert.ok(policesState['id1'].id === 'id1');
-        assert.ok(policesState['id1'].display_name === 'Test Policy');
-        assert.ok(policesState['id1'].post_duration === 100);
-        assert.ok(policesState['id1'].team_count === 2);
-        assert.ok(policesState['id1'].channel_count === 1);
+        assert.ok(policesState.id1.id === 'id1');
+        assert.ok(policesState.id1.display_name === 'Test Policy');
+        assert.ok(policesState.id1.post_duration === 100);
+        assert.ok(policesState.id1.team_count === 2);
+        assert.ok(policesState.id1.channel_count === 1);
     });
 
     it('getDataRetentionCustomPolicyTeams', async () => {
@@ -1349,7 +1349,7 @@ describe('Actions.Admin', () => {
         nock(Client4.getBaseRoute()).
             get('/data_retention/policies/id1/teams?page=0&per_page=50').
             reply(200, {
-                teams: teams,
+                teams,
                 total_count: 1,
             });
 
@@ -1359,7 +1359,7 @@ describe('Actions.Admin', () => {
         const teamsState = state.entities.teams.teams;
 
         assert.ok(teamsState);
-        assert.ok(teamsState['teamId1'].policy_id === 'id1');
+        assert.ok(teamsState.teamId1.policy_id === 'id1');
     });
 
     it('getDataRetentionCustomPolicyChannels', async () => {
@@ -1373,7 +1373,7 @@ describe('Actions.Admin', () => {
         nock(Client4.getBaseRoute()).
             get('/data_retention/policies/id1/channels?page=0&per_page=50').
             reply(200, {
-                channels: channels,
+                channels,
                 total_count: 1,
             });
 
@@ -1383,9 +1383,9 @@ describe('Actions.Admin', () => {
         const teamsState = state.entities.channels.channels;
 
         assert.ok(teamsState);
-        assert.ok(teamsState['channelId1'].policy_id === 'id1');
+        assert.ok(teamsState.channelId1.policy_id === 'id1');
     });
-    
+
     it('searchDataRetentionCustomPolicyTeams', async () => {
         nock(Client4.getBaseRoute()).
             post('/data_retention/policies/id1/teams/search').
@@ -1428,11 +1428,11 @@ describe('Actions.Admin', () => {
         const policesState = state.entities.admin.dataRetentionCustomPolicies;
         assert.ok(policesState);
 
-        assert.ok(policesState['id1'].id === 'id1');
-        assert.ok(policesState['id1'].display_name === 'Test');
-        assert.ok(policesState['id1'].post_duration === 100);
-        assert.ok(policesState['id1'].team_count === 2);
-        assert.ok(policesState['id1'].channel_count === 1);
+        assert.ok(policesState.id1.id === 'id1');
+        assert.ok(policesState.id1.display_name === 'Test');
+        assert.ok(policesState.id1.post_duration === 100);
+        assert.ok(policesState.id1.team_count === 2);
+        assert.ok(policesState.id1.channel_count === 1);
     });
 
     it('updateDataRetentionCustomPolicy', async () => {
@@ -1451,13 +1451,13 @@ describe('Actions.Admin', () => {
         const policyState = updateState.entities.admin.dataRetentionCustomPolicies;
         assert.ok(policyState);
 
-        assert.ok(policyState['id1'].id === 'id1');
-        assert.ok(policyState['id1'].display_name === 'Test123');
-        assert.ok(policyState['id1'].post_duration === 365);
-        assert.ok(policyState['id1'].team_count === 2);
-        assert.ok(policyState['id1'].channel_count === 1);
+        assert.ok(policyState.id1.id === 'id1');
+        assert.ok(policyState.id1.display_name === 'Test123');
+        assert.ok(policyState.id1.post_duration === 365);
+        assert.ok(policyState.id1.team_count === 2);
+        assert.ok(policyState.id1.channel_count === 1);
     });
-    
+
     it('createDataRetentionCustomPolicy', async () => {
         const policy = {
             display_name: 'Test',
@@ -1474,17 +1474,17 @@ describe('Actions.Admin', () => {
                 team_count: 2,
                 channel_count: 1,
             });
-            await Actions.createDataRetentionCustomPolicy(policy)(store.dispatch, store.getState);
+        await Actions.createDataRetentionCustomPolicy(policy)(store.dispatch, store.getState);
 
-            const state = store.getState();
-            const policesState = state.entities.admin.dataRetentionCustomPolicies;
-            assert.ok(policesState);
+        const state = store.getState();
+        const policesState = state.entities.admin.dataRetentionCustomPolicies;
+        assert.ok(policesState);
 
-            assert.ok(policesState['id1'].id === 'id1');
-            assert.ok(policesState['id1'].display_name === 'Test');
-            assert.ok(policesState['id1'].post_duration === 100);
-            assert.ok(policesState['id1'].team_count === 2);
-            assert.ok(policesState['id1'].channel_count === 1);
+        assert.ok(policesState.id1.id === 'id1');
+        assert.ok(policesState.id1.display_name === 'Test');
+        assert.ok(policesState.id1.post_duration === 100);
+        assert.ok(policesState.id1.team_count === 2);
+        assert.ok(policesState.id1.channel_count === 1);
     });
 
     it('removeDataRetentionCustomPolicyTeams', async () => {
@@ -1503,7 +1503,7 @@ describe('Actions.Admin', () => {
         nock(Client4.getBaseRoute()).
             get('/data_retention/policies/id1/teams?page=0&per_page=50').
             reply(200, {
-                teams: teams,
+                teams,
                 total_count: 2,
             });
 
@@ -1519,7 +1519,7 @@ describe('Actions.Admin', () => {
         const teamsState = state.entities.teams.teams;
 
         assert.ok(teamsState);
-        assert.ok(teamsState['teamId2'].policy_id === null);
+        assert.ok(teamsState.teamId2.policy_id === null);
     });
 
     it('removeDataRetentionCustomPolicyChannels', async () => {
@@ -1538,7 +1538,7 @@ describe('Actions.Admin', () => {
         nock(Client4.getBaseRoute()).
             get('/data_retention/policies/id1/channels?page=0&per_page=50').
             reply(200, {
-                channels: channels,
+                channels,
                 total_count: 1,
             });
 
@@ -1554,6 +1554,6 @@ describe('Actions.Admin', () => {
         const channelsState = state.entities.channels.channels;
 
         assert.ok(channelsState);
-        assert.ok(channelsState['channelId2'].policy_id === null);
+        assert.ok(channelsState.channelId2.policy_id === null);
     });
 });

--- a/packages/mattermost-redux/src/actions/admin.ts
+++ b/packages/mattermost-redux/src/actions/admin.ts
@@ -734,11 +734,11 @@ export function deleteDataRetentionCustomPolicy(id: string): ActionFunc {
     };
 }
 
-export function getDataRetentionCustomPolicyTeams(id: string, page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, includeTotalCount = false): ActionFunc {
+export function getDataRetentionCustomPolicyTeams(id: string, page = 0, perPage: number = General.TEAMS_CHUNK_SIZE): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         let data;
         try {
-            data = await Client4.getDataRetentionCustomPolicyTeams(id, page, perPage, includeTotalCount);
+            data = await Client4.getDataRetentionCustomPolicyTeams(id, page, perPage);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(
@@ -831,24 +831,39 @@ export function searchDataRetentionCustomPolicyChannels(id: string, term: string
 }
 
 export function createDataRetentionCustomPolicy(policy: CreateDataRetentionCustomPolicy): ActionFunc {
-    return bindClientFunc({
-        clientFunc: Client4.createDataRetentionPolicy,
-        onSuccess: AdminTypes.CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS,
-        params: [
-            policy,
-        ],
-    });
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        let data;
+        try {
+            data = await Client4.createDataRetentionPolicy(policy);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch, getState);
+            return {error};
+        }
+
+        dispatch(
+            {type: AdminTypes.CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS, data},
+        );
+
+        return {data};
+    };
 }
 
 export function updateDataRetentionCustomPolicy(id: string, policy: CreateDataRetentionCustomPolicy): ActionFunc {
-    return bindClientFunc({
-        clientFunc: Client4.updateDataRetentionPolicy,
-        onSuccess: AdminTypes.UPDATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS,
-        params: [
-            id,
-            policy,
-        ],
-    });
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        let data;
+        try {
+            data = await Client4.updateDataRetentionPolicy(id, policy);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch, getState);
+            return {error};
+        }
+
+        dispatch(
+            {type: AdminTypes.UPDATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS, data},
+        );
+
+        return {data};
+    };
 }
 
 export function addDataRetentionCustomPolicyTeams(id: string, teams: string[]): ActionFunc {

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -2725,9 +2725,9 @@ export default class Client4 {
         );
     }
 
-    getDataRetentionCustomPolicyTeams = (id: string, page = 0, perPage = PER_PAGE_DEFAULT, includeTotalCount = false) => {
+    getDataRetentionCustomPolicyTeams = (id: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
         return this.doFetch<Team[]>(
-            `${this.getDataRetentionRoute()}/policies/${id}/teams${buildQueryString({page, per_page: perPage, include_total_count: includeTotalCount})}`,
+            `${this.getDataRetentionRoute()}/policies/${id}/teams${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };

--- a/packages/mattermost-redux/src/reducers/entities/admin.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/admin.test.js
@@ -851,4 +851,168 @@ describe('reducers.entities.admin', () => {
             assert.deepEqual(actualState.ldapGroups, expectedState);
         });
     });
+
+    describe('Data Retention', () => {
+        it('initial state', () => {
+            const state = {};
+            const action = {};
+            const expectedState = {};
+
+            const actualState = reducer({dataRetentionCustomPolicies: state}, action);
+            assert.deepStrictEqual(actualState.dataRetentionCustomPolicies, expectedState);
+        });
+
+        it('RECEIVED_DATA_RETENTION_CUSTOM_POLICIES', () => {
+            const state = {};
+            const action = {
+                type: AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICIES,
+                data: {
+                    policies: [
+                        {
+                            id: 'id1',
+                            display_name: 'Test Policy',
+                            post_duration: 100,
+                            team_count: 2,
+                            channel_count: 1,
+                        },
+                        {
+                            id: 'id2',
+                            display_name: 'Test Policy 2',
+                            post_duration: 365,
+                            team_count: 0,
+                            channel_count: 9,
+                        },
+                    ],
+                    total_count: 2,
+                },
+            };
+            const expectedState = {
+                id1: {
+                    id: 'id1',
+                    display_name: 'Test Policy',
+                    post_duration: 100,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+                id2: {
+                    id: 'id2',
+                    display_name: 'Test Policy 2',
+                    post_duration: 365,
+                    team_count: 0,
+                    channel_count: 9,
+                },
+            };
+
+            const actualState = reducer({dataRetentionCustomPolicies: state}, action);
+            assert.deepStrictEqual(actualState.dataRetentionCustomPolicies, expectedState);
+        });
+
+        it('RECEIVED_DATA_RETENTION_CUSTOM_POLICY', () => {
+            const state = {};
+            const action = {
+                type: AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY,
+                data: {
+                    id: 'id1',
+                    display_name: 'Test Policy',
+                    post_duration: 100,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+            };
+            const expectedState = {
+                id1: {
+                    id: 'id1',
+                    display_name: 'Test Policy',
+                    post_duration: 100,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+            };
+
+            const actualState = reducer({dataRetentionCustomPolicies: state}, action);
+            assert.deepStrictEqual(actualState.dataRetentionCustomPolicies, expectedState);
+        });
+
+        it('DELETE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS', () => {
+            const state = {
+                id1: {
+                    id: 'id1',
+                    display_name: 'Test Policy',
+                    post_duration: 100,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+            };
+            const action = {
+                type: AdminTypes.DELETE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS,
+                data: {
+                    id: 'id1',
+                },
+            };
+            const expectedState = {};
+
+            const actualState = reducer({dataRetentionCustomPolicies: state}, action);
+            assert.deepStrictEqual(actualState.dataRetentionCustomPolicies, expectedState);
+        });
+
+        it('CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS', () => {
+            const state = {};
+            const action = {
+                type: AdminTypes.CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS,
+                data: {
+                    id: 'id1',
+                    display_name: 'Test Policy',
+                    post_duration: 100,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+            };
+            const expectedState = {
+                id1: {
+                    id: 'id1',
+                    display_name: 'Test Policy',
+                    post_duration: 100,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+            };
+
+            const actualState = reducer({dataRetentionCustomPolicies: state}, action);
+            assert.deepStrictEqual(actualState.dataRetentionCustomPolicies, expectedState);
+        });
+
+        it('UPDATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS', () => {
+            const state = {
+                id1: {
+                    id: 'id1',
+                    display_name: 'Test Policy',
+                    post_duration: 100,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+            };
+            const action = {
+                type: AdminTypes.CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS,
+                data: {
+                    id: 'id1',
+                    display_name: 'Test Policy 123',
+                    post_duration: 365,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+            };
+            const expectedState = {
+                id1: {
+                    id: 'id1',
+                    display_name: 'Test Policy 123',
+                    post_duration: 365,
+                    team_count: 2,
+                    channel_count: 1,
+                },
+            };
+
+            const actualState = reducer({dataRetentionCustomPolicies: state}, action);
+            assert.deepStrictEqual(actualState.dataRetentionCustomPolicies, expectedState);
+        });
+    });
 });

--- a/packages/mattermost-redux/src/reducers/entities/admin.ts
+++ b/packages/mattermost-redux/src/reducers/entities/admin.ts
@@ -587,7 +587,9 @@ function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action:
 
 function dataRetentionCustomPolicies(state: IDMappedObjects<DataRetentionCustomPolicy> = {}, action: GenericAction): IDMappedObjects<DataRetentionCustomPolicy> {
     switch (action.type) {
-    case AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY: {
+    case AdminTypes.CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS:
+    case AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY: 
+    case AdminTypes.UPDATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS: {
         return {
             ...state,
             [action.data.id]: action.data,

--- a/packages/mattermost-redux/src/reducers/entities/admin.ts
+++ b/packages/mattermost-redux/src/reducers/entities/admin.ts
@@ -588,7 +588,7 @@ function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action:
 function dataRetentionCustomPolicies(state: IDMappedObjects<DataRetentionCustomPolicy> = {}, action: GenericAction): IDMappedObjects<DataRetentionCustomPolicy> {
     switch (action.type) {
     case AdminTypes.CREATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS:
-    case AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY: 
+    case AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY:
     case AdminTypes.UPDATE_DATA_RETENTION_CUSTOM_POLICY_SUCCESS: {
         return {
             ...state,

--- a/packages/mattermost-redux/src/reducers/entities/channels.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/channels.test.js
@@ -1037,7 +1037,7 @@ describe('channels', () => {
             const nextState = channelsReducer(state, {
                 type: AdminTypes.REMOVE_DATA_RETENTION_CUSTOM_POLICY_CHANNELS_SUCCESS,
                 data: {
-                    channels: ['channel1', 'channel2']
+                    channels: ['channel1', 'channel2'],
                 },
             });
 

--- a/packages/mattermost-redux/src/reducers/entities/channels.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/channels.test.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {ChannelTypes, UserTypes, PostTypes} from 'mattermost-redux/action_types';
+import {ChannelTypes, UserTypes, PostTypes, AdminTypes} from 'mattermost-redux/action_types';
 import deepFreeze from 'mattermost-redux/utils/deep_freeze';
 
 import {General, Permissions} from 'mattermost-redux/constants';
@@ -943,6 +943,179 @@ describe('channels', () => {
 
             expect(nextState.channelMemberCountsByGroup.channel1['group-3'].channel_member_count).toEqual(12);
             expect(nextState.channelMemberCountsByGroup.channel1['group-3'].channel_member_timezones_count).toEqual(13);
+        });
+    });
+
+    describe('Data Retention Channels', () => {
+        test('RECEIVED_DATA_RETENTION_CUSTOM_POLICY_CHANNELS', () => {
+            const state = deepFreeze({
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        team_id: 'team',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                        team_id: 'team',
+                    },
+                    channel3: {
+                        id: 'channel3',
+                        team_id: 'team',
+                    },
+                },
+                channelModerations: {},
+                channelMemberCountsByGroup: {},
+            });
+
+            const nextState = channelsReducer(state, {
+                type: AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY_CHANNELS,
+                data: {
+                    channels: [{
+                        id: 'channel4',
+                        team_id: 'team',
+                    }],
+                    total_count: 1,
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.channels.channel1).toEqual({
+                id: 'channel1',
+                team_id: 'team',
+            });
+            expect(nextState.channels.channel2).toEqual({
+                id: 'channel2',
+                team_id: 'team',
+            });
+            expect(nextState.channels.channel3).toEqual({
+                id: 'channel3',
+                team_id: 'team',
+            });
+            expect(nextState.channels.channel4).toEqual({
+                id: 'channel4',
+                team_id: 'team',
+            });
+        });
+
+        test('REMOVE_DATA_RETENTION_CUSTOM_POLICY_CHANNELS_SUCCESS', () => {
+            const state = deepFreeze({
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        team_id: 'team',
+                        policy_id: 'policy1',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                        team_id: 'team',
+                        policy_id: 'policy1',
+                    },
+                    channel3: {
+                        id: 'channel3',
+                        team_id: 'team',
+                        policy_id: 'policy1',
+                    },
+                },
+                channelModerations: {},
+                channelMemberCountsByGroup: {},
+            });
+
+            const nextState = channelsReducer(state, {
+                type: AdminTypes.REMOVE_DATA_RETENTION_CUSTOM_POLICY_CHANNELS_SUCCESS,
+                data: {
+                    channels: ['channel1', 'channel2']
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.channels.channel1).toEqual({
+                id: 'channel1',
+                team_id: 'team',
+                policy_id: null,
+            });
+            expect(nextState.channels.channel2).toEqual({
+                id: 'channel2',
+                team_id: 'team',
+                policy_id: null,
+            });
+            expect(nextState.channels.channel3).toEqual({
+                id: 'channel3',
+                team_id: 'team',
+                policy_id: 'policy1',
+            });
+        });
+        test('RECEIVED_DATA_RETENTION_CUSTOM_POLICY_CHANNELS_SEARCH', () => {
+            const state = deepFreeze({
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        team_id: 'team',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                        team_id: 'team',
+                    },
+                    channel3: {
+                        id: 'channel3',
+                        team_id: 'team',
+                    },
+                },
+                channelModerations: {},
+                channelMemberCountsByGroup: {},
+            });
+
+            const nextState = channelsReducer(state, {
+                type: AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY_CHANNELS_SEARCH,
+                data: [
+                    {
+                        id: 'channel1',
+                        team_id: 'team',
+                    },
+                    {
+                        id: 'channel4',
+                        team_id: 'team',
+                    },
+                ],
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.channels.channel1).toEqual({
+                id: 'channel1',
+                team_id: 'team',
+            });
+            expect(nextState.channels.channel2).toEqual({
+                id: 'channel2',
+                team_id: 'team',
+            });
+            expect(nextState.channels.channel3).toEqual({
+                id: 'channel3',
+                team_id: 'team',
+            });
+            expect(nextState.channels.channel4).toEqual({
+                id: 'channel4',
+                team_id: 'team',
+            });
         });
     });
 });

--- a/packages/mattermost-redux/src/reducers/entities/teams.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/teams.test.js
@@ -183,7 +183,7 @@ describe('Data Retention Teams', () => {
         const nextState = teamsReducer(state, {
             type: AdminTypes.REMOVE_DATA_RETENTION_CUSTOM_POLICY_TEAMS_SUCCESS,
             data: {
-                teams: ['team1', 'team2']
+                teams: ['team1', 'team2'],
             },
         });
 

--- a/packages/mattermost-redux/src/reducers/entities/teams.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/teams.test.js
@@ -3,8 +3,9 @@
 
 import assert from 'assert';
 
-import {TeamTypes} from 'mattermost-redux/action_types';
+import {TeamTypes, AdminTypes} from 'mattermost-redux/action_types';
 import teamsReducer from 'mattermost-redux/reducers/entities/teams';
+import deepFreeze from 'mattermost-redux/utils/deep_freeze';
 
 describe('Reducers.teams.myMembers', () => {
     it('initial state', async () => {
@@ -106,5 +107,146 @@ describe('Reducers.teams.myMembers', () => {
         testAction.data = {team_id_2: myMember2};
         state = teamsReducer(state, testAction);
         assert.deepEqual(state.myMembers, {team_id_1: myMember1});
+    });
+});
+describe('Data Retention Teams', () => {
+    it('RECEIVED_DATA_RETENTION_CUSTOM_POLICY_TEAMS', async () => {
+        const state = deepFreeze({
+            currentTeamId: '',
+            teams: {
+                team1: {
+                    id: 'team1',
+                },
+                team2: {
+                    id: 'team2',
+                },
+                team3: {
+                    id: 'team3',
+                },
+            },
+            myMembers: {},
+            membersInTeam: {},
+            totalCount: 0,
+            stats: {},
+            groupsAssociatedToTeam: {},
+        });
+
+        const nextState = teamsReducer(state, {
+            type: AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY_TEAMS,
+            data: {
+                teams: [{
+                    id: 'team4',
+                }],
+                total_count: 1,
+            },
+        });
+
+        expect(nextState).not.toBe(state);
+        expect(nextState.teams.team1).toEqual({
+            id: 'team1',
+        });
+        expect(nextState.teams.team2).toEqual({
+            id: 'team2',
+        });
+        expect(nextState.teams.team3).toEqual({
+            id: 'team3',
+        });
+        expect(nextState.teams.team4).toEqual({
+            id: 'team4',
+        });
+    });
+
+    it('REMOVE_DATA_RETENTION_CUSTOM_POLICY_TEAMS_SUCCESS', async () => {
+        const state = deepFreeze({
+            currentTeamId: '',
+            teams: {
+                team1: {
+                    id: 'team1',
+                    policy_id: 'policy1',
+                },
+                team2: {
+                    id: 'team2',
+                    policy_id: 'policy1',
+                },
+                team3: {
+                    id: 'team3',
+                    policy_id: 'policy1',
+                },
+            },
+            myMembers: {},
+            membersInTeam: {},
+            totalCount: 0,
+            stats: {},
+            groupsAssociatedToTeam: {},
+        });
+
+        const nextState = teamsReducer(state, {
+            type: AdminTypes.REMOVE_DATA_RETENTION_CUSTOM_POLICY_TEAMS_SUCCESS,
+            data: {
+                teams: ['team1', 'team2']
+            },
+        });
+
+        expect(nextState).not.toBe(state);
+        expect(nextState.teams.team1).toEqual({
+            id: 'team1',
+            policy_id: null,
+        });
+        expect(nextState.teams.team2).toEqual({
+            id: 'team2',
+            policy_id: null,
+        });
+        expect(nextState.teams.team3).toEqual({
+            id: 'team3',
+            policy_id: 'policy1',
+        });
+    });
+
+    it('RECEIVED_DATA_RETENTION_CUSTOM_POLICY_TEAMS_SEARCH', async () => {
+        const state = deepFreeze({
+            currentTeamId: '',
+            teams: {
+                team1: {
+                    id: 'team1',
+                },
+                team2: {
+                    id: 'team2',
+                },
+                team3: {
+                    id: 'team3',
+                },
+            },
+            myMembers: {},
+            membersInTeam: {},
+            totalCount: 0,
+            stats: {},
+            groupsAssociatedToTeam: {},
+        });
+
+        const nextState = teamsReducer(state, {
+            type: AdminTypes.RECEIVED_DATA_RETENTION_CUSTOM_POLICY_TEAMS_SEARCH,
+            data: [
+                {
+                    id: 'team1',
+                },
+                {
+                    id: 'team4',
+                },
+            ],
+        });
+
+        expect(nextState).not.toBe(state);
+        expect(nextState.teams.team1).toEqual({
+            id: 'team1',
+        });
+        expect(nextState.teams.team2).toEqual({
+            id: 'team2',
+        });
+        expect(nextState.teams.team3).toEqual({
+            id: 'team3',
+        });
+        expect(nextState.teams.team4).toEqual({
+            id: 'team4',
+        });
     });
 });


### PR DESCRIPTION
#### Summary
Redux tests for data retention

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35653

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
