### PR TITLE
MM-35689 Fix error caused by trying to render non-string attachment field

### DIFF
--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.tsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.tsx.snap
@@ -272,6 +272,17 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
 </div>
 `;
 
+exports[`components/post_view/MessageAttachment should match snapshot and render a field with a number value 1`] = `
+<td
+  className="attachment-field"
+  key="attachment__field-0__1"
+>
+  <Connect(Markdown)
+    message="1234"
+  />
+</td>
+`;
+
 exports[`components/post_view/MessageAttachment should match snapshot when no footer is provided (even if footer_icon is provided) 1`] = `
 <div
   className="attachment attachment--pretext"

--- a/components/post_view/message_attachments/message_attachment/message_attachment.test.tsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.test.tsx
@@ -212,4 +212,23 @@ describe('components/post_view/MessageAttachment', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should match snapshot and render a field with a number value', () => {
+        const props = {
+            ...baseProps,
+            attachment: {
+                ...attachment,
+                fields: [
+                    {
+                        title: 'this is the title',
+                        value: 1234,
+                    },
+                ],
+            } as MessageAttachmentType,
+        };
+
+        const wrapper = shallow(<MessageAttachment {...props}/>);
+
+        expect(wrapper.find('.attachment-field')).toMatchSnapshot();
+    });
 });

--- a/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -263,7 +263,7 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                     className='attachment-field'
                     key={'attachment__field-' + i + '__' + nrTables}
                 >
-                    <Markdown message={field.value}/>
+                    <Markdown message={String(field.value)}/>
                 </td>,
             );
             rowPos += 1;


### PR DESCRIPTION
As far as I can tell, field values are the only thing in a message attachment that's allowed to be a string or a number, and we failed to check for that on the client before sending them into the Markdown component. I tried swapping other fields for numbers, but it seems like the server sanitizes those already even though I couldn't find exactly where that happens.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35689

#### Release Note
```release-note
Fixed error caused by a post created with a non-string attachment field.
```