### PR TITLE
MM-35237: CRT, Keep Threads mention badge on hover

### DIFF
--- a/components/threading/global_threads_link/global_threads_link.scss
+++ b/components/threading/global_threads_link/global_threads_link.scss
@@ -19,7 +19,7 @@
             }
         }
 
-        #SidebarContainer &:hover {
+        &:hover {
             padding-right: 16px !important;
 
             .badge {

--- a/components/threading/global_threads_link/global_threads_link.scss
+++ b/components/threading/global_threads_link/global_threads_link.scss
@@ -20,11 +20,11 @@
         }
 
         &:hover {
-            padding-right: 16px !important;
+            padding-right: 16px;
 
             .badge {
-                visibility: visible !important;
-                position: initial !important;
+                visibility: visible;
+                position: initial;
             }
         }
     }


### PR DESCRIPTION
- [MM-35237](https://mattermost.atlassian.net/browse/MM-35237): Fix prior css selector refactoring that negated keep-visible styling.

![CleanShot 2021-05-18 at 16 01 56](https://user-images.githubusercontent.com/11724372/118723241-c6c99380-b7f2-11eb-9855-f678f4a3b36d.gif)