### PR TITLE
ci/gitlab: add ssh keys to be able to fetch the repositories

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,14 @@ test: #todo check on how to create junit.xml, there currently is none
       prefix: ${CI_COMMIT_REF_SLUG}
     paths:
       - .npm/
+  before_script:
+    - 'which ssh-agent || ( apt-get update -y && apt-get install openssh-client git -y )'
+    - eval $(ssh-agent -s)
+    - echo "$SSH_PRIVATE_KEY_GITHUB" | tr -d '\r' | ssh-add -
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+    - ssh-keyscan github.com >> ~/.ssh/known_hosts
+    - chmod 644 ~/.ssh/known_hosts
   script:
     - npm ci --cache .npm --prefer-offline
 


### PR DESCRIPTION
#### Summary
the main branch is failing on the internal gitlab
https://git.internal.mattermost.com/mattermost/ci-only/mattermost-webapp/-/jobs/62157

this fix the job, tested in my fork internally: https://git.internal.mattermost.com/cpanato/mattermost-webapp/-/jobs/62226

#### Ticket Link
n/a

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:


-->

```release-note
NONE
```
