### PR TITLE
update pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,17 +49,18 @@ If no release notes are required write NONE. Use past-tense. Newlines are stripp
 
 Examples:
 
-```release-note
+```
 Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
 ```
 
-```release-note
+```
 Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
 ```
 
-```release-note
+```
 NONE
 ```
 -->
 ```release-note
+
 ```


### PR DESCRIPTION
#### Summary
Removing the `release-note` annotation from the examples, because the bot will read that and think there is a release-note set

Just realize this when opened a new PR and saw that did not mark the PR as missing a release note.

same was made here: https://github.com/mattermost/mattermost-server/pull/17480

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
