### PR TITLE
MM-35715: CRT removes comment count

### DIFF
--- a/components/post_view/post_info/post_info.tsx
+++ b/components/post_view/post_info/post_info.tsx
@@ -190,7 +190,7 @@ export default class PostInfo extends React.PureComponent<Props, State> {
             return null;
         }
 
-        const {isMobile, isReadOnly} = this.props;
+        const {isMobile, isReadOnly, collapsedThreadsEnabled} = this.props;
         const hover = this.props.hover || this.state.showEmojiPicker || this.state.showDotMenu || this.state.showOptionsMenuWithoutHover;
 
         const showCommentIcon = fromAutoResponder ||
@@ -201,7 +201,7 @@ export default class PostInfo extends React.PureComponent<Props, State> {
             commentIcon = (
                 <CommentIcon
                     handleCommentClick={this.props.handleCommentClick}
-                    commentCount={this.props.replyCount}
+                    commentCount={collapsedThreadsEnabled ? undefined : this.props.replyCount}
                     postId={post.id}
                     extraClass={commentIconExtraClass}
                 />
@@ -258,11 +258,11 @@ export default class PostInfo extends React.PureComponent<Props, State> {
                 data-testid={`post-menu-${post.id}`}
                 className={'col post-menu'}
             >
-                {!this.props.collapsedThreadsEnabled && dotMenu}
+                {!collapsedThreadsEnabled && dotMenu}
                 {postReaction}
                 {postFlagIcon}
                 {commentIcon}
-                {this.props.collapsedThreadsEnabled && dotMenu}
+                {collapsedThreadsEnabled && dotMenu}
             </div>
         );
     };


### PR DESCRIPTION
#### Summary

Removes comment count from post info component.
Justification: we show it in root post's thread footer.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35715

#### Screenshots

![image](https://user-images.githubusercontent.com/3829551/118959575-2054ce00-b96b-11eb-8dcc-5fc7b1019220.png)

#### Release Note

```release-note
NONE
```
