### PR TITLE
[MM-35796] Use same constant to validate permissions

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2593,7 +2593,7 @@ const AdminDefinition = {
                         placeholder: t('admin.customization.restrictLinkPreviewsExample'),
                         placeholder_default: 'E.g.: "internal.mycompany.com, images.example.com"',
                         isDisabled: it.any(
-                            it.not(it.userHasWritePermissionOnResource('site')),
+                            it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.POSTS)),
                             it.configIsFalse('ServiceSettings', 'EnableLinkPreviews'),
                         ),
                     },


### PR DESCRIPTION
#### Summary

Restrict domains for link previews should depend on the same permissions as enable link preview

#### Ticket Link

[MM-35796](https://mattermost.atlassian.net/browse/MM-35796)

#### Release Note

```release-note
Restrict domains for link previews depends on the same permissions as enable link preview
```
