### PR TITLE
Add rest field support

### DIFF
--- a/components/suggestion/command_provider/app_command_parser/app_command_parser.test.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser.test.ts
@@ -423,6 +423,60 @@ describe('AppCommandParser', () => {
                 command: '/jira issue create --project == test',
                 submit: {expectError: 'Multiple `=` signs are not allowed.'},
             },
+            {
+                title: 'rest field',
+                command: '/jira issue rest hello world',
+                autocomplete: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.Rest);
+                    expect(parsed.binding?.label).toBe('rest');
+                    expect(parsed.incomplete).toBe('hello world');
+                    expect(parsed.values?.summary).toBe(undefined);
+                }},
+                submit: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.Rest);
+                    expect(parsed.binding?.label).toBe('rest');
+                    expect(parsed.values?.summary).toBe('hello world');
+                }},
+            },
+            {
+                title: 'rest field with other field',
+                command: '/jira issue rest --verbose true hello world',
+                autocomplete: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.Rest);
+                    expect(parsed.binding?.label).toBe('rest');
+                    expect(parsed.incomplete).toBe('hello world');
+                    expect(parsed.values?.summary).toBe(undefined);
+                    expect(parsed.values?.verbose).toBe('true');
+                }},
+                submit: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.Rest);
+                    expect(parsed.binding?.label).toBe('rest');
+                    expect(parsed.values?.summary).toBe('hello world');
+                    expect(parsed.values?.verbose).toBe('true');
+                }},
+            },
+            {
+                title: 'rest field as flag with other field',
+                command: '/jira issue rest --summary "hello world" --verbose true',
+                autocomplete: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.EndValue);
+                    expect(parsed.binding?.label).toBe('rest');
+                    expect(parsed.incomplete).toBe('true');
+                    expect(parsed.values?.summary).toBe('hello world');
+                    expect(parsed.values?.verbose).toBe(undefined);
+                }},
+                submit: {verify: (parsed: ParsedCommand): void => {
+                    expect(parsed.state).toBe(ParseState.EndValue);
+                    expect(parsed.binding?.label).toBe('rest');
+                    expect(parsed.values?.summary).toBe('hello world');
+                    expect(parsed.values?.verbose).toBe('true');
+                }},
+            },
+            {
+                title: 'error: rest after rest field flag',
+                command: '/jira issue rest --summary "hello world" --verbose true hello world',
+                submit: {expectError: 'Unable to identify argument.'},
+            },
         ];
 
         table.forEach((tc) => {
@@ -512,6 +566,13 @@ describe('AppCommandParser', () => {
                     IconData: 'Create icon',
                     Description: 'Create a new Jira issue',
                 },
+                {
+                    Suggestion: 'rest',
+                    Complete: 'jira issue rest',
+                    Hint: 'rest hint',
+                    IconData: 'rest icon',
+                    Description: 'rest description',
+                },
             ]);
         });
 
@@ -532,6 +593,14 @@ describe('AppCommandParser', () => {
                     IconData: 'Create icon',
                     Description: 'Create a new Jira issue',
                 },
+                {
+                    Suggestion: 'rest',
+                    Complete: 'JiRa IsSuE rest',
+                    Hint: 'rest hint',
+                    IconData: 'rest icon',
+                    Description: 'rest description',
+                },
+
             ]);
         });
 

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
@@ -302,7 +302,7 @@ export class ParsedCommand {
                 }
 
                 if (c === '') {
-                    this.values![this.field.name] = this.incomplete;
+                    this.values[this.field.name] = this.incomplete;
                     return this;
                 }
 
@@ -541,13 +541,13 @@ export class ParsedCommand {
                     (!autocompleteMode && this.incomplete !== 'true' && this.incomplete !== 'false'))) {
                     // reset back where the value started, and treat as a new parameter
                     this.i = this.incompleteStart;
-                    this.values![this.field.name] = 'true';
+                    this.values[this.field.name] = 'true';
                     this.state = ParseState.StartParameter;
                 } else {
                     if (autocompleteMode && c === '') {
                         return this;
                     }
-                    this.values![this.field.name] = this.incomplete;
+                    this.values[this.field.name] = this.incomplete;
                     this.incomplete = '';
                     this.incompleteStart = this.i;
                     if (c === '') {

--- a/components/suggestion/command_provider/app_command_parser/tests/app_command_parser_test_data.ts
+++ b/components/suggestion/command_provider/app_command_parser/tests/app_command_parser_test_data.ts
@@ -181,6 +181,37 @@ export const createCommand: AppBinding = {
     } as AppForm,
 };
 
+export const restCommand: AppBinding = {
+    app_id: 'jira',
+    label: 'rest',
+    location: 'rest',
+    description: 'rest description',
+    icon: 'rest icon',
+    hint: 'rest hint',
+    form: {
+        call: {
+            path: '/create-issue',
+        },
+        fields: [
+            {
+                name: 'summary',
+                label: 'summary',
+                description: 'The Jira issue summary',
+                type: AppFieldTypes.TEXT,
+                hint: 'The thing is working great!',
+                position: -1,
+            },
+            {
+                name: 'verbose',
+                label: 'verbose',
+                description: 'display details',
+                type: AppFieldTypes.BOOL,
+                hint: 'yes or no!',
+            },
+        ],
+    } as AppForm,
+};
+
 export const testBindings: AppBinding[] = [
     {
         app_id: '',
@@ -202,6 +233,7 @@ export const testBindings: AppBinding[] = [
                     bindings: [
                         viewCommand,
                         createCommand,
+                        restCommand,
                     ],
                 }],
             },


### PR DESCRIPTION
#### Summary
If we set the autocomplete position of a text field, it becomes the "rest" argument.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30460

#### Screenshots
![Screenshot from 2021-05-25 12-41-56](https://user-images.githubusercontent.com/1933730/119490629-5922e780-bd5d-11eb-9a3f-1d7595af68b4.png)
![Screenshot from 2021-05-25 12-42-15](https://user-images.githubusercontent.com/1933730/119490635-5aecab00-bd5d-11eb-881d-2625053495f5.png)

#### Release Note
```release-note
Add "rest field" to app command parser.
```
