### PR TITLE
Reduce number of workers in CI tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "run": "webpack --progress --watch",
     "dev-server": "webpack serve --mode development",
     "test": "jest --maxWorkers=50%",
-    "test-ci": "jest --ci --maxWorkers=8",
+    "test-ci": "jest --ci --maxWorkers=4",
     "test-ci-gitlab": "jest --ci --maxWorkers=4",
     "stats": "cross-env NODE_ENV=production webpack --profile --json > webpack_stats.json",
     "updatesnapshot": "jest --updateSnapshot",


### PR DESCRIPTION
#### Summary

CI tests are running out of memory: https://app.circleci.com/pipelines/github/mattermost/mattermost-webapp/38725/workflows/5df25840-d23c-4df8-bd64-fd07f8a874ab/jobs/263776

This temporarily reduces the number of workers to the ones used in Gitlab.

#### Ticket Link
--


#### Release Note

```release-note
NONE
```
