### PR TITLE
WIP ci/test: add NODE_OPTIONS max_old_space_size=500

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ test: #todo check on how to create junit.xml, there currently is none
     - npm run check
 
     # unit tests
-    - npm run test-ci-gitlab
+    - npm run test-ci
   timeout: 3 hours
   rules:
     - if: '$CI_COMMIT_REF_NAME == "master" && $TEST == "yes"'

--- a/package.json
+++ b/package.json
@@ -263,7 +263,6 @@
     "dev-server": "webpack serve --mode development",
     "test": "jest --maxWorkers=50%",
     "test-ci": "NODE_OPTIONS=--max_old_space_size=500 jest --ci --maxWorkers=8",
-    "test-ci-gitlab": "jest --ci --maxWorkers=4",
     "stats": "cross-env NODE_ENV=production webpack --profile --json > webpack_stats.json",
     "updatesnapshot": "jest --updateSnapshot",
     "test:debug": "jest --forceExit --detectOpenHandles",

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "run": "webpack --progress --watch",
     "dev-server": "webpack serve --mode development",
     "test": "jest --maxWorkers=50%",
-    "test-ci": "jest --ci --maxWorkers=4",
+    "test-ci": "NODE_OPTIONS=--max_old_space_size=500 jest --ci --maxWorkers=8",
     "test-ci-gitlab": "jest --ci --maxWorkers=4",
     "stats": "cross-env NODE_ENV=production webpack --profile --json > webpack_stats.json",
     "updatesnapshot": "jest --updateSnapshot",


### PR DESCRIPTION
#### Summary
ci/test: add NODE_OPTIONS max_old_space_size=500

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
