### PR TITLE
[MM-35796] Use same constant to validate permissions (cherry-pick v5.35)

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2461,7 +2461,7 @@ const AdminDefinition = {
                         placeholder: t('admin.customization.restrictLinkPreviewsExample'),
                         placeholder_default: 'E.g.: "internal.mycompany.com, images.example.com"',
                         isDisabled: it.any(
-                            it.not(it.userHasWritePermissionOnResource('site')),
+                            it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.POSTS)),
                             it.configIsFalse('ServiceSettings', 'EnableLinkPreviews'),
                         ),
                     },


### PR DESCRIPTION
#### Summary

Cherry pick of #8141 

#### Release Note

```release-note
Restrict domains for link previews depends on the same permissions as enable link preview
```
