### PR TITLE
Add Markdown fields to app forms

### DIFF
--- a/components/apps_form/apps_form_field/apps_form_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_field.tsx
@@ -19,6 +19,8 @@ import ModalSuggestionList from 'components/suggestion/modal_suggestion_list.jsx
 import BoolSetting from 'components/widgets/settings/bool_setting';
 import Provider from 'components/suggestion/provider';
 
+import Markdown from 'components/markdown';
+
 import AppsFormSelectField from './apps_form_select_field';
 
 const TEXT_DEFAULT_MAX_LENGTH = 150;
@@ -123,7 +125,8 @@ export default class AppsFormField extends React.PureComponent<Props> {
             );
         }
 
-        if (field.type === 'text') {
+        switch (field.type) {
+        case AppFieldTypes.TEXT: {
             const subtype = field.subtype || 'text';
 
             let maxLength = field.max_length;
@@ -156,7 +159,9 @@ export default class AppsFormField extends React.PureComponent<Props> {
                     resizable={false}
                 />
             );
-        } else if (field.type === AppFieldTypes.CHANNEL || field.type === AppFieldTypes.USER) {
+        }
+        case AppFieldTypes.CHANNEL:
+        case AppFieldTypes.USER: {
             let selectedValue: string | undefined;
             if (this.props.value) {
                 selectedValue = (this.props.value as AppSelectOption).label;
@@ -174,7 +179,9 @@ export default class AppsFormField extends React.PureComponent<Props> {
                     listComponent={listComponent}
                 />
             );
-        } else if (field.type === AppFieldTypes.STATIC_SELECT || field.type === AppFieldTypes.DYNAMIC_SELECT) {
+        }
+        case AppFieldTypes.STATIC_SELECT:
+        case AppFieldTypes.DYNAMIC_SELECT: {
             return (
                 <AppsFormSelectField
                     {...this.props}
@@ -185,7 +192,8 @@ export default class AppsFormField extends React.PureComponent<Props> {
                     value={this.props.value as AppSelectOption | null}
                 />
             );
-        } else if (field.type === AppFieldTypes.BOOL) {
+        }
+        case AppFieldTypes.BOOL: {
             const boolValue = value as boolean;
             return (
                 <BoolSetting
@@ -199,6 +207,14 @@ export default class AppsFormField extends React.PureComponent<Props> {
                     onChange={onChange}
                 />
             );
+        }
+        case AppFieldTypes.MARKDOWN: {
+            return (
+                <Markdown
+                    message={field.description}
+                />
+            );
+        }
         }
 
         return null;

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
@@ -12,6 +12,7 @@ import {
     AppContext,
     AppForm,
     AppCallValues,
+    AppSelectOption,
     AutocompleteSuggestion,
     AutocompleteStaticSelect,
     Channel,
@@ -23,6 +24,7 @@ import {
     AppCallTypes,
     AppFieldTypes,
     makeAppBindingsSelector,
+    selectChannel,
     getChannel,
     getCurrentTeamId,
     doAppCall,
@@ -34,6 +36,8 @@ import {
     createCallRequest,
     selectUserByUsername,
     getUserByUsername,
+    selectUser,
+    getUser,
     getChannelByNameAndTeamName,
     getCurrentTeam,
     selectChannelByName,
@@ -566,6 +570,8 @@ export class AppCommandParser {
             return {call: null, errorMessage: parserErrorMessage(this.intl, parsed.error, parsed.command, parsed.i)};
         }
 
+        await this.addDefaultAndReadOnlyValues(parsed);
+
         const missing = this.getMissingFields(parsed);
         if (missing.length > 0) {
             const missingStr = missing.map((f) => f.label).join(', ');
@@ -579,6 +585,60 @@ export class AppCommandParser {
         }
 
         return this.composeCallFromParsed(parsed);
+    }
+
+    private async addDefaultAndReadOnlyValues(parsed: ParsedCommand) {
+        await Promise.all(parsed.form?.fields.map(async (f) => {
+            if (!f.value) {
+                return;
+            }
+
+            if (f.readonly || !(f.name in parsed.values)) {
+                switch (f.type) {
+                case AppFieldTypes.TEXT:
+                    parsed.values[f.name] = f.value as string;
+                    break;
+                case AppFieldTypes.BOOL:
+                    parsed.values[f.name] = 'true';
+                    break;
+                case AppFieldTypes.USER: {
+                    const userID = (f.value as AppSelectOption).value;
+                    let user = selectUser(this.store.getState(), userID);
+                    if (!user) {
+                        const dispatchResult = await this.store.dispatch(getUser(userID));
+                        if ('error' in dispatchResult) {
+                            // Silently fail on default value
+                            break;
+                        }
+                        user = dispatchResult.data;
+                    }
+                    parsed.values[f.name] = user.username;
+                    break;
+                }
+                case AppFieldTypes.CHANNEL: {
+                    const channelID = (f.value as AppSelectOption).label;
+                    let channel = selectChannel(this.store.getState(), channelID);
+                    if (!channel) {
+                        const dispatchResult = await this.store.dispatch(getChannel(channelID));
+                        if ('error' in dispatchResult) {
+                            // Silently fail on default value
+                            break;
+                        }
+                        channel = dispatchResult.data;
+                    }
+                    parsed.values[f.name] = channel.name;
+                    break;
+                }
+                case AppFieldTypes.STATIC_SELECT:
+                case AppFieldTypes.DYNAMIC_SELECT:
+                    parsed.values[f.name] = (f.value as AppSelectOption).value;
+                    break;
+                case AppFieldTypes.MARKDOWN:
+
+                    // Do nothing
+                }
+            }
+        }) || []);
     }
 
     // getSuggestionsBase is a synchronous function that returns results for base commands
@@ -840,7 +900,7 @@ export class AppCommandParser {
     // getChannel gets the channel in which the user is typing the command
     private getChannel = (): Channel | null => {
         const state = this.store.getState();
-        return getChannel(state, this.channelID);
+        return selectChannel(state, this.channelID);
     }
 
     public setChannelContext = (channelID: string, rootPostID?: string) => {

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser.ts
@@ -238,6 +238,7 @@ export class ParsedCommand {
             fields = this.form.fields;
         }
 
+        fields = fields.filter((f) => f.type !== AppFieldTypes.MARKDOWN && !f.readonly);
         this.state = ParseState.StartParameter;
         this.i = this.incompleteStart || 0;
         let flagEqualsUsed = false;

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
@@ -14,6 +14,7 @@ export type {
     AutocompleteUserSelect,
     AutocompleteChannelSelect,
     AppLookupResponse,
+    AppSelectOption,
 } from 'mattermost-redux/types/apps';
 
 export type {
@@ -47,12 +48,12 @@ export {
 export {makeAppBindingsSelector} from 'mattermost-redux/selectors/entities/apps';
 
 export {getPost} from 'mattermost-redux/selectors/entities/posts';
-export {getChannel, getCurrentChannel, getChannelByName as selectChannelByName} from 'mattermost-redux/selectors/entities/channels';
+export {getChannel as selectChannel, getCurrentChannel, getChannelByName as selectChannelByName} from 'mattermost-redux/selectors/entities/channels';
 export {getCurrentTeamId, getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
-export {getUserByUsername as selectUserByUsername} from 'mattermost-redux/selectors/entities/users';
+export {getUserByUsername as selectUserByUsername, getUser as selectUser} from 'mattermost-redux/selectors/entities/users';
 
-export {getUserByUsername} from 'mattermost-redux/actions/users';
-export {getChannelByNameAndTeamName} from 'mattermost-redux/actions/channels';
+export {getUserByUsername, getUser} from 'mattermost-redux/actions/users';
+export {getChannelByNameAndTeamName, getChannel} from 'mattermost-redux/actions/channels';
 
 export {doAppCall} from 'actions/apps';
 import {sendEphemeralPost} from 'actions/global_actions';

--- a/packages/mattermost-redux/src/constants/apps.ts
+++ b/packages/mattermost-redux/src/constants/apps.ts
@@ -47,4 +47,5 @@ export const AppFieldTypes: { [name: string]: AppFieldType } = {
     BOOL: 'bool',
     USER: 'user',
     CHANNEL: 'channel',
+    MARKDOWN: 'markdown',
 };


### PR DESCRIPTION
#### Summary
Add Markdown fields to app forms. Also piggybacks a fix to remove readonly fields from commands.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31052
https://mattermost.atlassian.net/browse/MM-36043

#### Related Pull Requests
Mobile: https://github.com/mattermost/mattermost-mobile/pull/5407
Apps Framework: 

#### Screenshots
![Screenshot from 2021-05-27 11-42-26](https://user-images.githubusercontent.com/1933730/119807341-5b16b300-bee3-11eb-8e55-ab82394416d7.png)
![Screenshot from 2021-05-27 11-42-38](https://user-images.githubusercontent.com/1933730/119807345-5baf4980-bee3-11eb-9731-1fdb5a5260b1.png)
![Screenshot from 2021-05-27 11-56-39](https://user-images.githubusercontent.com/1933730/119807346-5baf4980-bee3-11eb-9077-073fdc6af815.png)

#### Release Note
```release-note
Apps can now add arbitrary markdown in between fields on forms.
```
