### PR TITLE
Fixes: position of clear custom status icon

### DIFF
--- a/components/custom_status/custom_status.scss
+++ b/components/custom_status/custom_status.scss
@@ -1,6 +1,14 @@
 @import 'compass/utilities';
 @import 'compass/css3';
 
+.modal .StatusModal.GenericModal .StatusModal__clear-container.input-clear {
+    position: absolute;
+    top: 16px;
+    right: 20px;
+    color: rgba(var(--center-channel-color-rgb), 0.72);
+    opacity: 1;
+}
+
 .StatusModal {
     width: 600px;
 
@@ -58,14 +66,6 @@
         left: 10px;
     }
 
-    &.GenericModal &__clear-container {
-        position: absolute;
-        top: 17px;
-        right: 20px;
-        color: rgba(var(--center-channel-color-rgb), 0.72);
-        opacity: 1;
-    }
-
     &__emoji-button {
         background: transparent;
         border: none;
@@ -118,17 +118,17 @@
 .StatusModal__input {
     .input-clear-x {
         color: rgba(var(--center-channel-color-rgb), 0.56);
-    
+
         .icon {
             font-size: 20px;
         }
     }
-    
+
     .MaxLengthInput__validation {
         right: 44px !important;
         top: 17px !important;
     }
-    
+
     .MaxLengthInput.form-control.has-error {
         padding-right: 76px !important;
     }


### PR DESCRIPTION
#### Summary

CSS rules got overruled, and messed the clear input icon's position in custom status modal.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35544

#### Screenshots

![image](https://user-images.githubusercontent.com/3829551/119835758-c7a4a880-bf09-11eb-912f-c2ffdb018592.png)

#### Release Note

```release-note
NONE
```
