### PR TITLE
[MM-T1282] Add e2e test coverage for default behaviour when an empty site name is configured

### DIFF
--- a/e2e/cypress/integration/system_console/site_configuration/customization_spec.js
+++ b/e2e/cypress/integration/system_console/site_configuration/customization_spec.js
@@ -356,7 +356,6 @@ function saveSetting() {
 }
 
 function verifySiteNameInAboutModal(siteName) {
-
     // # Open the hamburger menu
     cy.get('button > span[class="menu-icon"]').click();
 

--- a/e2e/cypress/integration/system_console/site_configuration/customization_spec.js
+++ b/e2e/cypress/integration/system_console/site_configuration/customization_spec.js
@@ -289,6 +289,48 @@ describe('Customization', () => {
         // * Ensure that the custom branding text is empty
         cy.get('.signup__markdown').should('be.empty');
     });
+
+    it('MM-T1282 - Site Name help text matches text field behavior', () => {
+        // * Verify that the existing Site Name is empty
+        cy.findByTestId('TeamSettings.SiteNameinput').should('be.empty');
+
+        // # Configure a custom Site Name
+        const siteName = 'MM-T1282';
+        cy.findByTestId('TeamSettings.SiteNameinput').clear().type(siteName);
+
+        // # Save setting
+        saveSetting();
+
+        // # Logout
+        cy.apiLogout();
+
+        // * Ensure that the user was redirected to the login page after the logout
+        cy.url().should('include', '/login');
+
+        // * Ensure that the custom Site Name is shown in the login screen
+        cy.get('#site_name').should('have.text', siteName);
+
+        // # Log back in as an administrator
+        cy.apiAdminLogin();
+
+        // # Visit customization system console page
+        cy.visit('/admin_console/site_config/customization');
+
+        // # Empty the Site Name configuration
+        cy.findByTestId('TeamSettings.SiteNameinput').clear();
+
+        // # Save setting
+        saveSetting();
+
+        // # Logout
+        cy.apiLogout();
+
+        // * Ensure that the user was redirected to the login page after the logout
+        cy.url().should('include', '/login');
+
+        // * Ensure that the default Site Name is shown in the login screen
+        cy.get('#site_name').should('have.text', 'Mattermost');
+    });
 });
 
 function saveSetting() {

--- a/e2e/cypress/integration/system_console/site_configuration/customization_spec.js
+++ b/e2e/cypress/integration/system_console/site_configuration/customization_spec.js
@@ -360,7 +360,7 @@ function verifySiteNameInAboutModal(siteName) {
     // # Open the hamburger menu
     cy.get('button > span[class="menu-icon"]').click();
 
-    // # click to open about modal
+    // # Click to open about modal
     cy.findByText(`About ${siteName}`).click();
 
     // * Verify about text is visible

--- a/e2e/cypress/integration/system_console/site_configuration/customization_spec.js
+++ b/e2e/cypress/integration/system_console/site_configuration/customization_spec.js
@@ -307,7 +307,7 @@ describe('Customization', () => {
         // * Ensure that the user was redirected to the login page after the logout
         cy.url().should('include', '/login');
 
-        // * Ensure that the custom Site Name is shown in the login screen
+        // * Ensure that the custom Site Name is shown
         cy.get('#site_name').should('have.text', siteName);
 
         // # Log back in as an administrator
@@ -315,6 +315,9 @@ describe('Customization', () => {
 
         // # Visit customization system console page
         cy.visit('/admin_console/site_config/customization');
+
+        // * Ensure that the 'about' link and modal render the custom Site Name
+        verifySiteNameInAboutModal(siteName);
 
         // # Empty the Site Name configuration
         cy.findByTestId('TeamSettings.SiteNameinput').clear();
@@ -330,6 +333,15 @@ describe('Customization', () => {
 
         // * Ensure that the default Site Name is shown in the login screen
         cy.get('#site_name').should('have.text', 'Mattermost');
+
+        // # Log back in as an administrator
+        cy.apiAdminLogin();
+
+        // # Visit customization system console page
+        cy.visit('/admin_console/site_config/customization');
+
+        // * Ensure that the 'about' link and modal render the default Site Name
+        verifySiteNameInAboutModal('Mattermost');
     });
 });
 
@@ -341,4 +353,19 @@ function saveSetting() {
         click().
         should('be.disabled').
         wait(TIMEOUTS.HALF_SEC);
+}
+
+function verifySiteNameInAboutModal(siteName) {
+
+    // # Open the hamburger menu
+    cy.get('button > span[class="menu-icon"]').click();
+
+    // # click to open about modal
+    cy.findByText(`About ${siteName}`).click();
+
+    // * Verify about text is visible
+    cy.findByText(`About ${siteName}`).should('be.visible');
+
+    // # Close the modal
+    cy.get('div.modal-header button.close').should('exist').click();
 }


### PR DESCRIPTION
#### Summary
Adds an E2E test to cover the behaviour of the 'Site Name' customization configuration option (and default value).

#### Ticket Link
https://automation-test-cases.vercel.app/test/MM-T1282

#### Release Note
```release-note
NONE
```