### PR TITLE
tests/MM-T2365 : Scrolling in the channel is disabled when emoji picker is open(does not affect mobile apps or browser in mobile view)

### DIFF
--- a/e2e/cypress/integration/scroll/channel_scroll_spec.js
+++ b/e2e/cypress/integration/scroll/channel_scroll_spec.js
@@ -54,14 +54,14 @@ describe('Scroll', () => {
         cy.postMessage(lastMessageInCenter);
 
         // # scoll to top in center
-        cy.get('div.post-list__dynamic').should('be.visible').scrollTo('top', {duration: TIMEOUTS.ONE_SEC});
+        cy.get('div.post-list__dynamic').scrollTo('top', {duration: TIMEOUTS.ONE_SEC});
 
         // * Verify we scolled to top
         cy.findByText(firstMessageInCenter).should('exist').and('be.visible');
         cy.findByText(lastMessageInCenter).should('exist').and('not.be.visible');
 
         // # Scroll back to bottom
-        cy.get('div.post-list__dynamic').should('be.visible').scrollTo('bottom', {duration: TIMEOUTS.ONE_SEC});
+        cy.get('div.post-list__dynamic').scrollTo('bottom', {duration: TIMEOUTS.ONE_SEC});
 
         // * Verify we scolled to bottom
         cy.findByText(firstMessageInCenter).should('exist').and('not.be.visible');
@@ -72,8 +72,8 @@ describe('Scroll', () => {
             cy.clickPostReactionIcon(postId, 'CENTER');
         });
 
-        // # Now try to scroll in the center
-        cy.get('#post-list').scrollTo('top', {ensureScrollable: false, duration: TIMEOUTS.ONE_SEC});
+        // # Now try to scroll in the center with opened emoji picker
+        cy.get('div.post-list__dynamic').scrollTo('top', {ensureScrollable: false, duration: TIMEOUTS.ONE_SEC});
 
         // * Verify that scrolling didnt happen
         cy.findByText(firstMessageInCenter).should('exist').and('not.be.visible');
@@ -104,7 +104,7 @@ describe('Scroll', () => {
                 cy.findByText(lastMessageInRhs).should('exist').and('not.be.visible');
 
                 // # Scroll back to bottom
-                cy.get('.scrollbar--view').should('be.visible').scrollTo('bottom', {duration: TIMEOUTS.ONE_SEC});
+                cy.get('.scrollbar--view').scrollTo('bottom', {duration: TIMEOUTS.ONE_SEC});
 
                 // * Verify we scolled to bottom
                 cy.findByText(firstMessageInRhs).should('exist').and('not.be.visible');
@@ -122,10 +122,10 @@ describe('Scroll', () => {
             });
         });
 
-        // # Now try to scroll in the center
-        cy.get('#post-list').scrollTo('top', {ensureScrollable: false, duration: TIMEOUTS.ONE_SEC});
+        // # scoll to top in center too
+        cy.get('div.post-list__dynamic').scrollTo('top', {ensureScrollable: false, duration: TIMEOUTS.ONE_SEC});
 
-        // * Verify that scrolling didnt happen in Center
+        // * Verify that scrolling didnt happen in Center too when RHS emoji picker
         cy.findByText(firstMessageInCenter).should('exist').and('not.be.visible');
         cy.findByText(lastMessageInRhs).should('exist').and('be.visible');
 

--- a/e2e/cypress/support/ui_commands.d.ts
+++ b/e2e/cypress/support/ui_commands.d.ts
@@ -46,11 +46,15 @@ declare namespace Cypress {
         /**
          * Post message via center textbox by directly injected in the textbox
          * @param {string} message - message to be posted
+         * @param {boolean} isComment - Either post in Center or RHS
+         * - false      : posts in center (default)
+         * - true       : posts in rhs
          * @returns void
          *
          * @example
          *  cy.uiPostMessageQuickly('Hello world')
+         *  cy.uiPostMessageQuickly('Hello world', true)
          */
-        uiPostMessageQuickly(message: string): void;
+        uiPostMessageQuickly(message: string, isComment?: boolean): void;
     }
 }

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -99,11 +99,13 @@ Cypress.Commands.add('postMessageReplyInRHS', (message) => {
     postMessageAndWait('#reply_textbox', message, true);
 });
 
-Cypress.Commands.add('uiPostMessageQuickly', (message) => {
-    cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().
+Cypress.Commands.add('uiPostMessageQuickly', (message, isComment = false) => {
+    const textboxId = isComment ? '#reply_textbox' : '#post_textbox';
+
+    cy.get(textboxId, {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().
         invoke('val', message).wait(TIMEOUTS.HALF_SEC).type(' {backspace}{enter}');
     cy.waitUntil(() => {
-        return cy.get('#post_textbox').then((el) => {
+        return cy.get(textboxId).then((el) => {
             return el[0].textContent === '';
         });
     });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://automation-test-cases.vercel.app/test/MM-T2365

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
```release-note
NONE
```
