### PR TITLE
MM-36035 - Removing status from bot posts

### DIFF
--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -355,7 +355,7 @@ class ProfilePopover extends React.PureComponent {
                 />
                 <StatusIcon
                     className='status user-popover-status'
-                    status={this.props.status}
+                    status={this.props.hideStatus ? null : this.props.status}
                     button={true}
                 />
             </div>,


### PR DESCRIPTION
#### Summary
MM-36035 - Removing status from bot posts
Removed the status icon if any of these conditions are met.
- It's a bot
- It's a webook
- It's from autoresponder

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36035

```release-note
NONE
```
