### PR TITLE
tests/CTRL+CMD+K : Unread Channels and input field focus

### DIFF
--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_unreads_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_unreads_spec.js
@@ -116,30 +116,38 @@ describe('Keyboard Shortcuts', () => {
         cy.visit(`/${team1.name}/channels/town-square`);
 
         // # Post message in other channels by otherUser
-        teamAndChannels[0].channels.forEach((channel) => {
+        cy.postMessageAs({
+            sender: otherUser,
+            message: `Message on the ${teamAndChannels[0].channels[0].display_name}`,
+            channelId: teamAndChannels[0].channels[0].id,
+        }).then(() => {
             cy.postMessageAs({
                 sender: otherUser,
-                message: `Message on the ${channel.display_name}`,
-                channelId: channel.id,
-            });
-        });
+                message: `Message on the ${teamAndChannels[0].channels[1].display_name}`,
+                channelId: teamAndChannels[0].channels[1].id,
+            }).then(() => {
+                cy.postMessageAs({
+                    sender: otherUser,
+                    message: `Message on the ${teamAndChannels[0].channels[2].display_name}`,
+                    channelId: teamAndChannels[0].channels[2].id,
+                }).then(() => {
+                    // # Press keyboard shortcut for channel switcher
+                    cy.get('#post_textbox').cmdOrCtrlShortcut('k');
 
-        // # Wait a little for unread channel indicators to show up
-        cy.wait(TIMEOUTS.FIVE_SEC);
+                    // * Verify channel switcher shows up
+                    cy.get('.a11y__modal.channel-switcher').should('exist').and('be.visible').as('channelSwitcherDialog');
 
-        // # Press keyboard shortcut for channel switcher
-        cy.get('#post_textbox').cmdOrCtrlShortcut('k');
+                    // * Verify the focus is on switchers input field
+                    cy.focused().should('have.id', 'quickSwitchInput');
 
-        // * Verify channel switcher shows up
-        cy.get('.a11y__modal.channel-switcher').should('exist').and('be.visible').as('channelSwitcherDialog');
-
-        // * Verify the focus is on switchers input field
-        cy.focused().should('have.id', 'quickSwitchInput');
-
-        cy.get('@channelSwitcherDialog').within(() => {
-            // * Verify all unread channels names are showing up in the dialogs list
-            teamAndChannels[0].channels.forEach((channel) => {
-                cy.findByText(channel.display_name).should('be.visible');
+                    // * Verify all unread channels names are showing up in the dialogs list
+                    cy.get('@channelSwitcherDialog').within(() => {
+                        // * Verify all unread channels names are showing up in the dialogs list
+                        teamAndChannels[0].channels.forEach((channel) => {
+                            cy.findByText(channel.display_name).should('be.visible');
+                        });
+                    });
+                });
             });
         });
     });

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_unreads_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_unreads_spec.js
@@ -15,8 +15,8 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 describe('Keyboard Shortcuts', () => {
     let testUser;
     let otherUser;
-    const count = 3;
 
+    const count = 3;
     const teamAndChannels = [];
 
     before(() => {
@@ -50,6 +50,10 @@ describe('Keyboard Shortcuts', () => {
                 });
             });
         });
+    });
+
+    beforeEach(() => {
+        cy.apiLogin(testUser);
     });
 
     it('MM-T1241 - CTRL/CMD+K: Unreads', () => {

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_unreads_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_unreads_spec.js
@@ -108,4 +108,39 @@ describe('Keyboard Shortcuts', () => {
             cy.wrap(el).should('contain', team1Channels[1].display_name);
         });
     });
+
+    it('MM-T3002 CTRL/CMD+K - Unread Channels and input field focus', () => {
+        const team1 = teamAndChannels[0].team;
+
+        // # Visit town square channel by teamUser
+        cy.visit(`/${team1.name}/channels/town-square`);
+
+        // # Post message in other channels by otherUser
+        teamAndChannels[0].channels.forEach((channel) => {
+            cy.postMessageAs({
+                sender: otherUser,
+                message: `Message on the ${channel.display_name}`,
+                channelId: channel.id,
+            });
+        });
+
+        // # Wait a little for unread channel indicators to show up
+        cy.wait(TIMEOUTS.FIVE_SEC);
+
+        // # Press keyboard shortcut for channel switcher
+        cy.get('#post_textbox').cmdOrCtrlShortcut('k');
+
+        // * Verify channel switcher shows up
+        cy.get('.a11y__modal.channel-switcher').should('exist').and('be.visible').as('channelSwitcherDialog');
+
+        // * Verify the focus is on switchers input field
+        cy.focused().should('have.id', 'quickSwitchInput');
+
+        cy.get('@channelSwitcherDialog').within(() => {
+            // * Verify all unread channels names are showing up in the dialogs list
+            teamAndChannels[0].channels.forEach((channel) => {
+                cy.findByText(channel.display_name).should('be.visible');
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://automation-test-cases.vercel.app/test/MM-T3002

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
`#### Release Note
```release-note
NONE
```
