### PR TITLE
MM-36126 - prevent  purchase modal Object.keys invocation with null value

### DIFF
--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -338,7 +338,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                 </div>
                 <div className='RHS'>
                     <div className='price-container'>
-                        {this.props.isFreeTrial && Object.keys(this.props.products!).length > 1 &&
+                        {(this.props.isFreeTrial && this.props.products && Object.keys(this.props.products).length > 1) &&
                             <div className='select-plan'>
                                 <div className='title'>
                                     <FormattedMessage


### PR DESCRIPTION
#### Summary
prevent  purchase modal Object.keys invocation with null value


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36126

#### Release Note
```
NONE
```
