### PR TITLE
added `align-items: center` and increased `line-height` on the `span`

### DIFF
--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "utf-8";
 
 .channel-header {
     @include flex(0 0 63px);
@@ -21,6 +21,7 @@
         padding: 4px 4px;
         height: 24px;
         @include border-radius(4px);
+        align-items: center;
 
         &:hover {
             background: rgba(v(center-channel-color-rgb), 0.08);
@@ -36,6 +37,7 @@
         .heading span {
             overflow: hidden;
             text-overflow: ellipsis;
+            line-height: 20px;
         }
     }
 


### PR DESCRIPTION
#### Summary
vertically aligns text in the channel header trigger correctly. It is not cutting the lower parts of text when they are reaching down (as with the letters: `g`, `j`, `p`, `q` and `y`)

#### Ticket Link
Fixes [MM-35446](https://mattermost.atlassian.net/browse/MM-35446)

#### Screenshots
| before | after |
|-------|-------|
|<img width="862" alt="Screenshot 2021-06-02 at 11 07 17" src="https://user-images.githubusercontent.com/32863416/120452780-bdaff900-c392-11eb-979e-98b4b33f4c9a.png">|<img width="862" alt="Screenshot 2021-06-02 at 11 07 27" src="https://user-images.githubusercontent.com/32863416/120452792-c1438000-c392-11eb-9f9f-6cd2fb2eecc9.png">|


#### Release Note
```release-note
NONE
```
