### PR TITLE
MM-36172 - purchase modal empty address issue

### DIFF
--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -29,7 +29,6 @@ import RadioButtonGroup from 'components/common/radio_group';
 import {areBillingDetailsValid, BillingDetails} from 'types/cloud/sku';
 
 import {getNextBillingDate} from 'utils/utils';
-import {billingDetailsIsValid} from 'utils/cloud_utils';
 
 import PaymentForm from '../payment_form/payment_form';
 
@@ -278,7 +277,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                 name: this.props.customer?.payment_method.name,
             } as BillingDetails;
 
-            validBillingDetails = billingDetailsIsValid(initialBillingDetails);
+            validBillingDetails = areBillingDetailsValid(initialBillingDetails);
         }
 
         return (

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -29,6 +29,7 @@ import RadioButtonGroup from 'components/common/radio_group';
 import {areBillingDetailsValid, BillingDetails} from 'types/cloud/sku';
 
 import {getNextBillingDate} from 'utils/utils';
+import {billingDetailsIsValid} from 'utils/cloud_utils';
 
 import PaymentForm from '../payment_form/payment_form';
 
@@ -101,7 +102,7 @@ function findProductInDictionary(products: Dictionary<Product> | undefined, prod
     return currentProduct;
 }
 
-function selectselectedProduct(products: Dictionary<Product> | undefined, productId?: string | null) {
+function getSelectedProduct(products: Dictionary<Product> | undefined, productId?: string | null) {
     const currentProduct = findProductInDictionary(products, productId);
     let nextSku = CloudProducts.PROFESSIONAL;
     if (currentProduct?.sku === CloudProducts.PROFESSIONAL) {
@@ -119,15 +120,22 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
             billingDetails: null,
             cardInputComplete: false,
             processing: false,
-            editPaymentInfo: isEmpty(this.props.customer?.payment_method && this.props.customer?.billing_address),
+            editPaymentInfo: isEmpty(props.customer?.payment_method && props.customer?.billing_address),
             currentProduct: findProductInDictionary(props.products, props.productId),
-            selectedProduct: selectselectedProduct(props.products, props.productId),
+            selectedProduct: getSelectedProduct(props.products, props.productId),
         };
     }
 
-    componentDidMount() {
+    async componentDidMount() {
         pageVisited(TELEMETRY_CATEGORIES.CLOUD_PURCHASING, 'pageview_purchase');
-        this.props.actions.getCloudProducts();
+        if (isEmpty(this.state.currentProduct || this.state.selectedProduct)) {
+            await this.props.actions.getCloudProducts();
+            // eslint-disable-next-line react/no-did-mount-set-state
+            this.setState({
+                currentProduct: findProductInDictionary(this.props.products, this.props.productId),
+                selectedProduct: getSelectedProduct(this.props.products, this.props.productId),
+            });
+        }
 
         // this.fetchProductPrice();
         this.props.actions.getClientConfig();
@@ -257,6 +265,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
         );
 
         let initialBillingDetails;
+        let validBillingDetails = false;
 
         if (this.props.customer?.billing_address && this.props.customer?.payment_method) {
             initialBillingDetails = {
@@ -268,6 +277,8 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                 postalCode: this.props.customer?.billing_address.postal_code,
                 name: this.props.customer?.payment_method.name,
             } as BillingDetails;
+
+            validBillingDetails = billingDetailsIsValid(initialBillingDetails);
         }
 
         return (
@@ -308,7 +319,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                     </a>
                 </div>
                 <div className='central-panel'>
-                    {this.state.editPaymentInfo ?
+                    {(this.state.editPaymentInfo || !validBillingDetails) ?
                         <PaymentForm
                             className='normal-text'
                             onInputChange={this.onPaymentInput}

--- a/utils/cloud_utils.ts
+++ b/utils/cloud_utils.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {CloudCustomer} from 'mattermost-redux/types/cloud';
-import {BillingDetails} from 'types/cloud/sku';
 
 export function isCustomerCardExpired(customer?: CloudCustomer): boolean {
     if (!customer) {

--- a/utils/cloud_utils.ts
+++ b/utils/cloud_utils.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {CloudCustomer} from 'mattermost-redux/types/cloud';
+import {BillingDetails} from 'types/cloud/sku';
 
 export function isCustomerCardExpired(customer?: CloudCustomer): boolean {
     if (!customer) {
@@ -19,4 +20,18 @@ export function isCustomerCardExpired(customer?: CloudCustomer): boolean {
     // But credit cards expire at the end of their expiry month, so we can just use that number.
     const lastExpiryDate = new Date(expiryYear, customer.payment_method.exp_month, 1);
     return lastExpiryDate <= new Date();
+}
+
+export function billingDetailsIsValid(billingDetails: BillingDetails): boolean {
+    if (billingDetails == null) {
+        return false;
+    }
+    return Boolean(
+        billingDetails?.address &&
+        billingDetails?.city &&
+        billingDetails?.state &&
+        billingDetails?.country &&
+        billingDetails?.postalCode &&
+        billingDetails.name,
+    );
 }

--- a/utils/cloud_utils.ts
+++ b/utils/cloud_utils.ts
@@ -21,17 +21,3 @@ export function isCustomerCardExpired(customer?: CloudCustomer): boolean {
     const lastExpiryDate = new Date(expiryYear, customer.payment_method.exp_month, 1);
     return lastExpiryDate <= new Date();
 }
-
-export function billingDetailsIsValid(billingDetails: BillingDetails): boolean {
-    if (billingDetails == null) {
-        return false;
-    }
-    return Boolean(
-        billingDetails?.address &&
-        billingDetails?.city &&
-        billingDetails?.state &&
-        billingDetails?.country &&
-        billingDetails?.postalCode &&
-        billingDetails.name,
-    );
-}


### PR DESCRIPTION
#### Summary
There was a situation where the purchase modal was trying to show the payment information in the case where the customer has not it set already, which leaded with a component showing empty strings separated by commas. This PR makes sure that when the customer has no payment information, the fill in payment method form is shown.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36172

#### Release Note
```release-note
NONE
```
