### PR TITLE
Fix several autocomplete problems

### DIFF
--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -163,7 +163,12 @@ export function makeOnSubmit(channelId, rootId, latestPostId) {
         if (isReaction && emojiMap.has(isReaction[2])) {
             dispatch(submitReaction(latestPostId, isReaction[1], isReaction[2]));
         } else if (message.indexOf('/') === 0 && !options.ignoreSlash) {
-            await dispatch(submitCommand(channelId, rootId, draft));
+            try {
+                await dispatch(submitCommand(channelId, rootId, draft));
+            } catch (err) {
+                dispatch(updateCommentDraft(rootId, draft));
+                throw err;
+            }
         } else {
             dispatch(submitPost(channelId, rootId, draft));
         }

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -650,7 +650,9 @@ class CreateComment extends React.PureComponent {
         const {allowSending, withClosedCodeBlock, message} = postMessageOnKeyPress(e, this.state.draft.message, ctrlSend, codeBlockOnCtrlEnter, 0, 0, this.state.caretPosition);
 
         if (allowSending) {
-            e.persist();
+            if (e.persist) {
+                e.persist();
+            }
             if (this.textboxRef.current) {
                 this.textboxRef.current.blur();
             }

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -477,6 +477,10 @@ class CreatePost extends React.PureComponent {
 
         this.setState({submitting: true, serverError: null});
 
+        const fasterThanHumanWillClick = 150;
+        const forceFocus = (Date.now() - this.lastBlurAt < fasterThanHumanWillClick);
+        this.focusTextbox(forceFocus);
+
         const isReaction = Utils.REACTION_PATTERN.exec(post.message);
         if (post.message.indexOf('/') === 0 && !ignoreSlash) {
             this.setState({message: '', postError: null});
@@ -536,11 +540,6 @@ class CreatePost extends React.PureComponent {
         cancelAnimationFrame(this.saveDraftFrame);
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, null);
         this.draftsForChannel[channelId] = null;
-
-        const fasterThanHumanWillClick = 150;
-        const forceFocus = (Date.now() - this.lastBlurAt < fasterThanHumanWillClick);
-
-        this.focusTextbox(forceFocus);
     }
 
     handleNotifyAllConfirmation = (e) => {

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -454,10 +454,13 @@ export default class SuggestionBox extends React.PureComponent {
             fixedTerm = term.substring(0, term.length - EXECUTE_CURRENT_COMMAND_ITEM_ID.length);
             finish = true;
         }
-        if (this.props.replaceAllInputOnSelect) {
-            this.replaceText(fixedTerm);
-        } else {
-            this.addTextAtCaret(fixedTerm, matchedPretext);
+
+        if (!finish) {
+            if (this.props.replaceAllInputOnSelect) {
+                this.replaceText(fixedTerm);
+            } else {
+                this.addTextAtCaret(fixedTerm, matchedPretext);
+            }
         }
 
         if (this.props.onItemSelected) {
@@ -557,13 +560,14 @@ export default class SuggestionBox extends React.PureComponent {
 
     handleKeyDown = (e) => {
         if ((this.props.openWhenEmpty || this.props.value) && this.hasSuggestions()) {
+            const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
             if (Utils.isKeyPressed(e, KeyCodes.UP)) {
                 this.selectPrevious();
                 e.preventDefault();
             } else if (Utils.isKeyPressed(e, KeyCodes.DOWN)) {
                 this.selectNext();
                 e.preventDefault();
-            } else if (Utils.isKeyPressed(e, KeyCodes.ENTER) || (this.props.completeOnTab && Utils.isKeyPressed(e, KeyCodes.TAB))) {
+            } else if ((Utils.isKeyPressed(e, KeyCodes.ENTER) && !ctrlOrMetaKeyPressed) || (this.props.completeOnTab && Utils.isKeyPressed(e, KeyCodes.TAB))) {
                 let matchedPretext = '';
                 for (let i = 0; i < this.state.terms.length; i++) {
                     if (this.state.terms[i] === this.state.selection) {


### PR DESCRIPTION
#### Summary
The problems addressed are:
- Interactive dialogs and apps forms not getting the focus when executed from a slash command in the center channel. It did work on the RHS. Solved by moving the focus code before the command execution, so the interactive dialog can steal the focus when created.
- Crash when a command is executed by pressing the tab button to select the "Execute command" option on the RHS. Solved by applying the check on persist.
- Inconsistent updates on the draft of the RHS when submitting a command by hitting enter and therefore selecting the "Execute command" option. We just handle the word when it is not the case where the command is finished.
- Inconsistent updates on the draft when a command returned an error on the RHS. Solved by reapplying the draft on command errors.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34726

#### Related Pull Requests
None

#### Screenshots
None

#### Release Note
```release-note
NONE
```
