### PR TITLE
Fix plugin buttons on the LHS showing one below the other, instead of one after the other

### DIFF
--- a/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -25,9 +25,13 @@ exports[`components/sidebar should match snapshot 1`] = `
       unreadFilterEnabled={false}
     />
   </div>
-  <Connect(Pluggable)
-    pluggableName="LeftSidebarHeader"
-  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
   <Connect(SidebarChannelList)
     handleOpenMoreDirectChannelsModal={[Function]}
     onDragEnd={[Function]}
@@ -60,9 +64,13 @@ exports[`components/sidebar should match snapshot when direct channels modal is 
       unreadFilterEnabled={false}
     />
   </div>
-  <Connect(Pluggable)
-    pluggableName="LeftSidebarHeader"
-  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
   <Connect(SidebarChannelList)
     handleOpenMoreDirectChannelsModal={[Function]}
     onDragEnd={[Function]}
@@ -99,9 +107,13 @@ exports[`components/sidebar should match snapshot when more channels modal is op
       unreadFilterEnabled={false}
     />
   </div>
-  <Connect(Pluggable)
-    pluggableName="LeftSidebarHeader"
-  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
   <Connect(SidebarChannelList)
     handleOpenMoreDirectChannelsModal={[Function]}
     onDragEnd={[Function]}

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -192,7 +192,9 @@ export default class Sidebar extends React.PureComponent<Props, State> {
                         unreadFilterEnabled={this.props.unreadFilterEnabled}
                     />
                 </div>
-                <Pluggable pluggableName='LeftSidebarHeader'/>
+                <div className='sidebar--left__icons'>
+                    <Pluggable pluggableName='LeftSidebarHeader'/>
+                </div>
                 <SidebarChannelList
                     handleOpenMoreDirectChannelsModal={this.handleOpenMoreDirectChannelsModal}
                     onDragStart={this.onDragStart}


### PR DESCRIPTION
#### Summary
The new sidebar was not properly encapsulating the plugin buttons.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36199

#### Related Pull Requests
None

#### Screenshots
None

#### Release Note
```release-note
Fix bug with plugin icons showing as a column instead of as a row in the LHS.
```
