### PR TITLE
MM-35405: hides reply notifications user setting

### DIFF
--- a/components/user_settings/notifications/index.js
+++ b/components/user_settings/notifications/index.js
@@ -6,6 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import {updateMe} from 'mattermost-redux/actions/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
 import UserSettingsNotifications from './user_settings_notifications.jsx';
 
@@ -18,6 +19,7 @@ function mapStateToProps(state) {
     return {
         sendPushNotifications,
         enableAutoResponder,
+        isCollapsedThreadsEnabled: isCollapsedThreadsEnabled(state),
     };
 }
 

--- a/components/user_settings/notifications/user_settings_notifications.jsx
+++ b/components/user_settings/notifications/user_settings_notifications.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+/* eslint-disable max-lines */
 
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -128,6 +129,7 @@ export default class NotificationsTab extends React.PureComponent {
         actions: PropTypes.shape({
             updateMe: PropTypes.func.isRequired,
         }).isRequired,
+        isCollapsedThreadsEnabled: PropTypes.bool.isRequired,
     }
 
     static defaultProps = {
@@ -954,8 +956,12 @@ export default class NotificationsTab extends React.PureComponent {
                     <div className='divider-light'/>
                     {keysSection}
                     <div className='divider-light'/>
-                    {commentsSection}
-                    <div className='divider-light'/>
+                    {!this.props.isCollapsedThreadsEnabled && (
+                        <>
+                            {commentsSection}
+                            <div className='divider-light'/>
+                        </>
+                    )}
                     {autoResponderSection}
                     <div className='divider-dark'/>
                 </div>

--- a/components/user_settings/notifications/user_settings_notifications.test.js
+++ b/components/user_settings/notifications/user_settings_notifications.test.js
@@ -5,7 +5,6 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import UserSettingsNotifications from './user_settings_notifications';
-import SettingItemMin from 'components/setting_item_min';
 
 describe('components/user_settings/display/UserSettingsDisplay', () => {
     const user = {

--- a/components/user_settings/notifications/user_settings_notifications.test.js
+++ b/components/user_settings/notifications/user_settings_notifications.test.js
@@ -5,6 +5,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import UserSettingsNotifications from './user_settings_notifications';
+import SettingItemMin from 'components/setting_item_min';
 
 describe('components/user_settings/display/UserSettingsDisplay', () => {
     const user = {
@@ -20,6 +21,7 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         actions: {
             updateMe: jest.fn(() => Promise.resolve({})),
         },
+        isCollapsedThreadsEnabled: false,
     };
 
     test('should have called handleSubmit', async () => {
@@ -53,5 +55,22 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         expect(wrapper.state('isSaving')).toEqual(false);
         expect(wrapper.state('desktopActivity')).toEqual('on');
         expect(newUpdateSection).toHaveBeenCalledTimes(1);
+    });
+
+    test('should show reply notifications section when CRT off', () => {
+        const wrapper = shallow(
+            <UserSettingsNotifications {...requiredProps}/>,
+        );
+        expect(wrapper.exists('SettingItemMin[section="comments"]')).toBe(true);
+    });
+
+    test('should not show reply notifications section when CRT on', () => {
+        const wrapper = shallow(
+            <UserSettingsNotifications
+                {...requiredProps}
+                isCollapsedThreadsEnabled={true}
+            />,
+        );
+        expect(wrapper.exists('SettingItemMin[section="comments"]')).toBe(false);
     });
 });


### PR DESCRIPTION
#### Summary

When CRT is on reply notifications user setting makes no sense as it is.
This commit hides that section.
Later on a setting about threads will be added on desktop notifications section.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35405

#### Release Note

```release-note
NONE
```
