### PR TITLE
MM-36166 Force recalculate emoji picker position on open

### DIFF
--- a/components/emoji_picker/emoji_picker_overlay.jsx
+++ b/components/emoji_picker/emoji_picker_overlay.jsx
@@ -45,8 +45,13 @@ export default class EmojiPickerOverlay extends React.PureComponent {
         enableGifPicker: false,
     };
 
-    emojiPickerPosition = memoize((emojiTrigger) => {
+    emojiPickerPosition = memoize((emojiTrigger, show) => {
         let calculatedRightOffset = Constants.DEFAULT_EMOJI_PICKER_RIGHT_OFFSET;
+
+        if (!show) {
+            return calculatedRightOffset;
+        }
+
         if (emojiTrigger) {
             calculatedRightOffset = window.innerWidth - emojiTrigger.getBoundingClientRect().left - Constants.DEFAULT_EMOJI_PICKER_LEFT_OFFSET;
 
@@ -58,7 +63,11 @@ export default class EmojiPickerOverlay extends React.PureComponent {
         return calculatedRightOffset;
     });
 
-    getPlacement = memoize((target, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition) => {
+    getPlacement = memoize((target, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition, show) => {
+        if (!show) {
+            return 'top';
+        }
+
         if (target) {
             const targetBounds = target.getBoundingClientRect();
             return popOverOverlayPosition(targetBounds, window.innerHeight, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition);
@@ -68,14 +77,14 @@ export default class EmojiPickerOverlay extends React.PureComponent {
     });
 
     render() {
-        const {target, rightOffset, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition} = this.props;
+        const {target, rightOffset, spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition, show} = this.props;
 
-        const calculatedRightOffset = typeof rightOffset === 'undefined' ? this.emojiPickerPosition(target()) : rightOffset;
-        const placement = this.getPlacement(target(), spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition);
+        const calculatedRightOffset = typeof rightOffset === 'undefined' ? this.emojiPickerPosition(target(), show) : rightOffset;
+        const placement = this.getPlacement(target(), spaceRequiredAbove, spaceRequiredBelow, defaultHorizontalPosition, show);
 
         return (
             <Overlay
-                show={this.props.show}
+                show={show}
                 placement={placement}
                 rootClose={true}
                 container={this.props.container}


### PR DESCRIPTION
#### Summary
Add the `show` as an input to the memoized functions for determining emoji picker position.

@hmhealey I know you mentioned we had done this in other places differently but I couldn't find any good examples and this worked well enough. Feel free to point out a better way to do it though.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36166

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
