### PR TITLE
Cypress/E2E: Fix timeout error

### DIFF
--- a/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
@@ -23,9 +23,6 @@ describe('Recent Emoji', () => {
     });
 
     it('MM-T155 Recently used emoji reactions are shown first', () => {
-        // # Before test delete all recent emoji on local storage
-        cy.clearLocalStorage(/recent_emojis/);
-
         const firstEmoji = 5;
         const secondEmoji = 10;
 


### PR DESCRIPTION
#### Summary
Remove `cy.clearLocalStorage` that probably causing to hold test and eventually timeout error

#### Screenshots
<img width="1006" alt="Screen Shot 2021-06-05 at 7 11 09 AM" src="https://user-images.githubusercontent.com/5334504/120871074-3e5a3980-c5cd-11eb-9ba0-17358ee651f4.png">


#### Release Note
```
NONE
```
