### PR TITLE
MM-35804: hide unread indicator when not following thread

### DIFF
--- a/components/threading/channel_threads/thread_footer/thread_footer.test.tsx
+++ b/components/threading/channel_threads/thread_footer/thread_footer.test.tsx
@@ -156,6 +156,21 @@ describe('components/threading/channel_threads/thread_footer', () => {
         expect(wrapper.find(SimpleTooltip).find('.dot-unreads').exists()).toBe(true);
     });
 
+    test('should not show unread indicator if not following', () => {
+        thread.unread_replies = 2;
+        thread.is_following = false;
+
+        const {mountOptions} = mockStore(state);
+        const wrapper = mount(
+            <ThreadFooter
+                {...props}
+            />,
+            mountOptions,
+        );
+
+        expect(wrapper.find(SimpleTooltip).find('.dot-unreads').exists()).toBe(false);
+    });
+
     test('should should have avatars', () => {
         const {mountOptions} = mockStore(state);
         const wrapper = mount(

--- a/components/threading/channel_threads/thread_footer/thread_footer.tsx
+++ b/components/threading/channel_threads/thread_footer/thread_footer.tsx
@@ -68,7 +68,7 @@ function ThreadFooter({
 
     return (
         <div className='ThreadFooter'>
-            {threadIsSynthetic(thread) || !thread.unread_replies ? (
+            {!isFollowing || threadIsSynthetic(thread) || !thread.unread_replies ? (
                 <div className='indicator'/>
             ) : (
                 <SimpleTooltip


### PR DESCRIPTION
#### Summary
Hides unread dot when thread is not followed. Primarily for immediate feedback. (Responding to WS events have a slight delay.)

A follow-up item/PR will add: 
- reacting to `SocketEvents.THREAD_FOLLOW_CHANGED` will zero-out any unread counts for the unfollowed thread. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35804

#### Related Pull Requests

#### Screenshots

#### Release Note

```release-note
NONE
```
