### PR TITLE
MM-35837 Improve batching of channel-related actions on post receipt

### DIFF
--- a/actions/new_post.test.js
+++ b/actions/new_post.test.js
@@ -4,6 +4,7 @@
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 
+import {ChannelTypes} from 'mattermost-redux/action_types';
 import {receivedNewPost} from 'mattermost-redux/actions/posts';
 import {Posts} from 'mattermost-redux/constants';
 
@@ -13,9 +14,8 @@ import {Constants} from 'utils/constants';
 const mockStore = configureStore([thunk]);
 
 jest.mock('mattermost-redux/actions/channels', () => ({
-    markChannelAsUnread: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_UNREAD', args}),
-    markChannelAsRead: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_READ', args}),
-    markChannelAsViewed: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_VIEWED', args}),
+    ...jest.requireActual('mattermost-redux/actions/channels'),
+    markChannelAsReadOnServer: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_READ_ON_SERVER', args}),
 }));
 
 const POST_CREATED_TIME = Date.now();
@@ -90,30 +90,33 @@ describe('actions/new_post', () => {
     };
 
     test('completePostReceive', async () => {
-        const testStore = await mockStore(initialState);
+        const testStore = mockStore(initialState);
         const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL, user_id: 'some_user_id', create_at: POST_CREATED_TIME, props: {addedUserId: 'other_user_id'}};
         const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
 
         await testStore.dispatch(NewPostActions.completePostReceive(newPost, websocketProps));
         expect(testStore.getActions()).toEqual([
-            INCREASED_POST_VISIBILITY,
             {
                 meta: {batch: true},
-                payload: [receivedNewPost(newPost, false), STOP_TYPING],
+                payload: [
+                    INCREASED_POST_VISIBILITY,
+                    receivedNewPost(newPost, false),
+                    STOP_TYPING,
+                ],
                 type: 'BATCHING_REDUCER.BATCH',
             },
         ]);
     });
 
     describe('setChannelReadAndViewed', () => {
-        test('should mark channel as read when viewing channel', async () => {
+        test('should mark channel as read when viewing channel', () => {
             const channelId = 'channel';
             const currentUserId = 'user';
 
             const post1 = {id: 'post1', channel_id: channelId, create_at: 1000};
             const post2 = {id: 'post2', channel_id: channelId, create_at: 2000};
 
-            const testStore = await mockStore({
+            const testStore = mockStore({
                 entities: {
                     channels: {
                         currentChannelId: channelId,
@@ -146,25 +149,44 @@ describe('actions/new_post', () => {
 
             window.isActive = true;
 
-            await testStore.dispatch(NewPostActions.setChannelReadAndViewed(post2, {}, false));
+            const actions = NewPostActions.setChannelReadAndViewed(testStore.dispatch, testStore.getState, post2, {}, false);
 
-            expect(testStore.getActions()).toEqual([{
-                type: 'MOCK_MARK_CHANNEL_AS_READ',
-                args: [channelId, undefined, true],
-            }, {
-                type: 'MOCK_MARK_CHANNEL_AS_VIEWED',
-                args: [channelId],
-            }]);
+            expect(actions).toMatchObject([
+                {
+                    type: ChannelTypes.DECREMENT_UNREAD_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+                {
+                    type: ChannelTypes.DECREMENT_UNREAD_MENTION_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+                {
+                    type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
+                    data: {
+                        channel_id: channelId,
+                    },
+                },
+            ]);
+            expect(testStore.getActions()).toMatchObject([
+                {
+                    type: 'MOCK_MARK_CHANNEL_AS_READ_ON_SERVER',
+                    args: [channelId],
+                },
+            ]);
         });
 
-        test('should mark channel as unread when not actively viewing channel', async () => {
+        test('should mark channel as unread when not actively viewing channel', () => {
             const channelId = 'channel';
             const currentUserId = 'user';
 
             const post1 = {id: 'post1', channel_id: channelId, create_at: 1000};
             const post2 = {id: 'post2', channel_id: channelId, create_at: 2000};
 
-            const testStore = await mockStore({
+            const testStore = mockStore({
                 entities: {
                     channels: {
                         currentChannelId: channelId,
@@ -197,15 +219,26 @@ describe('actions/new_post', () => {
 
             window.isActive = false;
 
-            await testStore.dispatch(NewPostActions.setChannelReadAndViewed(post2, {}, false));
+            const actions = NewPostActions.setChannelReadAndViewed(testStore.dispatch, testStore.getState, post2, {}, false);
 
-            expect(testStore.getActions()).toEqual([{
-                type: 'MOCK_MARK_CHANNEL_AS_UNREAD',
-                args: [undefined, channelId, undefined, false, false],
-            }]);
+            expect(actions).toMatchObject([
+                {
+                    type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+                {
+                    type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+            ]);
+            expect(testStore.getActions()).toEqual([]);
         });
 
-        test('should not mark channel as read when not viewing channel', async () => {
+        test('should not mark channel as read when not viewing channel', () => {
             const channelId = 'channel1';
             const otherChannelId = 'channel2';
             const currentUserId = 'user';
@@ -213,7 +246,7 @@ describe('actions/new_post', () => {
             const post1 = {id: 'post1', channel_id: channelId, create_at: 1000};
             const post2 = {id: 'post2', channel_id: channelId, create_at: 2000};
 
-            const testStore = await mockStore({
+            const testStore = mockStore({
                 entities: {
                     channels: {
                         currentChannelId: otherChannelId,
@@ -248,15 +281,26 @@ describe('actions/new_post', () => {
 
             window.isActive = true;
 
-            await testStore.dispatch(NewPostActions.setChannelReadAndViewed(post2, {}, false));
+            const actions = NewPostActions.setChannelReadAndViewed(testStore.dispatch, testStore.getState, post2, {}, false);
 
-            expect(testStore.getActions()).toEqual([{
-                type: 'MOCK_MARK_CHANNEL_AS_UNREAD',
-                args: [undefined, channelId, undefined, false, false],
-            }]);
+            expect(actions).toMatchObject([
+                {
+                    type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+                {
+                    type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+            ]);
+            expect(testStore.getActions()).toEqual([]);
         });
 
-        test('should mark channel as read when not viewing channel and post is from current user', async () => {
+        test('should mark channel as read when not viewing channel and post is from current user', () => {
             const channelId = 'channel1';
             const otherChannelId = 'channel2';
             const currentUserId = 'user';
@@ -264,7 +308,7 @@ describe('actions/new_post', () => {
             const post1 = {id: 'post1', channel_id: channelId, create_at: 1000};
             const post2 = {id: 'post2', channel_id: channelId, create_at: 2000, user_id: currentUserId};
 
-            const testStore = await mockStore({
+            const testStore = mockStore({
                 entities: {
                     channels: {
                         currentChannelId: otherChannelId,
@@ -297,15 +341,31 @@ describe('actions/new_post', () => {
                 },
             });
 
-            await testStore.dispatch(NewPostActions.setChannelReadAndViewed(post2, {}, false));
+            const actions = NewPostActions.setChannelReadAndViewed(testStore.dispatch, testStore.getState, post2, {}, false);
 
-            expect(testStore.getActions()).toEqual([{
-                type: 'MOCK_MARK_CHANNEL_AS_READ',
-                args: [channelId, undefined, false],
-            }, {
-                type: 'MOCK_MARK_CHANNEL_AS_VIEWED',
-                args: [channelId],
-            }]);
+            expect(actions).toMatchObject([
+                {
+                    type: ChannelTypes.DECREMENT_UNREAD_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+                {
+                    type: ChannelTypes.DECREMENT_UNREAD_MENTION_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+                {
+                    type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
+                    data: {
+                        channel_id: channelId,
+                    },
+                },
+            ]);
+
+            // The post is from the current user, so no request should be made to the server to mark it as read
+            expect(testStore.getActions()).toEqual([]);
         });
 
         test('should mark channel as unread when not viewing channel and post is from webhook owned by current user', async () => {
@@ -316,7 +376,7 @@ describe('actions/new_post', () => {
             const post1 = {id: 'post1', channel_id: channelId, create_at: 1000};
             const post2 = {id: 'post2', channel_id: channelId, create_at: 2000, props: {from_webhook: 'true'}, user_id: currentUserId};
 
-            const testStore = await mockStore({
+            const testStore = mockStore({
                 entities: {
                     channels: {
                         currentChannelId: otherChannelId,
@@ -349,22 +409,33 @@ describe('actions/new_post', () => {
                 },
             });
 
-            await testStore.dispatch(NewPostActions.setChannelReadAndViewed(post2, {}, false));
+            const actions = NewPostActions.setChannelReadAndViewed(testStore.dispatch, testStore.getState, post2, {}, false);
 
-            expect(testStore.getActions()).toEqual([{
-                type: 'MOCK_MARK_CHANNEL_AS_UNREAD',
-                args: [undefined, channelId, undefined, false, false],
-            }]);
+            expect(actions).toMatchObject([
+                {
+                    type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+                {
+                    type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+            ]);
+            expect(testStore.getActions()).toEqual([]);
         });
 
-        test('should not mark channel as read when viewing channel that was marked as unread', async () => {
+        test('should not mark channel as read when viewing channel that was marked as unread', () => {
             const channelId = 'channel1';
             const currentUserId = 'user';
 
             const post1 = {id: 'post1', channel_id: channelId, create_at: 1000};
             const post2 = {id: 'post2', channel_id: channelId, create_at: 2000};
 
-            const testStore = await mockStore({
+            const testStore = mockStore({
                 entities: {
                     channels: {
                         currentChannelId: channelId,
@@ -389,12 +460,23 @@ describe('actions/new_post', () => {
                 },
             });
 
-            await testStore.dispatch(NewPostActions.setChannelReadAndViewed(post2, {}, false));
+            const actions = NewPostActions.setChannelReadAndViewed(testStore.dispatch, testStore.getState, post2, {}, false);
 
-            expect(testStore.getActions()).toEqual([{
-                type: 'MOCK_MARK_CHANNEL_AS_UNREAD',
-                args: [undefined, channelId, undefined, false, false],
-            }]);
+            expect(actions).toMatchObject([
+                {
+                    type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+                {
+                    type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
+                    data: {
+                        channelId,
+                    },
+                },
+            ]);
+            expect(testStore.getActions()).toEqual([]);
         });
     });
 });

--- a/actions/new_post.ts
+++ b/actions/new_post.ts
@@ -81,19 +81,11 @@ export function completePostReceive(post: Post, websocketMessageProps: NewPostMe
             ...setChannelReadAndViewed(dispatch, getState, post, websocketMessageProps, fetchedChannelMember),
         );
 
-        const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));
-
-        await sleep(1000);
-
         dispatch(batchActions(actions));
-
-        await sleep(1000);
 
         if (collapsedThreadsEnabled && post.root_id) {
             dispatch(setThreadRead(post));
         }
-
-        await sleep(1000);
 
         return dispatch(sendDesktopNotification(post, websocketMessageProps) as unknown as ActionFunc);
     };

--- a/actions/new_post.ts
+++ b/actions/new_post.ts
@@ -10,10 +10,7 @@ import {
     actionsToMarkChannelAsRead,
     actionsToMarkChannelAsUnread,
     actionsToMarkChannelAsViewed,
-    markChannelAsRead,
     markChannelAsReadOnServer,
-    markChannelAsUnread,
-    markChannelAsViewed,
 } from 'mattermost-redux/actions/channels';
 import * as PostActions from 'mattermost-redux/actions/posts';
 

--- a/actions/post_actions.test.js
+++ b/actions/post_actions.test.js
@@ -179,10 +179,13 @@ describe('Actions.Posts', () => {
 
         await testStore.dispatch(Actions.handleNewPost(newPost, msg));
         expect(testStore.getActions()).toEqual([
-            INCREASED_POST_VISIBILITY,
             {
                 meta: {batch: true},
-                payload: [PostActions.receivedNewPost(newPost, false), STOP_TYPING],
+                payload: [
+                    INCREASED_POST_VISIBILITY,
+                    PostActions.receivedNewPost(newPost, false),
+                    STOP_TYPING,
+                ],
                 type: 'BATCHING_REDUCER.BATCH',
             },
             {
@@ -210,12 +213,6 @@ describe('Actions.Posts', () => {
                             userId: newPost.user_id,
                         },
                     },
-                ],
-                type: 'BATCHING_REDUCER.BATCH',
-            },
-            {
-                meta: {batch: true},
-                payload: [
                     {
                         type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
                         data: {

--- a/packages/mattermost-redux/src/actions/channels.ts
+++ b/packages/mattermost-redux/src/actions/channels.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import * as Redux from 'redux';
+
 import {ChannelTypes, PreferenceTypes, UserTypes} from 'mattermost-redux/action_types';
 
 import {Client4} from 'mattermost-redux/client';
@@ -834,43 +836,44 @@ export function viewChannel(channelId: string, prevChannelId = ''): ActionFunc {
     };
 }
 
-export function markChannelAsViewed(channelId: string, prevChannelId = ''): ActionFunc {
+export function markChannelAsViewed(channelId: string, prevChannelId?: string): ActionFunc {
     return (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const actions: Action[] = [];
+        const actions = actionsToMarkChannelAsViewed(getState, channelId, prevChannelId);
 
-        const {myMembers} = getState().entities.channels;
-        const member = myMembers[channelId];
-        const state = getState();
-        if (member) {
-            actions.push({
-                type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
-                data: {...member, last_viewed_at: Date.now()},
-            });
-            if (isManuallyUnread(state, channelId)) {
-                actions.push({
-                    type: ChannelTypes.REMOVE_MANUALLY_UNREAD,
-                    data: {channelId},
-                });
-            }
-
-            dispatch(loadRolesIfNeeded(member.roles.split(' ')));
-        }
-
-        const prevMember = myMembers[prevChannelId];
-        if (prevMember && !isManuallyUnread(getState(), prevChannelId)) {
-            actions.push({
-                type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
-                data: {...prevMember, last_viewed_at: Date.now()},
-            });
-            dispatch(loadRolesIfNeeded(prevMember.roles.split(' ')));
-        }
-
-        if (actions.length) {
-            dispatch(batchActions(actions));
-        }
-
-        return {data: true};
+        return dispatch(batchActions(actions));
     };
+}
+
+export function actionsToMarkChannelAsViewed(getState: GetStateFunc, channelId: string, prevChannelId = '') {
+    const actions: Redux.AnyAction[] = [];
+
+    const state = getState();
+    const {myMembers} = state.entities.channels;
+
+    const member = myMembers[channelId];
+    if (member) {
+        actions.push({
+            type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
+            data: {...member, last_viewed_at: Date.now()},
+        });
+
+        if (isManuallyUnread(state, channelId)) {
+            actions.push({
+                type: ChannelTypes.REMOVE_MANUALLY_UNREAD,
+                data: {channelId},
+            });
+        }
+    }
+
+    const prevMember = myMembers[prevChannelId];
+    if (prevMember && !isManuallyUnread(state, prevChannelId)) {
+        actions.push({
+            type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
+            data: {...prevMember, last_viewed_at: Date.now()},
+        });
+    }
+
+    return actions;
 }
 
 export function getChannels(teamId: string, page = 0, perPage: number = General.CHANNELS_CHUNK_SIZE): ActionFunc {
@@ -1259,80 +1262,15 @@ export function updateChannelPurpose(channelId: string, purpose: string): Action
 
 export function markChannelAsRead(channelId: string, prevChannelId?: string, updateLastViewedAt = true): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const prevChanManuallyUnread = isManuallyUnread(getState(), prevChannelId);
+        const state = getState();
+        const prevChanManuallyUnread = isManuallyUnread(state, prevChannelId);
 
         // Send channel last viewed at to the server
         if (updateLastViewedAt) {
-            Client4.viewMyChannel(channelId, prevChanManuallyUnread ? '' : prevChannelId).then().catch((error) => {
-                forceLogoutIfNecessary(error, dispatch, getState);
-                dispatch(logError(error));
-                return {error};
-            });
+            dispatch(markChannelAsReadOnServer(channelId, prevChanManuallyUnread ? '' : prevChannelId));
         }
 
-        const state = getState();
-        const {channels, myMembers} = state.entities.channels;
-
-        // Update channel member objects to set all mentions and posts as viewed
-        const channel = channels[channelId];
-        const prevChannel = (!prevChanManuallyUnread && prevChannelId) ? channels[prevChannelId] : null; // May be null since prevChannelId is optional
-
-        // Update team member objects to set mentions and posts in channel as viewed
-        const channelMember = myMembers[channelId];
-        const prevChannelMember = (!prevChanManuallyUnread && prevChannelId) ? myMembers[prevChannelId] : null; // May also be null
-
-        const actions: Action[] = [];
-
-        if (channel && channelMember) {
-            actions.push({
-                type: ChannelTypes.DECREMENT_UNREAD_MSG_COUNT,
-                data: {
-                    teamId: channel.team_id,
-                    channelId,
-                    amount: channel.total_msg_count - channelMember.msg_count,
-                    amountRoot: channel.total_msg_count_root - channelMember.msg_count_root,
-                },
-            });
-
-            actions.push({
-                type: ChannelTypes.DECREMENT_UNREAD_MENTION_COUNT,
-                data: {
-                    teamId: channel.team_id,
-                    channelId,
-                    amount: channelMember.mention_count,
-                    amountRoot: channelMember.mention_count_root,
-                },
-            });
-        }
-
-        if (channel && isManuallyUnread(getState(), channelId)) {
-            actions.push({
-                type: ChannelTypes.REMOVE_MANUALLY_UNREAD,
-                data: {channelId},
-            });
-        }
-
-        if (prevChannel && prevChannelMember) {
-            actions.push({
-                type: ChannelTypes.DECREMENT_UNREAD_MSG_COUNT,
-                data: {
-                    teamId: prevChannel.team_id,
-                    channelId: prevChannelId,
-                    amount: prevChannel.total_msg_count - prevChannelMember.msg_count,
-                    amountRoot: prevChannel.total_msg_count_root - prevChannelMember.msg_count_root,
-                },
-            });
-
-            actions.push({
-                type: ChannelTypes.DECREMENT_UNREAD_MENTION_COUNT,
-                data: {
-                    teamId: prevChannel.team_id,
-                    channelId: prevChannelId,
-                    amount: prevChannelMember.mention_count,
-                    amountRoot: prevChannelMember.mention_count_root,
-                },
-            });
-        }
+        const actions = actionsToMarkChannelAsRead(getState, channelId, prevChannelId);
 
         if (actions.length > 0) {
             dispatch(batchActions(actions));
@@ -1342,8 +1280,89 @@ export function markChannelAsRead(channelId: string, prevChannelId?: string, upd
     };
 }
 
-// Increments the number of posts in the channel by 1 and marks it as unread if necessary
+export function markChannelAsReadOnServer(channelId: string, prevChannelId?: string): ActionFunc {
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        Client4.viewMyChannel(channelId, prevChannelId).then().catch((error) => {
+            forceLogoutIfNecessary(error, dispatch, getState);
+            dispatch(logError(error));
+            return {error};
+        });
 
+        return {data: true};
+    };
+}
+
+export function actionsToMarkChannelAsRead(getState: GetStateFunc, channelId: string, prevChannelId?: string) {
+    const state = getState();
+    const {channels, myMembers} = state.entities.channels;
+
+    const prevChanManuallyUnread = isManuallyUnread(state, prevChannelId);
+
+    // Update channel member objects to set all mentions and posts as viewed
+    const channel = channels[channelId];
+    const prevChannel = (!prevChanManuallyUnread && prevChannelId) ? channels[prevChannelId] : null; // May be null since prevChannelId is optional
+
+    // Update team member objects to set mentions and posts in channel as viewed
+    const channelMember = myMembers[channelId];
+    const prevChannelMember = (!prevChanManuallyUnread && prevChannelId) ? myMembers[prevChannelId] : null; // May also be null
+
+    const actions: Redux.AnyAction[] = [];
+
+    if (channel && channelMember) {
+        actions.push({
+            type: ChannelTypes.DECREMENT_UNREAD_MSG_COUNT,
+            data: {
+                teamId: channel.team_id,
+                channelId,
+                amount: channel.total_msg_count - channelMember.msg_count,
+                amountRoot: channel.total_msg_count_root - channelMember.msg_count_root,
+            },
+        });
+
+        actions.push({
+            type: ChannelTypes.DECREMENT_UNREAD_MENTION_COUNT,
+            data: {
+                teamId: channel.team_id,
+                channelId,
+                amount: channelMember.mention_count,
+                amountRoot: channelMember.mention_count_root,
+            },
+        });
+    }
+
+    if (channel && isManuallyUnread(getState(), channelId)) {
+        actions.push({
+            type: ChannelTypes.REMOVE_MANUALLY_UNREAD,
+            data: {channelId},
+        });
+    }
+
+    if (prevChannel && prevChannelMember) {
+        actions.push({
+            type: ChannelTypes.DECREMENT_UNREAD_MSG_COUNT,
+            data: {
+                teamId: prevChannel.team_id,
+                channelId: prevChannelId,
+                amount: prevChannel.total_msg_count - prevChannelMember.msg_count,
+                amountRoot: prevChannel.total_msg_count_root - prevChannelMember.msg_count_root,
+            },
+        });
+
+        actions.push({
+            type: ChannelTypes.DECREMENT_UNREAD_MENTION_COUNT,
+            data: {
+                teamId: prevChannel.team_id,
+                channelId: prevChannelId,
+                amount: prevChannelMember.mention_count,
+                amountRoot: prevChannelMember.mention_count_root,
+            },
+        });
+    }
+
+    return actions;
+}
+
+// Increments the number of posts in the channel by 1 and marks it as unread if necessary
 export function markChannelAsUnread(teamId: string, channelId: string, mentions: string[], fetchedChannelMember = false, isRoot = false): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
@@ -1391,6 +1410,51 @@ export function markChannelAsUnread(teamId: string, channelId: string, mentions:
 
         return {data: true};
     };
+}
+
+export function actionsToMarkChannelAsUnread(getState: GetStateFunc, teamId: string, channelId: string, mentions: string[], fetchedChannelMember = false, isRoot = false) {
+    const state = getState();
+    const {myMembers} = state.entities.channels;
+    const {currentUserId} = state.entities.users;
+
+    const actions: Redux.AnyAction[] = [{
+        type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
+        data: {
+            teamId,
+            channelId,
+            amount: 1,
+            amountRoot: isRoot ? 1 : 0,
+            onlyMentions: myMembers[channelId] && myMembers[channelId].notify_props &&
+                myMembers[channelId].notify_props.mark_unread === MarkUnread.MENTION,
+            fetchedChannelMember,
+        },
+    }];
+
+    if (!fetchedChannelMember) {
+        actions.push({
+            type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
+            data: {
+                channelId,
+                amountRoot: isRoot ? 1 : 0,
+                amount: 1,
+            },
+        });
+    }
+
+    if (mentions && mentions.indexOf(currentUserId) !== -1) {
+        actions.push({
+            type: ChannelTypes.INCREMENT_UNREAD_MENTION_COUNT,
+            data: {
+                teamId,
+                channelId,
+                amountRoot: isRoot ? 1 : 0,
+                amount: 1,
+                fetchedChannelMember,
+            },
+        });
+    }
+
+    return actions;
 }
 
 export function getChannelMembersByIds(channelId: string, userIds: string[]) {


### PR DESCRIPTION
One of the causes of slowdowns when receiving a post is that a lot of components re-render due to changes in `state.entities.channels.channels` (which happens whenever any channel changes). A lot of components depend on this object, particularly the sidebar.

Because of how the post receiving actions are written, we dispatch a few rounds of actions as we're updating various fields containing unread information. It's easier to see this when we add an artificial delay between the batches since you'll see the re-render flicker happen a few times as everything happens.

https://user-images.githubusercontent.com/3277310/121036766-ec581600-c77c-11eb-9071-d16045a921d1.mov

By making the code a bit clunkier, we remove an extra re-render and cut a fair bit of time off the render.

https://user-images.githubusercontent.com/3277310/121038000-e9a9f080-c77d-11eb-9aa7-8939307e3f25.mov

I compared the time taken by each `conn.onmessage` call done when the websocket event for the new post was received, and while the times were a bit inconsistent run to run (I blame my Macbook's thermal throttling), there seemed to be about a 40-50% decrease in time taken when viewing a channel with only a few posts.

![Screen Shot 2021-06-07 at 10 48 03 AM](https://user-images.githubusercontent.com/3277310/121038041-f1699500-c77d-11eb-8a6b-aaa6cfa3572b.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35837

#### Release Note
```release-note
Reduced time taken re-rendering when a post is received
```
