### PR TITLE
Allow uploading `.jpeg` files on Linux

### DIFF
--- a/components/__snapshots__/picture_selector.test.tsx.snap
+++ b/components/__snapshots__/picture_selector.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`components/picture_selector should match snapshot, default picture prov
   className="PictureSelector"
 >
   <input
-    accept=".jpg,.png,.bmp"
+    accept=".jpeg,.jpg,.png,.bmp"
     aria-hidden={true}
     className="PictureSelector__input hidden"
     data-testid="PictureSelector__input-picture_selector_test"
@@ -45,7 +45,7 @@ exports[`components/picture_selector should match snapshot, existing picture pro
   className="PictureSelector"
 >
   <input
-    accept=".jpg,.png,.bmp"
+    accept=".jpeg,.jpg,.png,.bmp"
     aria-hidden={true}
     className="PictureSelector__input hidden"
     data-testid="PictureSelector__input-picture_selector_test"
@@ -85,7 +85,7 @@ exports[`components/picture_selector should match snapshot, no picture selected 
   className="PictureSelector"
 >
   <input
-    accept=".jpg,.png,.bmp"
+    accept=".jpeg,.jpg,.png,.bmp"
     aria-hidden={true}
     className="PictureSelector__input hidden"
     data-testid="PictureSelector__input-picture_selector_test"

--- a/components/__snapshots__/setting_picture.test.jsx.snap
+++ b/components/__snapshots__/setting_picture.test.jsx.snap
@@ -50,7 +50,7 @@ exports[`components/SettingItemMin should match snapshot with active Save button
         />
         <span>
           <input
-            accept=".jpg,.png,.bmp"
+            accept=".jpeg,.jpg,.png,.bmp"
             aria-hidden={true}
             className="hidden"
             data-testid="uploadPicture"
@@ -148,7 +148,7 @@ exports[`components/SettingItemMin should match snapshot with active Save button
         />
         <span>
           <input
-            accept=".jpg,.png,.bmp"
+            accept=".jpeg,.jpg,.png,.bmp"
             aria-hidden={true}
             className="hidden"
             data-testid="uploadPicture"
@@ -256,7 +256,7 @@ exports[`components/SettingItemMin should match snapshot, on loading picture 1`]
         />
         <span>
           <input
-            accept=".jpg,.png,.bmp"
+            accept=".jpeg,.jpg,.png,.bmp"
             aria-hidden={true}
             className="hidden"
             data-testid="uploadPicture"
@@ -376,7 +376,7 @@ exports[`components/SettingItemMin should match snapshot, profile picture on fil
         />
         <span>
           <input
-            accept=".jpg,.png,.bmp"
+            accept=".jpeg,.jpg,.png,.bmp"
             aria-hidden={true}
             className="hidden"
             data-testid="uploadPicture"
@@ -484,7 +484,7 @@ exports[`components/SettingItemMin should match snapshot, profile picture on sou
         />
         <span>
           <input
-            accept=".jpg,.png,.bmp"
+            accept=".jpeg,.jpg,.png,.bmp"
             aria-hidden={true}
             className="hidden"
             data-testid="uploadPicture"
@@ -604,7 +604,7 @@ exports[`components/SettingItemMin should match snapshot, team icon on file 1`] 
         />
         <span>
           <input
-            accept=".jpg,.png,.bmp"
+            accept=".jpeg,.jpg,.png,.bmp"
             aria-hidden={true}
             className="hidden"
             data-testid="uploadPicture"
@@ -768,7 +768,7 @@ exports[`components/SettingItemMin should match snapshot, team icon on source 1`
         />
         <span>
           <input
-            accept=".jpg,.png,.bmp"
+            accept=".jpeg,.jpg,.png,.bmp"
             aria-hidden={true}
             className="hidden"
             data-testid="uploadPicture"
@@ -932,7 +932,7 @@ exports[`components/SettingItemMin should match snapshot, user icon on source 1`
         />
         <span>
           <input
-            accept=".jpg,.png,.bmp"
+            accept=".jpeg,.jpg,.png,.bmp"
             aria-hidden={true}
             className="hidden"
             data-testid="uploadPicture"

--- a/components/admin_console/brand_image_setting/brand_image_setting.jsx
+++ b/components/admin_console/brand_image_setting/brand_image_setting.jsx
@@ -247,7 +247,7 @@ export default class BrandImageSetting extends React.PureComponent {
                         <input
                             ref={this.fileInputRef}
                             type='file'
-                            accept='.jpg,.png,.bmp'
+                            accept={Constants.ACCEPT_STATIC_IMAGE}
                             disabled={this.props.disabled}
                             onChange={this.handleImageChange}
                         />

--- a/components/emoji/add_emoji/__snapshots__/add_emoji.test.tsx.snap
+++ b/components/emoji/add_emoji/__snapshots__/add_emoji.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`components/emoji/components/AddEmoji should match snapshot 1`] = `
                 />
               </button>
               <input
-                accept=".jpg,.png,.gif"
+                accept=".jpeg,.jpg,.png,.gif"
                 id="select-emoji"
                 multiple={false}
                 onChange={[Function]}
@@ -225,7 +225,7 @@ exports[`components/emoji/components/AddEmoji should select a file and match sna
                 />
               </button>
               <input
-                accept=".jpg,.png,.gif"
+                accept=".jpeg,.jpg,.png,.gif"
                 id="select-emoji"
                 multiple={false}
                 onChange={[Function]}
@@ -400,7 +400,7 @@ exports[`components/emoji/components/AddEmoji should update emoji name and match
                 />
               </button>
               <input
-                accept=".jpg,.png,.gif"
+                accept=".jpeg,.jpg,.png,.gif"
                 id="select-emoji"
                 multiple={false}
                 onChange={[Function]}

--- a/components/emoji/add_emoji/add_emoji.tsx
+++ b/components/emoji/add_emoji/add_emoji.tsx
@@ -16,6 +16,7 @@ import FormError from 'components/form_error';
 import SpinnerButton from 'components/spinner_button';
 import {browserHistory} from 'utils/browser_history';
 import {localizeMessage} from 'utils/utils.jsx';
+import {Constants} from 'utils/constants.jsx';
 
 import EmojiMap from 'utils/emoji_map';
 
@@ -352,7 +353,7 @@ export default class AddEmoji extends React.PureComponent<AddEmojiProps, AddEmoj
                                         <input
                                             id='select-emoji'
                                             type='file'
-                                            accept='.jpg,.png,.gif'
+                                            accept={Constants.ACCEPT_EMOJI_IMAGE}
                                             multiple={false}
                                             onChange={this.updateImage}
                                         />

--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -510,7 +510,7 @@ export default class AddBot extends React.PureComponent {
                                         defaultMessage='Upload Image'
                                     />
                                     <input
-                                        accept='.jpg,.png,.bmp'
+                                        accept={Constants.ACCEPT_STATIC_IMAGE}
                                         type='file'
                                         onChange={this.updatePicture}
                                     />

--- a/components/picture_selector.tsx
+++ b/components/picture_selector.tsx
@@ -5,6 +5,7 @@ import React, {useState, useEffect} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {localizeMessage} from 'utils/utils';
+import {Constants} from 'utils/constants';
 import * as FileUtils from 'utils/file_utils';
 
 import './picture_selector.scss';
@@ -104,7 +105,7 @@ const PictureSelector: React.FC<Props> = (props: Props) => {
                 data-testid={`PictureSelector__input-${name}`}
                 ref={inputRef}
                 className='PictureSelector__input hidden'
-                accept='.jpg,.png,.bmp'
+                accept={Constants.ACCEPT_STATIC_IMAGE}
                 type='file'
                 onChange={handleFileChange}
                 disabled={loadingPicture}

--- a/components/setting_picture.jsx
+++ b/components/setting_picture.jsx
@@ -276,7 +276,7 @@ export default class SettingPicture extends Component {
                         data-testid='uploadPicture'
                         ref={this.selectInput}
                         className='hidden'
-                        accept='.jpg,.png,.bmp'
+                        accept='.jpeg,.jpg,.png,.bmp'
                         type='file'
                         onChange={this.handleFileChange}
                         disabled={this.props.loadingPicture}

--- a/components/setting_picture.jsx
+++ b/components/setting_picture.jsx
@@ -276,7 +276,7 @@ export default class SettingPicture extends Component {
                         data-testid='uploadPicture'
                         ref={this.selectInput}
                         className='hidden'
-                        accept='.jpeg,.jpg,.png,.bmp'
+                        accept={Constants.ACCEPT_STATIC_IMAGE}
                         type='file'
                         onChange={this.handleFileChange}
                         disabled={this.props.loadingPicture}

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1631,6 +1631,8 @@ export const Constants = {
     TRANSPARENT_PIXEL: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
     TRIPLE_BACK_TICKS: /```/g,
     MAX_ATTACHMENT_FOOTER_LENGTH: 300,
+    ACCEPT_STATIC_IMAGE: '.jpeg,.jpg,.png,.bmp',
+    ACCEPT_EMOJI_IMAGE: '.jpeg,.jpg,.png,.gif',
 };
 
 export const ValidationErrors = {


### PR DESCRIPTION
#### Summary
Allow uploading JPEG files ending in `.jpeg` on Chromium on Linux (may also enable other platforms).

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/17728

#### Screenshots
Before:
![file-types-before](https://user-images.githubusercontent.com/13738432/121060921-d94b4300-c788-11eb-8147-9ce3e05cc7ad.png)

![file-types-after](https://user-images.githubusercontent.com/13738432/121060937-dfd9ba80-c788-11eb-8897-da1d2d7fdd7d.png)

#### Release Note
```release-note
Fixed ability to upload `.jpeg` files on Linux
```
