### PR TITLE
Export PurchaseModal component and related utils

### DIFF
--- a/plugins/export.js
+++ b/plugins/export.js
@@ -6,6 +6,10 @@ import {formatText} from 'utils/text_formatting';
 import {browserHistory} from 'utils/browser_history';
 import Textbox from 'components/textbox';
 
+import {openModal} from 'actions/views/modals';
+import {ModalIdentifiers} from 'utils/constants';
+import PurchaseModal from 'components/purchase_modal';
+
 // The following import has intentional side effects. Do not remove without research.
 import {openInteractiveDialog} from './interactive_dialog';
 
@@ -22,5 +26,8 @@ window.PDFJS = require('pdfjs-dist');
 // Functions and components exposed on window for plugins to use.
 window.PostUtils = {formatText, messageHtmlToComponent};
 window.openInteractiveDialog = openInteractiveDialog;
-window.WebappUtils = {browserHistory};
-window.Components = {Textbox};
+window.WebappUtils = {
+    browserHistory,
+    modals: {openModal, ModalIdentifiers},
+};
+window.Components = {Textbox, PurchaseModal};


### PR DESCRIPTION
#### Summary
In order to support Cloud in Incident Collaboration, we need to implement the upgrade flow triggered when users try to use a locked feature.

To keep the experience consistent, we are using the `PurchaseModal` component in two ways:
- When the user is interacting with the Messaging product (in an incident in a channel, for example), and the modal needs to be shown, we leverage the existing architecture by simply calling `openModal`, which pops up the already mounted component.
- When the user is in the backstage, there is no component already mounted, so we are mounting another one in our components hierarchy, and using the same `openModal` logic to show it.

This PR makes all this possible, exporting the needed elements so the plugins can use them; namely:
- The component itself, `PurchaseModal`.
- The function `openModal` to trigger its visibility.
- The constant `ModalIdentifiers`, which contains the ID required as one of the arguments to `openModal`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35626


#### Release Note
```release-note
NONE
```
