### PR TITLE
MM-34578 - update permission name to see button in main menu

### DIFF
--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -187,7 +187,7 @@ class MainMenu extends React.PureComponent {
             >
                 {isCloud && isFreeTrial &&
                     <Menu.Group>
-                        <SystemPermissionGate permissions={Permissions.SYSCONSOLE_WRITE_BILLING}>
+                        <SystemPermissionGate permissions={[Permissions.SYSCONSOLE_WRITE_BILLING]}>
                             <Menu.TopNotification
                                 show={true}
                                 id='topNotification'


### PR DESCRIPTION
#### Summary
This PR fixes the permissions to see the subscribe now button in the main menu.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34578

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/7894

#### Release Note
```release-note
NONE
```
