### PR TITLE
MM-35538 - display purchase modal when coming from email

### DIFF
--- a/components/admin_console/billing/billing_subscriptions/index.tsx
+++ b/components/admin_console/billing/billing_subscriptions/index.tsx
@@ -32,6 +32,7 @@ import {
 } from 'utils/constants';
 import {isCustomerCardExpired} from 'utils/cloud_utils';
 import {getRemainingDaysFromFutureTimestamp} from 'utils/utils.jsx';
+import {useQuery} from 'utils/http_utils';
 
 import BillingSummary from '../billing_summary';
 import PlanDetails from '../plan_details';
@@ -68,6 +69,9 @@ const BillingSubscriptions: React.FC = () => {
 
     const [showCreditCardBanner, setShowCreditCardBanner] = useState(true);
 
+    const query = useQuery();
+    const fromQueryParam = query.get('from');
+
     const product = useSelector((state: GlobalState) => {
         const products = state.entities.cloud.products!;
         if (!products) {
@@ -90,6 +94,15 @@ const BillingSubscriptions: React.FC = () => {
         }
         return products[keys[0]];
     });
+
+    // show the upgrade section when is a free tier customer
+    const onUpgradeMattermostCloud = () => {
+        trackEvent('cloud_admin', 'click_upgrade_mattermost_cloud');
+        dispatch(openModal({
+            modalId: ModalIdentifiers.CLOUD_PURCHASE,
+            dialogType: PurchaseModal,
+        }));
+    };
 
     const subscriptionPlan = product?.sku || CloudProducts.PROFESSIONAL;
 
@@ -115,6 +128,10 @@ const BillingSubscriptions: React.FC = () => {
 
         if (analytics && shouldShowInfoBanner()) {
             trackEvent(TELEMETRY_CATEGORIES.CLOUD_ADMIN, 'bannerview_user_limit_warning');
+        }
+
+        if (fromQueryParam === 'trial_ending_email') {
+            onUpgradeMattermostCloud();
         }
     }, []);
 
@@ -147,15 +164,6 @@ const BillingSubscriptions: React.FC = () => {
                 value: 'true',
             },
         ]));
-    };
-
-    // show the upgrade section when is a free tier customer
-    const onUpgradeMattermostCloud = () => {
-        trackEvent('cloud_admin', 'click_upgrade_mattermost_cloud');
-        dispatch(openModal({
-            modalId: ModalIdentifiers.CLOUD_PURCHASE,
-            dialogType: PurchaseModal,
-        }));
     };
 
     if (!subscription || !products) {

--- a/utils/http_utils.ts
+++ b/utils/http_utils.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useLocation} from 'react-router-dom';
+
+export function useQuery() {
+    return new URLSearchParams(useLocation().search);
+}


### PR DESCRIPTION
#### Summary
This PR adds logic to display the purchase modal when there is a query param called action and the value is show_purchase_modal. This initially works in conjunction with the trial_ending_soon email. Check the Related PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35538

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/17746)

#### Screenshots
<img width="1774" alt="Captura de pantalla 2021-06-08 a las 20 28 53" src="https://user-images.githubusercontent.com/10082627/121238222-28cc6480-c898-11eb-9f73-26bca1a3da7d.png">

#### Release Note

```release-note
NONE
```
