### PR TITLE
[MM-36173] Fix spacing and opacity on descriptions for special mentions

### DIFF
--- a/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
@@ -27,10 +27,12 @@ export default class AtMentionSuggestion extends Suggestion {
         if (item.username === 'all') {
             itemname = 'all';
             description = (
-                <FormattedMessage
-                    id='suggestion.mention.all'
-                    defaultMessage='Notifies everyone in this channel'
-                />
+                <span className='light ml-2'>
+                    <FormattedMessage
+                        id='suggestion.mention.all'
+                        defaultMessage='Notifies everyone in this channel'
+                    />
+                </span>
             );
             icon = (
                 <FormattedMessage
@@ -50,10 +52,12 @@ export default class AtMentionSuggestion extends Suggestion {
         } else if (item.username === 'channel') {
             itemname = 'channel';
             description = (
-                <FormattedMessage
-                    id='suggestion.mention.channel'
-                    defaultMessage='Notifies everyone in this channel'
-                />
+                <span className='light ml-2'>
+                    <FormattedMessage
+                        id='suggestion.mention.channel'
+                        defaultMessage='Notifies everyone in this channel'
+                    />
+                </span>
             );
             icon = (
                 <FormattedMessage
@@ -73,10 +77,12 @@ export default class AtMentionSuggestion extends Suggestion {
         } else if (item.username === 'here') {
             itemname = 'here';
             description = (
-                <FormattedMessage
-                    id='suggestion.mention.here'
-                    defaultMessage='Notifies everyone online in this channel'
-                />
+                <span className='light ml-2'>
+                    <FormattedMessage
+                        id='suggestion.mention.here'
+                        defaultMessage='Notifies everyone online in this channel'
+                    />
+                </span>
             );
             icon = (
                 <FormattedMessage


### PR DESCRIPTION
#### Summary
The descriptions for Special Mentions in the autocomplete popup were not spaced correctly and were showing up with a higher opacity compared to other entries. This PR adds the same class used on the other entries to correct the spacing and opacity.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36173

#### Screenshots
![Screen Shot 2021-06-08 at 2 34 49 PM](https://user-images.githubusercontent.com/52460000/121239023-ba22e300-c866-11eb-8a2a-fdeaf3b0fba3.png)

#### Release Note
```release-note
NONE
```
