### PR TITLE
[MM-36704] Add selector specifically for search channel name to handle its cases

### DIFF
--- a/actions/views/rhs.ts
+++ b/actions/views/rhs.ts
@@ -16,7 +16,7 @@ import * as PostActions from 'mattermost-redux/actions/posts';
 import {getCurrentUserId, getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannelId, getCurrentChannelNameForSearchShortcut} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
@@ -100,6 +100,13 @@ export function updateSearchTerms(terms: string) {
     return {
         type: ActionTypes.UPDATE_RHS_SEARCH_TERMS,
         terms,
+    };
+}
+
+export function updateSearchTermsForShortcut() {
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const currentChannelName = getCurrentChannelNameForSearchShortcut(getState());
+        return dispatch(updateSearchTerms(`in:${currentChannelName} `));
     };
 }
 

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {AnyAction, bindActionCreators, Dispatch} from 'redux';
 
 import {getMorePostsForSearch, getMoreFilesForSearch} from 'mattermost-redux/actions/search';
-import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel, getCurrentChannelNameForSearchShortcut} from 'mattermost-redux/selectors/entities/channels';
 
 import {
     updateSearchTerms,
@@ -35,6 +35,7 @@ function mapStateToProps(state: GlobalState) {
 
     return {
         currentChannel,
+        currentChannelName: getCurrentChannelNameForSearchShortcut(state),
         isRhsExpanded: getIsRhsExpanded(state),
         isRhsOpen: getIsRhsOpen(state),
         isSearchingTerm: getIsSearchingTerm(state),

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -5,10 +5,11 @@ import {connect} from 'react-redux';
 import {AnyAction, bindActionCreators, Dispatch} from 'redux';
 
 import {getMorePostsForSearch, getMoreFilesForSearch} from 'mattermost-redux/actions/search';
-import {getCurrentChannel, getCurrentChannelNameForSearchShortcut} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {
     updateSearchTerms,
+    updateSearchTermsForShortcut,
     showSearchResults,
     showChannelFiles,
     showMentions,
@@ -35,7 +36,6 @@ function mapStateToProps(state: GlobalState) {
 
     return {
         currentChannel,
-        currentChannelName: getCurrentChannelNameForSearchShortcut(state),
         isRhsExpanded: getIsRhsExpanded(state),
         isRhsOpen: getIsRhsOpen(state),
         isSearchingTerm: getIsSearchingTerm(state),
@@ -53,6 +53,7 @@ function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
     return {
         actions: bindActionCreators({
             updateSearchTerms,
+            updateSearchTermsForShortcut,
             updateSearchType,
             showSearchResults,
             showChannelFiles,

--- a/components/search/search.tsx
+++ b/components/search/search.tsx
@@ -68,7 +68,7 @@ const determineVisibleSearchHintOptions = (searchTerms: string, searchType: Sear
 };
 
 const Search: React.FC<Props> = (props: Props): JSX.Element => {
-    const {actions, searchTerms, searchType, currentChannel, currentChannelName, hideSearchBar, enableFindShortcut} = props;
+    const {actions, searchTerms, searchType, currentChannel, hideSearchBar, enableFindShortcut} = props;
 
     const intl = useIntl();
 
@@ -110,9 +110,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
                     actions.openRHSSearch();
                     setKeepInputFocused(true);
                 }
-                if (currentChannelName) {
-                    handleUpdateSearchTerms(`in:${currentChannelName} `);
-                }
+                actions.updateSearchTermsForShortcut();
                 handleFocus();
             }
         };
@@ -121,7 +119,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
         return () => {
             document.removeEventListener('keydown', handleKeyDown);
         };
-    }, [currentChannelName, hideSearchBar]);
+    }, [hideSearchBar]);
 
     useEffect((): void => {
         if (!Utils.isMobile()) {

--- a/components/search/search.tsx
+++ b/components/search/search.tsx
@@ -68,7 +68,7 @@ const determineVisibleSearchHintOptions = (searchTerms: string, searchType: Sear
 };
 
 const Search: React.FC<Props> = (props: Props): JSX.Element => {
-    const {actions, searchTerms, searchType, currentChannel, hideSearchBar, enableFindShortcut} = props;
+    const {actions, searchTerms, searchType, currentChannel, currentChannelName, hideSearchBar, enableFindShortcut} = props;
 
     const intl = useIntl();
 
@@ -110,8 +110,8 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
                     actions.openRHSSearch();
                     setKeepInputFocused(true);
                 }
-                if (currentChannel) {
-                    handleUpdateSearchTerms(`in:${currentChannel.name} `);
+                if (currentChannelName) {
+                    handleUpdateSearchTerms(`in:${currentChannelName} `);
                 }
                 handleFocus();
             }
@@ -121,7 +121,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
         return () => {
             document.removeEventListener('keydown', handleKeyDown);
         };
-    }, [currentChannel, hideSearchBar]);
+    }, [currentChannelName, hideSearchBar]);
 
     useEffect((): void => {
         if (!Utils.isMobile()) {

--- a/components/search/types.ts
+++ b/components/search/types.ts
@@ -39,7 +39,7 @@ export type StateProps = {
 export type DispatchProps = {
     actions: {
         updateSearchTerms: (term: string) => Action;
-        updateSearchTermsForShortcut: () => Action;
+        updateSearchTermsForShortcut: () => void;
         updateSearchType: (searchType: string) => Action;
         showSearchResults: (isMentionSearch: boolean) => Record<string, any>;
         showChannelFiles: (channelId: string) => void;

--- a/components/search/types.ts
+++ b/components/search/types.ts
@@ -34,12 +34,12 @@ export type StateProps = {
     isPinnedPosts: boolean;
     isChannelFiles: boolean;
     currentChannel?: Channel;
-    currentChannelName?: string;
 }
 
 export type DispatchProps = {
     actions: {
         updateSearchTerms: (term: string) => Action;
+        updateSearchTermsForShortcut: () => Action;
         updateSearchType: (searchType: string) => Action;
         showSearchResults: (isMentionSearch: boolean) => Record<string, any>;
         showChannelFiles: (channelId: string) => void;

--- a/components/search/types.ts
+++ b/components/search/types.ts
@@ -34,6 +34,7 @@ export type StateProps = {
     isPinnedPosts: boolean;
     isChannelFiles: boolean;
     currentChannel?: Channel;
+    currentChannelName?: string;
 }
 
 export type DispatchProps = {

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -292,7 +292,7 @@ export const getCurrentChannelNameForSearchShortcut: (state: GlobalState) => str
 
         // Replace spaces in GM channel names
         if (channel?.type === Constants.GM_CHANNEL) {
-            return `@${channel.display_name.replace(/ /g, '')}`;
+            return `@${channel.display_name.replace(/\s/g, '')}`;
         }
 
         return channel?.name;

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -3,7 +3,7 @@
 
 import {createSelector} from 'reselect';
 
-import {General, Permissions} from 'mattermost-redux/constants';
+import {General, Permissions, Preferences} from 'mattermost-redux/constants';
 import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
 
 import {getCategoryInTeamByType} from 'mattermost-redux/selectors/entities/channel_categories';
@@ -280,13 +280,12 @@ export const getCurrentChannelNameForSearchShortcut: (state: GlobalState) => str
     getAllChannels,
     getCurrentChannelId,
     (state: GlobalState): UsersState => state.entities.users,
-    getTeammateNameDisplaySetting,
-    (allChannels: IDMappedObjects<Channel>, currentChannelId: string, users: UsersState, teammateNameDisplay: string): string | undefined => {
+    (allChannels: IDMappedObjects<Channel>, currentChannelId: string, users: UsersState): string | undefined => {
         const channel = allChannels[currentChannelId];
 
         // Only get the extra info from users if we need it
         if (channel?.type === Constants.DM_CHANNEL) {
-            const dmChannelWithInfo = completeDirectChannelInfo(users, teammateNameDisplay, channel);
+            const dmChannelWithInfo = completeDirectChannelInfo(users, Preferences.DISPLAY_PREFER_USERNAME, channel);
             return `@${dmChannelWithInfo.display_name}`;
         }
 

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -52,6 +52,7 @@ import {
 import {
     canManageMembersOldPermissions,
     completeDirectChannelInfo,
+    completeDirectGroupInfo,
     newCompleteDirectChannelInfo,
     completeDirectChannelDisplayName,
     getUserIdFromChannelName,
@@ -291,7 +292,8 @@ export const getCurrentChannelNameForSearchShortcut: (state: GlobalState) => str
 
         // Replace spaces in GM channel names
         if (channel?.type === Constants.GM_CHANNEL) {
-            return `@${channel.display_name.replace(/\s/g, '')}`;
+            const gmChannelWithInfo = completeDirectGroupInfo(users, Preferences.DISPLAY_PREFER_USERNAME, channel, false);
+            return `@${gmChannelWithInfo.display_name.replace(/\s/g, '')}`;
         }
 
         return channel?.name;

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -276,6 +276,29 @@ export const getCurrentChannel: (state: GlobalState) => Channel = createSelector
     },
 );
 
+export const getCurrentChannelNameForSearchShortcut: (state: GlobalState) => string | undefined = createSelector(
+    getAllChannels,
+    getCurrentChannelId,
+    (state: GlobalState): UsersState => state.entities.users,
+    getTeammateNameDisplaySetting,
+    (allChannels: IDMappedObjects<Channel>, currentChannelId: string, users: UsersState, teammateNameDisplay: string): string | undefined => {
+        const channel = allChannels[currentChannelId];
+
+        // Only get the extra info from users if we need it
+        if (channel?.type === Constants.DM_CHANNEL) {
+            const dmChannelWithInfo = completeDirectChannelInfo(users, teammateNameDisplay, channel);
+            return `@${dmChannelWithInfo.display_name}`;
+        }
+
+        // Replace spaces in GM channel names
+        if (channel?.type === Constants.GM_CHANNEL) {
+            return `@${channel.display_name.replace(/ /g, '')}`;
+        }
+
+        return channel?.name;
+    },
+);
+
 export const getMyChannelMember: (state: GlobalState, channelId: string) => ChannelMembership | undefined | null = createSelector(
     getMyChannelMemberships,
     (state: GlobalState, channelId: string): string => channelId,

--- a/packages/mattermost-redux/src/utils/channel_utils.ts
+++ b/packages/mattermost-redux/src/utils/channel_utils.ts
@@ -429,10 +429,10 @@ export function getChannelsIdForTeam(state: GlobalState, teamId: string): string
     }, [] as string[]);
 }
 
-export function getGroupDisplayNameFromUserIds(userIds: string[], profiles: IDMappedObjects<UserProfile>, currentUserId: string, teammateNameDisplay: string): string {
+export function getGroupDisplayNameFromUserIds(userIds: string[], profiles: IDMappedObjects<UserProfile>, currentUserId: string, teammateNameDisplay: string, omitCurrentUser = true): string {
     const names: string[] = [];
     userIds.forEach((id) => {
-        if (id !== currentUserId) {
+        if (!(id === currentUserId && omitCurrentUser)) {
             names.push(displayUsername(profiles[id], teammateNameDisplay));
         }
     });
@@ -456,13 +456,13 @@ export function isDefault(channel: Channel): boolean {
     return channel.name === General.DEFAULT_CHANNEL;
 }
 
-function completeDirectGroupInfo(usersState: UsersState, teammateNameDisplay: string, channel: Channel) {
+export function completeDirectGroupInfo(usersState: UsersState, teammateNameDisplay: string, channel: Channel, omitCurrentUser = true) {
     const {currentUserId, profiles, profilesInChannel} = usersState;
     const profilesIds = profilesInChannel[channel.id];
     const gm = {...channel};
 
     if (profilesIds) {
-        gm.display_name = getGroupDisplayNameFromUserIds(profilesIds, profiles, currentUserId, teammateNameDisplay);
+        gm.display_name = getGroupDisplayNameFromUserIds(profilesIds, profiles, currentUserId, teammateNameDisplay, omitCurrentUser);
         return gm;
     }
 


### PR DESCRIPTION
#### Summary
Due to some weirdness with the way we process channels, we don't have a consistent way of using one field to search for or label our channels. DM/GM channels are searched for commonly by the users inside them, and other channels are search in by name.

Since adding our little search shortcut, I used the `name` of the channel which worked for non DM/GM channels, but for DM/GM channels things were a little inconsistent. In order to make things consistency, and get around some of the weirdness in how we fill channels, I've added a new selector specifically to get the name used for search and am using that to fill in the name when using the `Cmd/Ctrl+Shift+F` shortcut so that its consistent with how the suggestion provider does it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36074

#### Release Note
```release-note
NONE
```
