### PR TITLE
MM-35840: fixes up arrow edit in CRT

### DIFF
--- a/actions/views/create_comment.test.jsx
+++ b/actions/views/create_comment.test.jsx
@@ -79,7 +79,7 @@ const rootId = 'fc234c34c23';
 const currentUserId = '34jrnfj43';
 const teamId = '4j5nmn4j3';
 const channelId = '4j5j4k3k34j4';
-const latestPostId = rootId;
+const latestPostId = 'latestPostId';
 
 describe('rhs view actions', () => {
     const initialState = {
@@ -91,6 +91,14 @@ describe('rhs view actions', () => {
                         user_id: currentUserId,
                         message: 'test msg',
                         channel_id: channelId,
+                        root_id: rootId,
+                    },
+                    [rootId]: {
+                        id: rootId,
+                        user_id: currentUserId,
+                        message: 'root msg',
+                        channel_id: channelId,
+                        root_id: '',
                     },
                 },
                 postsInChannel: {
@@ -98,7 +106,9 @@ describe('rhs view actions', () => {
                         {order: [latestPostId], recent: true},
                     ],
                 },
-                postsInThread: {},
+                postsInThread: {
+                    [rootId]: [latestPostId],
+                },
                 messagesHistory: {
                     index: {
                         [Posts.MESSAGE_TYPES.COMMENT]: 0,
@@ -129,7 +139,7 @@ describe('rhs view actions', () => {
         },
         storage: {
             storage: {
-                [`${StoragePrefixes.COMMENT_DRAFT}${latestPostId}`]: {
+                [`${StoragePrefixes.COMMENT_DRAFT}${rootId}`]: {
                     value: {
                         message: '',
                         fileInfos: [],
@@ -348,7 +358,7 @@ describe('rhs view actions', () => {
                 ...initialState,
                 storage: {
                     storage: {
-                        [`${StoragePrefixes.COMMENT_DRAFT}${latestPostId}`]: {
+                        [`${StoragePrefixes.COMMENT_DRAFT}${rootId}`]: {
                             value: {
                                 message: '+:smile:',
                                 fileInfos: [],
@@ -457,7 +467,7 @@ describe('rhs view actions', () => {
     });
 
     describe('makeOnEditLatestPost', () => {
-        const onEditLatestPost = makeOnEditLatestPost(channelId, rootId);
+        const onEditLatestPost = makeOnEditLatestPost(rootId);
 
         test('it dispatches the correct actions', () => {
             store.dispatch(onEditLatestPost());

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -131,8 +131,8 @@ function makeMapDispatchToProps() {
             onMoveHistoryIndexForward = makeOnMoveHistoryIndex(ownProps.rootId, 1);
         }
 
-        if (rootId !== ownProps.rootId || channelId !== ownProps.channelId) {
-            onEditLatestPost = makeOnEditLatestPost(ownProps.channelId, ownProps.rootId);
+        if (rootId !== ownProps.rootId) {
+            onEditLatestPost = makeOnEditLatestPost(ownProps.rootId);
         }
 
         if (rootId !== ownProps.rootId || channelId !== ownProps.channelId || latestPostId !== ownProps.latestPostId) {

--- a/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -88,6 +88,10 @@ export function getPostIdsInCurrentChannel(state: GlobalState): Array<$ID<Post>>
     return getPostIdsInChannel(state, state.entities.channels.currentChannelId);
 }
 
+export function getPostIdsInThread(state: GlobalState, threadId: $ID<Post>): Array<$ID<Post>> | null {
+    return getPostsInThread(state)[threadId] ?? null;
+}
+
 // getPostsInCurrentChannel returns the posts loaded at the bottom of the channel. It does not include older posts
 // such as those loaded by viewing a thread or a permalink.
 export const getPostsInCurrentChannel: (state: GlobalState) => PostWithFormatData[] | undefined | null = (() => {


### PR DESCRIPTION
#### Summary
We used to get post ids from the channel to find current user's last
post. This worked in threads when CRT off, but if you turn CRT on
replies are not added in the channel thus not being able to find the
user's last post correctly (was always the root post).

This commit fixes that by getting post ids from the thread*
(`postsInThread` reducer) and not the channel, this way both CRT on/off are
working as expected.

*renamed the selector from `makeGetCurrentUsersLatestPost` to
`makeGetCurrentUsersLatestReply.

`#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35840

#### Release Note

```release-note
NONE
```
