### PR TITLE
MM-35919: CRT makes threads nav menu sticky

### DIFF
--- a/components/legacy_sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/components/legacy_sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should match sn
       pluggableName="LeftSidebarHeader"
     />
   </div>
+  <GlobalThreadsLink />
   <div
     aria-label="channel sidebar region"
     className="sidebar--left__list a11y__region"
@@ -76,7 +77,6 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should match sn
         className="nav-pills__container"
         id="sidebarChannelContainer"
       >
-        <GlobalThreadsLink />
         <ul
           aria-label="public channels"
           className="nav nav-pills nav-stacked a11y__section"
@@ -278,6 +278,7 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should match sn
       pluggableName="LeftSidebarHeader"
     />
   </div>
+  <GlobalThreadsLink />
   <div
     aria-label="channel sidebar region"
     className="sidebar--left__list a11y__region"
@@ -337,7 +338,6 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should match sn
         className="nav-pills__container"
         id="sidebarChannelContainer"
       >
-        <GlobalThreadsLink />
         <ul
           aria-label="public channels"
           className="nav nav-pills nav-stacked a11y__section"
@@ -539,6 +539,7 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should match sn
       pluggableName="LeftSidebarHeader"
     />
   </div>
+  <GlobalThreadsLink />
   <div
     aria-label="channel sidebar region"
     className="sidebar--left__list a11y__region"
@@ -598,7 +599,6 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should match sn
         className="nav-pills__container"
         id="sidebarChannelContainer"
       >
-        <GlobalThreadsLink />
         <ul
           aria-label="public channels"
           className="nav nav-pills nav-stacked a11y__section"
@@ -800,6 +800,7 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should match sn
       pluggableName="LeftSidebarHeader"
     />
   </div>
+  <GlobalThreadsLink />
   <div
     aria-label="channel sidebar region"
     className="sidebar--left__list a11y__region"
@@ -859,7 +860,6 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should match sn
         className="nav-pills__container"
         id="sidebarChannelContainer"
       >
-        <GlobalThreadsLink />
         <ul
           aria-label="public channels"
           className="nav nav-pills nav-stacked a11y__section"
@@ -1069,6 +1069,7 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should show/hid
       pluggableName="LeftSidebarHeader"
     />
   </div>
+  <GlobalThreadsLink />
   <div
     aria-label="channel sidebar region"
     className="sidebar--left__list a11y__region"
@@ -1128,7 +1129,6 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should show/hid
         className="nav-pills__container"
         id="sidebarChannelContainer"
       >
-        <GlobalThreadsLink />
         <ul
           aria-label="public channels"
           className="nav nav-pills nav-stacked a11y__section"
@@ -1330,6 +1330,7 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should show/hid
       pluggableName="LeftSidebarHeader"
     />
   </div>
+  <GlobalThreadsLink />
   <div
     aria-label="channel sidebar region"
     className="sidebar--left__list a11y__region"
@@ -1389,7 +1390,6 @@ exports[`component/legacy_sidebar/sidebar_channel/SidebarChannel should show/hid
         className="nav-pills__container"
         id="sidebarChannelContainer"
       >
-        <GlobalThreadsLink />
         <ul
           aria-label="public channels"
           className="nav nav-pills nav-stacked a11y__section"

--- a/components/legacy_sidebar/index.js
+++ b/components/legacy_sidebar/index.js
@@ -14,7 +14,7 @@ import {
 
 import Permissions from 'mattermost-redux/constants/permissions';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getBool as getBoolPreference, getSidebarPreferences} from 'mattermost-redux/selectors/entities/preferences';
+import {getBool as getBoolPreference, getSidebarPreferences, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
@@ -72,6 +72,7 @@ function mapStateToProps(state) {
         isOpen: getIsLhsOpen(state),
         unreads: getUnreads(state),
         viewArchivedChannels: config.ExperimentalViewArchivedChannels === 'true',
+        isCollapsedThreadsEnabled: isCollapsedThreadsEnabled(state),
     };
 }
 

--- a/components/legacy_sidebar/sidebar.jsx
+++ b/components/legacy_sidebar/sidebar.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 /* eslint-disable react/no-string-refs */
+/* eslint-disable max-lines */
 
 import $ from 'jquery';
 import React from 'react';
@@ -145,6 +146,11 @@ class LegacySidebar extends React.PureComponent {
          * Setting that enables user to view archived channels
          */
         viewArchivedChannels: PropTypes.bool,
+
+        /**
+         * Setting that enables user to view threads nav menu
+         */
+        isCollapsedThreadsEnabled: PropTypes.bool,
 
         actions: PropTypes.shape({
             close: PropTypes.func.isRequired,
@@ -533,6 +539,7 @@ class LegacySidebar extends React.PureComponent {
         const {orderedChannelIds} = this.state;
 
         const sectionsToHide = [SidebarChannelGroups.UNREADS, SidebarChannelGroups.FAVORITE];
+        let shownIndex = 0;
 
         return (
             <Scrollbars
@@ -550,7 +557,6 @@ class LegacySidebar extends React.PureComponent {
                     id='sidebarChannelContainer'
                     className='nav-pills__container'
                 >
-                    <GlobalThreadsLink/>
                     {orderedChannelIds.map((sec) => {
                         const section = {
                             type: sec.type,
@@ -565,6 +571,12 @@ class LegacySidebar extends React.PureComponent {
                         const sectionId = `${section.type}Channel`;
                         const ariaLabel = section.name.toLowerCase();
 
+                        let sectionHeaderClassName = 'sidebar-section__header';
+                        if (shownIndex === 0 && this.props.isCollapsedThreadsEnabled) {
+                            sectionHeaderClassName += ' margin-top--none';
+                        }
+                        shownIndex += 1;
+
                         return (
                             <ul
                                 key={section.type}
@@ -573,7 +585,7 @@ class LegacySidebar extends React.PureComponent {
                                 id={sectionId + 'List'}
                                 tabIndex='-1'
                             >
-                                <li className='sidebar-section__header'>
+                                <li className={sectionHeaderClassName}>
                                     <h4
                                         role='presentation'
                                         id={sectionId}
@@ -723,6 +735,9 @@ class LegacySidebar extends React.PureComponent {
                 <div className='sidebar--left__icons'>
                     <Pluggable pluggableName='LeftSidebarHeader'/>
                 </div>
+
+                <GlobalThreadsLink/>
+
                 <div
                     id='lhsList'
                     role='application'

--- a/components/sidebar/sidebar_channel_list/__snapshots__/sidebar_channel_list.test.tsx.snap
+++ b/components/sidebar/sidebar_channel_list/__snapshots__/sidebar_channel_list.test.tsx.snap
@@ -1,85 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SidebarChannelList should match snapshot 1`] = `
-<div
-  aria-label="channel sidebar region"
-  className="SidebarNavContainer a11y__region"
-  data-a11y-disable-nav={false}
-  data-a11y-sort-order="7"
-  id="sidebar-left"
-  onTransitionEnd={[Function]}
-  role="application"
->
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
-  <Scrollbars
-    autoHeight={false}
-    autoHeightMax={200}
-    autoHeightMin={0}
-    autoHide={true}
-    autoHideDuration={500}
-    autoHideTimeout={500}
-    hideTracksWhenNotNeeded={false}
-    onScroll={[Function]}
-    renderThumbHorizontal={[Function]}
-    renderThumbVertical={[Function]}
-    renderTrackHorizontal={[Function]}
-    renderTrackVertical={[Function]}
-    renderView={[Function]}
-    style={
-      Object {
-        "position": "absolute",
-      }
-    }
-    tagName="div"
-    thumbMinSize={30}
-    universal={false}
+<Fragment>
+  <GlobalThreadsLink />
+  <div
+    aria-label="channel sidebar region"
+    className="SidebarNavContainer a11y__region"
+    data-a11y-disable-nav={false}
+    data-a11y-sort-order="7"
+    id="sidebar-left"
+    onTransitionEnd={[Function]}
+    role="application"
   >
-    <GlobalThreadsLink />
-    <DragDropContext
-      onBeforeCapture={[Function]}
-      onBeforeDragStart={[Function]}
-      onDragEnd={[Function]}
-      onDragStart={[Function]}
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
     >
-      <Connect(Droppable)
-        direction="vertical"
-        droppableId="droppable-categories"
-        getContainerForClone={[Function]}
-        ignoreContainerClipping={false}
-        isCombineEnabled={false}
-        isDropDisabled={false}
-        mode="standard"
-        renderClone={null}
-        type="SIDEBAR_CATEGORY"
+      <DragDropContext
+        onBeforeCapture={[Function]}
+        onBeforeDragStart={[Function]}
+        onDragEnd={[Function]}
+        onDragStart={[Function]}
       >
-        <Component />
-      </Connect(Droppable)>
-    </DragDropContext>
-  </Scrollbars>
-</div>
+        <Connect(Droppable)
+          direction="vertical"
+          droppableId="droppable-categories"
+          getContainerForClone={[Function]}
+          ignoreContainerClipping={false}
+          isCombineEnabled={false}
+          isDropDisabled={false}
+          mode="standard"
+          renderClone={null}
+          type="SIDEBAR_CATEGORY"
+        >
+          <Component />
+        </Connect(Droppable)>
+      </DragDropContext>
+    </Scrollbars>
+  </div>
+</Fragment>
 `;
 
 exports[`SidebarChannelList should match snapshot 2`] = `

--- a/components/sidebar/sidebar_channel_list/sidebar_channel_list.tsx
+++ b/components/sidebar/sidebar_channel_list/sidebar_channel_list.tsx
@@ -504,47 +504,49 @@ export default class SidebarChannelList extends React.PureComponent<Props, State
         return (
 
             // NOTE: id attribute added to temporarily support the desktop app's at-mention DOM scraping of the old sidebar
-            <div
-                id='sidebar-left'
-                role='application'
-                aria-label={ariaLabel}
-                className={classNames('SidebarNavContainer a11y__region', {
-                    disabled: this.props.isUnreadFilterEnabled,
-                })}
-                data-a11y-disable-nav={Boolean(this.props.draggingState.type)}
-                data-a11y-sort-order='7'
-                onTransitionEnd={this.onTransitionEnd}
-            >
-                <UnreadChannelIndicator
-                    name='Top'
-                    show={this.state.showTopUnread}
-                    onClick={this.scrollToFirstUnreadChannel}
-                    extraClass='nav-pills__unread-indicator-top'
-                    content={above}
-                />
-                <UnreadChannelIndicator
-                    name='Bottom'
-                    show={this.state.showBottomUnread}
-                    onClick={this.scrollToLastUnreadChannel}
-                    extraClass='nav-pills__unread-indicator-bottom'
-                    content={below}
-                />
-                <Scrollbars
-                    ref={this.scrollbar}
-                    autoHide={true}
-                    autoHideTimeout={500}
-                    autoHideDuration={500}
-                    renderThumbHorizontal={renderThumbHorizontal}
-                    renderThumbVertical={renderThumbVertical}
-                    renderTrackVertical={renderTrackVertical}
-                    renderView={renderView}
-                    onScroll={this.onScroll}
-                    style={{position: 'absolute'}}
+            <>
+                <GlobalThreadsLink/>
+                <div
+                    id='sidebar-left'
+                    role='application'
+                    aria-label={ariaLabel}
+                    className={classNames('SidebarNavContainer a11y__region', {
+                        disabled: this.props.isUnreadFilterEnabled,
+                    })}
+                    data-a11y-disable-nav={Boolean(this.props.draggingState.type)}
+                    data-a11y-sort-order='7'
+                    onTransitionEnd={this.onTransitionEnd}
                 >
-                    <GlobalThreadsLink/>
-                    {channelList}
-                </Scrollbars>
-            </div>
+                    <UnreadChannelIndicator
+                        name='Top'
+                        show={this.state.showTopUnread}
+                        onClick={this.scrollToFirstUnreadChannel}
+                        extraClass='nav-pills__unread-indicator-top'
+                        content={above}
+                    />
+                    <UnreadChannelIndicator
+                        name='Bottom'
+                        show={this.state.showBottomUnread}
+                        onClick={this.scrollToLastUnreadChannel}
+                        extraClass='nav-pills__unread-indicator-bottom'
+                        content={below}
+                    />
+                    <Scrollbars
+                        ref={this.scrollbar}
+                        autoHide={true}
+                        autoHideTimeout={500}
+                        autoHideDuration={500}
+                        renderThumbHorizontal={renderThumbHorizontal}
+                        renderThumbVertical={renderThumbVertical}
+                        renderTrackVertical={renderTrackVertical}
+                        renderView={renderView}
+                        onScroll={this.onScroll}
+                        style={{position: 'absolute'}}
+                    >
+                        {channelList}
+                    </Scrollbars>
+                </div>
+            </>
         );
     }
 }

--- a/components/threading/global_threads_link/global_threads_link.scss
+++ b/components/threading/global_threads_link/global_threads_link.scss
@@ -32,7 +32,7 @@
 
 // legacy
 .sidebar--left .SidebarGlobalThreads {
-    margin-top: 10px;
+    margin-top: 13px;
     padding-bottom: 0;
 
     .icon {
@@ -43,10 +43,6 @@
         svg {
             fill: rgba(var(--sidebar-text-rgb), 0.6);
         }
-    }
-
-    + ul .sidebar-section__header {
-        margin-top: 0;
     }
 
     .SidebarChannelLinkLabel_wrapper {

--- a/sass/layout/_legacy-sidebar-left.scss
+++ b/sass/layout/_legacy-sidebar-left.scss
@@ -169,6 +169,10 @@
             padding: 0 12px 0 15px;
             text-transform: uppercase;
             height: 28px;
+
+            &.margin-top--none {
+                margin-top: 0;
+            }
         }
 
         li {


### PR DESCRIPTION
#### Summary

Threads nav menu, both in legacy and regular sidebar, is moved outside
of the scrollable area, so it always 'sticky' at the same position.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35919

#### Release Note

```release-note
NONE
```
