### PR TITLE
MM-35191 - show banner in user timezone

### DIFF
--- a/components/admin_console/billing/billing_summary/billing_summary.tsx
+++ b/components/admin_console/billing/billing_summary/billing_summary.tsx
@@ -94,7 +94,7 @@ export const freeTrial = (onUpgradeMattermostCloud: () => void, daysLeftOnTrial:
             <img src={upgradeMattermostCloudImage}/>
         </div>
         <div className='UpgradeMattermostCloud__title'>
-            {(daysLeftOnTrial !== TrialPeriodDays.TRIAL_1_DAY && daysLeftOnTrial !== TrialPeriodDays.TRIAL_0_DAYS) &&
+            {daysLeftOnTrial > TrialPeriodDays.TRIAL_1_DAY &&
                 <FormattedMessage
                     id='admin.billing.subscription.freeTrial.title'
                     defaultMessage={'You\'re currently on a free trial'}

--- a/components/admin_console/billing/billing_summary/billing_summary.tsx
+++ b/components/admin_console/billing/billing_summary/billing_summary.tsx
@@ -100,7 +100,7 @@ export const freeTrial = (onUpgradeMattermostCloud: () => void, daysLeftOnTrial:
                     defaultMessage={'You\'re currently on a free trial'}
                 />
             }
-            {daysLeftOnTrial === TrialPeriodDays.TRIAL_1_DAY &&
+            {(daysLeftOnTrial === TrialPeriodDays.TRIAL_1_DAY || daysLeftOnTrial === TrialPeriodDays.TRIAL_0_DAYS) &&
                 <FormattedMessage
                     id='admin.billing.subscription.freeTrial.lastDay.title'
                     defaultMessage={'Your free trial ends today'}
@@ -122,7 +122,7 @@ export const freeTrial = (onUpgradeMattermostCloud: () => void, daysLeftOnTrial:
                     values={{daysLeftOnTrial}}
                 />
             }
-            {(daysLeftOnTrial === TrialPeriodDays.TRIAL_1_DAY) &&
+            {(daysLeftOnTrial === TrialPeriodDays.TRIAL_1_DAY || daysLeftOnTrial === TrialPeriodDays.TRIAL_0_DAYS) &&
                 <FormattedMarkdownMessage
                     id='admin.billing.subscription.freeTrial.lastDay.description'
                     defaultMessage='Your free trial has ended. Add payment information to continue enjoying the benefits of Cloud Professional.'

--- a/components/admin_console/billing/billing_summary/billing_summary.tsx
+++ b/components/admin_console/billing/billing_summary/billing_summary.tsx
@@ -94,7 +94,7 @@ export const freeTrial = (onUpgradeMattermostCloud: () => void, daysLeftOnTrial:
             <img src={upgradeMattermostCloudImage}/>
         </div>
         <div className='UpgradeMattermostCloud__title'>
-            {daysLeftOnTrial !== TrialPeriodDays.TRIAL_1_DAY &&
+            {(daysLeftOnTrial !== TrialPeriodDays.TRIAL_1_DAY && daysLeftOnTrial !== TrialPeriodDays.TRIAL_0_DAYS) &&
                 <FormattedMessage
                     id='admin.billing.subscription.freeTrial.title'
                     defaultMessage={'You\'re currently on a free trial'}

--- a/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
@@ -165,13 +165,14 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
             />
         );
 
-        const userEndTrialHour = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'MMMM Do YYYY, HH:mm:ss', this.props.currentUser.timezone?.automaticTimezone as string);
+        const userEndTrialDate = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'MMMM Do YYYY', this.props.currentUser.timezone?.automaticTimezone as string);
+        const userEndTrialHour = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'HH:mm:ss', this.props.currentUser.timezone?.automaticTimezone as string);
 
         const trialLastDaysMsg = (
             <FormattedMessage
                 id='admin.billing.subscription.cloudTrial.lastDay'
-                defaultMessage='This is the last day of your free trial. Your access will expire at {userEndTrialHour}.'
-                values={{userEndTrialHour}}
+                defaultMessage='This is the last day of your free trial. Your access will expire on {userEndTrialDate} at {userEndTrialHour}.'
+                values={{userEndTrialHour, userEndTrialDate}}
             />
         );
 

--- a/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
@@ -51,7 +51,8 @@ enum TrialPeriodDays {
     TRIAL_14_DAYS = 14,
     TRIAL_3_DAYS = 3,
     TRIAL_2_DAYS = 2,
-    TRIAL_1_DAY = 1
+    TRIAL_1_DAY = 1,
+    TRIAL_0_DAYS = 0
 }
 
 class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
@@ -164,12 +165,12 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
             />
         );
 
-        const userEndTrialHour = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'MMMM Do YYYY, HH:mm:ss');
+        const userEndTrialHour = getLocaleDateFromUTC(1623326400, 'MMMM Do YYYY, HH:mm:ss', this.props.currentUser.timezone?.automaticTimezone as string);
 
         const trialLastDaysMsg = (
             <FormattedMessage
                 id='admin.billing.subscription.cloudTrial.lastDay'
-                defaultMessage='This is the last day of your free trial. Your access will expire at {userEndTrialHour} PT.'
+                defaultMessage='This is the last day of your free trial. Your access will expire at {userEndTrialHour}.'
                 values={{userEndTrialHour}}
             />
         );
@@ -182,6 +183,7 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
             bannerMessage = trialLessThan3DaysMsg;
             break;
         case TrialPeriodDays.TRIAL_1_DAY:
+        case TrialPeriodDays.TRIAL_0_DAYS:
             bannerMessage = trialLastDaysMsg;
             break;
         default:

--- a/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
@@ -165,7 +165,7 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
             />
         );
 
-        const userEndTrialDate = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'MMMM Do YYYY', this.props.currentUser.timezone?.automaticTimezone as string);
+        const userEndTrialDate = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'MMMM Do YYYY');
         const userEndTrialHour = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'HH:mm:ss', this.props.currentUser.timezone?.automaticTimezone as string);
 
         const trialLastDaysMsg = (

--- a/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
@@ -28,6 +28,7 @@ import {
 
 import AnnouncementBar from '../default_announcement_bar';
 import withGetCloudSubscription from '../../common/hocs/cloud/with_get_cloud_subscription';
+import {getLocaleDateFromUTC} from 'utils/utils';
 
 type Props = {
     userIsAdmin: boolean;
@@ -163,6 +164,16 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
             />
         );
 
+        const userEndTrialHour = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'MMMM Do YYYY, HH:mm:ss');
+
+        const trialLastDaysMsg = (
+            <FormattedMessage
+                id='admin.billing.subscription.cloudTrial.lastDay'
+                defaultMessage='This is the last day of your free trial. Your access will expire at {userEndTrialHour} PT.'
+                values={{userEndTrialHour}}
+            />
+        );
+
         let bannerMessage;
         let icon;
         switch (daysLeftOnTrial) {
@@ -171,7 +182,7 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
             bannerMessage = trialLessThan3DaysMsg;
             break;
         case TrialPeriodDays.TRIAL_1_DAY:
-            bannerMessage = t('admin.billing.subscription.cloudTrial.lastDay');
+            bannerMessage = trialLastDaysMsg;
             break;
         default:
             bannerMessage = trialMoreThan3DaysMsg;

--- a/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
+++ b/components/announcement_bar/cloud_trial_announcement_bar/cloud_trial_announcement_bar.tsx
@@ -165,7 +165,7 @@ class CloudTrialAnnouncementBar extends React.PureComponent<Props> {
             />
         );
 
-        const userEndTrialHour = getLocaleDateFromUTC(1623326400, 'MMMM Do YYYY, HH:mm:ss', this.props.currentUser.timezone?.automaticTimezone as string);
+        const userEndTrialHour = getLocaleDateFromUTC((this.props.subscription?.trial_end_at as number / 1000), 'MMMM Do YYYY, HH:mm:ss', this.props.currentUser.timezone?.automaticTimezone as string);
 
         const trialLastDaysMsg = (
             <FormattedMessage

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -268,7 +268,7 @@
   "admin.billing.subscription.cancelSubscriptionSection.description": "At this time, deleting a workspace can only be done with the help of a customer support representative.",
   "admin.billing.subscription.cancelSubscriptionSection.title": "Cancel your subscription",
   "admin.billing.subscription.cloudTrial.daysLeftOnTrial": "There are {daysLeftOnTrial} days left on your free trial",
-  "admin.billing.subscription.cloudTrial.lastDay": "This is the last day of your free trial. Your access will expire today at 11:59pm PT.",
+  "admin.billing.subscription.cloudTrial.lastDay": "This is the last day of your free trial. Your access will expire at {userEndTrialHour} PT.",
   "admin.billing.subscription.cloudTrial.moreThan3Days": "Your trial has started! There are {daysLeftOnTrial} days left",
   "admin.billing.subscription.cloudTrial.subscribe": "Subscribe",
   "admin.billing.subscription.cloudTrial.subscribeButton": "Subscribe Now",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -268,7 +268,7 @@
   "admin.billing.subscription.cancelSubscriptionSection.description": "At this time, deleting a workspace can only be done with the help of a customer support representative.",
   "admin.billing.subscription.cancelSubscriptionSection.title": "Cancel your subscription",
   "admin.billing.subscription.cloudTrial.daysLeftOnTrial": "There are {daysLeftOnTrial} days left on your free trial",
-  "admin.billing.subscription.cloudTrial.lastDay": "This is the last day of your free trial. Your access will expire at {userEndTrialHour} PT.",
+  "admin.billing.subscription.cloudTrial.lastDay": "This is the last day of your free trial. Your access will expire at {userEndTrialHour}.",
   "admin.billing.subscription.cloudTrial.moreThan3Days": "Your trial has started! There are {daysLeftOnTrial} days left",
   "admin.billing.subscription.cloudTrial.subscribe": "Subscribe",
   "admin.billing.subscription.cloudTrial.subscribeButton": "Subscribe Now",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -268,7 +268,7 @@
   "admin.billing.subscription.cancelSubscriptionSection.description": "At this time, deleting a workspace can only be done with the help of a customer support representative.",
   "admin.billing.subscription.cancelSubscriptionSection.title": "Cancel your subscription",
   "admin.billing.subscription.cloudTrial.daysLeftOnTrial": "There are {daysLeftOnTrial} days left on your free trial",
-  "admin.billing.subscription.cloudTrial.lastDay": "This is the last day of your free trial. Your access will expire at {userEndTrialHour}.",
+  "admin.billing.subscription.cloudTrial.lastDay": "This is the last day of your free trial. Your access will expire on {userEndTrialDate} at {userEndTrialHour}.",
   "admin.billing.subscription.cloudTrial.moreThan3Days": "Your trial has started! There are {daysLeftOnTrial} days left",
   "admin.billing.subscription.cloudTrial.subscribe": "Subscribe",
   "admin.billing.subscription.cloudTrial.subscribeButton": "Subscribe Now",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -268,7 +268,7 @@
   "admin.billing.subscription.cancelSubscriptionSection.description": "At this time, deleting a workspace can only be done with the help of a customer support representative.",
   "admin.billing.subscription.cancelSubscriptionSection.title": "Cancel your subscription",
   "admin.billing.subscription.cloudTrial.daysLeftOnTrial": "There are {daysLeftOnTrial} days left on your free trial",
-  "admin.billing.subscription.cloudTrial.lastDay": "This is the last day of your free trial. Your access will expire at 23:59 GMT-7.",
+  "admin.billing.subscription.cloudTrial.lastDay": "This is the last day of your free trial. Your access will expire on {userEndTrialDate} at {userEndTrialHour}.",
   "admin.billing.subscription.cloudTrial.moreThan3Days": "Your trial has started! There are {daysLeftOnTrial} days left",
   "admin.billing.subscription.cloudTrial.subscribe": "Subscribe",
   "admin.billing.subscription.cloudTrial.subscribeButton": "Subscribe Now",

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -259,6 +259,13 @@ export function getRemainingDaysFromFutureTimestamp(timestamp) {
     return Math.floor((utcFuture - utcToday) / MS_PER_DAY);
 }
 
+export function getLocaleDateFromUTC(timestamp, format = 'YYYY/MM/DD HH:mm:ss') {
+    if (!timestamp) {
+        return moment.now();
+    }
+    return moment.unix(timestamp).format(format);
+}
+
 // Replaces all occurrences of a pattern
 export function loopReplacePattern(text, pattern, replacement) {
     let result = text;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -259,11 +259,12 @@ export function getRemainingDaysFromFutureTimestamp(timestamp) {
     return Math.floor((utcFuture - utcToday) / MS_PER_DAY);
 }
 
-export function getLocaleDateFromUTC(timestamp, format = 'YYYY/MM/DD HH:mm:ss') {
+export function getLocaleDateFromUTC(timestamp, format = 'YYYY/MM/DD HH:mm:ss', userTimezone = '') {
     if (!timestamp) {
         return moment.now();
     }
-    return moment.unix(timestamp).format(format);
+    const timezone = userTimezone ? ' ' + moment().tz(userTimezone).format('z') : '';
+    return moment.unix(timestamp).format(format) + timezone;
 }
 
 // Replaces all occurrences of a pattern


### PR DESCRIPTION
#### Summary
Show cloud trial banner last day notification date in user local date timezone.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35191

https://mattermost.atlassian.net/browse/MM-36328


#### Screenshots
<img width="1011" alt="Captura de pantalla 2021-06-09 a las 20 49 32" src="https://user-images.githubusercontent.com/10082627/121411864-5e3e8400-c964-11eb-80c6-dbc9328a8bea.png">
<img width="1652" alt="Captura de pantalla 2021-06-09 a las 20 50 22" src="https://user-images.githubusercontent.com/10082627/121411880-61397480-c964-11eb-83c5-27e9aa84b44f.png">


#### Release Note
```release-note
NONE
```
