### PR TITLE
Cypress/E2E: Update Zephyr Scale API URL

### DIFF
--- a/e2e/utils/test_cases.js
+++ b/e2e/utils/test_cases.js
@@ -102,7 +102,7 @@ async function createTestCycle(startDate, endDate) {
         folderId: TM4J_FOLDER_ID,
     };
 
-    const response = await saveToEndpoint('https://api.adaptavist.io/tm4j/v2/testcycles', testCycle);
+    const response = await saveToEndpoint('https://api.zephyrscale.smartbear.com/v2/testcycles', testCycle);
     return response.data;
 }
 
@@ -169,7 +169,7 @@ const RETRY = [];
 async function saveTestExecution(testExecution, index) {
     await axios({
         method: 'POST',
-        url: 'https://api.adaptavist.io/tm4j/v2/testexecutions',
+        url: 'https://api.zephyrscale.smartbear.com/v2/testexecutions',
         headers: {
             'Content-Type': 'application/json; charset=utf-8',
             Authorization: process.env.TM4J_API_KEY,


### PR DESCRIPTION
#### Summary
- Need to update the API base url for zephyr to `https://api.zephyrscale.smartbear.com/v2`

Please see announcement here:
https://app.getbeamer.com/zephyrscale/en/breaking-changes-on-the-rest-api
https://support.smartbear.com/zephyr-scale-cloud/api-docs/

Note: I'm only updating repo from MM org. I also see the soon-to-be-obsolete URL `https://api.adaptavist.io/tm4j/v2` on Saturn's codebase but I'll let him update those in his own time.

#### Ticket Link
NA

#### Release Note
```release-note
NONE
```