### PR TITLE
MM-35806: shows participants when turning CRT on

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/posts.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/posts.test.js
@@ -73,6 +73,36 @@ describe('posts', () => {
                 });
             });
 
+            it('should add a newer post', () => {
+                const state = deepFreeze({
+                    post1: {id: 'post1', message: '123', update_at: 100},
+                });
+
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {id: 'post1', message: 'abc', update_at: 400},
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState.post1).not.toBe(state.post1);
+                expect(nextState).toEqual({
+                    post1: {id: 'post1', message: 'abc', update_at: 400},
+                });
+            });
+
+            it('should not add an older post', () => {
+                const state = deepFreeze({
+                    post1: {id: 'post1', message: '123', update_at: 400},
+                });
+
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {id: 'post1', message: 'abc', update_at: 100},
+                });
+
+                expect(nextState.post1).toBe(state.post1);
+            });
+
             it('should remove any pending posts when receiving the actual post', () => {
                 const state = deepFreeze({
                     pending: {id: 'pending'},

--- a/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -23,7 +23,7 @@ import {
     RelationOneToMany,
 } from 'mattermost-redux/types/utilities';
 
-import {comparePosts} from 'mattermost-redux/utils/post_utils';
+import {comparePosts, shouldUpdatePost} from 'mattermost-redux/utils/post_utils';
 
 export function removeUnneededMetadata(post: Post) {
     if (!post.metadata) {
@@ -262,8 +262,7 @@ export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: Ge
 }
 
 function handlePostReceived(nextState: any, post: Post) {
-    if (nextState[post.id] && nextState[post.id].update_at >= post.update_at) {
-        // The stored post is newer than the one we've received
+    if (!shouldUpdatePost(post, nextState[post.id])) {
         return nextState;
     }
 

--- a/packages/mattermost-redux/src/utils/post_utils.test.js
+++ b/packages/mattermost-redux/src/utils/post_utils.test.js
@@ -15,6 +15,7 @@ import {
     shouldFilterJoinLeavePost,
     isPostCommentMention,
     getEmbedFromMetadata,
+    shouldUpdatePost,
 } from 'mattermost-redux/utils/post_utils';
 
 describe('PostUtils', () => {
@@ -557,6 +558,76 @@ describe('PostUtils', () => {
             const embedValue = {type: 'opengraph', url: 'url'};
             const embedData = getEmbedFromMetadata({embeds: [embedValue, {type: 'image', url: 'url1'}]});
             assert.equal(embedData, embedValue);
+        });
+    });
+
+    describe('shouldUpdatePost', () => {
+        const storedPost = {
+            id: 'post1',
+            message: '123',
+            update_at: 100,
+            is_following: false,
+            participants: null,
+            reply_count: 4,
+        };
+
+        it('should return true for new posts', () => {
+            const post = {
+                ...storedPost,
+                update_at: 100,
+            };
+
+            expect(shouldUpdatePost(post, null)).toBe(true);
+        });
+
+        it('should return false for older posts', () => {
+            const post = {
+                ...storedPost,
+                update_at: 40,
+            };
+
+            expect(shouldUpdatePost(post, storedPost)).toBe(false);
+        });
+
+        it('should return true for newer posts', () => {
+            const post = {
+                id: 'post1',
+                message: 'test',
+                update_at: 400,
+                is_following: false,
+                participants: null,
+                reply_count: 4,
+            };
+            expect(shouldUpdatePost(post, storedPost)).toBe(true);
+        });
+
+        it('should return false for same posts', () => {
+            const post = {...storedPost};
+            expect(shouldUpdatePost(post, storedPost)).toBe(false);
+        });
+
+        it('should return true for same posts with participants changed', () => {
+            const post = {
+                ...storedPost,
+                participants: [],
+            };
+            expect(shouldUpdatePost(post, storedPost)).toBe(true);
+        });
+
+        it('should return true for same posts with reply_count changed', () => {
+            const post = {
+                ...storedPost,
+                reply_count: 2,
+            };
+            expect(shouldUpdatePost(post, storedPost)).toBe(true);
+        });
+
+        it('should return true for same posts with is_following changed', () => {
+            const post = {
+                ...storedPost,
+                is_following: true,
+            };
+            expect(shouldUpdatePost(post, storedPost)).toBe(true);
         });
     });
 });

--- a/packages/mattermost-redux/src/utils/post_utils.ts
+++ b/packages/mattermost-redux/src/utils/post_utils.ts
@@ -228,3 +228,36 @@ export function getEmbedFromMetadata(metadata: PostMetadata): PostEmbed | null {
 
     return metadata.embeds[0];
 }
+
+export function shouldUpdatePost(receivedPost: Post, storedPost?: Post): boolean {
+    if (!storedPost) {
+        return true;
+    }
+
+    if (storedPost.update_at > receivedPost.update_at) {
+        // The stored post is newer than the one we've received
+        return false;
+    }
+
+    if (
+        storedPost.update_at && receivedPost.update_at &&
+        storedPost.update_at === receivedPost.update_at
+    ) {
+        // The stored post has the same update at with the one we've received
+        if (
+            storedPost.is_following !== receivedPost.is_following ||
+            storedPost.reply_count !== receivedPost.reply_count ||
+            storedPost.participants?.length !== receivedPost.participants?.length
+        ) {
+            // CRT properties are not the same between posts
+            // e.g: in the case of toggling CRT on/off
+            return true;
+        }
+
+        // The stored post is the same as the one we've received
+        return false;
+    }
+
+    // The stored post is older than the one we've received
+    return true;
+}


### PR DESCRIPTION
#### Summary

Toggling CRT 'on' wouldn't show participants at all for unfollowed
posts.
We short-circuit receiving posts in the reducers based on old/new
post's `update_at` property. Posts have some extra properties though
which didn't got updated in redux when toggling CRT on.

This commit refactors the short-circuit into a `shouldUpdatePost` utility function,
taking into account not only the `update_at` but the CRT posts' extra
properties.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35806

#### Release Note

```release-note
NONE
```
