### PR TITLE
MM-35853 Properly memoize getUserTimezone selector

### DIFF
--- a/actions/views/rhs.ts
+++ b/actions/views/rhs.ts
@@ -132,7 +132,7 @@ export function performSearch(terms: string, isMentionSearch?: boolean) {
 
         // timezone offset in seconds
         const userId = getCurrentUserId(getState());
-        const userTimezone = getUserTimezone(getState(), userId);
+        const userTimezone = getUserTimezone(getState().entities.users.profiles, userId);
         const userCurrentTimezone = getUserCurrentTimezone(userTimezone);
         const timezoneOffset = ((userCurrentTimezone && (userCurrentTimezone.length > 0)) ? getUtcOffsetForTimeZone(userCurrentTimezone) : getBrowserUtcOffset()) * 60;
         const messagesPromise = dispatch(searchPostsWithParams(teamId, {terms, is_or_search: Boolean(isMentionSearch), include_deleted_channels: viewArchivedChannels, time_zone_offset: timezoneOffset, page: 0, per_page: 20}));

--- a/components/status_dropdown/index.ts
+++ b/components/status_dropdown/index.ts
@@ -20,20 +20,23 @@ import {GlobalState} from 'types/store';
 
 import StatusDropdown from './status_dropdown';
 
-function mapStateToProps(state: GlobalState) {
-    const currentUser = getCurrentUser(state);
+function makeMapStateToProps() {
     const getCustomStatus = makeGetCustomStatus();
 
-    const userId = currentUser?.id;
-    return {
-        userId,
-        profilePicture: Client4.getProfilePictureUrl(userId, currentUser?.last_picture_update),
-        autoResetPref: get(state, Preferences.CATEGORY_AUTO_RESET_MANUAL_STATUS, userId, ''),
-        status: getStatusForUserId(state, userId),
-        customStatus: getCustomStatus(state, userId),
-        isCustomStatusEnabled: isCustomStatusEnabled(state),
-        isStatusDropdownOpen: isStatusDropdownOpen(state),
-        showCustomStatusPulsatingDot: showStatusDropdownPulsatingDot(state),
+    return (state: GlobalState) => {
+        const currentUser = getCurrentUser(state);
+
+        const userId = currentUser?.id;
+        return {
+            userId,
+            profilePicture: Client4.getProfilePictureUrl(userId, currentUser?.last_picture_update),
+            autoResetPref: get(state, Preferences.CATEGORY_AUTO_RESET_MANUAL_STATUS, userId, ''),
+            status: getStatusForUserId(state, userId),
+            customStatus: getCustomStatus(state, userId),
+            isCustomStatusEnabled: isCustomStatusEnabled(state),
+            isStatusDropdownOpen: isStatusDropdownOpen(state),
+            showCustomStatusPulsatingDot: showStatusDropdownPulsatingDot(state),
+        };
     };
 }
 
@@ -48,4 +51,4 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(StatusDropdown);
+export default connect(makeMapStateToProps, mapDispatchToProps)(StatusDropdown);

--- a/components/suggestion/search_date_suggestion/index.ts
+++ b/components/suggestion/search_date_suggestion/index.ts
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
+import {makeGetUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 
 import {getCurrentDateForTimezone} from 'utils/timezone';
 import {areTimezonesEnabledAndSupported} from 'selectors/general';
@@ -14,26 +14,30 @@ import {GlobalState} from 'types/store';
 
 import SearchDateSuggestion from './search_date_suggestion';
 
-function mapStateToProps(state: GlobalState) {
-    const currentUserId = getCurrentUserId(state);
-    const userTimezone = getUserTimezone(state, currentUserId);
-    const locale = getCurrentLocale(state);
+function makeMapStateToProps() {
+    const getUserTimezone = makeGetUserTimezone();
 
-    const enableTimezone = areTimezonesEnabledAndSupported(state);
+    return (state: GlobalState) => {
+        const currentUserId = getCurrentUserId(state);
+        const userTimezone = getUserTimezone(state, currentUserId);
+        const locale = getCurrentLocale(state);
 
-    let currentDate;
-    if (enableTimezone) {
-        if (userTimezone.useAutomaticTimezone) {
-            currentDate = getCurrentDateForTimezone(userTimezone.automaticTimezone);
-        } else {
-            currentDate = getCurrentDateForTimezone(userTimezone.manualTimezone);
+        const enableTimezone = areTimezonesEnabledAndSupported(state);
+
+        let currentDate;
+        if (enableTimezone) {
+            if (userTimezone.useAutomaticTimezone) {
+                currentDate = getCurrentDateForTimezone(userTimezone.automaticTimezone);
+            } else {
+                currentDate = getCurrentDateForTimezone(userTimezone.manualTimezone);
+            }
         }
-    }
 
-    return {
-        currentDate,
-        locale,
+        return {
+            currentDate,
+            locale,
+        };
     };
 }
 
-export default connect(mapStateToProps)(SearchDateSuggestion);
+export default connect(makeMapStateToProps)(SearchDateSuggestion);

--- a/components/timestamp/index.ts
+++ b/components/timestamp/index.ts
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
+import {makeGetUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {UserTimezone} from 'mattermost-redux/types/users';
@@ -21,29 +21,33 @@ type Props = {
     userTimezone?: UserTimezone;
 }
 
-function mapStateToProps(state: GlobalState, {userTimezone}: Props) {
-    const currentUserId = getCurrentUserId(state);
+function makeMapStateToProps() {
+    const getUserTimezone = makeGetUserTimezone();
 
-    let timeZone: TimestampProps['timeZone'];
-    let hourCycle: TimestampProps['hourCycle'];
-    let hour12: TimestampProps['hour12'];
+    return (state: GlobalState, {userTimezone}: Props) => {
+        const currentUserId = getCurrentUserId(state);
 
-    if (areTimezonesEnabledAndSupported(state)) {
-        timeZone = getUserCurrentTimezone(userTimezone ?? getUserTimezone(state, currentUserId)) ?? undefined;
-    }
+        let timeZone: TimestampProps['timeZone'];
+        let hourCycle: TimestampProps['hourCycle'];
+        let hour12: TimestampProps['hour12'];
 
-    const useMilitaryTime = getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false);
+        if (areTimezonesEnabledAndSupported(state)) {
+            timeZone = getUserCurrentTimezone(userTimezone ?? getUserTimezone(state, currentUserId)) ?? undefined;
+        }
 
-    if (supportsHourCycle) {
-        hourCycle = useMilitaryTime ? 'h23' : 'h12';
-    } else {
-        hour12 = !useMilitaryTime;
-    }
+        const useMilitaryTime = getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false);
 
-    return {timeZone, hourCycle, hour12};
+        if (supportsHourCycle) {
+            hourCycle = useMilitaryTime ? 'h23' : 'h12';
+        } else {
+            hour12 = !useMilitaryTime;
+        }
+
+        return {timeZone, hourCycle, hour12};
+    };
 }
 
-export default connect(mapStateToProps)(Timestamp);
+export default connect(makeMapStateToProps)(Timestamp);
 
 export {default as SemanticTime} from './semantic_time';
 import * as RelativeRanges from './relative_ranges';

--- a/components/user_settings/display/index.ts
+++ b/components/user_settings/display/index.ts
@@ -13,7 +13,7 @@ import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getConfig, getSupportedTimezones as getTimezones, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {get, isCollapsedThreadsAllowed, getCollapsedThreadsPreference} from 'mattermost-redux/selectors/entities/preferences';
-import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
+import {makeGetUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
 
 import {Preferences} from 'utils/constants';
@@ -22,42 +22,46 @@ import {GlobalState} from 'types/store';
 
 import UserSettingsDisplay from './user_settings_display';
 
-function mapStateToProps(state: GlobalState) {
-    const config = getConfig(state);
-    const timezones = getTimezones(state);
-    const currentUserId = getCurrentUserId(state);
-    const userTimezone = getUserTimezone(state, currentUserId);
-    const automaticTimezoneNotSet = userTimezone && userTimezone.useAutomaticTimezone && !userTimezone.automaticTimezone;
-    const shouldAutoUpdateTimezone = !userTimezone || automaticTimezoneNotSet;
-    const allowCustomThemes = config.AllowCustomThemes === 'true';
-    const enableLinkPreviews = config.EnableLinkPreviews === 'true';
-    const defaultClientLocale = config.DefaultClientLocale as string;
-    const enableThemeSelection = config.EnableThemeSelection === 'true';
-    const enableTimezone = config.ExperimentalTimezone === 'true';
-    const lockTeammateNameDisplay = getLicense(state).LockTeammateNameDisplay === 'true' && config.LockTeammateNameDisplay === 'true';
-    const configTeammateNameDisplay = config.TeammateNameDisplay as string;
+function makeMapStateToProps() {
+    const getUserTimezone = makeGetUserTimezone();
 
-    return {
-        lockTeammateNameDisplay,
-        allowCustomThemes,
-        configTeammateNameDisplay,
-        enableLinkPreviews,
-        defaultClientLocale,
-        enableThemeSelection,
-        enableTimezone,
-        timezones,
-        userTimezone,
-        shouldAutoUpdateTimezone,
-        currentUserTimezone: getUserCurrentTimezone(userTimezone) as string,
-        availabilityStatusOnPosts: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AVAILABILITY_STATUS_ON_POSTS, Preferences.AVAILABILITY_STATUS_ON_POSTS_DEFAULT),
-        militaryTime: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, Preferences.USE_MILITARY_TIME_DEFAULT),
-        teammateNameDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.NAME_NAME_FORMAT, configTeammateNameDisplay),
-        channelDisplayMode: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT),
-        messageDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT),
-        collapseDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSE_DISPLAY, Preferences.COLLAPSE_DISPLAY_DEFAULT),
-        collapsedReplyThreadsAllowUserPreference: isCollapsedThreadsAllowed(state) && getConfig(state).CollapsedThreads as string !== 'always_on',
-        collapsedReplyThreads: getCollapsedThreadsPreference(state),
-        linkPreviewDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, Preferences.LINK_PREVIEW_DISPLAY_DEFAULT),
+    return (state: GlobalState) => {
+        const config = getConfig(state);
+        const timezones = getTimezones(state);
+        const currentUserId = getCurrentUserId(state);
+        const userTimezone = getUserTimezone(state, currentUserId);
+        const automaticTimezoneNotSet = userTimezone && userTimezone.useAutomaticTimezone && !userTimezone.automaticTimezone;
+        const shouldAutoUpdateTimezone = !userTimezone || automaticTimezoneNotSet;
+        const allowCustomThemes = config.AllowCustomThemes === 'true';
+        const enableLinkPreviews = config.EnableLinkPreviews === 'true';
+        const defaultClientLocale = config.DefaultClientLocale as string;
+        const enableThemeSelection = config.EnableThemeSelection === 'true';
+        const enableTimezone = config.ExperimentalTimezone === 'true';
+        const lockTeammateNameDisplay = getLicense(state).LockTeammateNameDisplay === 'true' && config.LockTeammateNameDisplay === 'true';
+        const configTeammateNameDisplay = config.TeammateNameDisplay as string;
+
+        return {
+            lockTeammateNameDisplay,
+            allowCustomThemes,
+            configTeammateNameDisplay,
+            enableLinkPreviews,
+            defaultClientLocale,
+            enableThemeSelection,
+            enableTimezone,
+            timezones,
+            userTimezone,
+            shouldAutoUpdateTimezone,
+            currentUserTimezone: getUserCurrentTimezone(userTimezone) as string,
+            availabilityStatusOnPosts: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.AVAILABILITY_STATUS_ON_POSTS, Preferences.AVAILABILITY_STATUS_ON_POSTS_DEFAULT),
+            militaryTime: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, Preferences.USE_MILITARY_TIME_DEFAULT),
+            teammateNameDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.NAME_NAME_FORMAT, configTeammateNameDisplay),
+            channelDisplayMode: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT),
+            messageDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT),
+            collapseDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSE_DISPLAY, Preferences.COLLAPSE_DISPLAY_DEFAULT),
+            collapsedReplyThreadsAllowUserPreference: isCollapsedThreadsAllowed(state) && getConfig(state).CollapsedThreads as string !== 'always_on',
+            collapsedReplyThreads: getCollapsedThreadsPreference(state),
+            linkPreviewDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, Preferences.LINK_PREVIEW_DISPLAY_DEFAULT),
+        };
     };
 }
 
@@ -71,4 +75,4 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(UserSettingsDisplay);
+export default connect(makeMapStateToProps, mapDispatchToProps)(UserSettingsDisplay);

--- a/packages/mattermost-redux/src/actions/timezone.ts
+++ b/packages/mattermost-redux/src/actions/timezone.ts
@@ -6,10 +6,11 @@ import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {updateMe} from './users';
+
 export function autoUpdateTimezone(deviceTimezone: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const currentUer = getCurrentUser(getState());
-        const currentTimezone = getUserTimezone(getState(), currentUer.id);
+        const currentUser = getCurrentUser(getState());
+        const currentTimezone = getUserTimezone(getState().entities.users.profiles, currentUser.id);
         const newTimezoneExists = currentTimezone.automaticTimezone !== deviceTimezone;
 
         if (currentTimezone.useAutomaticTimezone && newTimezoneExists) {
@@ -20,7 +21,7 @@ export function autoUpdateTimezone(deviceTimezone: string) {
             };
 
             const updatedUser = {
-                ...currentUer,
+                ...currentUser,
                 timezone,
             };
 

--- a/packages/mattermost-redux/src/selectors/entities/timezone.ts
+++ b/packages/mattermost-redux/src/selectors/entities/timezone.ts
@@ -7,9 +7,9 @@ import {getUsers} from 'mattermost-redux/selectors/entities/users';
 
 import {GlobalState} from 'mattermost-redux/types/store';
 import {IDMappedObjects} from 'mattermost-redux/types/utilities';
-import {UserProfile} from 'mattermost-redux/types/users';
+import {UserProfile, UserTimezone} from 'mattermost-redux/types/users';
 
-export function getUserTimezone(users: IDMappedObjects<UserProfile>, id: string): { useAutomaticTimezone: boolean; automaticTimezone: string; manualTimezone: string } {
+export function getUserTimezone(users: IDMappedObjects<UserProfile>, id: string): UserTimezone {
     const profile = users[id];
 
     if (profile && profile.timezone) {

--- a/packages/mattermost-redux/src/selectors/entities/timezone.ts
+++ b/packages/mattermost-redux/src/selectors/entities/timezone.ts
@@ -1,10 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {GlobalState} from 'mattermost-redux/types/store';
+import {createSelector} from 'reselect';
 
-export function getUserTimezone(state: GlobalState, id: string) {
-    const profile = state.entities.users.profiles[id];
+import {getUsers} from 'mattermost-redux/selectors/entities/users';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+import {IDMappedObjects} from 'mattermost-redux/types/utilities';
+import {UserProfile} from 'mattermost-redux/types/users';
+
+export function getUserTimezone(users: IDMappedObjects<UserProfile>, id: string): { useAutomaticTimezone: boolean; automaticTimezone: string; manualTimezone: string } {
+    const profile = users[id];
 
     if (profile && profile.timezone) {
         return {
@@ -18,6 +24,16 @@ export function getUserTimezone(state: GlobalState, id: string) {
         automaticTimezone: '',
         manualTimezone: '',
     };
+}
+
+export function makeGetUserTimezone() {
+    return createSelector(
+        getUsers,
+        (state: GlobalState, id: string) => id,
+        (users, id) => {
+            return getUserTimezone(users, id);
+        },
+    );
 }
 
 export function isTimezoneEnabled(state: GlobalState) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Added makeGetUserTimezone selector creator and updated getUserTimezone to require the user map being passed in.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35853

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
