### PR TITLE
MM-36257 Handle is_following not being set for edited posts

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -267,6 +267,11 @@ function handlePostReceived(nextState: any, post: Post) {
         return nextState;
     }
 
+    // Edited posts that don't have 'is_following' specified should maintain 'is_following' state
+    if (post.update_at > 0 && post.is_following == null && nextState[post.id]) {
+        post.is_following = nextState[post.id].is_following;
+    }
+
     if (post.delete_at > 0) {
         // We've received a deleted post, so mark the post as deleted if we already have it
         if (nextState[post.id]) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Companion PR to https://github.com/mattermost/mattermost-server/pull/17774 to appropriately handle 'is_following' not being set in responses to updated posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36257

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (https://github.com/mattermost/mattermost-server/pull/17774)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
