### PR TITLE
decreased opacity on muted channels for bot-icons and avatars (with a…

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -984,7 +984,7 @@
         }
 
         &.muted {
-            div.SidebarChannelLinkLabel_wrapper, > i, .status.status--group, .badge {
+            div.SidebarChannelLinkLabel_wrapper, > i, .status.status--group, .badge, .status-wrapper {
                 opacity: 0.4;
             }
         }


### PR DESCRIPTION
#### Summary
decreased opacity on muted channels for bot-icons and avatars (with and without status icon)

#### Ticket Link
[MM-36357](https://mattermost.atlassian.net/browse/MM-36357)

#### Screenshots
| Before | After |
|-------|-------|
|<img width="223" alt="Screenshot 2021-06-15 at 16 31 08" src="https://user-images.githubusercontent.com/32863416/122071575-2073ac80-cdf7-11eb-85f5-85813053ac16.png">|<img width="223" alt="Screenshot 2021-06-15 at 16 23 44" src="https://user-images.githubusercontent.com/32863416/122070340-2c12a380-cdf6-11eb-88c5-c66652cebd67.png">|

**EDIT**
changed before image, since it was not in muted state

```release-note
NONE
```
