### PR TITLE
Use reply count from post if thread not tracked in postsInThread reducer

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -396,11 +396,15 @@ export function makeGetProfilesForThread(): (state: GlobalState, props: {rootId:
 export function makeGetCommentCountForPost(): (state: GlobalState, post: Post) => number {
     return createSelector(
         getAllPosts,
-        (state: GlobalState, post: Post) => state.entities.posts.postsInThread[post ? post.root_id || post.id : ''] || [],
+        (state: GlobalState, post: Post) => state.entities.posts.postsInThread[post ? post.root_id || post.id : ''] || null,
         (state, post: Post) => post,
         (posts, postsForThread, post) => {
             if (!post) {
                 return 0;
+            }
+
+            if (!postsForThread) {
+                return post.reply_count;
             }
 
             let count = 0;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Quick fix for CRT where unfollowed posts didn't have reply counts showing up in the center channel.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
