### PR TITLE
MM-36218,MM-36219: CRT thread read flashes

### DIFF
--- a/actions/new_post.ts
+++ b/actions/new_post.ts
@@ -13,14 +13,12 @@ import {
     markChannelAsReadOnServer,
 } from 'mattermost-redux/actions/channels';
 import * as PostActions from 'mattermost-redux/actions/posts';
-import {updateThreadRead} from 'mattermost-redux/actions/threads';
 
 import {WebsocketEvents} from 'mattermost-redux/constants';
 
 import {getCurrentChannelId, isManuallyUnread} from 'mattermost-redux/selectors/entities/channels';
 import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getThread} from 'mattermost-redux/selectors/entities/threads';
 
 import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
@@ -143,24 +141,14 @@ export function setThreadRead(post: Post) {
     return (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState() as GlobalState;
 
-        const currentUserId = getCurrentUserId(state);
         const thread = getThread(state, post.root_id);
-        const currentTeamId = getCurrentTeamId(state);
 
         // mark a thread as read (when the user is viewing the thread)
-        if (
-            thread &&
-            post.user_id !== currentUserId &&
-            !isSystemMessage(post) &&
-            !isFromWebhook(post) &&
-            isThreadOpen(state, thread.id)
-        ) {
+        if (thread && isThreadOpen(state, thread.id)) {
             // update the new messages line (when there are no previous unreads)
             if (thread.last_reply_at < getThreadLastViewedAt(state, thread.id)) {
                 dispatch(updateThreadLastOpened(thread.id, post.create_at));
             }
-
-            dispatch(updateThreadRead(currentUserId, currentTeamId, thread.id, post.create_at + 1));
         }
 
         return {data: true};

--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -16,7 +16,7 @@ import {addRecentEmoji} from 'actions/emoji_actions';
 import * as StorageActions from 'actions/storage';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions.jsx';
 import * as RhsActions from 'actions/views/rhs';
-import {updateThreadLastOpened} from 'actions/views/threads';
+import {manuallyMarkThreadAsUnread} from 'actions/views/threads';
 import {isEmbedVisible, isInlineImageVisible} from 'selectors/posts';
 import {getSelectedPostId, getSelectedPostCardId, getRhsState} from 'selectors/rhs';
 import {
@@ -247,7 +247,7 @@ export function markPostAsUnread(post, location) {
         // if CRT:ON and this is from within ThreadViewer (e.g. post dot-menu), mark the thread as unread
         if (isCollapsedThreadsEnabled(state) && (location === 'RHS_ROOT' || location === 'RHS_COMMENT')) {
             const threadId = post.root_id || post.id;
-            dispatch(updateThreadLastOpened(threadId, post.create_at));
+            dispatch(manuallyMarkThreadAsUnread(threadId, post.create_at));
             await dispatch(ThreadActions.updateThreadRead(userId, currentTeamId, threadId, post.create_at));
         } else {
             // use normal channel unread system

--- a/actions/views/threads.ts
+++ b/actions/views/threads.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {batchActions} from 'redux-batched-actions';
+
 import {Threads} from 'utils/constants';
 
 export function updateThreadLastOpened(threadId: string, lastViewedAt: number) {
@@ -21,4 +23,14 @@ export function setSelectedThreadId(teamId: string, threadId: string | undefined
             team_id: teamId,
         },
     };
+}
+
+export function manuallyMarkThreadAsUnread(threadId: string, lastViewedAt: number) {
+    return batchActions([
+        updateThreadLastOpened(threadId, lastViewedAt),
+        {
+            type: Threads.MANUALLY_UNREAD_THREAD,
+            data: {threadId},
+        },
+    ]);
 }

--- a/components/threading/global_threads/thread_menu/thread_menu.test.tsx
+++ b/components/threading/global_threads/thread_menu/thread_menu.test.tsx
@@ -8,7 +8,7 @@ import {shallow} from 'enzyme';
 import {setThreadFollow, updateThreadRead} from 'mattermost-redux/actions/threads';
 jest.mock('mattermost-redux/actions/threads');
 
-import {updateThreadLastOpened} from 'actions/views/threads';
+import {manuallyMarkThreadAsUnread} from 'actions/views/threads';
 jest.mock('actions/views/threads');
 
 import ThreadMenu from '../thread_menu';
@@ -141,7 +141,7 @@ describe('components/threading/common/thread_menu', () => {
         wrapper.find('button').simulate('click');
         wrapper.find(Menu.ItemAction).find({text: 'Mark as read'}).simulate('click');
         expect(updateThreadRead).toHaveBeenCalledWith('uid', 'tid', '1y8hpek81byspd4enyk9mp1ncw', 1612582579566);
-        expect(updateThreadLastOpened).toHaveBeenCalledWith('1y8hpek81byspd4enyk9mp1ncw', 1612582579566);
+        expect(manuallyMarkThreadAsUnread).toHaveBeenCalledWith('1y8hpek81byspd4enyk9mp1ncw', 1612582579566);
         expect(mockDispatch).toHaveBeenCalledTimes(2);
         resetFakeDate();
     });
@@ -156,7 +156,7 @@ describe('components/threading/common/thread_menu', () => {
         wrapper.find('button').simulate('click');
         wrapper.find(Menu.ItemAction).find({text: 'Mark as unread'}).simulate('click');
         expect(updateThreadRead).toHaveBeenCalledWith('uid', 'tid', '1y8hpek81byspd4enyk9mp1ncw', 1610486901110);
-        expect(updateThreadLastOpened).toHaveBeenCalledWith('1y8hpek81byspd4enyk9mp1ncw', 1610486901110);
+        expect(manuallyMarkThreadAsUnread).toHaveBeenCalledWith('1y8hpek81byspd4enyk9mp1ncw', 1610486901110);
         expect(mockDispatch).toHaveBeenCalledTimes(2);
     });
 

--- a/components/threading/global_threads/thread_menu/thread_menu.tsx
+++ b/components/threading/global_threads/thread_menu/thread_menu.tsx
@@ -11,7 +11,7 @@ import {UserThread} from 'mattermost-redux/types/threads';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {setThreadFollow, updateThreadRead} from 'mattermost-redux/actions/threads';
-import {updateThreadLastOpened} from 'actions/views/threads';
+import {manuallyMarkThreadAsUnread} from 'actions/views/threads';
 
 import {
     flagPost as savePost,
@@ -58,6 +58,20 @@ function ThreadMenu({
     } = useThreadRouting();
 
     const isSaved = useSelector((state: GlobalState) => get(state, Preferences.CATEGORY_FLAGGED_POST, threadId, null) != null);
+
+    const handleReadUnread = useCallback(() => {
+        const lastViewedAt = hasUnreads ? Date.now() : unreadTimestamp;
+
+        dispatch(manuallyMarkThreadAsUnread(threadId, lastViewedAt));
+        dispatch(updateThreadRead(currentUserId, currentTeamId, threadId, lastViewedAt));
+    }, [
+        currentUserId,
+        currentTeamId,
+        threadId,
+        hasUnreads,
+        updateThreadRead,
+        unreadTimestamp,
+    ]);
 
     return (
         <MenuWrapper
@@ -109,10 +123,7 @@ function ThreadMenu({
                         id: t('threading.threadMenu.markUnread'),
                         defaultMessage: 'Mark as unread',
                     })}
-                    onClick={useCallback(() => {
-                        dispatch(updateThreadLastOpened(threadId, hasUnreads ? Date.now() : unreadTimestamp));
-                        dispatch(updateThreadRead(currentUserId, currentTeamId, threadId, hasUnreads ? Date.now() : unreadTimestamp));
-                    }, [currentUserId, currentTeamId, threadId, hasUnreads, updateThreadRead, unreadTimestamp])}
+                    onClick={handleReadUnread}
                 />
 
                 <Menu.ItemAction

--- a/reducers/views/threads.ts
+++ b/reducers/views/threads.ts
@@ -31,7 +31,24 @@ export const lastViewedAt = (state: ViewsState['threads']['lastViewedAt'] | Reco
     return state;
 };
 
+export function manuallyUnread(state: ViewsState['threads']['manuallyUnread'] | Record<string, unknown> = {}, action: GenericAction) {
+    switch (action.type) {
+    case Threads.CHANGED_LAST_VIEWED_AT:
+        return {
+            ...state,
+            [action.data.threadId]: false,
+        };
+    case Threads.MANUALLY_UNREAD_THREAD:
+        return {
+            ...state,
+            [action.data.threadId]: true,
+        };
+    }
+    return state;
+}
+
 export default combineReducers({
     selectedThreadIdInTeam,
     lastViewedAt,
+    manuallyUnread,
 });

--- a/selectors/views/threads.ts
+++ b/selectors/views/threads.ts
@@ -70,3 +70,7 @@ export const getOpenThreadId: (state: GlobalState) => $ID<UserThread> | null = c
 export const isThreadOpen = (state: GlobalState, threadId: $ID<UserThread>): boolean => {
     return threadId === getOpenThreadId(state);
 };
+
+export const isThreadManuallyUnread = (state: GlobalState, threadId: $ID<UserThread>): boolean => {
+    return state.views.threads.manuallyUnread[threadId] || false;
+};

--- a/types/store/views.ts
+++ b/types/store/views.ts
@@ -156,5 +156,6 @@ export type ViewsState = {
     threads: {
         selectedThreadIdInTeam: RelationOneToOne<Team, $ID<UserThread> | null>;
         lastViewedAt: {[id: string]: number};
+        manuallyUnread: {[id: string]: boolean};
     };
 };

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -440,6 +440,7 @@ export const RecommendedNextSteps = {
 export const Threads = {
     CHANGED_SELECTED_THREAD: 'changed_selected_thread',
     CHANGED_LAST_VIEWED_AT: 'changed_last_viewed_at',
+    MANUALLY_UNREAD_THREAD: 'manually_unread_thread',
 };
 
 export const CloudBanners = {


### PR DESCRIPTION
#### Summary

New messages that arrive while the thread is open are marked as read and
the indicators don't flash anymore.

Furthermore if a thread is manually marked as unread it should stay
unread even if new messages arrive while it's open.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36218
https://mattermost.atlassian.net/browse/MM-36219

#### Release Note

```release-note
NONE
```
