### PR TITLE
MM-36542: getOpenThreadId should consider suppressed RHS

### DIFF
--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -221,7 +221,7 @@ export default class SidebarRight extends React.PureComponent {
                         getFocus={this.getSearchBarFocus}
                         channelDisplayName={rhsChannel ? rhsChannel.display_name : ''}
                     >
-                        {content}
+                        {isOpen && content}
                     </Search>
                 </div>
             </div>

--- a/selectors/views/threads.test.ts
+++ b/selectors/views/threads.test.ts
@@ -37,28 +37,6 @@ describe('selectors/views/threads', () => {
         },
     }) as unknown as GlobalState;
 
-    describe('getOpenThreadId', () => {
-        test('should return selected post id if it exists and rhs is open', () => {
-            const state = makeState(null, 'selected_post_id');
-            expect(selectors.getOpenThreadId(state)).toBe('selected_post_id');
-        });
-
-        test('should return null if selected post id exists but rhs is closed ', () => {
-            const state = makeState(null, 'selected_post_id', false);
-            expect(selectors.getOpenThreadId(state)).toBe(null);
-        });
-
-        test('should return selected thread id is selected post doesn\'t exist', () => {
-            const state = makeState('selected_thread_id', '');
-            expect(selectors.getOpenThreadId(state)).toBe('selected_thread_id');
-        });
-
-        test('should return null when neither selected post nor selected thread exist', () => {
-            const state = makeState(null, '');
-            expect(selectors.getOpenThreadId(state)).toBe(null);
-        });
-    });
-
     describe('isThreadOpen', () => {
         test('should return true when a specific thread is open', () => {
             const state = makeState('selected_thread_id', '');
@@ -73,6 +51,12 @@ describe('selectors/views/threads', () => {
         test('should return false when no threads are open', () => {
             const state = makeState(null, '');
             expect(selectors.isThreadOpen(state, 'post_id')).toBe(false);
+        });
+
+        test('should return true for either thread with both threads are open', () => {
+            const state = makeState('selected_thread_id', 'selected_post_id');
+            expect(selectors.isThreadOpen(state, 'selected_thread_id')).toBe(true);
+            expect(selectors.isThreadOpen(state, 'selected_post_id')).toBe(true);
         });
     });
 });

--- a/selectors/views/threads.test.ts
+++ b/selectors/views/threads.test.ts
@@ -6,7 +6,7 @@ import {GlobalState} from 'types/store';
 import * as selectors from './threads';
 
 describe('selectors/views/threads', () => {
-    const makeState = (selectedThreadId: string|null, selectedPostId: string) => ({
+    const makeState = (selectedThreadId: string|null, selectedPostId: string, isSidebarOpen = true) => ({
         entities: {
             teams: {
                 currentTeamId: 'current_team_id',
@@ -31,14 +31,21 @@ describe('selectors/views/threads', () => {
             },
             rhs: {
                 selectedPostId,
+                isSidebarOpen,
             },
+            rhsSuppressed: false,
         },
     }) as unknown as GlobalState;
 
     describe('getOpenThreadId', () => {
-        test('should return selected post id if it exists', () => {
+        test('should return selected post id if it exists and rhs is open', () => {
             const state = makeState(null, 'selected_post_id');
             expect(selectors.getOpenThreadId(state)).toBe('selected_post_id');
+        });
+
+        test('should return null if selected post id exists but rhs is closed ', () => {
+            const state = makeState(null, 'selected_post_id', false);
+            expect(selectors.getOpenThreadId(state)).toBe(null);
         });
 
         test('should return selected thread id is selected post doesn\'t exist', () => {

--- a/selectors/views/threads.ts
+++ b/selectors/views/threads.ts
@@ -62,22 +62,11 @@ export function makeGetThreadLastViewedAt(): (state: GlobalState, threadId: $ID<
     );
 }
 
-export const getOpenThreadId: (state: GlobalState) => $ID<UserThread> | null = createSelector(
-    'getOpenThreadId',
-    getSelectedThreadIdInCurrentTeam,
-    getSelectedPostId,
-    getIsRhsOpen,
-    (selectedThreadId, selectedPostId, isRhsOpen) => {
-        if (isRhsOpen && selectedPostId) {
-            return selectedPostId;
-        }
-
-        return selectedThreadId;
-    },
-);
-
 export const isThreadOpen = (state: GlobalState, threadId: $ID<UserThread>): boolean => {
-    return threadId === getOpenThreadId(state);
+    return (
+        threadId === getSelectedThreadIdInCurrentTeam(state) ||
+        (getIsRhsOpen(state) && threadId === getSelectedPostId(state))
+    );
 };
 
 export const isThreadManuallyUnread = (state: GlobalState, threadId: $ID<UserThread>): boolean => {

--- a/selectors/views/threads.ts
+++ b/selectors/views/threads.ts
@@ -13,7 +13,7 @@ import {UserThread} from 'mattermost-redux/types/threads';
 
 import {GlobalState} from 'types/store';
 import {ViewsState} from 'types/store/views';
-import {getSelectedPostId} from 'selectors/rhs';
+import {getIsRhsOpen, getSelectedPostId} from 'selectors/rhs';
 
 export function getSelectedThreadIdInTeam(state: GlobalState) {
     return state.views.threads.selectedThreadIdInTeam;
@@ -66,8 +66,13 @@ export const getOpenThreadId: (state: GlobalState) => $ID<UserThread> | null = c
     'getOpenThreadId',
     getSelectedThreadIdInCurrentTeam,
     getSelectedPostId,
-    (selectedThreadId, selectedPostId) => {
-        return selectedPostId || selectedThreadId;
+    getIsRhsOpen,
+    (selectedThreadId, selectedPostId, isRhsOpen) => {
+        if (isRhsOpen && selectedPostId) {
+            return selectedPostId;
+        }
+
+        return selectedThreadId;
     },
 );
 


### PR DESCRIPTION
#### Summary

Fixes a bug when suppressing RHS via going to global threads,
and then receiving new replies to the thread open in the suppressed RHS,
kept marking them as read.

This commit changes `getOpenThreadId` to consider if RHS is open or not.
Also mounts/unmounts components in the RHS with account to RHS hidden/visible,
this change was made because right now we can suppress the RHS and that action
does not clear the rhsState nor the selectedPostId etc..

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36542

#### Release Note
```release-note
NONE
```
