### PR TITLE
MM-36561: fixes loader shown on socket reconnect

### DIFF
--- a/components/threading/thread_viewer/thread_viewer.tsx
+++ b/components/threading/thread_viewer/thread_viewer.tsx
@@ -311,7 +311,7 @@ export default class ThreadViewer extends React.Component<Props, State> {
     // scrolls to either bottom or new messages line
     private onInit = async (reconnected = false): Promise<void> => {
         if (reconnected || this.morePostsToFetch()) {
-            this.setState({isLoading: true});
+            this.setState({isLoading: !reconnected});
             await this.props.actions.getPostThread(this.props.selected.id, !reconnected);
         }
 
@@ -319,7 +319,7 @@ export default class ThreadViewer extends React.Component<Props, State> {
             this.props.isCollapsedThreadsEnabled &&
             this.props.userThread == null
         ) {
-            this.setState({isLoading: true});
+            this.setState({isLoading: !reconnected});
             await this.fetchThread();
         }
 


### PR DESCRIPTION
#### Summary

The loader was shown in ThreadViewer upon websocket reconnection.
This commit fixes that, so the loader now shows only on mount and upon changing selected thread.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36561

#### Release Note

```release-note
NONE
```
