### PR TITLE
MM-36430 Show thread as followed immediately on webapp when marking posts unread from the thread

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -244,9 +244,10 @@ export function markPostAsUnread(post, location) {
         const userId = getCurrentUserId(state);
         const currentTeamId = getCurrentTeamId(state);
 
-        // if CRT:ON and this is from within ThreadViewer (e.g. post dot-menu), mark the thread as unread
+        // if CRT:ON and this is from within ThreadViewer (e.g. post dot-menu), mark the thread as unread and followed
         if (isCollapsedThreadsEnabled(state) && (location === 'RHS_ROOT' || location === 'RHS_COMMENT')) {
             const threadId = post.root_id || post.id;
+            ThreadActions.handleFollowChanged(dispatch, threadId, currentTeamId, true);
             dispatch(manuallyMarkThreadAsUnread(threadId, post.create_at));
             await dispatch(ThreadActions.updateThreadRead(userId, currentTeamId, threadId, post.create_at));
         } else {


### PR DESCRIPTION
#### Summary
It gets followed by the server but we just needed to set that state on the client too.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36430

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
