### PR TITLE
MM-30446: Fix toast dismiss hover console error

### DIFF
--- a/components/toast/__snapshots__/toast.test.tsx.snap
+++ b/components/toast/__snapshots__/toast.test.tsx.snap
@@ -18,29 +18,29 @@ exports[`components/Toast should match snapshot for hiding toast 1`] = `
       child
     </span>
   </div>
-  <div
-    className="toast__dismiss"
-    data-testid="dismissToast"
-    onClick={[Function]}
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={400}
+    overlay={<div />}
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
   >
-    <OverlayTrigger
-      defaultOverlayShown={false}
-      delayShow={400}
-      overlay={<div />}
-      placement="bottom"
-      trigger={
-        Array [
-          "hover",
-          "focus",
-        ]
-      }
+    <div
+      className="toast__dismiss"
+      data-testid="dismissToast"
+      onClick={[Function]}
     >
       <CloseIcon
         className="close-btn"
         id="dismissToast"
       />
-    </OverlayTrigger>
-  </div>
+    </div>
+  </OverlayTrigger>
 </div>
 `;
 
@@ -62,48 +62,48 @@ exports[`components/Toast should match snapshot for showing toast 1`] = `
       child
     </span>
   </div>
-  <div
-    className="toast__dismiss"
-    data-testid="dismissToast"
-    onClick={[Function]}
-  >
-    <OverlayTrigger
-      defaultOverlayShown={false}
-      delayShow={400}
-      overlay={
-        <Tooltip
-          bsClass="tooltip"
-          id="toast-close__tooltip"
-          placement="right"
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={400}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="toast-close__tooltip"
+        placement="right"
+      >
+        <FormattedMessage
+          defaultMessage="Close"
+          id="general_button.close"
+        />
+        <div
+          className="tooltip__shortcut--txt"
         >
           <FormattedMessage
-            defaultMessage="Close"
-            id="general_button.close"
+            defaultMessage="esc"
+            id="general_button.esc"
           />
-          <div
-            className="tooltip__shortcut--txt"
-          >
-            <FormattedMessage
-              defaultMessage="esc"
-              id="general_button.esc"
-            />
-          </div>
-        </Tooltip>
-      }
-      placement="bottom"
-      trigger={
-        Array [
-          "hover",
-          "focus",
-        ]
-      }
+        </div>
+      </Tooltip>
+    }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <div
+      className="toast__dismiss"
+      data-testid="dismissToast"
+      onClick={[Function]}
     >
       <CloseIcon
         className="close-btn"
         id="dismissToast"
       />
-    </OverlayTrigger>
-  </div>
+    </div>
+  </OverlayTrigger>
 </div>
 `;
 
@@ -125,48 +125,48 @@ exports[`components/Toast should match snapshot for toast width less than 780px 
       child
     </span>
   </div>
-  <div
-    className="toast__dismiss"
-    data-testid="dismissToast"
-    onClick={[Function]}
-  >
-    <OverlayTrigger
-      defaultOverlayShown={false}
-      delayShow={400}
-      overlay={
-        <Tooltip
-          bsClass="tooltip"
-          id="toast-close__tooltip"
-          placement="right"
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={400}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="toast-close__tooltip"
+        placement="right"
+      >
+        <FormattedMessage
+          defaultMessage="Close"
+          id="general_button.close"
+        />
+        <div
+          className="tooltip__shortcut--txt"
         >
           <FormattedMessage
-            defaultMessage="Close"
-            id="general_button.close"
+            defaultMessage="esc"
+            id="general_button.esc"
           />
-          <div
-            className="tooltip__shortcut--txt"
-          >
-            <FormattedMessage
-              defaultMessage="esc"
-              id="general_button.esc"
-            />
-          </div>
-        </Tooltip>
-      }
-      placement="bottom"
-      trigger={
-        Array [
-          "hover",
-          "focus",
-        ]
-      }
+        </div>
+      </Tooltip>
+    }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <div
+      className="toast__dismiss"
+      data-testid="dismissToast"
+      onClick={[Function]}
     >
       <CloseIcon
         className="close-btn"
         id="dismissToast"
       />
-    </OverlayTrigger>
-  </div>
+    </div>
+  </OverlayTrigger>
 </div>
 `;
 
@@ -188,48 +188,48 @@ exports[`components/Toast should match snapshot to have extraClasses 1`] = `
       child
     </span>
   </div>
-  <div
-    className="toast__dismiss"
-    data-testid="dismissToast-extraClasses"
-    onClick={[Function]}
-  >
-    <OverlayTrigger
-      defaultOverlayShown={false}
-      delayShow={400}
-      overlay={
-        <Tooltip
-          bsClass="tooltip"
-          id="toast-close__tooltip"
-          placement="right"
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={400}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="toast-close__tooltip"
+        placement="right"
+      >
+        <FormattedMessage
+          defaultMessage="Close"
+          id="general_button.close"
+        />
+        <div
+          className="tooltip__shortcut--txt"
         >
           <FormattedMessage
-            defaultMessage="Close"
-            id="general_button.close"
+            defaultMessage="esc"
+            id="general_button.esc"
           />
-          <div
-            className="tooltip__shortcut--txt"
-          >
-            <FormattedMessage
-              defaultMessage="esc"
-              id="general_button.esc"
-            />
-          </div>
-        </Tooltip>
-      }
-      placement="bottom"
-      trigger={
-        Array [
-          "hover",
-          "focus",
-        ]
-      }
+        </div>
+      </Tooltip>
+    }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <div
+      className="toast__dismiss"
+      data-testid="dismissToast-extraClasses"
+      onClick={[Function]}
     >
       <CloseIcon
         className="close-btn"
         id="dismissToast"
       />
-    </OverlayTrigger>
-  </div>
+    </div>
+  </OverlayTrigger>
 </div>
 `;
 
@@ -244,28 +244,28 @@ exports[`components/Toast should match snapshot to not have actions 1`] = `
       child
     </span>
   </div>
-  <div
-    className="toast__dismiss"
-    data-testid="dismissToast"
-    onClick={[Function]}
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={400}
+    overlay={<div />}
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
   >
-    <OverlayTrigger
-      defaultOverlayShown={false}
-      delayShow={400}
-      overlay={<div />}
-      placement="bottom"
-      trigger={
-        Array [
-          "hover",
-          "focus",
-        ]
-      }
+    <div
+      className="toast__dismiss"
+      data-testid="dismissToast"
+      onClick={[Function]}
     >
       <CloseIcon
         className="close-btn"
         id="dismissToast"
       />
-    </OverlayTrigger>
-  </div>
+    </div>
+  </OverlayTrigger>
 </div>
 `;

--- a/components/toast/toast.tsx
+++ b/components/toast/toast.tsx
@@ -95,22 +95,22 @@ export default class Toast extends React.PureComponent<Props> {
                     {showActions && jumpSection()}
                     {this.props.children}
                 </div>
-                <div
-                    className='toast__dismiss'
-                    onClick={this.handleDismiss}
-                    data-testid={extraClasses ? `dismissToast-${extraClasses}` : 'dismissToast'}
+                <OverlayTrigger
+                    delayShow={Constants.OVERLAY_TIME_DELAY}
+                    placement='bottom'
+                    overlay={closeTooltip}
                 >
-                    <OverlayTrigger
-                        delayShow={Constants.OVERLAY_TIME_DELAY}
-                        placement='bottom'
-                        overlay={closeTooltip}
+                    <div
+                        className='toast__dismiss'
+                        onClick={this.handleDismiss}
+                        data-testid={extraClasses ? `dismissToast-${extraClasses}` : 'dismissToast'}
                     >
                         <CloseIcon
                             className='close-btn'
                             id='dismissToast'
                         />
-                    </OverlayTrigger>
-                </div>
+                    </div>
+                </OverlayTrigger>
             </div>
         );
     }

--- a/components/toast/toast.tsx
+++ b/components/toast/toast.tsx
@@ -4,8 +4,9 @@
 import React, {ReactNode, MouseEventHandler} from 'react';
 
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
+import OverlayTrigger from 'components/overlay_trigger';
 import UnreadBelowIcon from 'components/widgets/icons/unread_below_icon';
 import CloseIcon from 'components/widgets/icons/close_icon';
 import Constants from 'utils/constants';


### PR DESCRIPTION
#### Summary
- Use `IntlContext`-compatible OverlayTrigger
  - Allows previously-hidden tooltip to work again 
  <img width="139" alt="CleanShot 2021-06-18 at 12 04 42@2x" src="https://user-images.githubusercontent.com/11724372/122595195-b7c24500-d02d-11eb-9b3b-9f1f23f2c3e1.png">
- Hoist OverlayTrigger to wrap clickable element (synchronize tooltip with hover/clickable element)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30446

#### Screenshots
![CleanShot 2021-06-18 at 11 44 53](https://user-images.githubusercontent.com/11724372/122596540-a1b58400-d02f-11eb-9b57-8df59c0e1bcd.gif)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
