### PR TITLE
[MM-35392, MM-35972] CRT: cross team unreads handling

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -1441,9 +1441,9 @@ function handleThreadReadChanged(msg) {
                 msg.data.channel_id,
                 {
                     lastViewedAt: msg.data.timestamp,
-                    prevUnreadMentions: thread?.unread_mentions ?? msg.data.prev_unread_mentions, // TODO
+                    prevUnreadMentions: thread?.unread_mentions ?? msg.data.prev_unread_mentions,
                     newUnreadMentions: msg.data.unread_mentions,
-                    prevUnreadReplies: thread?.unread_replies ?? msg.data.prev_unread_replies, // TODO
+                    prevUnreadReplies: thread?.unread_replies ?? msg.data.prev_unread_replies,
                     newUnreadReplies: msg.data.unread_replies,
                 },
             );

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -1493,6 +1493,6 @@ function handleThreadFollowChanged(msg) {
         if (!thread && msg.data.state && msg.data.reply_count) {
             await doDispatch(fetchThread(getCurrentUserId(state), getCurrentTeamId(state), msg.data.thread_id, true));
         }
-        handleFollowChanged(doDispatch, msg.data.thread_id, msg.broadcast.team_id, msg.data.state);
+        handleFollowChanged(doDispatch, doGetState, msg.data.thread_id, msg.broadcast.team_id, msg.data.state);
     };
 }

--- a/components/app.jsx
+++ b/components/app.jsx
@@ -11,7 +11,7 @@ import store from 'stores/redux_store.jsx';
 
 import {makeAsyncComponent} from 'components/async_load';
 
-import CRTPostsChannelResetWatcher from 'components/threading/channel_threads/posts_channel_reset_watcher';
+import CrtToggleWatcher from 'components/threading/crt_toggle_watcher';
 const LazyRoot = React.lazy(() => import('components/root'));
 
 const Root = makeAsyncComponent(LazyRoot);
@@ -20,14 +20,15 @@ class App extends React.PureComponent {
     render() {
         return (
             <Provider store={store}>
-                <CRTPostsChannelResetWatcher/>
+                <CrtToggleWatcher/>
                 <Router history={browserHistory}>
                     <Route
                         path='/'
                         component={Root}
                     />
                 </Router>
-            </Provider>);
+            </Provider>
+        );
     }
 }
 

--- a/components/needs_team/index.ts
+++ b/components/needs_team/index.ts
@@ -9,7 +9,7 @@ import {loadProfilesForDirect} from 'mattermost-redux/actions/users';
 import {fetchMyChannelsAndMembers, viewChannel} from 'mattermost-redux/actions/channels';
 import {getMyTeamUnreads, getTeamByName, selectTeam} from 'mattermost-redux/actions/teams';
 import {getGroups, getAllGroupsAssociatedToChannelsInTeam, getAllGroupsAssociatedToTeam, getGroupsByUserId} from 'mattermost-redux/actions/groups';
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {getTheme, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
@@ -43,6 +43,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     return {
         license,
         theme: getTheme(state),
+        collapsedThreads: isCollapsedThreadsEnabled(state),
         mfaRequired: checkIfMFARequired(currentUser, license, config, ownProps.match.url),
         currentUser,
         currentTeamId: getCurrentTeamId(state),

--- a/components/needs_team/needs_team.tsx
+++ b/components/needs_team/needs_team.tsx
@@ -24,6 +24,7 @@ import ChannelController from 'components/channel_layout/channel_controller';
 import Pluggable from 'plugins/pluggable';
 
 import LocalStorageStore from 'stores/local_storage_store';
+import type {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
 const BackstageController = makeAsyncComponent(LazyBackstageController);
 
@@ -49,7 +50,7 @@ type Props = {
     useLegacyLHS: boolean;
     actions: {
         fetchMyChannelsAndMembers: (teamId: string) => Promise<{ data: { channels: Channel[]; members: ChannelMembership[] } }>;
-        getMyTeamUnreads: () => Promise<{data: any; error?: any}>;
+        getMyTeamUnreads: (collapsedThreads: boolean) => Promise<{data: any; error?: any}>;
         viewChannel: (channelId: string, prevChannelId?: string | undefined) => Promise<{data: boolean}>;
         markChannelAsReadOnFocus: (channelId: string) => Promise<{data: any; error?: any}>;
         getTeamByName: (teamName: string) => Promise<{data: Team}>;
@@ -75,6 +76,7 @@ type Props = {
     };
     teamsList: Team[];
     theme: any;
+    collapsedThreads: ReturnType<typeof isCollapsedThreadsEnabled>;
     plugins?: any;
     selectedThreadId: string | null;
 }
@@ -230,7 +232,7 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
 
         // If current team is set, then this is not first load
         // The first load action pulls team unreads
-        this.props.actions.getMyTeamUnreads();
+        this.props.actions.getMyTeamUnreads(this.props.collapsedThreads);
         this.props.actions.selectTeam(team);
         this.props.actions.setPreviousTeamId(team.id);
 

--- a/components/threading/crt_toggle_watcher/crt_toggle_watcher.tsx
+++ b/components/threading/crt_toggle_watcher/crt_toggle_watcher.tsx
@@ -4,22 +4,29 @@
 import {useEffect, useRef} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
 
-import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {isEmpty} from 'lodash';
+
+import {isCollapsedThreadsEnabled, getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
 
 import {resetReloadPostsInChannel} from 'mattermost-redux/actions/posts';
+import {getMyTeamUnreads} from 'mattermost-redux/actions/teams';
 
-const PostsChannelResetWatcher = () => {
+const CrtToggleWatcher = () => {
     const dispatch = useDispatch();
     const isCRTEnabled = useSelector(isCollapsedThreadsEnabled);
+    const preferencesLoaded = !isEmpty(useSelector(getMyPreferences));
     const loaded = useRef(false);
     useEffect(() => {
         if (loaded.current) {
             dispatch(resetReloadPostsInChannel());
-        } else {
+            if (isCRTEnabled) {
+                dispatch(getMyTeamUnreads(isCRTEnabled));
+            }
+        } else if (preferencesLoaded) {
             loaded.current = true;
         }
-    }, [isCRTEnabled]);
+    }, [preferencesLoaded, isCRTEnabled]);
     return null;
 };
 
-export default PostsChannelResetWatcher;
+export default CrtToggleWatcher;

--- a/components/threading/crt_toggle_watcher/index.ts
+++ b/components/threading/crt_toggle_watcher/index.ts
@@ -1,4 +1,4 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export {default} from './posts_channel_reset_watcher';
+export {default} from './crt_toggle_watcher';

--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -79,7 +79,7 @@ const GlobalThreads = () => {
     }, [currentTeamId, selectedThreadId, threadIdentifier]);
 
     useEffect(() => {
-        dispatch(getThreads(currentUserId, currentTeamId, {unread: filter === 'unread', perPage: 200}));
+        dispatch(getThreads(currentUserId, currentTeamId, {perPage: 200}));
     }, [currentUserId, currentTeamId, filter]);
 
     useEffect(() => {

--- a/components/threading/global_threads_link/global_threads_link.tsx
+++ b/components/threading/global_threads_link/global_threads_link.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useCallback} from 'react';
+import React, {useCallback} from 'react';
 import {Link, useRouteMatch, useLocation, matchPath} from 'react-router-dom';
 import classNames from 'classnames';
 import {useIntl} from 'react-intl';
@@ -9,13 +9,11 @@ import {useSelector, useDispatch} from 'react-redux';
 
 import {getThreadCountsInCurrentTeam} from 'mattermost-redux/selectors/entities/threads';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
-import {getThreads} from 'mattermost-redux/actions/threads';
 
 import {t} from 'utils/i18n';
 
 import {suppressRHS} from 'actions/views/rhs';
 import {isUnreadFilterEnabled} from 'selectors/views/channel_sidebar';
-import {useThreadRouting} from '../hooks';
 
 import ChannelMentionBadge from 'components/sidebar/sidebar_channel/channel_mention_badge';
 
@@ -26,12 +24,11 @@ import './global_threads_link.scss';
 const GlobalThreadsLink = () => {
     const {formatMessage} = useIntl();
     const dispatch = useDispatch();
-    const isFeatureEnabled = useSelector(isCollapsedThreadsEnabled);
 
+    const isFeatureEnabled = useSelector(isCollapsedThreadsEnabled);
     const {url} = useRouteMatch();
     const {pathname} = useLocation();
     const inGlobalThreads = matchPath(pathname, {path: '/:team/threads/:threadIdentifier?'}) != null;
-    const {currentTeamId, currentUserId} = useThreadRouting();
 
     const counts = useSelector(getThreadCountsInCurrentTeam);
     const unreadsOnly = useSelector(isUnreadFilterEnabled);
@@ -40,13 +37,6 @@ const GlobalThreadsLink = () => {
     const closeRHS = useCallback(() => {
         dispatch(suppressRHS);
     }, []);
-
-    useEffect(() => {
-        // load counts if necessary
-        if (isFeatureEnabled) {
-            dispatch(getThreads(currentUserId, currentTeamId, {perPage: 5}));
-        }
-    }, [currentTeamId, isFeatureEnabled]);
 
     if (!isFeatureEnabled || (unreadsOnly && !inGlobalThreads && !someUnreadThreads)) {
         // hide link if feature disabled or filtering unreads and there are no unread threads

--- a/packages/mattermost-redux/src/actions/teams.ts
+++ b/packages/mattermost-redux/src/actions/teams.ts
@@ -17,6 +17,8 @@ import {Team, TeamMembership, TeamMemberWithError, GetTeamMembersOpts, TeamsWith
 
 import {UserProfile} from 'mattermost-redux/types/users';
 
+import {isCollapsedThreadsEnabled} from '../selectors/entities/preferences';
+
 import {selectChannel} from './channels';
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -74,10 +76,13 @@ export function getMyTeams(): ActionFunc {
     });
 }
 
-export function getMyTeamUnreads(): ActionFunc {
+export function getMyTeamUnreads(collapsedThreads: boolean): ActionFunc {
     return bindClientFunc({
         clientFunc: Client4.getMyTeamUnreads,
         onSuccess: TeamTypes.RECEIVED_MY_TEAM_UNREADS,
+        params: [
+            collapsedThreads,
+        ],
     });
 }
 
@@ -667,7 +672,7 @@ export function joinTeam(inviteId: string, teamId: string): ActionFunc {
             return {error};
         }
 
-        getMyTeamUnreads()(dispatch, getState);
+        getMyTeamUnreads(isCollapsedThreadsEnabled(state))(dispatch, getState);
 
         await Promise.all([
             getTeam(teamId)(dispatch, getState),

--- a/packages/mattermost-redux/src/actions/threads.ts
+++ b/packages/mattermost-redux/src/actions/threads.ts
@@ -196,6 +196,8 @@ export function handleFollowChanged(
     threadId: string,
     teamId: string,
     following: boolean,
+    prevUnreadMentions = 0, // TODO provide
+    prevUnreadReplies = 0, // TODO provide
 ) {
     if (!following) {
         const state = getState();
@@ -208,9 +210,9 @@ export function handleFollowChanged(
             thread?.post?.channel_id,
             {
                 lastViewedAt: thread?.last_viewed_at,
-                prevUnreadMentions: thread?.unread_mentions, // TODO manually fetch, for multi-tab
+                prevUnreadMentions: thread?.unread_mentions ?? prevUnreadMentions, // TODO manually fetch, for multi-tab
                 newUnreadMentions: 0,
-                prevUnreadReplies: thread?.unread_replies, // TODO manually fetch, for multi-tab
+                prevUnreadReplies: thread?.unread_replies ?? prevUnreadReplies, // TODO manually fetch, for multi-tab
                 newUnreadReplies: 0,
             },
         );

--- a/packages/mattermost-redux/src/actions/threads.ts
+++ b/packages/mattermost-redux/src/actions/threads.ts
@@ -16,8 +16,6 @@ import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-
 import {getThreadsInChannel} from 'mattermost-redux/selectors/entities/threads';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
@@ -202,21 +200,20 @@ export function handleFollowChanged(
     if (!following) {
         const state = getState();
         const thread = state.entities.threads.threads[threadId];
-        if (thread) {
-            handleReadChanged(
-                dispatch,
-                thread.id,
-                teamId,
-                thread.post.channel_id,
-                {
-                    lastViewedAt: thread.last_viewed_at,
-                    prevUnreadMentions: thread.unread_mentions,
-                    newUnreadMentions: 0,
-                    prevUnreadReplies: thread.unread_replies,
-                    newUnreadReplies: 0,
-                },
-            );
-        }
+
+        handleReadChanged(
+            dispatch,
+            threadId,
+            teamId,
+            thread?.post?.channel_id,
+            {
+                lastViewedAt: thread?.last_viewed_at,
+                prevUnreadMentions: thread?.unread_mentions, // TODO manually fetch, for multi-tab
+                newUnreadMentions: 0,
+                prevUnreadReplies: thread?.unread_replies, // TODO manually fetch, for multi-tab
+                newUnreadReplies: 0,
+            },
+        );
     }
 
     dispatch({

--- a/packages/mattermost-redux/src/actions/users.ts
+++ b/packages/mattermost-redux/src/actions/users.ts
@@ -20,6 +20,8 @@ import {getCurrentUserId, getUsers} from 'mattermost-redux/selectors/entities/us
 
 import {Dictionary} from 'mattermost-redux/types/utilities';
 
+import {isCollapsedThreadsEnabled} from '../selectors/entities/preferences';
+
 import {getAllCustomEmojis} from './emojis';
 import {getClientConfig, setServerVersion} from './general';
 import {getMyTeams, getMyTeamMembers, getMyTeamUnreads} from './teams';
@@ -128,6 +130,8 @@ export function loginById(id: string, password: string, mfaToken = ''): ActionFu
 
 function completeLogin(data: UserProfile): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
+        const collapsedThreads = isCollapsedThreadsEnabled(state);
         dispatch({
             type: UserTypes.RECEIVED_ME,
             data,
@@ -139,7 +143,7 @@ function completeLogin(data: UserProfile): ActionFunc {
 
         try {
             const membersRequest: Promise<TeamMembership[]> = Client4.getMyTeamMembers();
-            const unreadsRequest = Client4.getMyTeamUnreads();
+            const unreadsRequest = Client4.getMyTeamUnreads(collapsedThreads);
 
             teamMembers = await membersRequest;
             const teamUnreads = await unreadsRequest;
@@ -152,6 +156,10 @@ function completeLogin(data: UserProfile): ActionFunc {
                     member.msg_count = u.msg_count;
                     member.mention_count_root = u.mention_count_root;
                     member.msg_count_root = u.msg_count_root;
+                    if (collapsedThreads) {
+                        member.thread_count = u.thread_count;
+                        member.thread_mention_count = u.thread_mention_count;
+                    }
                 }
             }
         } catch (error) {
@@ -170,7 +178,7 @@ function completeLogin(data: UserProfile): ActionFunc {
 
         const serverVersion = Client4.getServerVersion();
         dispatch(setServerVersion(serverVersion));
-        if (!isMinimumServerVersion(serverVersion, 4, 7) && getConfig(getState()).EnableCustomEmoji === 'true') {
+        if (!isMinimumServerVersion(serverVersion, 4, 7) && getConfig(state).EnableCustomEmoji === 'true') {
             dispatch(getAllCustomEmojis());
         }
 
@@ -225,7 +233,6 @@ export function loadMe(): ActionFunc {
             dispatch(getMyPreferences()),
             dispatch(getMyTeams()),
             dispatch(getMyTeamMembers()),
-            dispatch(getMyTeamUnreads()),
         ];
 
         // Sometimes the server version is set in one or the other
@@ -236,6 +243,9 @@ export function loadMe(): ActionFunc {
         }
 
         await Promise.all(promises);
+
+        const collapsedReplies = isCollapsedThreadsEnabled(getState());
+        dispatch(getMyTeamUnreads(collapsedReplies));
 
         const {currentUserId} = getState().entities.users;
         const user = getState().entities.users.profiles[currentUserId];
@@ -445,9 +455,7 @@ export function getProfilesNotInTeam(teamId: string, groupConstrained: boolean, 
             return {error};
         }
 
-        const receivedProfilesListActionType = groupConstrained ?
-            UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_TEAM_AND_REPLACE :
-            UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_TEAM;
+        const receivedProfilesListActionType = groupConstrained ? UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_TEAM_AND_REPLACE : UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_TEAM;
 
         dispatch(batchActions([
             {
@@ -571,9 +579,7 @@ export function getProfilesNotInChannel(teamId: string, channelId: string, group
             return {error};
         }
 
-        const receivedProfilesListActionType = groupConstrained ?
-            UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_CHANNEL_AND_REPLACE :
-            UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_CHANNEL;
+        const receivedProfilesListActionType = groupConstrained ? UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_CHANNEL_AND_REPLACE : UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_CHANNEL;
 
         dispatch(batchActions([
             {

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -1234,9 +1234,9 @@ export default class Client4 {
         );
     };
 
-    getMyTeamUnreads = () => {
+    getMyTeamUnreads = (collapsedThreads = false) => {
         return this.doFetch<TeamUnread[]>(
-            `${this.getUserRoute('me')}/teams/unread`,
+            `${this.getUserRoute('me')}/teams/unread${buildQueryString({collapsedThreads})}`,
             {method: 'get'},
         );
     };

--- a/packages/mattermost-redux/src/types/teams.ts
+++ b/packages/mattermost-redux/src/types/teams.ts
@@ -5,12 +5,7 @@ import {ServerError} from './errors';
 import {UserProfile} from './users';
 import {Dictionary, RelationOneToOne} from './utilities';
 
-export type TeamMembership = {
-    mention_count: number;
-    msg_count: number;
-    mention_count_root: number;
-    msg_count_root: number;
-    team_id: string;
+export type TeamMembership = TeamUnread & {
     user_id: string;
     roles: string;
     delete_at: number;

--- a/packages/mattermost-redux/src/types/teams.ts
+++ b/packages/mattermost-redux/src/types/teams.ts
@@ -61,6 +61,8 @@ export type TeamUnread = {
     msg_count: number;
     mention_count_root: number;
     msg_count_root: number;
+    thread_count: number;
+    thread_mention_count: number;
 };
 
 export type GetTeamMembersOpts = {


### PR DESCRIPTION
#### Summary
 - Include `prevUnreadMentions`, `prevUnreadReplies` for calculating thread-unread increment/decrement
 - Include thread unreads (per-team) to existing getMyTeamUnreads pipeline/flow
 - Utilize `channel_type` in `handleThreadReadChanged` to determine if GM/DM (should affect all team counts)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35392
https://mattermost.atlassian.net/browse/MM-35972
https://mattermost.atlassian.net/browse/MM-35393

#### Related Pull Requests

https://github.com/mattermost/mattermost-server/pull/17813

#### Screenshots


#### Release Note

```release-note
NONE
```
