### PR TITLE
Block only file drops, not all the kind of drops (from drag and drops)

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -112,8 +112,10 @@ export default class Root extends React.PureComponent {
 
         // Prevent drag and drop files from navigating away from the app
         document.addEventListener('drop', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
+            if (e.dataTransfer.items.length > 0 && e.dataTransfer.items[0].kind === 'file') {
+                e.preventDefault();
+                e.stopPropagation();
+            }
         });
 
         document.addEventListener('dragover', (e) => {


### PR DESCRIPTION
#### Summary
Block only file drops, not all the kind of drops (from drag and drops).

This is done because react-dnd, used in focalboard, relies on the document drop event, and this was blocking all the cases.

This should help other plugins creator that wants to use react-dnd or any other dnd that follows the same pattern.

#### Ticket Link
[MM-36964](https://mattermost.atlassian.net/browse/MM-36964)

#### Release Note
```release-note
NONE
```