### PR TITLE
[MM-36481] Fix thumbsup emoji parsing to support skin tones

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -109,7 +109,7 @@
   "add_emoji.imageRequired": "An image is required for the emoji",
   "add_emoji.imageTooLarge": "Unable to create emoji. Image must be less than 1 MB in size.",
   "add_emoji.name": "Name",
-  "add_emoji.name.help": "Specify an emoji name that's up to 64 characters. It can contain lowercase letters, numbers, and the symbols '-' and '_'.",
+  "add_emoji.name.help": "Specify an emoji name that's up to 64 characters. It can contain lowercase letters, numbers, and the symbols '-', '+' and '_'.",
   "add_emoji.nameInvalid": "An emoji's name can only contain lowercase letters, numbers, and the symbols '-' and '_'.",
   "add_emoji.nameRequired": "A name is required for the emoji",
   "add_emoji.nameTaken": "This name is already in use by a system emoji. Please choose another name.",

--- a/utils/emoticons.test.tsx
+++ b/utils/emoticons.test.tsx
@@ -25,8 +25,6 @@ describe('Emoticons', () => {
             mask: [':-x'],
             heart: ['<3', '&lt;3'],
             broken_heart: ['</3', '&lt;/3'],
-            thumbsup: [':+1:'],
-            thumbsdown: [':-1:'],
         };
         Array.prototype.concat(...Object.values(emoticonPatterns)).forEach((emoticon) => {
             test(`text sequence '${emoticon}' should be recognized as an emoticon`, () => {
@@ -117,7 +115,7 @@ describe('Emoticons', () => {
         describe('multiple', () => {
             test('shorthand forms', () => {
                 expect(Emoticons.matchEmoticons(':+1: :D')).
-                    toEqual([':D', ':+1:']);
+                    toEqual([':+1:', ':D']);
             });
 
             test('named emoticons forms', () => {
@@ -127,7 +125,7 @@ describe('Emoticons', () => {
 
             test('mixed', () => {
                 expect(Emoticons.matchEmoticons(':thumbs_up: :smile: :+1: :D')).
-                    toEqual([':thumbs_up:', ':smile:', ':D', ':+1:']);
+                    toEqual([':thumbs_up:', ':smile:', ':+1:', ':D']);
             });
         });
 

--- a/utils/emoticons.tsx
+++ b/utils/emoticons.tsx
@@ -20,11 +20,9 @@ export const emoticonPatterns: { [key: string]: RegExp } = {
     mask: /(^|\B)(:-x)($|\b)/gi, // :-x
     heart: /(^|\B)(<3|&lt;3)($|\b)/g, // <3
     broken_heart: /(^|\B)(<\/3|&lt;\/3)($|\b)/g, // </3
-    thumbsup: /(^|\B)(:\+1:)($|\B)/g, // :+1:
-    thumbsdown: /(^|\B)(:-1:)($|\B)/g, // :-1:
 };
 
-export const EMOJI_PATTERN = /(:([a-zA-Z0-9_-]+):)/g;
+export const EMOJI_PATTERN = /(:([a-zA-Z0-9_+-]+):)/g;
 
 export function matchEmoticons(text: string): RegExpMatchArray | null {
     let emojis = text.match(EMOJI_PATTERN);


### PR DESCRIPTION
#### Summary

Thumbs up wasn't being skin toned properly, updated the regex to support that.

#### Ticket Link

[MM-36481](https://mattermost.atlassian.net/browse/MM-36481)

#### Related PRs

- Server https://github.com/mattermost/mattermost-server/pull/17846

#### Screenshots
<img width="251" alt="Screen Shot 2021-06-28 at 19 48 16" src="https://user-images.githubusercontent.com/1515906/123681390-1071b900-d84a-11eb-81ae-3aa3ad1076b0.png">


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
