### PR TITLE
Fixed: overflowing text now truncates

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -216,6 +216,11 @@
                     display: inherit;
                 }
             }
+            span {
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
         }
         .SidebarChannelNavigator_divider {
             border-right: 1px solid var(--sidebar-text-16);


### PR DESCRIPTION
#### Summary
Fix to text overflowing in "Find channel" bar. CSS properties for span added in sidebar class.

#### Ticket Link
[JIRA Ticket MM-36355](https://mattermost.atlassian.net/browse/MM-36355)
[GitHub Issue #17763](https://github.com/mattermost/mattermost-server/issues/17763#event-4939754877) (Opened in server repo)

#### Related Pull Requests
None

#### Screenshots
Text now is only in one line and uses ellipsis when truncation is necessary.
<img width="252" alt="Screen Shot 2021-06-28 at 4 13 41 PM" src="https://user-images.githubusercontent.com/22950294/123716178-cc24ef80-d82e-11eb-81e4-4e0923d0472f.png">


#### Release Note
```release-note
NONE
```
