### PR TITLE
[MM-36714] - Renew Now button in announcement bar lost its styling

### DIFF
--- a/sass/components/_announcement-bar.scss
+++ b/sass/components/_announcement-bar.scss
@@ -17,10 +17,10 @@
 
     .announcement-bar__text {
         display: flex;
-        width: 100%;
         overflow: hidden;
-        justify-content: center;
+        width: 100%;
         align-items: center;
+        justify-content: center;
         white-space: nowrap;
 
         > p {

--- a/sass/components/_announcement-bar.scss
+++ b/sass/components/_announcement-bar.scss
@@ -17,6 +17,8 @@
 
     .announcement-bar__text {
         display: flex;
+        width: 100%;
+        justify-content: center;
         overflow: hidden;
         align-items: center;
         white-space: nowrap;
@@ -32,6 +34,14 @@
             font-style: normal;
             font-weight: 600;
             line-height: 20px;
+        }
+
+        .annnouncementBar__purchaseNow, .annnouncementBar__renewLicense {
+            margin-top: 0;
+        }
+
+        .annnouncementBar__renewLicense {
+            border-color: $white;
         }
     }
 

--- a/sass/components/_announcement-bar.scss
+++ b/sass/components/_announcement-bar.scss
@@ -18,8 +18,8 @@
     .announcement-bar__text {
         display: flex;
         width: 100%;
-        justify-content: center;
         overflow: hidden;
+        justify-content: center;
         align-items: center;
         white-space: nowrap;
 
@@ -36,7 +36,8 @@
             line-height: 20px;
         }
 
-        .annnouncementBar__purchaseNow, .annnouncementBar__renewLicense {
+        .annnouncementBar__purchaseNow,
+        .annnouncementBar__renewLicense {
             margin-top: 0;
         }
 


### PR DESCRIPTION
#### Summary
This PR fixes styling of the announcement banner

#### Ticket Link
[MM-36714](https://mattermost.atlassian.net/browse/MM-36714?atlOrigin=eyJpIjoiYTBmOGU3MTJlOTc0NDA4MGFjNzU5N2EwNWMxNDBjN2MiLCJwIjoiaiJ9)

#### Screenshots
<img width="1792" alt="Screenshot 2021-06-29 at 14 18 55" src="https://user-images.githubusercontent.com/28563179/123789047-66e00580-d8e5-11eb-93e9-1404dadbee84.png">


#### Release Note

```release-note
NONE

```
