### PR TITLE
[MM-36618] Save skin tone to preferences

### DIFF
--- a/actions/emoji_actions.js
+++ b/actions/emoji_actions.js
@@ -49,13 +49,13 @@ export function setUserSkinTone(skin) {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
-        const teamOrderPreferences = [{
+        const skinTonePreference = [{
             user_id: currentUserId,
             name: Preferences.EMOJI_SKINTONE,
             category: Preferences.CATEGORY_EMOJI,
             value: skin,
         }];
-        dispatch(savePreferences(currentUserId, teamOrderPreferences));
+        dispatch(savePreferences(currentUserId, skinTonePreference));
     };
 }
 

--- a/actions/emoji_actions.js
+++ b/actions/emoji_actions.js
@@ -4,12 +4,14 @@
 import * as EmojiActions from 'mattermost-redux/actions/emojis';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {setRecentEmojis} from 'actions/local_storage';
 import {getEmojiMap, getRecentEmojis, isCustomEmojiEnabled} from 'selectors/emojis';
 import {isCustomStatusEnabled, makeGetCustomStatus} from 'selectors/views/custom_status';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 
-import {ActionTypes} from 'utils/constants';
+import {ActionTypes, Preferences} from 'utils/constants';
 import {EmojiIndicesByAlias} from 'utils/emoji';
 
 export function loadRecentlyUsedCustomEmojis() {
@@ -43,13 +45,17 @@ export function incrementEmojiPickerPage() {
     };
 }
 
-export function setRecentSkin(skin) {
-    return (dispatch) => {
-        dispatch({
-            type: ActionTypes.SET_RECENT_SKIN,
-            data: skin,
-        });
-        return {data: skin};
+export function setUserSkinTone(skin) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const currentUserId = getCurrentUserId(state);
+        const teamOrderPreferences = [{
+            user_id: currentUserId,
+            name: Preferences.EMOJI_SKINTONE,
+            category: Preferences.CATEGORY_EMOJI,
+            value: skin,
+        }];
+        dispatch(savePreferences(currentUserId, teamOrderPreferences));
     };
 }
 

--- a/actions/local_storage.jsx
+++ b/actions/local_storage.jsx
@@ -29,12 +29,3 @@ export function setRecentEmojis(recentEmojis = []) {
     };
 }
 
-export function persistRecentSkin(recentSkin = 'default') {
-    return (dispatch, getState) => {
-        const currentUserId = getCurrentUserId(getState());
-
-        LocalStorageStore.setRecentSkin(currentUserId, recentSkin);
-
-        return {data: recentSkin};
-    };
-}

--- a/components/emoji_picker/components/emoji_picker_skin.jsx
+++ b/components/emoji_picker/components/emoji_picker_skin.jsx
@@ -27,7 +27,7 @@ const skinToneEmojis = new Map(skinsList.map((pair) => [pair[1], Emoji.Emojis[Em
 
 export class EmojiPickerSkin extends React.PureComponent {
     static propTypes = {
-        recentSkin: PropTypes.string.isRequired,
+        userSkinTone: PropTypes.string.isRequired,
         onSkinSelected: PropTypes.func.isRequired,
         intl: intlShape.isRequired,
     };
@@ -52,7 +52,7 @@ export class EmojiPickerSkin extends React.PureComponent {
 
     hideSkinTonePicker = (skin) => {
         this.setState({pickerExtended: false});
-        if (skin !== this.props.recentSkin) {
+        if (skin !== this.props.userSkinTone) {
             this.props.onSkinSelected(skin);
         }
     }
@@ -88,7 +88,7 @@ export class EmojiPickerSkin extends React.PureComponent {
                 <div className='skin-tones__close'>
                     <button
                         className='skin-tones__close-icon'
-                        onClick={() => this.hideSkinTonePicker(this.props.recentSkin)}
+                        onClick={() => this.hideSkinTonePicker(this.props.userSkinTone)}
                     >
                         <i className='icon-close icon--no-spacing icon-16'/>
                     </button>
@@ -105,7 +105,7 @@ export class EmojiPickerSkin extends React.PureComponent {
         );
     }
     collapsed() {
-        const emoji = skinToneEmojis.get(this.props.recentSkin);
+        const emoji = skinToneEmojis.get(this.props.userSkinTone);
         const spriteClassName = classNames('emojisprite', `emoji-category-${emoji.category}`, `emoji-${emoji.image}`);
         const tooltip = (
             <Tooltip
@@ -129,11 +129,11 @@ export class EmojiPickerSkin extends React.PureComponent {
                 <div className='skin-tones__icon'>
                     <img
                         alt={'emoji skin tone picker'}
-                        data-testid={`skin-picked-${this.props.recentSkin}`}
+                        data-testid={`skin-picked-${this.props.userSkinTone}`}
                         src={imgTrans}
                         className={spriteClassName}
                         onClick={this.showSkinTonePicker}
-                        aria-label={this.ariaLabel(this.props.recentSkin)}
+                        aria-label={this.ariaLabel(this.props.userSkinTone)}
                         role='button'
                     />
                 </div>

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -99,7 +99,7 @@ export default class EmojiPicker extends React.PureComponent {
         customEmojisEnabled: PropTypes.bool,
         emojiMap: PropTypes.object.isRequired,
         recentEmojis: PropTypes.array.isRequired,
-        recentSkin: PropTypes.string.isRequired,
+        userSkinTone: PropTypes.string.isRequired,
         customEmojiPage: PropTypes.number.isRequired,
         visible: PropTypes.bool,
         currentTeamName: PropTypes.string.isRequired,
@@ -107,8 +107,7 @@ export default class EmojiPicker extends React.PureComponent {
             getCustomEmojis: PropTypes.func.isRequired,
             searchCustomEmojis: PropTypes.func.isRequired,
             incrementEmojiPickerPage: PropTypes.func.isRequired,
-            setRecentSkin: PropTypes.func.isRequired,
-            persistRecentSkin: PropTypes.func.isRequired,
+            setUserSkinTone: PropTypes.func.isRequired,
         }).isRequired,
         filter: PropTypes.string.isRequired,
         handleFilterChange: PropTypes.func.isRequired,
@@ -135,7 +134,7 @@ export default class EmojiPicker extends React.PureComponent {
                     return emojiMap.get(name);
                 });
             } else {
-                const indices = Emoji.EmojiIndicesByCategory.get(props.recentSkin).get(category) || [];
+                const indices = Emoji.EmojiIndicesByCategory.get(props.userSkinTone).get(category) || [];
                 categoryEmojis = indices.map((index) => Emoji.Emojis[index]);
                 if (category === 'custom') {
                     categoryEmojis = categoryEmojis.concat([...customEmojiMap.values()]);
@@ -166,8 +165,8 @@ export default class EmojiPicker extends React.PureComponent {
     }
 
     static getDerivedStateFromProps(props, state) {
-        let updatedState = {emojiMap: props.emojiMap, recentSkin: props.recentSkin};
-        if (JSON.stringify(Object.keys(state.categories)) !== state.categoryKeys || props.emojiMap !== state.emojiMap || props.recentSkin !== state.recentSkin) {
+        let updatedState = {emojiMap: props.emojiMap, userSkinTone: props.userSkinTone};
+        if (JSON.stringify(Object.keys(state.categories)) !== state.categoryKeys || props.emojiMap !== state.emojiMap || props.userSkinTone !== state.userSkinTone) {
             const {categories, allEmojis} = EmojiPicker.getEmojis(props, state);
             updatedState = {...updatedState, categories, allEmojis, categoryKeys: JSON.stringify(Object.keys(categories))};
         }
@@ -486,8 +485,7 @@ export default class EmojiPicker extends React.PureComponent {
     }
 
     onSkinSelected = (skin) => {
-        this.props.actions.setRecentSkin(skin);
-        this.props.actions.persistRecentSkin(skin);
+        this.props.actions.setUserSkinTone(skin);
     }
 
     getCategoryByIndex = (index) => {
@@ -643,7 +641,7 @@ export default class EmojiPicker extends React.PureComponent {
                     </FormattedMessage>
                 </div>
                 <EmojiPickerSkin
-                    recentSkin={this.props.recentSkin}
+                    userSkinTone={this.props.userSkinTone}
                     onSkinSelected={this.onSkinSelected}
                 />
             </div>

--- a/components/emoji_picker/emoji_picker.test.jsx
+++ b/components/emoji_picker/emoji_picker.test.jsx
@@ -43,8 +43,7 @@ describe('components/emoji_picker/EmojiPicker', () => {
         getCustomEmojis: jest.fn(),
         incrementEmojiPickerPage: jest.fn(),
         searchCustomEmojis: jest.fn(),
-        setRecentSkin: jest.fn(),
-        persistRecentSkin: jest.fn(),
+        setUserSkinTone: jest.fn(),
     };
 
     const customEmojis = new Map();
@@ -70,7 +69,7 @@ describe('components/emoji_picker/EmojiPicker', () => {
         actions,
         filter: '',
         handleFilterChange: jest.fn(),
-        recentSkin: 'default',
+        userSkinTone: 'default',
         currentTeamName: 'testTeam',
     };
 

--- a/components/emoji_picker/index.js
+++ b/components/emoji_picker/index.js
@@ -6,9 +6,8 @@ import {bindActionCreators} from 'redux';
 
 import {getCustomEmojis, searchCustomEmojis} from 'mattermost-redux/actions/emojis';
 
-import {incrementEmojiPickerPage, setRecentSkin} from 'actions/emoji_actions';
-import {persistRecentSkin} from 'actions/local_storage';
-import {getEmojiMap, getRecentEmojis, getRecentSkin} from 'selectors/emojis';
+import {incrementEmojiPickerPage, setUserSkinTone} from 'actions/emoji_actions';
+import {getEmojiMap, getRecentEmojis, getUserSkinTone} from 'selectors/emojis';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import EmojiPicker from './emoji_picker.jsx';
@@ -20,7 +19,7 @@ function mapStateToProps(state) {
         customEmojiPage: state.views.emoji.emojiPickerCustomPage,
         emojiMap: getEmojiMap(state),
         recentEmojis: getRecentEmojis(state),
-        recentSkin: getRecentSkin(state),
+        userSkinTone: getUserSkinTone(state),
         currentTeamName: currentTeam.name,
     };
 }
@@ -31,8 +30,7 @@ function mapDispatchToProps(dispatch) {
             getCustomEmojis,
             searchCustomEmojis,
             incrementEmojiPickerPage,
-            setRecentSkin,
-            persistRecentSkin,
+            setUserSkinTone,
         }, dispatch),
     };
 }

--- a/reducers/views/emoji.js
+++ b/reducers/views/emoji.js
@@ -35,18 +35,7 @@ function shortcutReactToLastPostEmittedFrom(state = '', action) {
     }
 }
 
-function userSkinTone(state = '', action) {
-    switch (action.type) {
-    case ActionTypes.SET_RECENT_SKIN: {
-        return action.data;
-    }
-    default:
-        return state;
-    }
-}
-
 export default combineReducers({
     emojiPickerCustomPage,
     shortcutReactToLastPostEmittedFrom,
-    userSkinTone,
 });

--- a/reducers/views/emoji.js
+++ b/reducers/views/emoji.js
@@ -35,7 +35,7 @@ function shortcutReactToLastPostEmittedFrom(state = '', action) {
     }
 }
 
-function recentSkin(state = '', action) {
+function userSkinTone(state = '', action) {
     switch (action.type) {
     case ActionTypes.SET_RECENT_SKIN: {
         return action.data;
@@ -48,5 +48,5 @@ function recentSkin(state = '', action) {
 export default combineReducers({
     emojiPickerCustomPage,
     shortcutReactToLastPostEmittedFrom,
-    recentSkin,
+    userSkinTone,
 });

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -6,14 +6,13 @@ import {createSelector} from 'reselect';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
 import {Constants, Preferences} from 'utils/constants';
 import {getItemFromStorage} from 'selectors/storage';
 import EmojiMap from 'utils/emoji_map';
-import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 export const getEmojiMap = createSelector(
     'getEmojiMap',
@@ -41,15 +40,9 @@ export const getRecentEmojis = createSelector(
     },
 );
 
-// todo rename to getEmojiSkin
-export const getUserSkinTone = createSelector(
-    'getUserSkinTone',
-    getMyPreferences,
-    (prefs) => {
-        const key = getPreferenceKey(Preferences.CATEGORY_EMOJI, Preferences.EMOJI_SKINTONE);
-        return prefs[key]?.value || 'default';
-    },
-);
+export function getUserSkinTone(state) {
+    return get(state, Preferences.CATEGORY_EMOJI, Preferences.EMOJI_SKINTONE, 'default');
+}
 
 export function isCustomEmojiEnabled(state) {
     const config = getConfig(state);

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -6,12 +6,14 @@ import {createSelector} from 'reselect';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
-import {Constants} from 'utils/constants';
+import {Constants, Preferences} from 'utils/constants';
 import {getItemFromStorage} from 'selectors/storage';
 import EmojiMap from 'utils/emoji_map';
+import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
 
 export const getEmojiMap = createSelector(
     'getEmojiMap',
@@ -39,18 +41,15 @@ export const getRecentEmojis = createSelector(
     },
 );
 
-function getStateRecentSkin(state) {
-    return state.views.emoji?.recentSkin;
-}
-
-export function getRecentSkin(state) {
-    const stateSkin = getStateRecentSkin(state);
-    if (stateSkin) {
-        return stateSkin;
-    }
-    const recentSkin = LocalStorageStore.getRecentSkin(getCurrentUserId(state));
-    return recentSkin || 'default';
-}
+// todo rename to getEmojiSkin
+export const getUserSkinTone = createSelector(
+    'getUserSkinTone',
+    getMyPreferences,
+    (prefs) => {
+        const key = getPreferenceKey(Preferences.CATEGORY_EMOJI, Preferences.EMOJI_SKINTONE);
+        return prefs[key]?.value || 'default';
+    },
+);
 
 export function isCustomEmojiEnabled(state) {
     const config = getConfig(state);

--- a/stores/local_storage_store.jsx
+++ b/stores/local_storage_store.jsx
@@ -9,7 +9,6 @@ const getPreviousTeamIdKey = (userId) => ['user_prev_team', userId].join(':');
 const getPreviousChannelNameKey = (userId, teamId) => ['user_team_prev_channel', userId, teamId].join(':');
 export const getPenultimateChannelNameKey = (userId, teamId) => ['user_team_penultimate_channel', userId, teamId].join(':');
 const getRecentEmojisKey = (userId) => ['recent_emojis', userId].join(':');
-const getRecentSkinKey = (userId) => ['recent_skin', userId].join(':');
 const getWasLoggedInKey = () => 'was_logged_in';
 const teamIdJoinedOnLoadKey = 'teamIdJoinedOnLoad';
 
@@ -96,16 +95,6 @@ class LocalStorageStoreClass {
         if (recentEmojis.length) {
             this.setItem(getRecentEmojisKey(userId), JSON.stringify(recentEmojis));
         }
-    }
-
-    getRecentSkin(userId) {
-        const recentSkin = this.getItem(getRecentSkinKey(userId));
-
-        return recentSkin || 'default';
-    }
-
-    setRecentSkin(userId, recentSkin = 'default') {
-        this.setItem(getRecentSkinKey(userId), recentSkin);
     }
 
     getTeamIdJoinedOnLoad() {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -110,6 +110,8 @@ export const Preferences = {
     CLOUD_UPGRADE_BANNER: 'cloud_upgrade_banner',
     CLOUD_TRIAL_BANNER: 'cloud_trial_banner',
     ADMIN_CLOUD_UPGRADE_PANEL: 'admin_cloud_upgrade_panel',
+    CATEGORY_EMOJI: 'emoji',
+    EMOJI_SKINTONE: 'emoji_skintone',
 };
 
 export const ActionTypes = keyMirror({
@@ -1594,7 +1596,6 @@ export const Constants = {
     DEFAULT_TERMS_OF_SERVICE_RE_ACCEPTANCE_PERIOD: 365,
     EMOJI_PATH: '/static/emoji',
     RECENT_EMOJI_KEY: 'recentEmojis',
-    RECENT_SKIN_KEY: 'recentSkin',
     DEFAULT_WEBHOOK_LOGO: logoWebhook,
     MHPNS: 'https://push.mattermost.com',
     MTPNS: 'https://push-test.mattermost.com',


### PR DESCRIPTION
#### Summary

User skin tone selection was persisted to localstorage and we are switching that to the user preferences in the server.

#### Ticket Link

[MM-36618](https://mattermost.atlassian.net/browse/MM-36618)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
