### PR TITLE
MM-36730: permalinks to replies sometimes throw

### DIFF
--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -160,7 +160,7 @@ class RhsComment extends React.PureComponent {
 
     scrollIntoHighlight = () => {
         window.requestAnimationFrame(() => {
-            if (!this.props.isInViewport(this.postRef.current)) {
+            if (this.postRef.current && !this.props.isInViewport(this.postRef.current)) {
                 this.postRef.current.scrollIntoView();
             }
         });

--- a/components/threading/thread_viewer/thread_viewer.tsx
+++ b/components/threading/thread_viewer/thread_viewer.tsx
@@ -346,9 +346,10 @@ export default class ThreadViewer extends React.Component<Props, State> {
         return Boolean(this.props.highlightedPostId || this.newMessagesRef.current);
     }
 
-    isInViewport = (element: HTMLDivElement|null): boolean => {
+    isInViewport = (element: HTMLDivElement): boolean => {
         const containerHeight = this.containerRef.current?.getBoundingClientRect().height;
-        if (!element || !containerHeight) {
+
+        if (!containerHeight) {
             return false;
         }
 


### PR DESCRIPTION
#### Summary

It seemed that `componentDidUpdate` didn't have the `postRef` setted yet,
thus producing an error on scrolling to highlighted reply id.
This commit fixes it by:
  1. Changing the `isInViewport` function signature to
     always expect the element to exist.
  2. Ensure `postRef` exists before scrolling into view.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36730

#### Release Note

```release-note
NONE
```
