### PR TITLE
MM-36612: opening channel switcher while in threads throws

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+/* eslint-disable max-lines */
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -642,7 +643,7 @@ export default class SwitchChannelProvider extends Provider {
         const channelList = [];
         for (let i = 0; i < channels.length; i++) {
             const channel = channels[i];
-            if (channel.id === currentChannel.id) {
+            if (channel.id === currentChannel?.id) {
                 continue;
             }
             let wrappedChannel = {channel, name: channel.name, deactivated: false};


### PR DESCRIPTION
#### Summary

Current channel doesn't exist when in global threads, so channel
switcher throws error.
This commit fixes that error.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36612

#### Release Note

```release-note
NONE
```
