### PR TITLE
MM-35439: CRT, clicking x unread threads

### DIFF
--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -198,7 +198,7 @@ const GlobalThreads = () => {
                                 link: (chunks) => (
                                     <Link
                                         key='single'
-                                        to={url + '/' + unreadThreadIds[0]}
+                                        to={`${url}/${unreadThreadIds[0]}`}
                                         onClick={handleSelectUnread}
                                     >
                                         {chunks}

--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {memo, useEffect} from 'react';
+import React, {memo, useCallback, useEffect} from 'react';
 import {useIntl} from 'react-intl';
 import {isEmpty} from 'lodash';
 import {Link, useRouteMatch} from 'react-router-dom';
@@ -93,6 +93,10 @@ const GlobalThreads = () => {
         return () => {
             dispatch(setSelectedThreadId(currentTeamId, ''));
         };
+    }, []);
+
+    const handleSelectUnread = useCallback(() => {
+        setFilter(ThreadFilter.unread);
     }, []);
 
     return (
@@ -194,7 +198,8 @@ const GlobalThreads = () => {
                                 link: (chunks) => (
                                     <Link
                                         key='single'
-                                        to={url}
+                                        to={url + '/' + unreadThreadIds[0]}
+                                        onClick={handleSelectUnread}
                                     >
                                         {chunks}
                                     </Link>


### PR DESCRIPTION
#### Summary

Clicking x unread threads in global threads was a no-op.

This commit changes that so the first unread thread and the
Unreads tab are selected.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35439

#### Release Note

```release-note
NONE
```
