### PR TITLE
[MM-36613] Adapt to mobile view

### DIFF
--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -141,6 +141,7 @@
                 margin-right: 5px;
                 margin-left: 5px;
                 opacity: 1;
+                border-radius: 0;
             }
         }
 
@@ -256,6 +257,8 @@
 
         &--active {
             position: absolute;
+            width: 100%;
+            justify-content: space-around;
 
             .skin-tones__close,
             .skin-tones__icons {
@@ -306,14 +309,15 @@
         justify-content: space-between;
 
         &.skin-tones__content__single {
-            width: 32px;
+            padding-left: 10px;
+            padding-right: 4px;
         }
     }
 
     .emoji-picker__text-container {
         position: relative;
         z-index: 5;
-        width: 284px;
+        width: 95%;
         height: 32px;
         border: 1px solid var(--center-channel-color-24);
         border-radius: 4px;
@@ -431,7 +435,7 @@
 
     .emoji-picker__container {
         position: relative;
-        width: 325px;
+        min-width: 325px;
         min-height: 100%;
     }
 

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -525,14 +525,13 @@
         .emoji-picker__category {
             width: 30px;
             height: 30px;
-            padding-top: 4px;
         }
+    }
+    .emoji-picker__search-container {
+        height: 40px;
     }
 
     .emoji-picker__items {
-        // !important is used to overide inline styles
-        // used on larger screens
-        height: auto !important;
         flex-grow: 1;
 
         .emoji-picker__category-header {
@@ -564,7 +563,6 @@
     .emoji-picker__preview {
         width: 100%;
         height: 60px;
-        padding: 10px 10px 0;
     }
 
     .MenuWrapper {


### PR DESCRIPTION
#### Summary

Adapt emoji picker to mobile view

#### Ticket Link

[MM-36613](https://mattermost.atlassian.net/browse/MM-36613)

#### Screenshots
<img width="476" alt="Screen Shot 2021-06-30 at 13 23 42" src="https://user-images.githubusercontent.com/1515906/123952569-770be980-d9a6-11eb-9fc1-d44c5de23436.png">
<img width="462" alt="Screen Shot 2021-06-30 at 13 23 36" src="https://user-images.githubusercontent.com/1515906/123952574-783d1680-d9a6-11eb-91e7-699d0ca2a375.png">

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
