### PR TITLE
[MM-36809] Suggest only skintones along user skin tone selection

### DIFF
--- a/components/suggestion/emoticon_provider.jsx
+++ b/components/suggestion/emoticon_provider.jsx
@@ -109,9 +109,10 @@ export default class EmoticonProvider extends Provider {
     findAndSuggestEmojis(text, partialName, resultsCallback) {
         const recentMatched = [];
         const matched = [];
-
-        const emojiMap = getEmojiMap(store.getState());
-        const recentEmojis = getRecentEmojis(store.getState());
+        const state = store.getState();
+        const skintone = state.entities?.preferences?.myPreferences['emoji--emoji_skintone']?.value || 'default';
+        const emojiMap = getEmojiMap(state);
+        const recentEmojis = getRecentEmojis(state);
 
         // Check for named emoji
         for (const [name, emoji] of emojiMap) {
@@ -127,7 +128,10 @@ export default class EmoticonProvider extends Provider {
                             recentMatched :
                             matched;
 
-                        matchedArray.push({name: alias, emoji});
+                        // if the emoji has skin, only add those that match with the user selected skin.
+                        if (Emoticons.emojiMatchesSkin(emoji, skintone)) {
+                            matchedArray.push({name: alias, emoji});
+                        }
                         break;
                     }
                 }

--- a/packages/mattermost-redux/src/types/emojis.ts
+++ b/packages/mattermost-redux/src/types/emojis.ts
@@ -29,6 +29,8 @@ export type SystemEmoji = {
     short_names: string[];
     category: EmojiCategory;
     batch: number;
+    skins?: string[];
+    skin_variations?: unknown[]; // we currently don't have a use for it other than knowing the field exists.
 };
 export type Emoji = SystemEmoji | CustomEmoji;
 export type EmojisState = {

--- a/utils/emoticons.tsx
+++ b/utils/emoticons.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+import {Emoji} from 'mattermost-redux/types/emojis';
 
 export const emoticonPatterns: { [key: string]: RegExp } = {
     slightly_smiling_face: /(^|\B)(:-?\))($|\B)/g, // :)
@@ -85,6 +86,25 @@ export function handleEmoticons(
     return output;
 }
 
-export function renderEmoji(name: string, matchText: string) {
+export function renderEmoji(name: string, matchText: string): string {
     return `<span data-emoticon="${name}">${matchText}</span>`;
+}
+
+// if an emoji
+// - has `skin_variations` then it uses the default skin (yellow)
+// - has `skins` it's first value is considered the skin version (it can contain more values)
+// - any other case it doesn't have variations or is a custom emoji.
+function getSkin(emoji: Emoji) {
+    if ('skin_variations' in emoji) {
+        return 'default';
+    }
+    if ('skins' in emoji) {
+        return emoji.skins && emoji.skins[0];
+    }
+    return null;
+}
+
+export function emojiMatchesSkin(emoji: Emoji, skin: string): boolean {
+    const emojiSkin = getSkin(emoji);
+    return !emojiSkin || emojiSkin === skin;
 }


### PR DESCRIPTION
#### Summary

When the user starts typing an emoji, suggest only emojis that match the selected skin tone (if possible)

this doesn't fix the known issue about searching and switching the skin.

#### Ticket Link
[MM-36809](https://mattermost.atlassian.net/browse/MM-36809)

#### Screenshots

<img width="660" alt="Screen Shot 2021-06-30 at 17 11 02" src="https://user-images.githubusercontent.com/1515906/123985972-315f1900-d9c6-11eb-93a7-7aeba9ecd727.png">

#### Release Note
```release-note
NONE
```
