### PR TITLE
[MM-35249] Ensure window size is at least 0 before checking for mobile

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1293,7 +1293,7 @@ export function isValidBotUsername(name) {
 }
 
 export function isMobile() {
-    return window.innerWidth <= Constants.MOBILE_SCREEN_WIDTH;
+    return window.innerWidth > 0 && window.innerWidth <= Constants.MOBILE_SCREEN_WIDTH;
 }
 
 export function loadImage(url, onLoad, onProgress) {


### PR DESCRIPTION
#### Summary
The Desktop App on Windows/Linux seems to have a bug where the browser thinks the window size is 0x0 when the app is loaded. This triggers `isMobile()` to return `true`, which focuses the search bar immediately when the app is loaded.

This PR makes sure the window size is >0 before we return `true` for `isMobile()`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35249

#### Release Note
```release-note
NONE
```
