### PR TITLE
[MM-37074] Encapsulate inserted GIFs in inline image markdown

### DIFF
--- a/components/gif_picker/gif_picker.jsx
+++ b/components/gif_picker/gif_picker.jsx
@@ -59,7 +59,7 @@ export default class GifPicker extends React.PureComponent {
     }
 
     handleItemClick = (gif) => {
-        this.props.onGifClick(gif.max5mbGif);
+        this.props.onGifClick('![' + (gif.title.replace(/]/g, '\\]') + '](' + gif.max5mbGif + ')');
     }
 
     render() {

--- a/components/gif_picker/gif_picker.jsx
+++ b/components/gif_picker/gif_picker.jsx
@@ -59,7 +59,7 @@ export default class GifPicker extends React.PureComponent {
     }
 
     handleItemClick = (gif) => {
-        this.props.onGifClick('![' + (gif.title.replace(/]/g, '\\]') + '](' + gif.max5mbGif + ')');
+        this.props.onGifClick('![' + gif.title.replace(/]|\[/g, '\\$&') + '](' + gif.max5mbGif + ')');
     }
 
     render() {


### PR DESCRIPTION
#### Summary
Changes Markdown inserted by GIF picker from
```markdown
https://thumbs.gfycat.com/LikableValidAlpineroadguidetigerbeetle-size_restricted.gif
```
to
```markdown
![Beverly Hills Cop - OK gesture](https://thumbs.gfycat.com/LikableValidAlpineroadguidetigerbeetle-size_restricted.gif)
```

#### Ticket Link
As per **Other notes** of [\[MM-12290\]](https://mattermost.atlassian.net/browse/MM-12290)
https://mattermost.atlassian.net/browse/MM-37074

#### Screenshots
![link only](https://user-images.githubusercontent.com/28617290/124703182-f95d5600-df30-11eb-9db1-6f8048cc1c01.png "before")  
![inlined image](https://user-images.githubusercontent.com/28617290/124703213-0aa66280-df31-11eb-904e-ea92d2b3862e.png "after")

#### Release Note
```release-note
Improved default rendering of images inserted via the GIF picker.
```
