### PR TITLE
MM-36873 Fix text wrapping in channel navigator

### DIFF
--- a/components/sidebar/channel_navigator/channel_navigator.tsx
+++ b/components/sidebar/channel_navigator/channel_navigator.tsx
@@ -66,10 +66,12 @@ export default class ChannelNavigator extends React.PureComponent<Props> {
                 aria-label={Utils.localizeMessage('sidebar_left.channel_navigator.channelSwitcherLabel', 'Channel Switcher')}
             >
                 <i className='icon icon-magnify'/>
-                <FormattedMessage
-                    id='sidebar_left.channel_navigator.jumpTo'
-                    defaultMessage='Find channel'
-                />
+                <span className={'SidebarChannelNavigator_jumpToText'}>
+                    <FormattedMessage
+                        id='sidebar_left.channel_navigator.jumpTo'
+                        defaultMessage='Find channel'
+                    />
+                </span>
                 <div className={'SidebarChannelNavigator_shortcutText'}>
                     {channelSwitchTextShortcutDefault}
                 </div>

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -206,6 +206,12 @@
                 font-size: 18px;
             }
 
+            .SidebarChannelNavigator_jumpToText {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
             .SidebarChannelNavigator_shortcutText {
                 display: none;
                 padding-right: 3px;


### PR DESCRIPTION
"Find channel" wraps in some other languages when there's less space because the user is using a browser.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36873

#### Screenshots
![Screen Shot 2021-07-07 at 9 31 41 AM](https://user-images.githubusercontent.com/3277310/124767826-26e0da00-df06-11eb-8a28-b2d26c1ef366.png)

#### Release Note
```release-note
Fixed text wrapping in "Find channel" button when using certain languages
```
