### PR TITLE
MM36936 - fix cloud subscribe api URI path

### DIFF
--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -3650,7 +3650,7 @@ export default class Client4 {
 
     subscribeCloudProduct = (productId: string) => {
         return this.doFetch<CloudCustomer>(
-            `${this.getCloudRoute()}/cloud/subscription`,
+            `${this.getCloudRoute()}/subscription`,
             {method: 'put', body: JSON.stringify({product_id: productId})},
         );
     }


### PR DESCRIPTION
#### Summary
This PR fixes the cloud subscribe api call by removing the duplicated "cloud" word in the URI path

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36936

#### Release Note

```release-note
NONE
```
