### PR TITLE
Check whether the list element is present or not before accessing the index

### DIFF
--- a/components/suggestion/modal_suggestion_list.jsx
+++ b/components/suggestion/modal_suggestion_list.jsx
@@ -92,7 +92,7 @@ export default class ModalSuggestionList extends React.PureComponent {
             return 0;
         }
 
-        const listElement = this.suggestionList.current.getContent()[0];
+        const listElement = this.suggestionList.current?.getContent()?.[0];
         if (!listElement) {
             return 0;
         }


### PR DESCRIPTION
#### Summary
Fix a crash when adding a user to a channel from the user popover.

This was caused due to not checking whether the content was being returned or not.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36955

#### Related Pull Requests
None

#### Release Note
```release-note
None
```
