### PR TITLE
Fix dynamic and static select not being readonly

### DIFF
--- a/components/apps_form/apps_form_field/apps_form_select_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_select_field.tsx
@@ -81,6 +81,7 @@ export default class AppsFormSelectField extends React.PureComponent<Props, Stat
                     placeholder={placeholder}
                     value={value}
                     onChange={this.onChange as any} // types are not working correctly for multiselect
+                    isDisabled={field.readonly}
                     {...commonProps}
                 />
             </div>
@@ -104,6 +105,7 @@ export default class AppsFormSelectField extends React.PureComponent<Props, Stat
                     placeholder={placeholder}
                     value={value}
                     onChange={this.onChange as any} // types are not working correctly for multiselect
+                    isDisabled={field.readonly}
                     {...commonProps}
                 />
             </div>


### PR DESCRIPTION
#### Summary
Static and Dynamic selects were not respecting the readonly parameter. Now they are.

#### Ticket Link
None

#### Release Note
```release-note
None
```
