### PR TITLE
Adjust feature flag language in System Console

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -907,7 +907,7 @@
   "admin.false": "false",
   "admin.feature_flags.flag": "Flag",
   "admin.feature_flags.flag_value": "Value",
-  "admin.feature_flags.introBanner": "Feature flag values displayed here show the status of features enabled on this server. The values here are only for use debugging by the Mattermost support team.",
+  "admin.feature_flags.introBanner": "The following feature flag values show the status of features enabled on this instance. The values are used for debugging purposes by the Mattermost support team.",
   "admin.feature_flags.title": "Feature Flags",
   "admin.field_names.allowBannerDismissal": "Allow banner dismissal",
   "admin.field_names.bannerColor": "Banner color",


### PR DESCRIPTION
#### Summary
Enhance UI text and fix grammar of System Console > Feature Flags page. Includes changing the word `server` to `instance`, which is the term used to refer to both Mattermost "servers" and Mattermost Cloud "workspaces"


#### Ticket Link
N/A

#### Related Pull Requests
N/A

#### Screenshots
![image](https://user-images.githubusercontent.com/13119842/125455481-b323d0f1-d6d8-4d07-8ac5-7141ccb1c6fc.png)

#### Release Note
NONE