### PR TITLE
Do not save drafts until typing has stopped for X milliseconds

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -38,6 +38,8 @@ import MessageSubmitError from 'components/message_submit_error';
 
 const KeyCodes = Constants.KeyCodes;
 
+const CreateCommentDraftTimeoutMilliseconds = 500;
+
 class CreateComment extends React.PureComponent {
     static propTypes = {
 
@@ -306,7 +308,7 @@ class CreateComment extends React.PureComponent {
         document.removeEventListener('keydown', this.focusTextboxIfNecessary);
 
         if (this.saveDraftFrame) {
-            cancelAnimationFrame(this.saveDraftFrame);
+            clearTimeout(this.saveDraftFrame);
 
             this.props.onUpdateCommentDraft(this.state.draft);
         }
@@ -708,10 +710,10 @@ class CreateComment extends React.PureComponent {
         const {draft} = this.state;
         const updatedDraft = {...draft, message};
 
-        cancelAnimationFrame(this.saveDraftFrame);
-        this.saveDraftFrame = requestAnimationFrame(() => {
+        clearTimeout(this.saveDraftFrame);
+        this.saveDraftFrame = setTimeout(() => {
             this.props.onUpdateCommentDraft(updatedDraft);
-        });
+        }, CreateCommentDraftTimeoutMilliseconds);
 
         this.setState({draft: updatedDraft, serverError}, () => {
             if (this.props.scrollToBottom) {

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint-disable max-lines */
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -45,6 +47,8 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx'
 import MessageSubmitError from 'components/message_submit_error';
 
 const KeyCodes = Constants.KeyCodes;
+
+const CreatePostDraftTimeoutMilliseconds = 500;
 
 // Temporary fix for IE-11, see MM-13423
 function trimRight(str) {
@@ -375,7 +379,7 @@ class CreatePost extends React.PureComponent {
         if (this.saveDraftFrame) {
             const channelId = this.props.currentChannel.id;
             this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, this.draftsForChannel[channelId]);
-            cancelAnimationFrame(this.saveDraftFrame);
+            clearTimeout(this.saveDraftFrame);
         }
     }
 
@@ -532,7 +536,7 @@ class CreatePost extends React.PureComponent {
             postError: null,
         });
 
-        cancelAnimationFrame(this.saveDraftFrame);
+        clearTimeout(this.saveDraftFrame);
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, null);
         this.draftsForChannel[channelId] = null;
     }
@@ -802,10 +806,10 @@ class CreatePost extends React.PureComponent {
             ...this.props.draft,
             message,
         };
-        cancelAnimationFrame(this.saveDraftFrame);
-        this.saveDraftFrame = requestAnimationFrame(() => {
+        clearTimeout(this.saveDraftFrame);
+        this.saveDraftFrame = setTimeout(() => {
             this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft);
-        });
+        }, CreatePostDraftTimeoutMilliseconds);
         this.draftsForChannel[channelId] = draft;
     }
 


### PR DESCRIPTION
#### Summary
Currently, we were saving drafts for messages being typed into the post and comment textboxes on animation frames which can occur quite frequently. Saving drafts also seems to be less performant on some browser/OS/device combinations than on others. They also fire off a number of dispatches and change redux state which can negatively impact performance too. During some local testing, where I added a console log for each draft save, I was seeing it saved on every single key press which is 1) saving significantly more often than necessary and 2) could be negatively impacting performance, particularly in certain environments.

This is after typing about 100 characters into the post textbox:
<img width="142" alt="Screen Shot 2021-07-13 at 8 28 02 AM" src="https://user-images.githubusercontent.com/2672098/125454081-ddad8a4c-8e15-4611-bc13-ac5901081b98.png">

In addition some very useful profiles from the community on Firefox are showing `saveDraftFrame` being called about every 100ms during typing and was taking up the majority of the JS processing time in the profile:
<img width="787" alt="Screen Shot 2021-07-12 at 1 43 29 PM" src="https://user-images.githubusercontent.com/2672098/125455513-84bc9001-c6d5-4765-b3cb-c92167f4297e.png">

This PR moves from using animation frames to save the draft to a more controlled `setTimeout` which will only save the draft after 500ms of no typing has occurred (or the component unmounts).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Improve typing performance in affected environments by reducing the frequency at which drafts are saved
```
