### PR TITLE
Add balancing call to TestHelper.tearDown() in mattermost-redux test

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/integrations.test.js
+++ b/packages/mattermost-redux/src/selectors/entities/integrations.test.js
@@ -55,4 +55,6 @@ describe('Selectors.Integrations', () => {
         const autocompleteCommandsForTeam = [command3];
         assert.deepEqual(getAutocompleteCommandsList(testState), autocompleteCommandsForTeam);
     });
+
+    TestHelper.tearDown();
 });


### PR DESCRIPTION
#### Summary
This change doesn't fix any particular issue, nor does it add functionality, and I don't think it is required or important.  All it does is make sure that calls to `TestHelper.initBasic` and `TestHelper.tearDown` are balanced in the codebase; one teardown call was missing.

#### Ticket Link
N/A

#### Related Pull Requests
N/A

#### Release Note
```release-note
NONE
```
