### PR TITLE
[Re: MM-35696]: Expose Timestamp and ReactIntl for usage in plugins

### DIFF
--- a/plugins/export.js
+++ b/plugins/export.js
@@ -10,12 +10,15 @@ import {openModal} from 'actions/views/modals';
 import {ModalIdentifiers} from 'utils/constants';
 import PurchaseModal from 'components/purchase_modal';
 
+import Timestamp from 'components/timestamp';
+
 // The following import has intentional side effects. Do not remove without research.
 import {openInteractiveDialog} from './interactive_dialog';
 
 // Common libraries exposed on window for plugins to use as Webpack externals.
 window.React = require('react');
 window.ReactDOM = require('react-dom');
+window.ReactIntl = require('react-intl');
 window.Redux = require('redux');
 window.ReactRedux = require('react-redux');
 window.ReactBootstrap = require('react-bootstrap');
@@ -30,4 +33,9 @@ window.WebappUtils = {
     browserHistory,
     modals: {openModal, ModalIdentifiers},
 };
-window.Components = {Textbox, PurchaseModal};
+
+window.Components = {
+    Textbox,
+    PurchaseModal,
+    Timestamp,
+};


### PR DESCRIPTION
#### Summary

To allow for better number, plural, datetime, etc. message formatting in plugins: 

- Expose `<Timestamp>` for usage in plugins; potentially/ideally a stop-gap until Common Components
- Expose `react-intl` for usage in plugins alongside other existing globals (react, react-router-dom, redux, etc.)
- Prop-syntax improvement for `<Timestamp/>`, support `UnitDescriptor` as a valid relative unit for easier custom ranges 
  E.g. Within `props.units`, the terser `['day', -30]` auto-expands to `{within: ['day', -30], display: ['day']}`

While this is stand alone, [MM-35696](https://mattermost.atlassian.net/browse/MM-35696) depends on this. Ref: https://github.com/mattermost/mattermost-plugin-incident-collaboration/pull/634


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Allow for `react-intl` and `<Timestamp/>` usage in plugins
```
