### PR TITLE
[MM-37108] Only make request if server is enterprise ready

### DIFF
--- a/components/admin_console/license_settings/license_settings.jsx
+++ b/components/admin_console/license_settings/license_settings.jsx
@@ -67,13 +67,12 @@ export default class LicenseSettings extends React.PureComponent {
     }
 
     componentDidMount() {
-        if (!this.props.enterpriseReady) {
+        if (this.props.enterpriseReady) {
+            this.props.actions.getPrevTrialLicense();
+        } else {
             this.reloadPercentage();
         }
         this.props.actions.getLicenseConfig();
-        if (this.props.enterpriseReady) {
-            this.props.actions.getPrevTrialLicense();
-        }
         AdminActions.getStandardAnalytics();
     }
 

--- a/components/admin_console/license_settings/license_settings.jsx
+++ b/components/admin_console/license_settings/license_settings.jsx
@@ -71,7 +71,9 @@ export default class LicenseSettings extends React.PureComponent {
             this.reloadPercentage();
         }
         this.props.actions.getLicenseConfig();
-        this.props.actions.getPrevTrialLicense();
+        if (this.props.enterpriseReady) {
+            this.props.actions.getPrevTrialLicense();
+        }
         AdminActions.getStandardAnalytics();
     }
 


### PR DESCRIPTION
#### Summary

Making the `getPrevTrialLicense()` request was causing a panic server side when in team edition. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37108

#### Release Note

```release-note
NONE
```

#### Related PRs

https://github.com/mattermost/mattermost-server/pull/17933
