### PR TITLE
[MM-34895] send timestamp after last_reply_at when viewing thread

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -1470,6 +1470,11 @@ function handleThreadUpdated(msg) {
         let lastViewedAt;
         if (isThreadOpen(state, threadData.id) && !isThreadManuallyUnread(state, threadData.id)) {
             lastViewedAt = Date.now();
+
+            // Sometimes `Date.now()` was generating a timestamp before the
+            // last_reply_at of the thread, thus marking the thread as unread
+            // instead of read. Here we set the timestamp to after the
+            // last_reply_at if this happens.
             if (lastViewedAt < threadData.last_reply_at) {
                 lastViewedAt = threadData.last_reply_at + 1;
             }

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -1470,6 +1470,9 @@ function handleThreadUpdated(msg) {
         let lastViewedAt;
         if (isThreadOpen(state, threadData.id) && !isThreadManuallyUnread(state, threadData.id)) {
             lastViewedAt = Date.now();
+            if (lastViewedAt < threadData.last_reply_at) {
+                lastViewedAt = threadData.last_reply_at + 1;
+            }
 
             // prematurely update thread data as read
             // so we won't flash the indicators when


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When the user posts a message in a thread, the server responds with a THREAD_UPDATED event. In the websocket handler for this event, the thread is immediately marked as read if that thread is open. 

Looking at the community server responses on my local machine - the `create_at` of user's post  was `1626446482669`. The webapp then sends a request to mark the thread as read with the timestamp `1626446482566` (`Date.Now()`)

The mark as read timestamp is before the `create_at` of the post created. **Could be this because of some clock skew?** I have updated the code to set the read time as just after the `create_at `of the post, if `Date.Now` is before the `create_at` time of the post.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-34895

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
