### PR TITLE
MM-37048 Temporarily store drafts in localStorage and rehydrate manually to fix persistence issues

### DIFF
--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -39,8 +39,16 @@ export function clearCommentDraftUploads() {
     });
 }
 
+// Temporarily store draft manually in localStorage since the current version of redux-persist
+// we're on will not save the draft quickly enough on page unload.
 export function updateCommentDraft(rootId, draft) {
-    return setGlobalItem(`${StoragePrefixes.COMMENT_DRAFT}${rootId}`, draft);
+    const key = `${StoragePrefixes.COMMENT_DRAFT}${rootId}`;
+    if (draft) {
+        localStorage.setItem(key, JSON.stringify(draft));
+    } else {
+        localStorage.removeItem(draft);
+    }
+    return setGlobalItem(key, draft);
 }
 
 export function makeOnMoveHistoryIndex(rootId, direction) {

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -342,6 +342,7 @@ class CreateComment extends React.PureComponent {
         if (this.saveDraftFrame) {
             clearTimeout(this.saveDraftFrame);
             this.props.onUpdateCommentDraft(this.state.draft);
+            this.saveDraftFrame = null;
         }
     }
 

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -287,6 +287,7 @@ class CreateComment extends React.PureComponent {
         this.focusTextbox();
         document.addEventListener('paste', this.pasteHandler);
         document.addEventListener('keydown', this.focusTextboxIfNecessary);
+        window.addEventListener('beforeunload', this.saveDraft);
         if (useGroupMentions) {
             getChannelMemberCountsByGroup(channelId);
         }
@@ -303,12 +304,8 @@ class CreateComment extends React.PureComponent {
         this.props.resetCreatePostRequest();
         document.removeEventListener('paste', this.pasteHandler);
         document.removeEventListener('keydown', this.focusTextboxIfNecessary);
-
-        if (this.saveDraftFrame) {
-            clearTimeout(this.saveDraftFrame);
-
-            this.props.onUpdateCommentDraft(this.state.draft);
-        }
+        window.removeEventListener('beforeunload', this.saveDraft);
+        this.saveDraft();
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -338,6 +335,13 @@ class CreateComment extends React.PureComponent {
                 this.props.scrollToBottom();
             }
             this.doInitialScrollToBottom = false;
+        }
+    }
+
+    saveDraft = () => {
+        if (this.saveDraftFrame) {
+            clearTimeout(this.saveDraftFrame);
+            this.props.onUpdateCommentDraft(this.state.draft);
         }
     }
 

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -345,6 +345,7 @@ class CreatePost extends React.PureComponent {
         this.focusTextbox();
         document.addEventListener('paste', this.pasteHandler);
         document.addEventListener('keydown', this.documentKeyHandler);
+        window.addEventListener('beforeunload', this.saveDraft);
         this.setOrientationListeners();
 
         if (useGroupMentions) {
@@ -357,6 +358,7 @@ class CreatePost extends React.PureComponent {
         if (prevProps.currentChannel.id !== currentChannel.id) {
             this.lastChannelSwitchAt = Date.now();
             this.focusTextbox();
+            this.saveDraft(prevProps);
             if (useGroupMentions) {
                 actions.getChannelMemberCountsByGroup(currentChannel.id, isTimezoneEnabled);
             }
@@ -375,10 +377,15 @@ class CreatePost extends React.PureComponent {
     componentWillUnmount() {
         document.removeEventListener('paste', this.pasteHandler);
         document.removeEventListener('keydown', this.documentKeyHandler);
+        window.addEventListener('beforeunload', this.saveDraft);
         this.removeOrientationListeners();
+        this.saveDraft();
+    }
+
+    saveDraft = (props = this.props) => {
         if (this.saveDraftFrame) {
-            const channelId = this.props.currentChannel.id;
-            this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, this.draftsForChannel[channelId]);
+            const channelId = props.currentChannel.id;
+            props.actions.setDraft(StoragePrefixes.DRAFT + channelId, this.draftsForChannel[channelId]);
             clearTimeout(this.saveDraftFrame);
         }
     }

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -387,6 +387,7 @@ class CreatePost extends React.PureComponent {
             const channelId = props.currentChannel.id;
             props.actions.setDraft(StoragePrefixes.DRAFT + channelId, this.draftsForChannel[channelId]);
             clearTimeout(this.saveDraftFrame);
+            this.saveDraftFrame = null;
         }
     }
 

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -383,7 +383,7 @@ class CreatePost extends React.PureComponent {
     }
 
     saveDraft = (props = this.props) => {
-        if (this.saveDraftFrame) {
+        if (this.saveDraftFrame && props.currentChannel) {
             const channelId = props.currentChannel.id;
             props.actions.setDraft(StoragePrefixes.DRAFT + channelId, this.draftsForChannel[channelId]);
             clearTimeout(this.saveDraftFrame);

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -116,6 +116,17 @@ function onSubmitPost(post, fileInfos) {
     };
 }
 
+// Temporarily store draft manually in localStorage since the current version of redux-persist
+// we're on will not save the draft quickly enough on page unload.
+function setDraft(key, value) {
+    if (value) {
+        localStorage.setItem(key, JSON.stringify(value));
+    } else {
+        localStorage.removeItem(key);
+    }
+    return setGlobalItem(key, value);
+}
+
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
@@ -125,7 +136,7 @@ function mapDispatchToProps(dispatch) {
             moveHistoryIndexForward,
             addReaction,
             removeReaction,
-            setDraft: setGlobalItem,
+            setDraft,
             clearDraftUploads: actionOnGlobalItemsWithPrefix,
             selectPostFromRightHandSideSearchByPostId,
             setEditingPost,


### PR DESCRIPTION
#### Summary
This is a follow-up PR to #8396 that fixes an issue where drafts were sometimes not persisted after a refresh if the save draft timeout didn't have time to fire.

Unfortunately the really out of date version of redux-persist works in mysterious ways and doesn't store the drafts quick enough upon page unload so the drafts wouldn't be persisted. Instead I modified drafts to also temporarily be stored directly into localStorage and then added some manual rehydration of the drafts into redux on app load. It's not ideal since we're storing the drafts twice now but I feel like this is an "ok enough" solution until we do a proper re-visit to storage and drafts.

#### Ticket Link
Follow-up to https://mattermost.atlassian.net/browse/MM-37048

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
