### PR TITLE
[MM-35552] Prevent opening of Search Tabs on Chrome when using Account Settings modal keyboard shortcut

### DIFF
--- a/components/legacy_sidebar/header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/legacy_sidebar/header/dropdown/sidebar_header_dropdown.jsx
@@ -53,6 +53,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent {
 
     handleKeyDown = (e) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey && isKeyPressed(e, Constants.KeyCodes.A)) {
+            e.preventDefault();
             this.props.actions.openModal({ModalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal});
         }
     }

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -100,6 +100,7 @@ class MainMenu extends React.PureComponent {
 
     handleKeyDown = (e) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey && isKeyPressed(e, Constants.KeyCodes.A)) {
+            e.preventDefault();
             this.props.actions.openModal({ModalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal});
         }
     }

--- a/components/user_settings/modal/user_settings_modal.tsx
+++ b/components/user_settings/modal/user_settings_modal.tsx
@@ -169,6 +169,7 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
 
     handleKeyDown = (e: KeyboardEvent) => {
         if (Utils.cmdOrCtrlPressed(e) && e.shiftKey && Utils.isKeyPressed(e, Constants.KeyCodes.A)) {
+            e.preventDefault();
             this.handleHide();
         }
     }


### PR DESCRIPTION
#### Summary
When using `CTRL/CMD+SHIFT+A` to open the Account Settings modal, on Chrome, the new 'Search Tabs' dropdown would also fire, interfering with our workflow. This PR stops the 'Search Tabs' dropdown from opening with the keyboard shortcut when Mattermost is active.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35552

#### Release Note
```release-note
NONE
```
