### PR TITLE
MM-36854: Export ChannelInviteModal and ChannelMembersModal for plugins to use

### DIFF
--- a/plugins/export.js
+++ b/plugins/export.js
@@ -10,6 +10,7 @@ import {openModal} from 'actions/views/modals';
 import {ModalIdentifiers} from 'utils/constants';
 import PurchaseModal from 'components/purchase_modal';
 import ChannelInviteModal from 'components/channel_invite_modal';
+import ChannelMembersModal from 'components/channel_members_modal';
 
 import Timestamp from 'components/timestamp';
 
@@ -40,4 +41,5 @@ window.Components = {
     PurchaseModal,
     Timestamp,
     ChannelInviteModal,
+    ChannelMembersModal,
 };

--- a/plugins/export.js
+++ b/plugins/export.js
@@ -9,6 +9,7 @@ import Textbox from 'components/textbox';
 import {openModal} from 'actions/views/modals';
 import {ModalIdentifiers} from 'utils/constants';
 import PurchaseModal from 'components/purchase_modal';
+import ChannelInviteModal from 'components/channel_invite_modal';
 
 import Timestamp from 'components/timestamp';
 
@@ -38,4 +39,5 @@ window.Components = {
     Textbox,
     PurchaseModal,
     Timestamp,
+    ChannelInviteModal,
 };


### PR DESCRIPTION
#### Summary
This PR exports the `ChannelInviteModal` and the `ChannelMembersModal` components, so that we can pass the needed parameters to `openModal` from the new RHS in Incident Collaboration.

In short, this PR allows us to make the interactions with the participants section in the video work:

https://user-images.githubusercontent.com/3924815/126299946-1572ff16-6db5-43c9-aa94-5f49245a38a7.mp4



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36854

#### Release Note

```release-note
Exported ChannelInviteModal and ChannelMembersModal components for plugins 
```
