### PR TITLE
[MM-37189] fix style issue in ProductNoticesModal

### DIFF
--- a/components/generic_modal.scss
+++ b/components/generic_modal.scss
@@ -70,7 +70,7 @@
 
         .close {
             top: 6px;
-            right: 4px;
+            right: 6px;
             display: flex;
             width: 4rem;
             height: 4rem;

--- a/components/product_notices_modal/product_notices_modal.scss
+++ b/components/product_notices_modal/product_notices_modal.scss
@@ -3,7 +3,7 @@
 .productNotices {
     width: 692px;
 
-    .modal-content {
+    .app__body .modal & .modal-content {
         padding: 40px;
     }
 
@@ -59,7 +59,7 @@
         margin-top: calc(50vh - 307px);
     }
 
-    &.GenericModal .modal-footer {
+    .app__body .modal & .modal-footer {
         position: relative;
         padding: 0;
     }

--- a/components/product_notices_modal/product_notices_modal.scss
+++ b/components/product_notices_modal/product_notices_modal.scss
@@ -18,6 +18,7 @@
 
     .productNotices__helpText {
         margin-top: 8px;
+
         p {
             margin-bottom: 32px;
         }

--- a/components/product_notices_modal/product_notices_modal.scss
+++ b/components/product_notices_modal/product_notices_modal.scss
@@ -20,7 +20,7 @@
         margin-top: 8px;
 
         p {
-            margin-bottom: 32px;
+            margin-bottom: 16px;
         }
     }
 
@@ -28,7 +28,7 @@
         display: block;
         max-height: 347px;
         border: 1px solid var(--center-channel-color-16);
-        margin: 20px auto 0;
+        margin: 32px auto 0;
         border-radius: 4px;
     }
 

--- a/components/product_notices_modal/product_notices_modal.scss
+++ b/components/product_notices_modal/product_notices_modal.scss
@@ -9,6 +9,7 @@
 
     .GenericModal__header {
         padding: 0;
+        margin-bottom: 16px;
     }
 
     .GenericModal__body {
@@ -17,6 +18,9 @@
 
     .productNotices__helpText {
         margin-top: 8px;
+        p {
+            margin-bottom: 32px;
+        }
     }
 
     .productNotices__img {
@@ -32,7 +36,7 @@
     }
 
     .modal-footer {
-        margin-top: 20px;
+        margin-top: 32px;
     }
 
     .productNotices__info {
@@ -54,7 +58,7 @@
         vertical-align: middle;
     }
 
-    &.GenericModal.modal-dialog {
+    .app__body .modal &.modal-dialog {
         height: unset;
         margin-top: calc(50vh - 307px);
     }


### PR DESCRIPTION
#### Summary
CSS of ``ProductNoticesModal`` was getting overridden because of recent changes intended to increase the CSS specificity of ``GenericModal`` CSS. These changes are increasing the css specificity of ProductNoticesModal.


#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-37189](https://mattermost.atlassian.net/browse/MM-37189)

#### Related Pull Requests
- None

#### Screenshots
<img width="1680" alt="Screenshot 2021-07-21 at 11 09 07 AM" src="https://user-images.githubusercontent.com/16203333/126436792-6b2d05d6-efe1-4857-9618-bd2abf083e24.png">
<img width="1680" alt="Screenshot 2021-07-21 at 11 08 56 AM" src="https://user-images.githubusercontent.com/16203333/126436805-8c7bea47-1322-4537-9203-6cf5c24fc392.png">
<img width="1678" alt="Screenshot 2021-07-21 at 11 08 38 AM" src="https://user-images.githubusercontent.com/16203333/126436809-25d8857d-66bd-4e1a-8409-4f3290c48bcb.png">
<img width="1680" alt="Screenshot 2021-07-21 at 11 08 19 AM" src="https://user-images.githubusercontent.com/16203333/126436819-b10d392d-5687-40dc-9f4d-a79f722a5a68.png">




#### Release Note

```release-note
 fixes style issue with ProductNoticesModal
```
