### PR TITLE
Fix draft removal on create_comment and unload in create_post

### DIFF
--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -46,7 +46,7 @@ export function updateCommentDraft(rootId, draft) {
     if (draft) {
         localStorage.setItem(key, JSON.stringify(draft));
     } else {
-        localStorage.removeItem(draft);
+        localStorage.removeItem(key);
     }
     return setGlobalItem(key, draft);
 }

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -345,7 +345,7 @@ class CreatePost extends React.PureComponent {
         this.focusTextbox();
         document.addEventListener('paste', this.pasteHandler);
         document.addEventListener('keydown', this.documentKeyHandler);
-        window.addEventListener('beforeunload', this.saveDraft);
+        window.addEventListener('beforeunload', this.unloadHandler);
         this.setOrientationListeners();
 
         if (useGroupMentions) {
@@ -377,8 +377,12 @@ class CreatePost extends React.PureComponent {
     componentWillUnmount() {
         document.removeEventListener('paste', this.pasteHandler);
         document.removeEventListener('keydown', this.documentKeyHandler);
-        window.addEventListener('beforeunload', this.saveDraft);
+        window.addEventListener('beforeunload', this.unloadHandler);
         this.removeOrientationListeners();
+        this.saveDraft();
+    }
+
+    unloadHandler = () => {
         this.saveDraft();
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix draft removal on create_comment and unload in create_post. Thanks @larkox for the catches.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
