### PR TITLE
fix: drop manual capitalization in global threads

### DIFF
--- a/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
+++ b/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`components/threading/global_threads/thread_item should report total num
       Team name
     </Memo(Badge)>
     <Connect(injectIntl(Timestamp))
-      capitalize={true}
       className="alt-hidden"
       day="numeric"
       units={
@@ -127,7 +126,6 @@ exports[`components/threading/global_threads/thread_item should report unread me
       Team name
     </Memo(Badge)>
     <Connect(injectIntl(Timestamp))
-      capitalize={true}
       className="alt-hidden"
       day="numeric"
       units={
@@ -236,7 +234,6 @@ exports[`components/threading/global_threads/thread_item should report unread me
       Team name
     </Memo(Badge)>
     <Connect(injectIntl(Timestamp))
-      capitalize={true}
       className="alt-hidden"
       day="numeric"
       units={

--- a/components/threading/global_threads/thread_item/thread_item.tsx
+++ b/components/threading/global_threads/thread_item/thread_item.tsx
@@ -147,7 +147,6 @@ function ThreadItem({
                     {...THREADING_TIME}
                     className='alt-hidden'
                     value={lastReplyAt}
-                    capitalize={true}
                 />
             </h1>
             <div className='menu-anchor alt-visible'>


### PR DESCRIPTION
#### Summary
ThreadItem > Timestamp: drop manual capitalization (that had been used for 'Now') to not alter built-in CLDR specifics.

See thread: https://community.mattermost.com/core/pl/a7n1ihmy57fnzruhb7rmr8mzqy


E.g. `de`:
```diff
- Vor 5 stunden
+ vor 5 Stunden
```
<img width="404" alt="CleanShot 2021-07-26 at 11 14 48@2x" src="https://user-images.githubusercontent.com/11724372/127023034-d0919e32-ba26-4c3a-b12b-597a315f72eb.png">


`en`: 
```diff
- Now
+ now
```
<img width="405" alt="CleanShot 2021-07-26 at 11 01 07@2x" src="https://user-images.githubusercontent.com/11724372/127021178-278e642a-0cd6-47b6-b93b-0476a7066df0.png">




Re: 'Now' / 'now', Atlassian-Jira uses the latter ('now'), and in-fact seems to be leveraging `react-intl` as well.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
