### PR TITLE
[MM-37106] - Can't return to Getting Started flow from Threads view

### DIFF
--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -32,6 +32,7 @@ import RHSSearchNav from 'components/rhs_search_nav';
 import Header from 'components/widgets/header';
 import LoadingScreen from 'components/loading_screen';
 import NoResultsIndicator from 'components/no_results_indicator';
+import NextStepsView from 'components/next_steps_view';
 
 import {useThreadRouting} from '../hooks';
 import ChatIllustration from '../common/chat_illustration';
@@ -55,6 +56,7 @@ const GlobalThreads = () => {
     const selectedThread = useSelector((state: GlobalState) => getThread(state, threadIdentifier));
     const selectedThreadId = useSelector(getSelectedThreadIdInCurrentTeam);
     const selectedPost = useSelector((state: GlobalState) => getPost(state, threadIdentifier!));
+    const showNextStepsEphemeral = useSelector((state: GlobalState) => state.views.nextSteps.show);
     const threadIds = useSelector((state: GlobalState) => getThreadOrderInCurrentTeam(state, selectedThread?.id), shallowEqual);
     const unreadThreadIds = useSelector((state: GlobalState) => getUnreadThreadOrderInCurrentTeam(state, selectedThread?.id), shallowEqual);
     const numUnread = counts?.total_unread_threads || 0;
@@ -97,6 +99,10 @@ const GlobalThreads = () => {
     const handleSelectUnread = useCallback(() => {
         setFilter(ThreadFilter.unread);
     }, []);
+
+    if (showNextStepsEphemeral) {
+        return <NextStepsView/>;
+    }
 
     return (
         <div


### PR DESCRIPTION
#### Summary
This PR adds the onboarding flow to the threads view inorder to ensure it can be toggled back on while in the threads view

#### Ticket Link
[MM-37106](https://mattermost.atlassian.net/browse/MM-37106?atlOrigin=eyJpIjoiYWQ1YTZiY2I3ZDk1NGE2ZTk5M2JhMjRmNGY1Yzc0ZTYiLCJwIjoiaiJ9)

#### Related Pull Requests
Depends on [https://github.com/mattermost/mattermost-webapp/pull/8437](https://github.com/mattermost/mattermost-webapp/pull/8437)

#### Release Note

```release-note
NONE

```
