### PR TITLE
[MM-37064] - Onboarding flow is showing for existing users

### DIFF
--- a/components/next_steps_view/steps.ts
+++ b/components/next_steps_view/steps.ts
@@ -150,6 +150,8 @@ export const isOnboardingHidden = createSelector(
     'isOnboardingHidden',
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
     (stepPreferences) => {
+        // Before onboarding was introduced, there were existing users that didn't have step preferences set.
+        // We don't want onboarding to suddenly pop up for them.
         if (stepPreferences.length === 0) {
             return true;
         }
@@ -163,9 +165,6 @@ export const showNextSteps = createSelector(
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
     (state: GlobalState) => nextStepsNotFinished(state),
     (stepPreferences, nextStepsNotFinished) => {
-        if (stepPreferences.length === 0) {
-            return false;
-        }
         if (stepPreferences.some((pref) => (pref.name === RecommendedNextSteps.SKIP && pref.value === 'true'))) {
             return false;
         }
@@ -180,9 +179,6 @@ export const showNextStepsTips = createSelector(
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
     (state: GlobalState) => nextStepsNotFinished(state),
     (stepPreferences, nextStepsNotFinished) => {
-        if (stepPreferences.length === 0) {
-            return false;
-        }
         if (stepPreferences.some((pref) => (pref.name === RecommendedNextSteps.SKIP && pref.value === 'true'))) {
             return true;
         }
@@ -198,9 +194,6 @@ export const nextStepsNotFinished = createSelector(
     (state: GlobalState) => getCurrentUser(state),
     (state: GlobalState) => isFirstAdmin(state),
     (stepPreferences, currentUser, firstAdmin) => {
-        if (stepPreferences.length === 0) {
-            return false;
-        }
         const roles = firstAdmin ? `first_admin ${currentUser.roles}` : currentUser.roles;
         const checkPref = (step: StepType) => stepPreferences.some((pref) => (pref.name === step.id && pref.value === 'true') || !isStepForUser(step, roles));
         return !Steps.every(checkPref);

--- a/components/next_steps_view/steps.ts
+++ b/components/next_steps_view/steps.ts
@@ -150,6 +150,9 @@ export const isOnboardingHidden = createSelector(
     'isOnboardingHidden',
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
     (stepPreferences) => {
+        if (stepPreferences.length === 0) {
+            return true;
+        }
         return stepPreferences.some((pref) => (pref.name === RecommendedNextSteps.HIDE && pref.value === 'true'));
     },
 );
@@ -160,6 +163,9 @@ export const showNextSteps = createSelector(
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
     (state: GlobalState) => nextStepsNotFinished(state),
     (stepPreferences, nextStepsNotFinished) => {
+        if (stepPreferences.length === 0) {
+            return false;
+        }
         if (stepPreferences.some((pref) => (pref.name === RecommendedNextSteps.SKIP && pref.value === 'true'))) {
             return false;
         }
@@ -174,6 +180,9 @@ export const showNextStepsTips = createSelector(
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
     (state: GlobalState) => nextStepsNotFinished(state),
     (stepPreferences, nextStepsNotFinished) => {
+        if (stepPreferences.length === 0) {
+            return false;
+        }
         if (stepPreferences.some((pref) => (pref.name === RecommendedNextSteps.SKIP && pref.value === 'true'))) {
             return true;
         }
@@ -189,6 +198,9 @@ export const nextStepsNotFinished = createSelector(
     (state: GlobalState) => getCurrentUser(state),
     (state: GlobalState) => isFirstAdmin(state),
     (stepPreferences, currentUser, firstAdmin) => {
+        if (stepPreferences.length === 0) {
+            return false;
+        }
         const roles = firstAdmin ? `first_admin ${currentUser.roles}` : currentUser.roles;
         const checkPref = (step: StepType) => stepPreferences.some((pref) => (pref.name === step.id && pref.value === 'true') || !isStepForUser(step, roles));
         return !Steps.every(checkPref);

--- a/components/sidebar/sidebar_next_steps/remove_next_steps_modal.tsx
+++ b/components/sidebar/sidebar_next_steps/remove_next_steps_modal.tsx
@@ -64,7 +64,7 @@ export default function RemoveNextStepsModal(props: Props) {
             >
                 <FormattedMessage
                     id={'remove_next_steps_modal.mainText'}
-                    defaultMessage='This will remove this section from your sidebar, but you can access it later in the Getting Started section of the Main Menu.'
+                    defaultMessage='This will remove this section from your sidebar, but you can access it later in the Tips and Next steps section of the Main Menu.'
                 />
             </GenericModal>
         </>

--- a/components/sidebar/sidebar_next_steps/sidebar_next_steps.tsx
+++ b/components/sidebar/sidebar_next_steps/sidebar_next_steps.tsx
@@ -102,6 +102,10 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
     }
 
     render() {
+        if (this.props.preferences.length === 0) {
+            return null;
+        }
+
         if (this.props.preferences.some((pref) => pref.name === RecommendedNextSteps.HIDE && pref.value === 'true')) {
             return null;
         }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3942,7 +3942,7 @@
   "remove_next_steps_modal.confirm": "Remove",
   "remove_next_steps_modal.header": "Remove {title}?",
   "remove_next_steps_modal.helpText": "Access {title} any time through the Main Menu",
-  "remove_next_steps_modal.mainText": "This will remove this section from your sidebar, but you can access it later in the Getting Started section of the Main Menu.",
+  "remove_next_steps_modal.mainText": "This will remove this section from your sidebar, but you can access it later in the Tips and Next steps section of the Main Menu.",
   "removed_channel.channelName": "the channel",
   "removed_channel.from": "Removed from ",
   "removed_channel.okay": "Okay",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -3935,7 +3935,7 @@
   "remove_next_steps_modal.confirm": "Remove",
   "remove_next_steps_modal.header": "Remove {title}?",
   "remove_next_steps_modal.helpText": "Access {title} any time through the Main Menu",
-  "remove_next_steps_modal.mainText": "This will remove this section from your sidebar, but you can access it later in the Getting Started section of the Main Menu.",
+  "remove_next_steps_modal.mainText": "This will remove this section from your sidebar, but you can access it later in the Tips and Next steps section of the Main Menu.",
   "removed_channel.channelName": "the channel",
   "removed_channel.from": "Removed from ",
   "removed_channel.okay": "Okay",


### PR DESCRIPTION
#### Summary
 In this PR, we check if the stepPreferences are empty. If they're empty, we hide the onboarding process. We do this because, we know that existing users don't have those preferences set as the onboarding flow (where users get the opportunity to set them) didn't exist until now for self managed existing users.

All new users created from now on will have those preferences set to show for them, such that they can view the onboarding process the first time they log in or use the app.

#### Ticket Link
[MM-37064](https://mattermost.atlassian.net/browse/MM-37064?atlOrigin=eyJpIjoiZDZkNTg3N2E3OGFiNGNiZjg5OWZhMjE1YTgxZGJmZDkiLCJwIjoiaiJ9)

#### Related Pull Requests

- Has server changes [https://github.com/mattermost/mattermost-server/pull/17977](https://github.com/mattermost/mattermost-server/pull/17977)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
```release-note
NONE
```
