### PR TITLE
Cypress/E2E Maintenance: Remove old Data Retention Policy

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/settings_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/settings_spec.js
@@ -17,41 +17,6 @@ describe('Settings', () => {
         cy.apiRequireLicense();
     });
 
-    it('MM-T1161 Data retention - Settings are saved', () => {
-        cy.visit('/admin_console/compliance/data_retention');
-
-        // # Change dropdown
-        cy.findByTestId('enableMessageDeletiondropdown').select('Keep messages for a set amount of time');
-
-        // * Verify that button is enabled
-        cy.get('#adminConsoleWrapper .wrapper--fixed > .admin-console__wrapper').
-            within(() => {
-                cy.get('.job-table__panel button').should('be.enabled');
-            });
-
-        // # Save setting
-        cy.findByTestId('saveSetting').should('be.enabled').click().wait(TIMEOUTS.HALF_SEC);
-
-        // * Confirm that modal shows up
-        cy.get('#confirmModalLabel').should('be.visible').should('have.text', 'Confirm data retention policy');
-        cy.get('#confirmModalButton').should('be.enabled').click();
-
-        // # Change dropdown
-        cy.findByTestId('enableMessageDeletiondropdown').select('Keep all messages indefinitely');
-
-        // * Verify that button is disabled
-        cy.get('#adminConsoleWrapper .wrapper--fixed > .admin-console__wrapper').
-            within(() => {
-                cy.get('.job-table__panel button').should('be.disabled');
-            });
-
-        cy.findByTestId('saveSetting').should('be.enabled').click().wait(TIMEOUTS.HALF_SEC);
-
-        // * Confirm that modal shows up
-        cy.get('#confirmModalLabel').should('be.visible').should('have.text', 'Confirm data retention policy');
-        cy.get('#confirmModalButton').should('be.enabled').click();
-    });
-
     it('MM-T1181 Compliance and Auditing: Run a report, it appears in the job table', () => {
         cy.visit('/admin_console/compliance/monitoring');
 

--- a/e2e/cypress/integration/enterprise/system_console/sidebar_link_navigation_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/sidebar_link_navigation_spec.js
@@ -60,11 +60,6 @@ describe('System Console - Enterprise', () => {
             url: 'admin_console/authentication/guest_access',
         },
         {
-            header: 'Data Retention Policy',
-            sidebar: 'Data Retention Policy',
-            url: 'admin_console/compliance/data_retention',
-        },
-        {
             header: 'Compliance Export (Beta)',
             sidebar: 'Compliance Export (Beta)',
             url: 'admin_console/compliance/export',

--- a/e2e/cypress/integration/enterprise/visual_regression/system_console/compliance_section_spec.js
+++ b/e2e/cypress/integration/enterprise/visual_regression/system_console/compliance_section_spec.js
@@ -16,12 +16,6 @@ describe('System Console - Compliance', () => {
     const testCases = [
         {
             section: 'Compliance',
-            header: 'Data Retention Policy',
-            sidebar: 'Data Retention Policy',
-            url: 'admin_console/compliance/data_retention',
-        },
-        {
-            section: 'Compliance',
             header: 'Compliance Export (Beta)',
             sidebar: 'Compliance Export (Beta)',
             url: 'admin_console/compliance/export',

--- a/e2e/cypress/integration/system_console/feature_discovery_spec.js
+++ b/e2e/cypress/integration/system_console/feature_discovery_spec.js
@@ -30,7 +30,6 @@ describe('Feature discovery', () => {
             {sidebarName: 'SAML 2.0', featureDiscoveryTitle: 'SAML'},
             {sidebarName: 'OpenID Connect', featureDiscoveryTitle: 'OpenID Connect'},
             {sidebarName: 'Groups', featureDiscoveryTitle: 'Active Directory/LDAP groups'},
-            {sidebarName: 'Data Retention Policy', featureDiscoveryTitle: 'data retention schedules'},
             {sidebarName: 'Compliance Export', featureDiscoveryTitle: 'compliance exports'},
             {sidebarName: 'System Roles', featureDiscoveryTitle: 'controlled access to the System Console'},
             {sidebarName: 'Permissions', featureDiscoveryTitle: 'role-based permissions'},


### PR DESCRIPTION
#### Summary
- Removed old Data Retention Policy
- Archived [MM-T1161](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T1161)

`e2e/cypress/integration/enterprise/system_console/compliance/data_retention_policies_spec.js` already has the test cases for the new data retention policies.

Note: I'll let you guys decide when to merge this as I understand the custom data retention feature will be graduated soon.

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-07-21 at 10 59 01 AM](https://user-images.githubusercontent.com/487991/126540415-4478a28f-3686-48b4-bc86-ebcfa0c59c7d.png)
![Screen Shot 2021-07-21 at 11 01 07 AM](https://user-images.githubusercontent.com/487991/126540419-cc177051-11b3-497c-897b-dd35cafda2ee.png)
![Screen Shot 2021-07-21 at 11 02 49 AM](https://user-images.githubusercontent.com/487991/126540421-561f609f-2e10-48b1-ad9a-1eef2ec35240.png)
![Screen Shot 2021-07-21 at 11 18 53 AM](https://user-images.githubusercontent.com/487991/126540423-7bb9f7db-3545-4621-94a7-9bd5c2bcd5bd.png)


#### Release Note
```release-note
NONE
```