### PR TITLE
Fixes global threads crash on md images

### DIFF
--- a/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
+++ b/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
@@ -67,6 +67,12 @@ exports[`components/threading/global_threads/thread_item should report total num
     tabIndex={0}
   >
     <Connect(Markdown)
+      imageProps={
+        Object {
+          "onImageHeightChanged": [Function],
+          "onImageLoaded": [Function],
+        }
+      }
       message="test msg"
       options={
         Object {
@@ -178,6 +184,12 @@ exports[`components/threading/global_threads/thread_item should report unread me
     tabIndex={0}
   >
     <Connect(Markdown)
+      imageProps={
+        Object {
+          "onImageHeightChanged": [Function],
+          "onImageLoaded": [Function],
+        }
+      }
       message="test msg"
       options={
         Object {
@@ -287,6 +299,12 @@ exports[`components/threading/global_threads/thread_item should report unread me
     tabIndex={0}
   >
     <Connect(Markdown)
+      imageProps={
+        Object {
+          "onImageHeightChanged": [Function],
+          "onImageLoaded": [Function],
+        }
+      }
       message="test msg"
       options={
         Object {

--- a/components/threading/global_threads/thread_item/thread_item.tsx
+++ b/components/threading/global_threads/thread_item/thread_item.tsx
@@ -82,11 +82,10 @@ function ThreadItem({
 
     const selectHandler = useCallback(() => select(threadId), []);
 
-    const onImageHeightChanged = useCallback(() => {}, []);
-
-    const onImageLoaded = useCallback(() => {}, []);
-
-    const imageProps = useMemo(() => ({onImageHeightChanged, onImageLoaded}), [onImageHeightChanged, onImageLoaded]);
+    const imageProps = useMemo(() => ({
+        onImageHeightChanged: () => {},
+        onImageLoaded: () => {},
+    }), []);
 
     const goToInChannelHandler = useCallback((e: MouseEvent) => {
         e.stopPropagation();

--- a/components/threading/global_threads/thread_item/thread_item.tsx
+++ b/components/threading/global_threads/thread_item/thread_item.tsx
@@ -82,6 +82,12 @@ function ThreadItem({
 
     const selectHandler = useCallback(() => select(threadId), []);
 
+    const onImageHeightChanged = useCallback(() => {}, []);
+
+    const onImageLoaded = useCallback(() => {}, []);
+
+    const imageProps = useMemo(() => ({onImageHeightChanged, onImageLoaded}), [onImageHeightChanged, onImageLoaded]);
+
     const goToInChannelHandler = useCallback((e: MouseEvent) => {
         e.stopPropagation();
         goToInChannel(threadId);
@@ -182,6 +188,8 @@ function ThreadItem({
                 <Markdown
                     message={post?.message ?? '(message deleted)'}
                     options={markdownPreviewOptions}
+                    imagesMetadata={post?.metadata && post?.metadata?.images}
+                    imageProps={imageProps}
                 />
             </div>
             <div className='activity'>


### PR DESCRIPTION
#### Summary
MarkdownImageExpanded needs onImageHeightChanged prop to be defined,
this commit adds that, but not using it, since we have fixed height for
thread items.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37079

#### Screenshots

expanded
![expanded](https://user-images.githubusercontent.com/3829551/126650175-00b42f2b-8fa3-4f86-8c95-44e3bd63eaac.png)

collapsed
![collapsed](https://user-images.githubusercontent.com/3829551/126650217-73fdc7a7-bac6-49f1-a139-8e5c3f56ca05.png)

#### Release Note

```release-note
NONE
```
