### PR TITLE
Fixes Thread in thread viewer displayed vertically

### DIFF
--- a/components/threading/global_threads/thread_pane/thread_pane.scss
+++ b/components/threading/global_threads/thread_pane/thread_pane.scss
@@ -40,7 +40,7 @@
             align-items: center;
             margin: 0 10px 0 0;
             color: rgba(var(--center-channel-color-rgb), 1);
-            grid-template-columns: min-content 1fr;
+            grid-template-columns: max-content 1fr;
 
             > span {
                 padding-right: 8px;


### PR DESCRIPTION
#### Summary

"Thread" h3 title in thread pane is displayed vertically in some languages (e.g: Japanese).
This commit fixes that by enlarging the column as much as needed so text
won't wrap.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36863

#### Release Note

```release-note
NONE
```
