### PR TITLE
MM-377220 Fix theming and stying of Add Users to Channel modals 

### DIFF
--- a/components/channel_invite_modal/__snapshots__/channel_invite_modal.test.tsx.snap
+++ b/components/channel_invite_modal/__snapshots__/channel_invite_modal.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`components/channel_invite_modal should match snapshot for channel_invit
   autoFocus={true}
   backdrop={true}
   bsClass="modal"
-  dialogClassName="a11y__modal channel-switcher"
+  dialogClassName="a11y__modal channel-invite"
   dialogComponentClass={[Function]}
   enforceFocus={true}
   id="addUsersToChannelModal"
@@ -44,7 +44,7 @@ exports[`components/channel_invite_modal should match snapshot for channel_invit
     role="application"
   >
     <div
-      className="channel-switcher__header"
+      className="channel-invite__header"
     >
       <h1>
         <MemoizedFormattedMessage
@@ -59,7 +59,7 @@ exports[`components/channel_invite_modal should match snapshot for channel_invit
       </h1>
     </div>
     <div
-      className="channel-switcher__content"
+      className="channel-invite__content"
     >
       <MultiSelect
         ariaLabelRenderer={[Function]}
@@ -167,7 +167,7 @@ exports[`components/channel_invite_modal should match snapshot with exclude and 
   autoFocus={true}
   backdrop={true}
   bsClass="modal"
-  dialogClassName="a11y__modal channel-switcher"
+  dialogClassName="a11y__modal channel-invite"
   dialogComponentClass={[Function]}
   enforceFocus={true}
   id="addUsersToChannelModal"
@@ -204,7 +204,7 @@ exports[`components/channel_invite_modal should match snapshot with exclude and 
     role="application"
   >
     <div
-      className="channel-switcher__header"
+      className="channel-invite__header"
     >
       <h1>
         <MemoizedFormattedMessage
@@ -219,7 +219,7 @@ exports[`components/channel_invite_modal should match snapshot with exclude and 
       </h1>
     </div>
     <div
-      className="channel-switcher__content"
+      className="channel-invite__content"
     >
       <MultiSelect
         ariaLabelRenderer={[Function]}

--- a/components/channel_invite_modal/channel_invite_modal.tsx
+++ b/components/channel_invite_modal/channel_invite_modal.tsx
@@ -321,7 +321,7 @@ export default class ChannelInviteModal extends React.PureComponent<Props, State
         return (
             <Modal
                 id='addUsersToChannelModal'
-                dialogClassName='a11y__modal channel-switcher'
+                dialogClassName='a11y__modal channel-invite'
                 show={this.state.show}
                 onHide={this.onHide}
                 onExited={this.props.onHide}
@@ -336,11 +336,11 @@ export default class ChannelInviteModal extends React.PureComponent<Props, State
                     role='application'
                     className='overflow--visible'
                 >
-                    <div className='channel-switcher__header'>
+                    <div className='channel-invite__header'>
                         {header}
                     </div>
                     {inviteError}
-                    <div className='channel-switcher__content'>
+                    <div className='channel-invite__content'>
                         {content}
                     </div>
                 </Modal.Body>

--- a/components/multiselect/multiselect.tsx
+++ b/components/multiselect/multiselect.tsx
@@ -498,7 +498,7 @@ export default class MultiSelect<T extends Value> extends React.PureComponent<Pr
                     </div>}
                 </div>
                 {this.props.saveButtonPosition === 'bottom' &&
-                <div className='channel-switcher__footer'>
+                <div className='multi-select__footer'>
                     <SaveButton
                         id='saveItems'
                         saving={this.props.saving}

--- a/e2e/cypress/integration/enterprise/accessibility/accessibility_modals_dialogs_spec.js
+++ b/e2e/cypress/integration/enterprise/accessibility/accessibility_modals_dialogs_spec.js
@@ -199,7 +199,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
 
         // * Verify the accessibility support in Add people Dialog`
         cy.get('#addUsersToChannelModal').should('have.attr', 'role', 'dialog').and('have.attr', 'aria-labelledby', 'channelInviteModalLabel').within(() => {
-            cy.get('.channel-switcher__header').should('be.visible').and('contain', `Add people to ${testChannel.display_name}`);
+            cy.get('.channel-invite__header').should('be.visible').and('contain', `Add people to ${testChannel.display_name}`);
             cy.get('.modal-header button.close').should('have.attr', 'aria-label', 'Close');
 
             // * Verify the accessibility support in search input

--- a/e2e/cypress/integration/messaging/focus_move_spec.js
+++ b/e2e/cypress/integration/messaging/focus_move_spec.js
@@ -35,7 +35,7 @@ function verifyFocusInAddChannelMemberModal() {
     cy.get('#selectItems input').should('have.value', 'A');
 
     // # Click anywhere in the modal that is not on a field that can take focus
-    cy.get('.channel-switcher__header').click();
+    cy.get('.channel-invite__header').click();
 
     // * Note the focus has been removed from the search box
     cy.get('#selectItems input').should('not.be.focused');

--- a/e2e/cypress/integration/notifications/browser_tab_notification_spec.js
+++ b/e2e/cypress/integration/notifications/browser_tab_notification_spec.js
@@ -124,7 +124,7 @@ describe('Notifications', () => {
         cy.get('#member_popover').should('be.visible').click();
         cy.contains('Manage Members').click();
         cy.contains('Add Members').click();
-        cy.get('.channel-switcher__content input').should('exist').type(`${user1.username}{enter}`);
+        cy.get('.channel-invite__content input').should('exist').type(`${user1.username}{enter}`);
         cy.get('#saveItems').click();
         cy.wait(TIMEOUTS.HALF_SEC);
 

--- a/sass/components/_channel-invite-modal.scss
+++ b/sass/components/_channel-invite-modal.scss
@@ -1,0 +1,126 @@
+@charset "UTF-8";
+
+.app__body .modal .channel-invite__content {
+    .multi-select__container {
+        padding: 0 2.4rem;
+    }
+
+    .react-select__multi-value {
+        border-radius: 50px;
+    }
+
+    .multi-select__help {
+        padding: 8px 2.4rem 0;
+    }
+
+    .filtered-user-list {
+        display: block;
+        height: auto;
+    }
+
+    .react-select__multi-value__label {
+        display: flex;
+        align-items: center;
+        padding: 4px;
+        color: inherit;
+        font-size: 14px;
+        font-weight: 600;
+    }
+
+    .react-select__value__name {
+        margin: 0 0 0 8px;
+    }
+
+    .react-select__multi-value__remove {
+        margin-right: 4px;
+    }
+
+    .multi-select__wrapper {
+        position: absolute;
+        z-index: 5;
+        overflow: auto;
+        width: calc(100% - 48px);
+        height: auto;
+        max-height: 272px;
+        padding: 12px 0;
+        border: 1px solid rgba(var(--sys-center-channel-color-rgb), 0.16);
+        margin: -28px 0 0 24px;
+        background: rgba(var(--sys-center-channel-bg-rgb), 1);
+        border-radius: 4px;
+        box-shadow: $elevation-4;
+
+        .app__body & {
+            border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+            background: rgba(var(--center-channel-bg-rgb), 1);
+        }
+    }
+
+    .multi-select__footer {
+        padding: 0 24px 24px 0;
+        text-align: right;
+    }
+
+    .btn-primary {
+        height: 40px;
+        padding: 0 36px;
+        border-radius: 4px;
+        font-size: 14px;
+        font-weight: 600;
+    }
+
+    .no-channel-message {
+        padding: 1rem;
+        font-size: 1.4rem;
+
+        .primary-message {
+            margin: 0;
+            font-size: inherit;
+        }
+    }
+
+    .react-select__value-container {
+        padding: 0 16px;
+        font-size: 16px;
+
+        &.react-select__value-container--has-value {
+            padding: 0 8px;
+        }
+    }
+
+    .more-modal__list {
+        height: auto;
+
+        .more-modal__options {
+            overflow: visible;
+            min-height: auto;
+        }
+    }
+
+    .react-select__control.react-select-auto {
+        min-height: 48px;
+        padding: 3px 0;
+    }
+
+    .loading-screen {
+        position: relative !important;
+        padding: 1rem;
+    }
+
+    .more-modal__actions {
+        display: none;
+    }
+
+    .more-modal__row {
+        height: 40px;
+        padding: 0 2.4rem;
+        border: none;
+
+        .more-modal__name {
+            font-weight: 400;
+        }
+    }
+
+    .more-modal__details {
+        padding-left: 12px;
+    }
+}

--- a/sass/components/_channel-invite-modal.scss
+++ b/sass/components/_channel-invite-modal.scss
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-.app__body .modal .channel-invite__content {
+.modal .channel-invite__content {
     .multi-select__container {
         padding: 0 2.4rem;
     }
@@ -43,16 +43,9 @@
         height: auto;
         max-height: 272px;
         padding: 12px 0;
-        border: 1px solid rgba(var(--sys-center-channel-color-rgb), 0.16);
         margin: -28px 0 0 24px;
-        background: rgba(var(--sys-center-channel-bg-rgb), 1);
         border-radius: 4px;
         box-shadow: $elevation-4;
-
-        .app__body & {
-            border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
-            background: rgba(var(--center-channel-bg-rgb), 1);
-        }
     }
 
     .multi-select__footer {
@@ -122,5 +115,23 @@
 
     .more-modal__details {
         padding-left: 12px;
+    }
+}
+
+body.app__body {
+    .channel-invite {
+        .multi-select__wrapper {
+            border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+            background: rgba(var(--center-channel-bg-rgb), 1);
+        }
+    }
+}
+
+body:not(.app__body) {
+    .channel-invite {
+        .multi-select__wrapper {
+            border: 1px solid rgba(var(--sys-center-channel-color-rgb), 0.16);
+            background: rgba(var(--sys-center-channel-bg-rgb), 1);
+        }
     }
 }

--- a/sass/components/_channel-switcher.scss
+++ b/sass/components/_channel-switcher.scss
@@ -1,40 +1,152 @@
 @charset "UTF-8";
 
-.app__body {
+.modal {
+    .channel-switcher,
+    .channel-invite {
+        &.modal-dialog {
+            margin-top: calc(50vh - 240px);
+        }
+
+        .modal-body {
+            max-height: 100%;
+            padding: 0;
+        }
+
+        .modal-content {
+            border-radius: 8px;
+        }
+
+        .modal-header {
+            min-height: 0;
+            padding: 0;
+            border: none;
+            background: transparent;
+
+            .close {
+                top: 6px;
+                right: 4px;
+                display: flex;
+                width: 4rem;
+                height: 4rem;
+                align-items: center;
+                justify-content: center;
+                border-radius: 4px;
+                font-size: 32px;
+                font-weight: 400;
+            }
+        }
+    }
+
+    .channel-switcher {
+        .suggestion-list {
+            position: relative;
+        }
+
+        .suggestion-list__content {
+            height: calc(100vh - 110px);
+            max-height: 100%;
+        }
+    }
+
+    .channel-switcher__suggestion-box {
+        position: relative;
+        height: 362px;
+        padding: 0;
+
+        .icon-magnify {
+            position: absolute;
+            top: 1.1rem;
+            left: 3.4rem;
+            display: flex;
+            width: 2rem;
+            height: 2rem;
+            align-items: center;
+            opacity: 0.48;
+        }
+
+        .badge {
+            top: 10px;
+            right: 16px;
+        }
+
+        .form-control {
+            width: calc(100% - 48px);
+            height: 40px;
+            padding: 0 34px;
+            margin: 0 24px;
+            border-radius: 4px;
+
+            &:focus {
+                padding: 0 33px;
+                border: 2px solid v(button-bg);
+            }
+        }
+
+        .suggestion-list {
+            padding-top: 0.6rem;
+            border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+            margin-top: 2.3rem;
+        }
+
+        .suggestion-list__content {
+            overflow: auto;
+            width: 100%;
+            height: auto;
+            padding: 0;
+            border: none;
+            box-shadow: none;
+        }
+
+        .status-wrapper {
+            overflow: visible;
+            height: 24px;
+            margin-top: 4px;
+            margin-right: 12px;
+
+            .status {
+                right: -2px;
+                bottom: -4px;
+
+                svg {
+                    left: 2px;
+                    max-width: 11px;
+                }
+            }
+        }
+
+        .Avatar {
+            width: 24px;
+            height: 24px;
+
+            &-sm {
+                margin: 0;
+            }
+        }
+
+        .suggestion-list__divider {
+            &:first-child {
+                margin: 0;
+
+                &::before {
+                    display: none;
+                }
+            }
+        }
+
+        .suggestion-list__icon {
+            height: auto;
+        }
+    }
+}
+
+body.app__body {
     .modal {
         .channel-switcher,
         .channel-invite {
-            &.modal-dialog {
-                margin-top: calc(50vh - 240px);
-            }
-
-            .modal-body {
-                max-height: 100%;
-                padding: 0;
-            }
-
-            .modal-content {
-                border-radius: 8px;
-            }
-
             .modal-header {
-                min-height: 0;
-                padding: 0;
-                border: none;
-                background: transparent;
-
                 .close {
-                    top: 6px;
-                    right: 4px;
-                    display: flex;
-                    width: 4rem;
-                    height: 4rem;
-                    align-items: center;
-                    justify-content: center;
-                    border-radius: 4px;
+                    // This rule needs to be very specific to override the colour of the close button used for other modals
                     color: rgba(var(--center-channel-color-rgb), 0.56);
-                    font-size: 32px;
-                    font-weight: 400;
 
                     &:hover {
                         background-color:
@@ -47,126 +159,49 @@
 
                     &:active {
                         background-color: rgba(var(--button-bg-rgb), 0.08);
-                        color: v(button-bg);
+                        color: var(--button-bg);
                     }
                 }
-            }
-        }
-
-        .channel-switcher {
-            .suggestion-list {
-                position: relative;
-            }
-
-            .suggestion-list__content {
-                height: calc(100vh - 110px);
-                max-height: 100%;
-            }
-        }
-
-        .channel-switcher__suggestion-box {
-            position: relative;
-            height: 362px;
-            padding: 0;
-
-            .icon-magnify {
-                position: absolute;
-                top: 1.1rem;
-                left: 3.4rem;
-                display: flex;
-                width: 2rem;
-                height: 2rem;
-                align-items: center;
-                opacity: 0.48;
-            }
-
-            .badge {
-                top: 10px;
-                right: 16px;
-            }
-
-            .form-control {
-                width: calc(100% - 48px);
-                height: 40px;
-                padding: 0 34px;
-                margin: 0 24px;
-                border-radius: 4px;
-
-                &:focus {
-                    padding: 0 33px;
-                    border: 2px solid v(button-bg);
-                }
-            }
-
-            .suggestion-list {
-                padding-top: 0.6rem;
-                border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
-                margin-top: 2.3rem;
-            }
-
-            .suggestion-list__content {
-                overflow: auto;
-                width: 100%;
-                height: auto;
-                padding: 0;
-                border: none;
-                box-shadow: none;
-            }
-
-            .status-wrapper {
-                overflow: visible;
-                height: 24px;
-                margin-top: 4px;
-                margin-right: 12px;
-
-                .status {
-                    right: -2px;
-                    bottom: -4px;
-
-                    svg {
-                        left: 2px;
-                        max-width: 11px;
-                    }
-                }
-            }
-
-            .Avatar {
-                width: 24px;
-                height: 24px;
-
-                &-sm {
-                    margin: 0;
-                }
-            }
-
-            .suggestion-list__divider {
-                &:first-child {
-                    margin: 0;
-
-                    &::before {
-                        display: none;
-                    }
-                }
-            }
-
-            .suggestion-list__icon {
-                height: auto;
             }
         }
     }
+}
 
-    .channel-switcher__hint {
-        font-size: 12px;
-    }
+// Colour overrides for the System Console
+body:not(.app__body) {
+    .channel-switcher,
+    .channel-invite {
+        .close {
+            color: rgba(var(--sys-center-channel-color-rgb), 0.56);
 
-    .channel-switcher__header,
-    .channel-invite__header {
-        padding: 2.4rem 2.4rem 1.6rem;
+            &:hover {
+                background-color:
+                    rgba(
+                        var(--sys-center-channel-color-rgb),
+                        0.08
+                    );
+                color: rgba(var(--sys-center-channel-color-rgb), 0.72);
+            }
 
-        h1 {
-            margin: 0 0 0.8rem;
-            font-size: 2rem;
-            font-weight: 600;
+            &:active {
+                background-color: rgba(var(--sys-button-bg-rgb), 0.08);
+                color: var(--sys-button-bg);
+            }
         }
+    }
+}
+
+.channel-switcher__hint {
+    font-size: 12px;
+}
+
+.channel-switcher__header,
+.channel-invite__header {
+    padding: 2.4rem 2.4rem 1.6rem;
+
+    h1 {
+        margin: 0 0 0.8rem;
+        font-size: 2rem;
+        font-weight: 600;
     }
 }

--- a/sass/components/_channel-switcher.scss
+++ b/sass/components/_channel-switcher.scss
@@ -2,23 +2,15 @@
 
 .app__body {
     .modal {
-        .channel-switcher {
+        .channel-switcher,
+        .channel-invite {
             &.modal-dialog {
                 margin-top: calc(50vh - 240px);
-            }
-
-            .suggestion-list {
-                position: relative;
             }
 
             .modal-body {
                 max-height: 100%;
                 padding: 0;
-            }
-
-            .suggestion-list__content {
-                height: calc(100vh - 110px);
-                max-height: 100%;
             }
 
             .modal-content {
@@ -61,128 +53,14 @@
             }
         }
 
-        .channel-switcher__content {
-            .multi-select__container {
-                padding: 0 2.4rem;
+        .channel-switcher {
+            .suggestion-list {
+                position: relative;
             }
 
-            .react-select__multi-value {
-                border-radius: 50px;
-            }
-
-            .multi-select__help {
-                padding: 8px 2.4rem 0;
-            }
-
-            .filtered-user-list {
-                display: block;
-                height: auto;
-            }
-
-            .react-select__multi-value__label {
-                display: flex;
-                align-items: center;
-                padding: 4px;
-                color: inherit;
-                font-size: 14px;
-                font-weight: 600;
-            }
-
-            .react-select__value__name {
-                margin: 0 0 0 8px;
-            }
-
-            .react-select__multi-value__remove {
-                margin-right: 4px;
-            }
-
-            .multi-select__wrapper {
-                position: absolute;
-                z-index: 5;
-                overflow: auto;
-                width: calc(100% - 48px);
-                height: auto;
-                max-height: 272px;
-                padding: 12px 0;
-                border: 1px solid rgba(var(--sys-center-channel-color-rgb), 0.16);
-                margin: -28px 0 0 24px;
-                background: rgba(var(--sys-center-channel-bg-rgb), 1);
-                border-radius: 4px;
-                box-shadow: $elevation-4;
-
-                .app__body & {
-                    border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
-                    background: rgba(var(--center-channel-bg-rgb), 1);
-                }
-            }
-
-            .channel-switcher__footer {
-                padding: 0 24px 24px 0;
-                text-align: right;
-            }
-
-            .btn-primary {
-                height: 40px;
-                padding: 0 36px;
-                border-radius: 4px;
-                font-size: 14px;
-                font-weight: 600;
-            }
-
-            .no-channel-message {
-                padding: 1rem;
-                font-size: 1.4rem;
-
-                .primary-message {
-                    margin: 0;
-                    font-size: inherit;
-                }
-            }
-
-            .react-select__value-container {
-                padding: 0 16px;
-                font-size: 16px;
-
-                &.react-select__value-container--has-value {
-                    padding: 0 8px;
-                }
-            }
-
-            .more-modal__list {
-                height: auto;
-
-                .more-modal__options {
-                    overflow: visible;
-                    min-height: auto;
-                }
-            }
-
-            .react-select__control.react-select-auto {
-                min-height: 48px;
-                padding: 3px 0;
-            }
-
-            .loading-screen {
-                position: relative !important;
-                padding: 1rem;
-            }
-
-            .more-modal__actions {
-                display: none;
-            }
-
-            .more-modal__row {
-                height: 40px;
-                padding: 0 2.4rem;
-                border: none;
-
-                .more-modal__name {
-                    font-weight: 400;
-                }
-            }
-
-            .more-modal__details {
-                padding-left: 12px;
+            .suggestion-list__content {
+                height: calc(100vh - 110px);
+                max-height: 100%;
             }
         }
 
@@ -281,7 +159,8 @@
         font-size: 12px;
     }
 
-    .channel-switcher__header {
+    .channel-switcher__header,
+    .channel-invite__header {
         padding: 2.4rem 2.4rem 1.6rem;
 
         h1 {

--- a/sass/components/_module.scss
+++ b/sass/components/_module.scss
@@ -5,6 +5,7 @@
 @import 'badge';
 @import 'buttons';
 @import 'channel-header__icon';
+@import 'channel-invite-modal';
 @import 'channel-switcher';
 @import 'dropdown';
 @import 'emoticons';


### PR DESCRIPTION
In January, we updated the styling of the Add Users to Channel modal to more closely match the Channel Switcher (#7172). These styles didn't take into account the fact that the modal existed in the System Console as well though, so in March, we fixed that but broke the styles of the dropdown and close button outside of the System Console (#7696). A couple weeks ago, we attempted to fix the appearance of the close button, but that entirely broke the styling of the modal in the System Console (#8366).

With all that said and done, I think I've fixed all the existing issues around that modal without reintroducing any other bugs. I also split up the CSS a bit better beetween the Add Users to Channel modal and Channel Switcher since they shared CSS in a way that was causing them to break each other. There's a video below going through both modals in light and dark themes to ensure they look correct.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37220

#### Screenshots
https://user-images.githubusercontent.com/3277310/126688729-6894cd4e-0925-432d-9b77-5f82da63dcf4.mov

#### Release Note

```release-note
Fixed appearance of Channel Switcher and Add Users to Channel modals
```
