### PR TITLE
MM-36573 Fix console error when viewing channel on an unsupported CRT client while webapp is open with CRT on

### DIFF
--- a/packages/mattermost-redux/src/actions/threads.ts
+++ b/packages/mattermost-redux/src/actions/threads.ts
@@ -223,6 +223,9 @@ export function handleAllThreadsInChannelMarkedRead(dispatch: DispatchFunc, getS
     const state = getState();
     const threadsInChannel = getThreadsInChannel(state, channelId);
     const channel = getChannel(state, channelId);
+    if (channel == null) {
+        return;
+    }
     const teamId = channel.team_id;
     const actions = [];
 


### PR DESCRIPTION
#### Summary
Fix console error when viewing channel on an unsupported CRT client while webapp is open with CRT on.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36573

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
