### PR TITLE
fix: Subscription title in system console billing is singular

### DIFF
--- a/components/admin_console/billing/billing_subscriptions/index.tsx
+++ b/components/admin_console/billing/billing_subscriptions/index.tsx
@@ -181,7 +181,7 @@ const BillingSubscriptions: React.FC = () => {
         <div className='wrapper--fixed BillingSubscriptions'>
             <FormattedAdminHeader
                 id='admin.billing.subscription.title'
-                defaultMessage='Subscriptions'
+                defaultMessage='Subscription'
             />
             <div className='admin-console__wrapper'>
                 <div className='admin-console__content'>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -355,7 +355,7 @@
   "admin.billing.subscription.purchaseModal.currentPlan": "Current Plan",
   "admin.billing.subscription.questions": "Questions?",
   "admin.billing.subscription.stateprovince": "State/Province",
-  "admin.billing.subscription.title": "Subscriptions",
+  "admin.billing.subscription.title": "Subscription",
   "admin.billing.subscription.unlimitedUsers": "Unlimited Users",
   "admin.billing.subscription.updatePaymentInfo": "Update Payment Information",
   "admin.billing.subscription.upgrade": "Upgrade",


### PR DESCRIPTION
#### Summary
Fixes a typo. Subscription title should be singular in the System Console billing page for cloud accounts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30538

#### Screenshots
Title now reads "Subscription"

![subscription-singular](https://user-images.githubusercontent.com/13738432/126699888-517be804-fc29-484c-9a78-01b44e83b4b7.png)

#### Release Note
```release-note
Fixed System Console billing subscription title to be singular
```
