### PR TITLE
Last 4 credit card digits as a string

### DIFF
--- a/packages/mattermost-redux/src/types/cloud.ts
+++ b/packages/mattermost-redux/src/types/cloud.ts
@@ -82,7 +82,7 @@ export type Address = {
 // PaymentMethod represents methods of payment for a customer.
 export type PaymentMethod = {
     type: string;
-    last_four: number;
+    last_four: string;
     exp_month: number;
     exp_year: number;
     card_brand: string;


### PR DESCRIPTION
#### Summary
Represent last four digits of credit card as a string. The private code backing this has similar changes. It will make credit card numbers with leading digits of 0 in the last 4 digits show properly in the System Console, including invoices downloaded from the console.

Supporting PRs:
https://github.com/mattermost/customer-web-server/pull/529
https://github.com/mattermost/mattermost-server/pull/17996

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31950


#### UI Changes
![last4-system-console-payment-information](https://user-images.githubusercontent.com/13738432/126842825-5a953afa-394d-4de4-bd03-6635323141ba.png)
![last4-invoice](https://user-images.githubusercontent.com/13738432/126842836-0f60b462-5db1-427f-9ee0-d04496450ebc.png)


#### Related Pull Requests
- There is also an accompanying server change: https://github.com/mattermost/mattermost-server/pull/17996

```release-note
Fixed display of last 4 credit card digits
```
