### PR TITLE
MM-37422: Fix Safari overflow scrolling issue

### DIFF
--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -204,7 +204,11 @@ export default class SidebarRight extends React.PureComponent {
 
         return (
             <div
-                className={classNames('sidebar--right', {'sidebar--right--expanded': isSidebarRightExpanded}, {'move--left': isOpen})}
+                className={classNames('sidebar--right', {
+                    'sidebar--right--expanded': isSidebarRightExpanded,
+                    'move--left': isOpen,
+                    hidden: !isOpen,
+                })}
                 id='sidebar-right'
                 role='complementary'
                 ref={this.sidebarRight}

--- a/components/threading/thread_viewer/thread_viewer.tsx
+++ b/components/threading/thread_viewer/thread_viewer.tsx
@@ -614,7 +614,15 @@ export default class ThreadViewer extends React.Component<Props, State> {
         }
 
         if (this.state.isLoading) {
-            return <LoadingScreen style={{height: '100%'}}/>;
+            return (
+                <LoadingScreen
+                    style={{
+                        display: 'grid',
+                        placeContent: 'center',
+                        flex: '1',
+                    }}
+                />
+            );
         }
 
         return (


### PR DESCRIPTION
This fix makes RHS hidden when closed.

#### Summary
When RHS is closed, it is currently still block-displayed. This overflows `#channel_view` (its `overflow: hidden` normally takes care of this) and causes odd scroll position issues in Safari. `channel_header` will slide up out-of-viewport, and there will be a blank space below `create_post`, with everything between shifted up.

![image](https://user-images.githubusercontent.com/11724372/127024327-2f4ffd76-3501-44ec-92f2-7b0d451de379.png)


Repro steps: 
- In Safari, open webapp and ensure Collapsed Reply Threads is Enabled
- Go to a channel with at least one thread with at least 1 reply
- Refresh
- Open any thread with at least 1 reply
- = Channel Header will disappear, and there will be space below the message input


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-37422

Otherwise, link the JIRA ticket.
-->


#### Screenshots
With `#channel_view {/* overflow: hidden */}`
<img width="681" alt="CleanShot 2021-07-26 at 10 17 12@2x" src="https://user-images.githubusercontent.com/11724372/127019593-c9b76641-a4a4-4650-b5b3-a76548b255c6.png">


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fix Safari overflow scroll glitch
```
