### PR TITLE
[MM-37377] - LHS does not update after Getting Started steps are complete

### DIFF
--- a/components/next_steps_view/steps.test.tsx
+++ b/components/next_steps_view/steps.test.tsx
@@ -68,7 +68,7 @@ describe('components/next_steps_view/steps', () => {
         expect(isOnboardingHidden(state as any)).toBe(true);
     });
 
-    test('should not show the view if all steps are complete', () => {
+    test('myPreferences all completed and nextStepsNotFinished is false', () => {
         const state = {
             entities: {
                 general: {
@@ -105,7 +105,8 @@ describe('components/next_steps_view/steps', () => {
             },
         };
 
-        expect(nextStepsNotFinished(state as any)).toBe(true);
+        // all the steps are finished
+        expect(nextStepsNotFinished(state as any)).toBe(false);
     });
 
     test('should only show admin steps for admin users', () => {

--- a/components/next_steps_view/steps.ts
+++ b/components/next_steps_view/steps.ts
@@ -193,9 +193,10 @@ export const nextStepsNotFinished = createSelector(
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
     (state: GlobalState) => getCurrentUser(state),
     (state: GlobalState) => isFirstAdmin(state),
-    (stepPreferences, currentUser, firstAdmin) => {
+    (state: GlobalState) => getSteps(state),
+    (stepPreferences, currentUser, firstAdmin, mySteps) => {
         const roles = firstAdmin ? `first_admin ${currentUser.roles}` : currentUser.roles;
         const checkPref = (step: StepType) => stepPreferences.some((pref) => (pref.name === step.id && pref.value === 'true') || !isStepForUser(step, roles));
-        return !Steps.every(checkPref);
+        return !mySteps.every(checkPref);
     },
 );

--- a/components/sidebar/sidebar_next_steps/remove_next_steps_modal.tsx
+++ b/components/sidebar/sidebar_next_steps/remove_next_steps_modal.tsx
@@ -64,7 +64,10 @@ export default function RemoveNextStepsModal(props: Props) {
             >
                 <FormattedMessage
                     id={'remove_next_steps_modal.mainText'}
-                    defaultMessage='This will remove this section from your sidebar, but you can access it later in the Tips and Next steps section of the Main Menu.'
+                    defaultMessage='This will remove this section from your sidebar, but you can access it later in the {title} section of the Main Menu.'
+                    values={{
+                        title: screenTitle,
+                    }}
                 />
             </GenericModal>
         </>

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_sysadmin_onboarding_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_sysadmin_onboarding_spec.js
@@ -37,6 +37,7 @@ describe('Cloud Onboarding - Sysadmin', () => {
             'notification_setup',
             'team_setup',
             'invite_members',
+            'enter_support_email',
             'hide',
             'skip',
         ];
@@ -136,7 +137,7 @@ describe('Cloud Onboarding - Sysadmin', () => {
         cy.get('.Card__body.expanded .TeamProfileStep').should('exist').should('be.visible');
 
         // * Step counter should not increment
-        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '0 / 4 steps complete');
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '0 / 5 steps complete');
     });
 
     it('MM-T3328 Sysadmin - Skip Getting Started', () => {

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_sysadmin_onboarding_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_sysadmin_onboarding_spec.js
@@ -96,9 +96,23 @@ describe('Cloud Onboarding - Sysadmin', () => {
         // * Step counter should increment
         cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '4 / 4 steps complete');
 
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .EnterSupportEmailStep').should('be.visible');
+
+        // # Enter email addresses
+        cy.get('#input_enter_support_email').should('be.visible').type('robot@gmail.com');
+
+        // # Click Finish button
+        cy.findByTestId('EnterSupportEmailStep__finishButton').should('be.visible').and('not.be.disabled').click();
+
+        // * Step counter should increment
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '5 / 5 steps complete');
+
         // * Should show Tips and Next Steps
         cy.findByText('Tips & Next Steps').should('be.visible');
         cy.findByText('A few other areas to explore').should('be.visible');
+        cy.get('.SidebarNextSteps .SidebarNextSteps__top').should('contain', 'Tips & Next steps');
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', 'A few other areas to explore');
 
         // * Transition screen should be visible
         cy.get('.NextStepsView__transitionView.completed').should('be.visible');

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_sysadmin_onboarding_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_sysadmin_onboarding_spec.js
@@ -62,7 +62,7 @@ describe('Cloud Onboarding - Sysadmin', () => {
         cy.findByTestId('CompleteProfileStep__saveProfileButton').should('be.visible').and('not.be.disabled').click();
 
         // * Step counter should increment
-        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '1 / 4 steps complete');
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '1 / 5 steps complete');
 
         // * Check to make sure card is expanded
         cy.get('.Card__body.expanded .TeamProfileStep').should('be.visible');
@@ -77,7 +77,7 @@ describe('Cloud Onboarding - Sysadmin', () => {
         cy.findByTestId('TeamProfileStep__saveTeamButton').should('be.visible').and('not.be.disabled').click();
 
         // * Step counter should increment
-        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '2 / 4 steps complete');
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '2 / 5 steps complete');
 
         // * Check to make sure card is expanded
         cy.findByText('We recommend enabling desktop notifications so you don’t miss any important communications.').should('be.visible');
@@ -85,7 +85,7 @@ describe('Cloud Onboarding - Sysadmin', () => {
         cy.findByRole('button', {name: 'Set up notifications'}).should('be.visible').click();
 
         // * Step counter should increment
-        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '3 / 4 steps complete');
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '3 / 5 steps complete');
 
         // * Check to make sure card is expanded
         cy.get('.Card__body.expanded .InviteMembersStep').should('be.visible');
@@ -94,7 +94,7 @@ describe('Cloud Onboarding - Sysadmin', () => {
         cy.findByTestId('InviteMembersStep__finishButton').should('be.visible').and('not.be.disabled').click();
 
         // * Step counter should increment
-        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '4 / 4 steps complete');
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '4 / 5 steps complete');
 
         // * Check to make sure card is expanded
         cy.get('.Card__body.expanded .EnterSupportEmailStep').should('be.visible');

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3937,7 +3937,7 @@
   "remove_next_steps_modal.confirm": "Remove",
   "remove_next_steps_modal.header": "Remove {title}?",
   "remove_next_steps_modal.helpText": "Access {title} any time through the Main Menu",
-  "remove_next_steps_modal.mainText": "This will remove this section from your sidebar, but you can access it later in the Tips and Next steps section of the Main Menu.",
+  "remove_next_steps_modal.mainText": "This will remove this section from your sidebar, but you can access it later in the {title} section of the Main Menu.",
   "removed_channel.channelName": "the channel",
   "removed_channel.from": "Removed from ",
   "removed_channel.okay": "Okay",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -3937,7 +3937,7 @@
   "remove_next_steps_modal.confirm": "Remove",
   "remove_next_steps_modal.header": "Remove {title}?",
   "remove_next_steps_modal.helpText": "Access {title} any time through the Main Menu",
-  "remove_next_steps_modal.mainText": "This will remove this section from your sidebar, but you can access it later in the Tips and Next steps section of the Main Menu.",
+  "remove_next_steps_modal.mainText": "This will remove this section from your sidebar, but you can access it later in the {title} section of the Main Menu.",
   "removed_channel.channelName": "the channel",
   "removed_channel.from": "Removed from ",
   "removed_channel.okay": "Okay",


### PR DESCRIPTION
#### Summary
- Makes sure that when Getting Started steps are finished, the sidebar updates to "Next Steps and Tips"
- Fixes Modal text when closing Getting Started and Next Steps and Tips

#### Ticket Link
[MM-37377](https://mattermost.atlassian.net/browse/MM-37377?atlOrigin=eyJpIjoiNzA4Y2VjNTQwODFiNGExMzkwYTRjMGJmNjRkNDI5NjkiLCJwIjoiaiJ9)


#### Release Note
```release-note
NONE

```
