### PR TITLE
fix whitespace in refresh bar

### DIFF
--- a/components/announcement_bar/version_bar/__snapshots__/version_bar.test.tsx.snap
+++ b/components/announcement_bar/version_bar/__snapshots__/version_bar.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`components/VersionBar should match snapshot - bar rendered after server
         defaultMessage="A new version of Mattermost is available."
         id="version_bar.new"
       />
-       
+       
       <a
         onClick={[Function]}
       >

--- a/components/announcement_bar/version_bar/__snapshots__/version_bar.test.tsx.snap
+++ b/components/announcement_bar/version_bar/__snapshots__/version_bar.test.tsx.snap
@@ -10,9 +10,13 @@ exports[`components/VersionBar should match snapshot - bar rendered after server
         defaultMessage="A new version of Mattermost is available."
         id="version_bar.new"
       />
-       
       <a
         onClick={[Function]}
+        style={
+          Object {
+            "marginLeft": ".5rem",
+          }
+        }
       >
         <Memo(MemoizedFormattedMessage)
           defaultMessage="Refresh the app now"

--- a/components/announcement_bar/version_bar/version_bar.tsx
+++ b/components/announcement_bar/version_bar/version_bar.tsx
@@ -59,7 +59,7 @@ export default class VersionBar extends React.PureComponent <Props, State> {
                                 id='version_bar.new'
                                 defaultMessage='A new version of Mattermost is available.'
                             />
-                            {' '}
+                            &nbsp;
                             <a onClick={this.reloadPage}>
                                 <FormattedMessage
                                     id='version_bar.refresh'

--- a/components/announcement_bar/version_bar/version_bar.tsx
+++ b/components/announcement_bar/version_bar/version_bar.tsx
@@ -59,7 +59,10 @@ export default class VersionBar extends React.PureComponent <Props, State> {
                                 id='version_bar.new'
                                 defaultMessage='A new version of Mattermost is available.'
                             />
-                            <a onClick={this.reloadPage} style={{marginLeft: '.5rem'}}>
+                            <a
+                                onClick={this.reloadPage}
+                                style={{marginLeft: '.5rem'}}
+                            >
                                 <FormattedMessage
                                     id='version_bar.refresh'
                                     defaultMessage='Refresh the app now'

--- a/components/announcement_bar/version_bar/version_bar.tsx
+++ b/components/announcement_bar/version_bar/version_bar.tsx
@@ -59,8 +59,7 @@ export default class VersionBar extends React.PureComponent <Props, State> {
                                 id='version_bar.new'
                                 defaultMessage='A new version of Mattermost is available.'
                             />
-                            &nbsp;
-                            <a onClick={this.reloadPage}>
+                            <a onClick={this.reloadPage} style={{marginLeft: '.5rem'}}>
                                 <FormattedMessage
                                     id='version_bar.refresh'
                                     defaultMessage='Refresh the app now'


### PR DESCRIPTION
#### Summary
Change whitespace in refresh bar to be an `&nbsp;` instead of a `' '`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37426

#### Related Pull Requests

#### Screenshots
before:
![before-nbsp](https://user-images.githubusercontent.com/13738432/127228799-5715b3ed-7fbc-4c80-8710-9ee932df285b.png)


after:
![after-nbsp](https://user-images.githubusercontent.com/13738432/127228805-56ac4299-7ad9-47ac-b365-9517c97b1a66.png)


#### Release Note
```release-note
Change whitespace in refresh bar so that it always displays to user.
```
