### PR TITLE
[MM-32187]fix deleted message timestamp position issue

### DIFF
--- a/components/post_view/post_time/post_time.tsx
+++ b/components/post_view/post_time/post_time.tsx
@@ -75,7 +75,7 @@ export default class PostTime extends React.PureComponent<Props> {
         const content = isMobile() || !isPermalink ? (
             <div
                 role='presentation'
-                className='post_permalink_mobile_view'
+                className='post__permalink post_permalink_mobile_view'
             >
                 {postTime}
             </div>


### PR DESCRIPTION
#### Summary
When user post multiple message and delete in between message we show other user ``(message deleted)`` on hover timestamp is shown, which have position issue in case of deleted message, which this pr will fix.

#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-32187](https://mattermost.atlassian.net/browse/MM-32187)


#### Related Pull Requests
None

#### Screenshots
<img width="933" alt="Screenshot 2021-07-28 at 4 46 32 PM" src="https://user-images.githubusercontent.com/16203333/127314049-89fbdc15-1a59-40e6-b564-4db0a68ebf5f.png">


#### Release Note
```release-note
 fixes timestamp position issue when user delete message
```
