### PR TITLE
[MM-37118] Don't mark channel as read for reply posts with CRT on

### DIFF
--- a/actions/new_post.ts
+++ b/actions/new_post.ts
@@ -104,8 +104,11 @@ export function setChannelReadAndViewed(dispatch: DispatchFunc, getState: GetSta
     let markAsReadOnServer = false;
 
     // Skip marking a channel as read (when the user is viewing a channel)
-    // if they have manually marked it as unread.
-    if (!isManuallyUnread(getState(), post.channel_id)) {
+    // if they have manually marked it as unread, or if they are replying to
+    // a thread
+    const isCRTReply = isCollapsedThreadsEnabled(state) && post.root_id;
+
+    if (!isManuallyUnread(getState(), post.channel_id) && !(isCRTReply)) {
         if (
             post.user_id === getCurrentUserId(state) &&
             !isSystemMessage(post) &&


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- With CRT on, posting a reply to a thread should NOT mark the channel containing the the thread as read
- This PR fixes the "new messages" line issue uncovered in the server PR
 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-37118
 
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes
https://github.com/mattermost/mattermost-server/pull/17965


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
