### PR TITLE
MM-37495: CRT, always enable mark all as unread

### DIFF
--- a/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
+++ b/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
@@ -36,12 +36,10 @@ exports[`components/threading/global_threads/thread_list should match snapshot 1
       >
         <SimpleTooltip
           content="Mark all as read"
-          disabled={false}
           id="threadListMarkRead"
         >
           <Memo(Button)
             className="Button___large Button___icon"
-            disabled={false}
             onClick={[Function]}
           >
             <span

--- a/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/components/threading/global_threads/thread_list/thread_list.tsx
@@ -98,7 +98,6 @@ const ThreadList = ({
                     <div className='right-anchor'>
                         <SimpleTooltip
                             id='threadListMarkRead'
-                            disabled={!someUnread}
                             content={formatMessage({
                                 id: 'threading.threadList.markRead',
                                 defaultMessage: 'Mark all as read',
@@ -106,7 +105,6 @@ const ThreadList = ({
                         >
                             <Button
                                 className={'Button___large Button___icon'}
-                                disabled={!someUnread}
                                 onClick={handleAllMarkedRead}
                             >
                                 <span className='Icon'>


### PR DESCRIPTION
#### Summary

Allows users to click the "mark all as unread" button even if there are
no unread threads in the list. Currently the button is disabled unless
there are unread threads.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37495

#### Release Note

```release-note
NONE
```
