### PR TITLE
MM-36646: reverts post paddings when CRT enabled

### DIFF
--- a/components/channel_layout/center_channel/center_channel.tsx
+++ b/components/channel_layout/center_channel/center_channel.tsx
@@ -100,7 +100,7 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
                         <ChannelHeaderMobile/>
                     </div>
                 </div>
-                <div className={classNames('row main', {'CollapsedReplies___feature-enabled': isCollapsedThreadsEnabled})}>
+                <div className='row main'>
                     <Switch>
                         <Route
                             path={`${url}/pl/:postid`}

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -2085,10 +2085,3 @@
 .app__body .post-list__table .post.current--user.post--highlight.post--hovered .post-collapse__gradient {
     background: linear-gradient(rgba(var(--mention-highlight-bg-mixed-rgb), 0.5), rgba(var(--mention-highlight-bg-mixed-rgb), 1));
 }
-
-.CollapsedReplies___feature-enabled {
-    .post.other--root {
-        padding-top: 8px;
-        padding-bottom: 8px;
-    }
-}


### PR DESCRIPTION
#### Summary

When turning on the collapsed replies there's a big gap between the
first and second consecutive post from the same person.
This commit removes that gap.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36646

#### Screenshots
_before_:
![image](https://user-images.githubusercontent.com/3829551/127484993-0b9b5e07-62dd-4934-950f-1279ee57df5d.png)

_after_:
![image](https://user-images.githubusercontent.com/3829551/127484951-239b1128-2842-4204-a2bc-9e7c37741a3f.png)

#### Release Note

```release-note
NONE
```
