### PR TITLE
Make rootId prop optional for Textbox

### DIFF
--- a/components/rhs_thread/index.ts
+++ b/components/rhs_thread/index.ts
@@ -24,7 +24,7 @@ function makeMapStateToProps() {
         const channel = getSelectedChannel(state);
         let posts: Post[] = [];
         if (selected) {
-            posts = getPostsForThread(state, {rootId: selected.id});
+            posts = getPostsForThread(state, selected.id);
         }
 
         return {

--- a/components/textbox/index.ts
+++ b/components/textbox/index.ts
@@ -26,7 +26,7 @@ import Textbox from './textbox';
 
 type Props = {
     channelId: string;
-    rootId: string;
+    rootId?: string;
 };
 
 /* eslint-disable camelcase */
@@ -54,7 +54,7 @@ const makeMapStateToProps = () => {
             currentTeamId: teamId,
             profilesInChannel: profilesWithLastViewAtInChannel,
             autocompleteGroups,
-            priorityProfiles: getProfilesForThread(state, ownProps),
+            priorityProfiles: getProfilesForThread(state, ownProps.rootId ?? ''),
         };
     };
 };

--- a/components/textbox/textbox.tsx
+++ b/components/textbox/textbox.tsx
@@ -24,7 +24,7 @@ import * as Utils from 'utils/utils.jsx';
 type Props = {
     id: string;
     channelId: string;
-    rootId: string;
+    rootId?: string;
     tabIndex?: number;
     value: string;
     onChange: (e: ChangeEvent<HTMLInputElement>) => void;

--- a/components/threading/global_threads/thread_item/index.ts
+++ b/components/threading/global_threads/thread_item/index.ts
@@ -30,7 +30,7 @@ function makeMapStateToProps() {
             currentRelativeTeamUrl: getCurrentRelativeTeamUrl(state),
             displayName: getDisplayName(state, post.user_id, true),
             post,
-            postsInThread: getPostsForThread(state, {rootId: post.id}),
+            postsInThread: getPostsForThread(state, post.id),
             thread: getThread(state, threadId),
         };
     };

--- a/components/threading/global_threads/thread_pane/thread_pane.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.tsx
@@ -54,7 +54,7 @@ const ThreadPane = ({
 
     const channel = useSelector((state: GlobalState) => getChannel(state, {id: channelId}));
     const post = useSelector((state: GlobalState) => getPost(state, thread.id));
-    const postsInThread = useSelector((state: GlobalState) => getPostsForThread(state, {rootId: post.id}));
+    const postsInThread = useSelector((state: GlobalState) => getPostsForThread(state, post.id));
     const selectHandler = useCallback(() => select(), []);
     let unreadTimestamp = post.edit_at || post.create_at;
 

--- a/components/threading/thread_viewer/index.ts
+++ b/components/threading/thread_viewer/index.ts
@@ -46,7 +46,7 @@ function makeMapStateToProps() {
         let lastViewedAt;
         let userThread: UserThread | null = null;
         if (selected) {
-            posts = getPostsForThread(state, {rootId: selected.id});
+            posts = getPostsForThread(state, selected.id);
             userThread = getThread(state, selected.id);
             lastViewedAt = getThreadLastViewedAt(state, selected.id);
         }

--- a/packages/mattermost-redux/src/selectors/entities/posts.test.js
+++ b/packages/mattermost-redux/src/selectors/entities/posts.test.js
@@ -70,36 +70,32 @@ describe('Selectors.Posts', () => {
     it('should return single post with no children', () => {
         const getPostsForThread = Selectors.makeGetPostsForThread();
 
-        assert.deepEqual(getPostsForThread(testState, {channelId: '2', rootId: 'f'}), [posts.f]);
+        assert.deepEqual(getPostsForThread(testState, 'f'), [posts.f]);
     });
 
     it('should return post with children', () => {
         const getPostsForThread = Selectors.makeGetPostsForThread();
 
-        assert.deepEqual(getPostsForThread(testState, {channelId: '1', rootId: 'a'}), [posts.e, posts.c, posts.a]);
+        assert.deepEqual(getPostsForThread(testState, 'a'), [posts.e, posts.c, posts.a]);
     });
 
-    it('should return memoized result for identical props', () => {
+    it('should return memoized result for identical rootId', () => {
         const getPostsForThread = Selectors.makeGetPostsForThread();
 
-        const props = {channelId: '1', rootId: 'a'};
-        const result = getPostsForThread(testState, props);
+        const result = getPostsForThread(testState, 'a');
 
-        assert.equal(result, getPostsForThread(testState, props));
+        assert.equal(result, getPostsForThread(testState, 'a'));
     });
 
     it('should return memoized result for multiple selectors with different props', () => {
         const getPostsForThread1 = Selectors.makeGetPostsForThread();
         const getPostsForThread2 = Selectors.makeGetPostsForThread();
 
-        const props1 = {channelId: '1', rootId: 'a'};
-        const result1 = getPostsForThread1(testState, props1);
+        const result1 = getPostsForThread1(testState, 'a');
+        const result2 = getPostsForThread2(testState, 'b');
 
-        const props2 = {channelId: '1', rootId: 'b'};
-        const result2 = getPostsForThread2(testState, props2);
-
-        assert.equal(result1, getPostsForThread1(testState, props1));
-        assert.equal(result2, getPostsForThread2(testState, props2));
+        assert.equal(result1, getPostsForThread1(testState, 'a'));
+        assert.equal(result2, getPostsForThread2(testState, 'b'));
     });
 
     it('should return reactions for post', () => {
@@ -2450,7 +2446,7 @@ describe('makeGetProfilesForThread', () => {
             },
         };
 
-        assert.deepEqual(getProfilesForThread(state, {rootId: '1001'}), [user3, user2]);
+        assert.deepEqual(getProfilesForThread(state, '1001'), [user3, user2]);
     });
 
     it('should return empty array if profiles data does not exist', () => {
@@ -2476,6 +2472,6 @@ describe('makeGetProfilesForThread', () => {
             },
         };
 
-        assert.deepEqual(getProfilesForThread(state, {rootId: '1001'}), []);
+        assert.deepEqual(getProfilesForThread(state, '1001'), []);
     });
 });

--- a/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -350,12 +350,12 @@ export function makeGetPostsAroundPost(): (state: GlobalState, postId: $ID<Post>
 // That selector will take a props object (containing a rootId field) as its
 // only argument and will be memoized based on that argument.
 
-export function makeGetPostsForThread(): (state: GlobalState, props: {rootId: $ID<Post>}) => Post[] {
+export function makeGetPostsForThread(): (state: GlobalState, rootId: string) => Post[] {
     return createIdsSelector(
         'makeGetPostsForThread',
         getAllPosts,
-        (state: GlobalState, props: {rootId: $ID<Post>}) => state.entities.posts.postsInThread[props.rootId],
-        (state: GlobalState, props: {rootId: $ID<Post>}) => state.entities.posts.posts[props.rootId],
+        (state: GlobalState, rootId: string) => state.entities.posts.postsInThread[rootId],
+        (state: GlobalState, rootId: string) => state.entities.posts.posts[rootId],
         (posts, postsForThread, rootPost) => {
             const thread: Post[] = [];
 
@@ -378,7 +378,7 @@ export function makeGetPostsForThread(): (state: GlobalState, props: {rootId: $I
 }
 
 // The selector below filters current user if it exists. Excluding currentUser is just for convinience
-export function makeGetProfilesForThread(): (state: GlobalState, props: {rootId: $ID<Post>}) => UserProfile[] {
+export function makeGetProfilesForThread(): (state: GlobalState, rootId: string) => UserProfile[] {
     const getPostsForThread = makeGetPostsForThread();
     return createSelector(
         'makeGetProfilesForThread',


### PR DESCRIPTION
Something definitely got messed up here, probably by me.

To make it optional, I had to fix the type of the arguments to a couple selectors to avoid making everything weird. I think this makes everything look nicer overall anyway.

#### Release Note
```release-note
NONE
```
