### PR TITLE
Upgrading german to official language

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -412,7 +412,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
               Array [
                 Object {
                   "order": 0,
-                  "text": "Deutsch (Beta)",
+                  "text": "Deutsch",
                   "value": "de",
                 },
                 Object {

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -286,7 +286,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
               Array [
                 Object {
                   "order": 0,
-                  "text": "Deutsch (Beta)",
+                  "text": "Deutsch",
                   "value": "de",
                 },
                 Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -30,7 +30,7 @@ import store from 'stores/redux_store.jsx';
 const languages = {
     de: {
         value: 'de',
-        name: 'Deutsch (Beta)',
+        name: 'Deutsch',
         order: 0,
         url: de,
     },


### PR DESCRIPTION
#### Summary
German translations are back at 100% and no need to keep German in Beta. We have multiple new maintainers for German now
#### Related Pull Requests
None
#### Screenshots
#### Release Note
```

```
```release-note
Reinstate German as official language. 
```
