### PR TITLE
ESLint overlay trigger error help message

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,11 @@
     "no-only-tests/no-only-tests": ["error", {"focus": ["only", "skip"]}],
     "react/style-prop-object": [2, {
       "allow": ["Timestamp"]
+    }],
+    "no-restricted-imports": ["error", {
+      "paths": [
+        {"name": "react-bootstrap", "importNames": ["OverlayTrigger"], "message": "Please use OverlayTrigger from '/components/overlay_trigger' instead"}
+      ]
     }]
   },
   "overrides": [

--- a/components/channel_header_mobile/channel_info_button/channel_info_button.test.js
+++ b/components/channel_header_mobile/channel_info_button/channel_info_button.test.js
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+
+// eslint-disable-next-line no-restricted-imports
 import {OverlayTrigger as BaseOverlayTrigger} from 'react-bootstrap';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';

--- a/components/overlay_trigger.test.tsx
+++ b/components/overlay_trigger.test.tsx
@@ -3,6 +3,7 @@
 
 import {mount} from 'enzyme';
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {OverlayTrigger as BaseOverlayTrigger} from 'react-bootstrap';
 import {FormattedMessage, IntlProvider} from 'react-intl';
 

--- a/components/overlay_trigger.tsx
+++ b/components/overlay_trigger.tsx
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+
+// eslint-disable-next-line no-restricted-imports
 import {OverlayTrigger as OriginalOverlayTrigger, OverlayTriggerProps} from 'react-bootstrap';
 import {IntlContext, IntlShape} from 'react-intl';
 


### PR DESCRIPTION
#### Summary
Eslint error when trying to use OverlayTrigger directly from react-bootstrap, which doesn't forward `Intl.Context` to overlay content.

<img width="749" alt="CleanShot 2021-08-02 at 17 10 43@2x" src="https://user-images.githubusercontent.com/11724372/127930169-c6f724f7-e218-4632-b5d5-cdfec627b00d.png">

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
