### PR TITLE
[MM-37460] - Add tip for downloading desktop app to the Getting Started page

### DIFF
--- a/components/next_steps_view/__snapshots__/next_steps_view.test.tsx.snap
+++ b/components/next_steps_view/__snapshots__/next_steps_view.test.tsx.snap
@@ -69,6 +69,9 @@ exports[`components/next_steps_view should match snapshot 1`] = `
         <GettingStartedSvg />
       </div>
     </div>
+    <DownloadSection
+      isFirstAdmin={true}
+    />
   </div>
   <div
     className="NextStepsView__viewWrapper NextStepsView__transitionView"

--- a/components/next_steps_view/download_section.tsx
+++ b/components/next_steps_view/download_section.tsx
@@ -1,0 +1,125 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import * as UserAgent from 'utils/user_agent';
+import * as Utils from 'utils/utils';
+import {trackEvent} from 'actions/telemetry_actions';
+
+import downloadApps from 'images/download-app.svg';
+import Card from 'components/card/card';
+
+import {getAnalyticsCategory} from './step_helpers';
+
+type Props = {
+    isFirstAdmin: boolean;
+}
+
+function DownloadSection(props: Props): JSX.Element | null {
+    if (Utils.isMobile()) {
+        return (
+            <div className='NextStepsView__tipsMobileMessage'>
+                <Card expanded={true}>
+                    <div className='Card__body'>
+                        <i className='icon icon-laptop'/>
+                        <FormattedMessage
+                            id='next_steps_view.mobile_tips_message'
+                            defaultMessage='To configure your workspace, continue on a desktop computer.'
+                        />
+                    </div>
+                </Card>
+            </div>
+        );
+    } else if (!UserAgent.isDesktopApp()) {
+        return (
+            <div className='NextStepsView__download'>
+                <img src={downloadApps}/>
+                <div className='NextStepsView__downloadText'>
+                    <h4>
+                        <FormattedMessage
+                            id='next_steps_view.downloadDesktopAndMobile'
+                            defaultMessage='Download the Desktop and Mobile apps'
+                        />
+                    </h4>
+                    <div className='NextStepsView__downloadButtons'>
+                        <button
+                            className='NextStepsView__button NextStepsView__downloadForPlatformButton secondary'
+                            onClick={() => downloadLatest(props.isFirstAdmin)}
+                        >
+                            {getDownloadButtonString()}
+                        </button>
+                        <button
+                            className='NextStepsView__button NextStepsView__downloadAnyButton tertiary'
+                            onClick={() => seeAllApps(props.isFirstAdmin)}
+                        >
+                            <FormattedMessage
+                                id='next_steps_view.seeAllTheApps'
+                                defaultMessage='See all the apps'
+                            />
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return null;
+}
+
+const getDownloadButtonString = () => {
+    if (UserAgent.isWindows()) {
+        return (
+            <FormattedMessage
+                id='next_steps_view.tips.getForWindows'
+                defaultMessage='Get Mattermost for Windows'
+            />
+        );
+    }
+
+    if (UserAgent.isMac()) {
+        return (
+            <FormattedMessage
+                id='next_steps_view.tips.getForMac'
+                defaultMessage='Get Mattermost for Mac'
+            />
+        );
+    }
+
+    // TODO: isLinux?
+
+    return (
+        <FormattedMessage
+            id='next_steps_view.tips.getForDefault'
+            defaultMessage='Get Mattermost'
+        />
+    );
+};
+
+const seeAllApps = (isAdmin: boolean) => {
+    trackEvent(getAnalyticsCategory(isAdmin), 'cloud_see_all_apps');
+    window.open('https://mattermost.com/download/#mattermostApps', '_blank');
+};
+
+const downloadLatest = (isAdmin: boolean) => {
+    const baseLatestURL = 'https://latest.mattermost.com/mattermost-desktop-';
+
+    if (UserAgent.isWindows()) {
+        trackEvent(getAnalyticsCategory(isAdmin), 'click_download_app', {app: 'windows'});
+        window.open(`${baseLatestURL}exe`, '_blank');
+        return;
+    }
+
+    if (UserAgent.isMac()) {
+        trackEvent(getAnalyticsCategory(isAdmin), 'click_download_app', {app: 'mac'});
+        window.open(`${baseLatestURL}dmg`, '_blank');
+        return;
+    }
+
+    // TODO: isLinux?
+
+    seeAllApps(isAdmin);
+};
+
+export default DownloadSection;

--- a/components/next_steps_view/download_section.tsx
+++ b/components/next_steps_view/download_section.tsx
@@ -123,3 +123,4 @@ const downloadLatest = (isAdmin: boolean) => {
 };
 
 export default DownloadSection;
+

--- a/components/next_steps_view/download_section.tsx
+++ b/components/next_steps_view/download_section.tsx
@@ -4,8 +4,8 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import * as UserAgent from 'utils/user_agent';
-import * as Utils from 'utils/utils';
+import {isDesktopApp, isWindows, isMac} from 'utils/user_agent';
+import {isMobile} from 'utils/utils';
 import {trackEvent} from 'actions/telemetry_actions';
 
 import downloadApps from 'images/download-app.svg';
@@ -18,7 +18,7 @@ type Props = {
 }
 
 function DownloadSection(props: Props): JSX.Element | null {
-    if (Utils.isMobile()) {
+    if (isMobile()) {
         return (
             <div className='NextStepsView__tipsMobileMessage'>
                 <Card expanded={true}>
@@ -32,7 +32,7 @@ function DownloadSection(props: Props): JSX.Element | null {
                 </Card>
             </div>
         );
-    } else if (!UserAgent.isDesktopApp()) {
+    } else if (!isDesktopApp()) {
         return (
             <div className='NextStepsView__download'>
                 <img src={downloadApps}/>
@@ -69,7 +69,7 @@ function DownloadSection(props: Props): JSX.Element | null {
 }
 
 const getDownloadButtonString = () => {
-    if (UserAgent.isWindows()) {
+    if (isWindows()) {
         return (
             <FormattedMessage
                 id='next_steps_view.tips.getForWindows'
@@ -78,7 +78,7 @@ const getDownloadButtonString = () => {
         );
     }
 
-    if (UserAgent.isMac()) {
+    if (isMac()) {
         return (
             <FormattedMessage
                 id='next_steps_view.tips.getForMac'
@@ -105,13 +105,13 @@ const seeAllApps = (isAdmin: boolean) => {
 const downloadLatest = (isAdmin: boolean) => {
     const baseLatestURL = 'https://latest.mattermost.com/mattermost-desktop-';
 
-    if (UserAgent.isWindows()) {
+    if (isWindows()) {
         trackEvent(getAnalyticsCategory(isAdmin), 'click_download_app', {app: 'windows'});
         window.open(`${baseLatestURL}exe`, '_blank');
         return;
     }
 
-    if (UserAgent.isMac()) {
+    if (isMac()) {
         trackEvent(getAnalyticsCategory(isAdmin), 'click_download_app', {app: 'mac'});
         window.open(`${baseLatestURL}dmg`, '_blank');
         return;

--- a/components/next_steps_view/next_steps_tips.tsx
+++ b/components/next_steps_view/next_steps_tips.tsx
@@ -17,10 +17,8 @@ import MoreChannels from 'components/more_channels';
 import TeamMembersModal from 'components/team_members_modal';
 import MarketplaceModal from 'components/plugin_marketplace';
 import RemoveNextStepsModal from 'components/sidebar/sidebar_next_steps/remove_next_steps_modal';
-import downloadApps from 'images/download-app.svg';
 
 import {browserHistory} from 'utils/browser_history';
-import * as UserAgent from 'utils/user_agent';
 import {
     ModalIdentifiers,
     RecommendedNextSteps,
@@ -33,60 +31,7 @@ import {getAnalyticsCategory} from './step_helpers';
 import IncidentsSvg from './images/incidents.svg';
 import DocumentsSvg from './images/documents.svg';
 import PluginsSvg from './images/plugins.svg';
-
-const seeAllApps = (isAdmin: boolean) => {
-    trackEvent(getAnalyticsCategory(isAdmin), 'cloud_see_all_apps');
-    window.open('https://mattermost.com/download/#mattermostApps', '_blank');
-};
-
-const downloadLatest = (isAdmin: boolean) => {
-    const baseLatestURL = 'https://latest.mattermost.com/mattermost-desktop-';
-
-    if (UserAgent.isWindows()) {
-        trackEvent(getAnalyticsCategory(isAdmin), 'click_download_app', {app: 'windows'});
-        window.open(`${baseLatestURL}exe`, '_blank');
-        return;
-    }
-
-    if (UserAgent.isMac()) {
-        trackEvent(getAnalyticsCategory(isAdmin), 'click_download_app', {app: 'mac'});
-        window.open(`${baseLatestURL}dmg`, '_blank');
-        return;
-    }
-
-    // TODO: isLinux?
-
-    seeAllApps(isAdmin);
-};
-
-const getDownloadButtonString = () => {
-    if (UserAgent.isWindows()) {
-        return (
-            <FormattedMessage
-                id='next_steps_view.tips.getForWindows'
-                defaultMessage='Get Mattermost for Windows'
-            />
-        );
-    }
-
-    if (UserAgent.isMac()) {
-        return (
-            <FormattedMessage
-                id='next_steps_view.tips.getForMac'
-                defaultMessage='Get Mattermost for Mac'
-            />
-        );
-    }
-
-    // TODO: isLinux?
-
-    return (
-        <FormattedMessage
-            id='next_steps_view.tips.getForDefault'
-            defaultMessage='Get Mattermost'
-        />
-    );
-};
+import DownloadSection from './download_section';
 
 const openAdminConsole = (isAdmin: boolean) => {
     trackEvent(getAnalyticsCategory(isAdmin), 'click_admin_console');
@@ -264,54 +209,6 @@ export default function NextStepsTips(props: Props) {
         );
     }
 
-    let downloadSection;
-    if (Utils.isMobile()) {
-        downloadSection = (
-            <div className='NextStepsView__tipsMobileMessage'>
-                <Card expanded={true}>
-                    <div className='Card__body'>
-                        <i className='icon icon-laptop'/>
-                        <FormattedMessage
-                            id='next_steps_view.mobile_tips_message'
-                            defaultMessage='To configure your workspace, continue on a desktop computer.'
-                        />
-                    </div>
-                </Card>
-            </div>
-        );
-    } else if (!UserAgent.isDesktopApp()) {
-        downloadSection = (
-            <div className='NextStepsView__download'>
-                <img src={downloadApps}/>
-                <div className='NextStepsView__downloadText'>
-                    <h4>
-                        <FormattedMessage
-                            id='next_steps_view.downloadDesktopAndMobile'
-                            defaultMessage='Download the Desktop and Mobile apps'
-                        />
-                    </h4>
-                    <div className='NextStepsView__downloadButtons'>
-                        <button
-                            className='NextStepsView__button NextStepsView__downloadForPlatformButton secondary'
-                            onClick={() => downloadLatest(props.isFirstAdmin)}
-                        >
-                            {getDownloadButtonString()}
-                        </button>
-                        <button
-                            className='NextStepsView__button NextStepsView__downloadAnyButton tertiary'
-                            onClick={() => seeAllApps(props.isFirstAdmin)}
-                        >
-                            <FormattedMessage
-                                id='next_steps_view.seeAllTheApps'
-                                defaultMessage='See all the apps'
-                            />
-                        </button>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-
     let channelsSection;
     if (props.isFirstAdmin) {
         channelsSection = (
@@ -407,7 +304,7 @@ export default function NextStepsTips(props: Props) {
                     {nonMobileTips}
                     {channelsSection}
                 </div>
-                {downloadSection}
+                <DownloadSection isFirstAdmin={props.isFirstAdmin}/>
             </div>
         </div>
     );

--- a/components/next_steps_view/next_steps_tips.tsx
+++ b/components/next_steps_view/next_steps_tips.tsx
@@ -18,6 +18,7 @@ import TeamMembersModal from 'components/team_members_modal';
 import MarketplaceModal from 'components/plugin_marketplace';
 import RemoveNextStepsModal from 'components/sidebar/sidebar_next_steps/remove_next_steps_modal';
 
+
 import {browserHistory} from 'utils/browser_history';
 import {
     ModalIdentifiers,
@@ -27,11 +28,12 @@ import {
 import CloseIcon from 'components/widgets/icons/close_icon';
 import * as Utils from 'utils/utils';
 
+import DownloadSection from './download_section';
+
 import {getAnalyticsCategory} from './step_helpers';
 import IncidentsSvg from './images/incidents.svg';
 import DocumentsSvg from './images/documents.svg';
 import PluginsSvg from './images/plugins.svg';
-import DownloadSection from './download_section';
 
 const openAdminConsole = (isAdmin: boolean) => {
     trackEvent(getAnalyticsCategory(isAdmin), 'click_admin_console');

--- a/components/next_steps_view/next_steps_tips.tsx
+++ b/components/next_steps_view/next_steps_tips.tsx
@@ -18,7 +18,6 @@ import TeamMembersModal from 'components/team_members_modal';
 import MarketplaceModal from 'components/plugin_marketplace';
 import RemoveNextStepsModal from 'components/sidebar/sidebar_next_steps/remove_next_steps_modal';
 
-
 import {browserHistory} from 'utils/browser_history';
 import {
     ModalIdentifiers,

--- a/components/next_steps_view/next_steps_view.tsx
+++ b/components/next_steps_view/next_steps_view.tsx
@@ -20,6 +20,7 @@ import loadingIcon from 'images/spinner-48x48-blue.apng';
 import {StepType} from './steps';
 import './next_steps_view.scss';
 import NextStepsTips from './next_steps_tips';
+import DownloadSection from './download_section';
 import OnboardingBgSvg from './images/onboarding-bg-svg';
 import GettingStartedSvg from './images/getting-started-svg';
 import CloudLogoSvg from './images/cloud-logo-svg';
@@ -321,6 +322,7 @@ export default class NextStepsView extends React.PureComponent<Props, State> {
                         <GettingStartedSvg/>
                     </div>
                 </div>
+                <DownloadSection isFirstAdmin={this.props.isFirstAdmin}/>
             </div>
         );
     }


### PR DESCRIPTION
#### Summary
This PR refactors out the code to create a new component "DownloadSection" that contains a tip for users to download desktop or mobile apps. The component is then added to both the Getting Started and NextSteps and Tips pages

#### Ticket Link
[MM-37460](https://mattermost.atlassian.net/browse/MM-37460?atlOrigin=eyJpIjoiNDc3YTU0NzA4ZjBiNDMxM2I5NTVmNmVmODljMGIzZjYiLCJwIjoiaiJ9)

#### Screenshots
<img width="1792" alt="Screenshot 2021-08-04 at 09 22 06" src="https://user-images.githubusercontent.com/28563179/128131898-7cc5297f-5408-4805-ba9d-3680f89cc7f7.png">

----
<img width="1792" alt="Screenshot 2021-08-04 at 09 24 37" src="https://user-images.githubusercontent.com/28563179/128132209-617d1ccd-8c67-4367-97a0-822f68b5a0eb.png">



#### Release Note
```release-note
NONE
```
