### PR TITLE
Cypress/E2E: Add flag disabling limit to Docker resource when launching chrome, add "@timeout_error" metadata and only remove plugin by ID

### DIFF
--- a/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Group: @emoji
+// Group: @emoji @timeout_error
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 

--- a/e2e/cypress/integration/plugins/plugin_install_spec.js
+++ b/e2e/cypress/integration/plugins/plugin_install_spec.js
@@ -16,7 +16,7 @@
  */
 
 // Stage: @prod
-// Group: @system_console @plugin @not_cloud
+// Group: @system_console @plugin @not_cloud @timeout_error
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {demoPlugin} from '../../utils/plugins';
@@ -27,7 +27,7 @@ describe('Plugins Management', () => {
     before(() => {
         cy.shouldNotRunOnCloudEdition();
         cy.shouldHavePluginUploadEnabled();
-        cy.apiUninstallAllPlugins();
+        cy.apiRemovePluginById(demoPlugin.id);
     });
 
     it('MM-T2400 Plugins Management', () => {
@@ -84,11 +84,13 @@ describe('Plugins Management', () => {
 
         // * Verify final disabled state
         verifyStatus(demoPlugin.id, 'This plugin is not enabled.');
-        cy.findByText('Enable').should('be.visible');
+        cy.findByTestId(demoPlugin.id).scrollIntoView().
+            findByText('Enable').should('be.visible');
     });
 });
 
 function verifyStatus(pluginId, message) {
     waitForAlertMessage(pluginId, message);
-    cy.findByText(message).should('be.visible');
+    cy.findByTestId(pluginId).scrollIntoView().
+        findByText(message).should('be.visible');
 }

--- a/e2e/cypress/integration/plugins/plugin_startup_fail_spec.js
+++ b/e2e/cypress/integration/plugins/plugin_startup_fail_spec.js
@@ -15,7 +15,7 @@
  */
 
 // Stage: @prod
-// Group: @system_console @plugin @not_cloud
+// Group: @system_console @plugin @not_cloud @timeout_error
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {gitlabPlugin} from '../../utils/plugins';
@@ -24,7 +24,7 @@ describe('If plugins fail to start, they can be disabled', () => {
     before(() => {
         cy.shouldNotRunOnCloudEdition();
         cy.shouldHavePluginUploadEnabled();
-        cy.apiUninstallAllPlugins();
+        cy.apiRemovePluginById(gitlabPlugin.id);
 
         // # Visit plugin management in the system console
         cy.visit('/admin_console/plugins/plugin_management');

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -52,6 +52,10 @@ module.exports = (on, config) => {
             launchOptions.args.push('--load-extension=cypress/extensions/Ignore-X-Frame-headers');
         }
 
+        if (browser.family === 'chromium' && browser.name !== 'electron') {
+            launchOptions.args.push('--disable-dev-shm-usage');
+        }
+
         return launchOptions;
     });
 


### PR DESCRIPTION
#### Summary
This PR attempts to isolate and debug further the timeout error happening on the following specs:
1. recently_used_emoji_spec.js
2. plugin_install_spec.js
3. plugin_startup_fail_spec.js

- The `--disable-dev-shm-usage` for launching Chrome removes the limitation to Docker resource where Cypress is running. Such might solve the issue of hang up if the timeout error is due to some CPU/memory limitation.
- `@timeout_error` test metadata will be used to isolate the said plugins for further investigation in CI.
- The other one related to plugin is to only remove a specific plugin as much as possible.

#### Release Note
```release-note
NONE
```
