### PR TITLE
[MM-36943] Fix message attachment fields alignment

### DIFF
--- a/sass/layout/_webhooks.scss
+++ b/sass/layout/_webhooks.scss
@@ -294,6 +294,7 @@
 
         .attachment-fields {
             width: 100%;
+            table-layout: fixed;
 
             .attachment-field__caption {
                 padding-top: 0.7em;


### PR DESCRIPTION
#### Summary
Fix message attachment fields alignment.

#### Ticket Link
Fix https://github.com/mattermost/mattermost-plugin-aws-SNS/issues/66
Fix https://github.com/matterpoll/matterpoll/issues/391
Fix https://github.com/mattermost/mattermost-server/issues/17859
Fix https://mattermost.atlassian.net/browse/MM-36943
https://mattermost.atlassian.net/browse/MM-36943

#### Related Pull Requests
None

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/1933730/128504808-2efb3da0-d5a1-43bc-980a-d74634df4365.png)

#### Release Note
```release-note
Fix bug that kept message attachment fields unaligned.
```
