### PR TITLE
MM-37333 - fix info banner colors

### DIFF
--- a/components/alert_banner.scss
+++ b/components/alert_banner.scss
@@ -98,7 +98,7 @@
     }
 }
 
-.AlertBanner--system {
+.AlertBanner--sys {
     &.danger {
         border-color: rgba(var(--sys-error-text-color-rgb), 0.24);
         background: rgba(var(--sys-error-text-color-rgb), 0.08);


### PR DESCRIPTION
#### Summary
This PR fixes a regression where the alert banners css style class name was changed from --sys to --system.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37333

#### Related Pull Requests

#### Screenshots

Before:


<img width="1276" alt="Captura de pantalla 2021-08-09 a las 13 36 43" src="https://user-images.githubusercontent.com/10082627/128700751-c580173e-88f4-4cb4-aeaa-e385aa27a158.png">

After:

<img width="1369" alt="Captura de pantalla 2021-08-09 a las 13 36 24" src="https://user-images.githubusercontent.com/10082627/128700745-576918d4-8d5c-4a03-a316-c603b971148c.png">



#### Release Note

```release-note
NONE
```
