### PR TITLE
[MM-37715] - Hide global header preference when the feature flag is d…

### DIFF
--- a/components/user_settings/display/index.ts
+++ b/components/user_settings/display/index.ts
@@ -59,7 +59,7 @@ function mapStateToProps(state: GlobalState) {
         collapsedReplyThreadsAllowUserPreference: isCollapsedThreadsAllowed(state) && getConfig(state).CollapsedThreads as string !== 'always_on',
         collapsedReplyThreads: getCollapsedThreadsPreference(state),
         linkPreviewDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, Preferences.LINK_PREVIEW_DISPLAY_DEFAULT),
-        globalHeaderEnabled: getGlobalHeaderEnabled(state),
+        globalHeaderAllowed: getFeatureFlagValue(state, 'GlobalHeader') === 'true',
     };
 }
 

--- a/components/user_settings/display/index.ts
+++ b/components/user_settings/display/index.ts
@@ -10,13 +10,12 @@ import {GenericAction} from 'mattermost-redux/types/actions';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getSupportedTimezones} from 'mattermost-redux/actions/general';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
-import {getConfig, getSupportedTimezones as getTimezones, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, getSupportedTimezones as getTimezones, getLicense, getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {get, isCollapsedThreadsAllowed, getCollapsedThreadsPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
 
-import {getGlobalHeaderEnabled} from 'selectors/global_header';
 import {GlobalState} from 'types/store';
 import {Preferences} from 'utils/constants';
 

--- a/components/user_settings/display/index.ts
+++ b/components/user_settings/display/index.ts
@@ -16,9 +16,9 @@ import {get, isCollapsedThreadsAllowed, getCollapsedThreadsPreference} from 'mat
 import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
 
-import {Preferences} from 'utils/constants';
-
+import {getGlobalHeaderEnabled} from 'selectors/global_header';
 import {GlobalState} from 'types/store';
+import {Preferences} from 'utils/constants';
 
 import UserSettingsDisplay from './user_settings_display';
 
@@ -59,6 +59,7 @@ function mapStateToProps(state: GlobalState) {
         collapsedReplyThreadsAllowUserPreference: isCollapsedThreadsAllowed(state) && getConfig(state).CollapsedThreads as string !== 'always_on',
         collapsedReplyThreads: getCollapsedThreadsPreference(state),
         linkPreviewDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, Preferences.LINK_PREVIEW_DISPLAY_DEFAULT),
+        globalHeaderEnabled: getGlobalHeaderEnabled(state),
     };
 }
 

--- a/components/user_settings/display/user_settings_display.test.tsx
+++ b/components/user_settings/display/user_settings_display.test.tsx
@@ -65,7 +65,7 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         collapseDisplay: '',
         linkPreviewDisplay: '',
         globalHeaderDisplay: '',
-        globalHeaderEnabled: true,
+        globalHeaderAllowed: true,
     };
 
     test('should match snapshot, no active section', () => {

--- a/components/user_settings/display/user_settings_display.test.tsx
+++ b/components/user_settings/display/user_settings_display.test.tsx
@@ -65,6 +65,7 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         collapseDisplay: '',
         linkPreviewDisplay: '',
         globalHeaderDisplay: '',
+        globalHeaderEnabled: true,
     };
 
     test('should match snapshot, no active section', () => {

--- a/components/user_settings/display/user_settings_display.tsx
+++ b/components/user_settings/display/user_settings_display.tsx
@@ -102,7 +102,7 @@ type Props = {
     collapsedReplyThreads: string;
     collapsedReplyThreadsAllowUserPreference: boolean;
     linkPreviewDisplay: string;
-    globalHeaderEnabled: boolean;
+    globalHeaderAllowed: boolean;
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => void;
         getSupportedTimezones: () => void;

--- a/components/user_settings/display/user_settings_display.tsx
+++ b/components/user_settings/display/user_settings_display.tsx
@@ -102,6 +102,7 @@ type Props = {
     collapsedReplyThreads: string;
     collapsedReplyThreadsAllowUserPreference: boolean;
     linkPreviewDisplay: string;
+    globalHeaderEnabled: boolean;
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => void;
         getSupportedTimezones: () => void;
@@ -961,7 +962,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                     {collapsedReplyThreads}
                     {channelDisplayModeSection}
                     {languagesSection}
-                    {showGlobalHeader}
+                    {this.props.globalHeaderEnabled && showGlobalHeader}
                 </div>
             </div>
         );

--- a/components/user_settings/display/user_settings_display.tsx
+++ b/components/user_settings/display/user_settings_display.tsx
@@ -962,7 +962,7 @@ export default class UserSettingsDisplay extends React.PureComponent<Props, Stat
                     {collapsedReplyThreads}
                     {channelDisplayModeSection}
                     {languagesSection}
-                    {this.props.globalHeaderEnabled && showGlobalHeader}
+                    {this.props.globalHeaderAllowed && showGlobalHeader}
                 </div>
             </div>
         );


### PR DESCRIPTION
#### Summary
When the feature flag is disabled the global header option should not appear in account settings. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37715

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/8509#issuecomment-894425122

#### Release Note
```release-note
NONE
```

