### PR TITLE
[MM-36842] - Send email invites when clicking Next button in Onboarding

### DIFF
--- a/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
+++ b/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
@@ -197,10 +197,15 @@ class InviteMembersStep extends React.PureComponent<Props, State> {
         }
     }
 
-    sendEmailInvites = async () => {
+    sendEmailInvites = async (): Promise<boolean> => {
+        // if no emails in the input, do nothing
+        if (this.state.emails.length === 0) {
+            return true;
+        }
+
         if (this.state.emails.some((email) => email.error)) {
             this.setState({emailError: Utils.localizeMessage('next_steps_view.invite_members_step.invalidEmail', 'One or more email addresses are invalid'), emailsSent: undefined});
-            return;
+            return false;
         }
 
         trackEvent(getAnalyticsCategory(this.props.isAdmin), 'click_send_invitations', {num_invitations: this.state.emails.length});
@@ -211,7 +216,7 @@ class InviteMembersStep extends React.PureComponent<Props, State> {
         if (error || !data.length || data.some((result) => result.error)) {
             trackEvent(getAnalyticsCategory(this.props.isAdmin), 'error_sending_invitations');
             this.setState({emailError: Utils.localizeMessage('next_steps_view.invite_members_step.errorSendingEmails', 'There was a problem sending your invitations. Please try again.'), emailsSent: undefined});
-            return;
+            return false;
         }
 
         trackEvent(getAnalyticsCategory(this.props.isAdmin), 'invitations_sent', {num_invitations_sent: data.length});
@@ -219,14 +224,19 @@ class InviteMembersStep extends React.PureComponent<Props, State> {
         this.setState({emailError: undefined, emailsSent: data.length}, () => {
             setTimeout(() => this.setState({emailsSent: undefined}), 4000);
         });
+
+        return true;
     }
 
     onSkip = () => {
         this.props.onSkip(this.props.id);
     }
 
-    onFinish = () => {
-        this.props.onFinish(this.props.id);
+    onFinish = async () => {
+        const sent = await this.sendEmailInvites();
+        if (sent) {
+            this.props.onFinish(this.props.id);
+        }
     }
 
     copyLink = () => {

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/invite_member_by_email_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/invite_member_by_email_spec.js
@@ -162,7 +162,7 @@ describe('Cloud Onboarding - Sysadmin invite members by email', () => {
         cy.get('.InviteMembersStep__invitationResults').should('contain', 'One or more email addresses are invalid');
     });
 
-    it('MM-T3332_3 Pressing next with empty input finishes the step', () => {
+    it('MM-T3332_4 Pressing next with empty input finishes the step', () => {
         // * Make sure channel view has loaded
         cy.url().should('include', townSquarePage);
 

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/invite_member_by_email_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/invite_member_by_email_spec.js
@@ -141,4 +141,41 @@ describe('Cloud Onboarding - Sysadmin invite members by email', () => {
         // * Verify that the error message shows
         cy.get('.InviteMembersStep__invitationResults').should('contain', 'One or more email addresses are invalid');
     });
+
+    it('MM-T3332_3 Invite with invalid emails when next button is pressed', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Click Invite members to the team header
+        cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .InviteMembersStep').should('be.visible');
+
+        // # Enter email addresses
+        cy.get('#MultiInput_InviteMembersStep__membersListInput input').should('be.visible').type('bill.s.preston@wyldstallyns.com,theodoreloganwyldstallynscom,', {force: true});
+
+        // # Click Finish button
+        cy.findByTestId('InviteMembersStep__finishButton').should('be.visible').and('not.be.disabled').click();
+
+        // * Verify that the error message shows
+        cy.get('.InviteMembersStep__invitationResults').should('contain', 'One or more email addresses are invalid');
+    });
+
+    it('MM-T3332_3 Pressing next with empty input finishes the step', () => {
+        // * Make sure channel view has loaded
+        cy.url().should('include', townSquarePage);
+
+        // # Click Invite members to the team header
+        cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();
+
+        // * Check to make sure card is expanded
+        cy.get('.Card__body.expanded .InviteMembersStep').should('be.visible');
+
+        // # Click Finish button
+        cy.findByTestId('InviteMembersStep__finishButton').should('be.visible').and('not.be.disabled').click();
+
+        // * Step counter should increment
+        cy.get('.SidebarNextSteps .SidebarNextSteps__middle').should('contain', '1 / 5 steps complete');
+    });
 });


### PR DESCRIPTION
#### Summary
In the onboarding step for sending email invites, when "Finish" is clicked:
- If input has invalid emails they'll be validated and emails won't be sent. The step will also not complete
- If input has valid emails, they'll be sent, just like if the send button was pressed and step will complete
- if no emails are present in the input, clicking the finish step will simply finish the step

#### Ticket Link
[MM-36842](https://mattermost.atlassian.net/browse/MM-36842?atlOrigin=eyJpIjoiMDRiZWZiOTgwNzA3NGVjNGIzNTI2MDA1MDIzNWY1OWIiLCJwIjoiaiJ9)

#### Release Note
```release-note
NONE
```
