### PR TITLE
Update compass-icon `icon-file-document-outline` to match icon font rename

### DIFF
--- a/components/channel_header/__snapshots__/channel_header.test.jsx.snap
+++ b/components/channel_header/__snapshots__/channel_header.test.jsx.snap
@@ -125,7 +125,7 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -305,7 +305,7 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -485,7 +485,7 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -665,7 +665,7 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -813,7 +813,7 @@ exports[`components/ChannelHeader should render archived view 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -1002,7 +1002,7 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -1182,7 +1182,7 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -1347,7 +1347,7 @@ exports[`components/ChannelHeader should render properly when custom status is e
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -1576,7 +1576,7 @@ exports[`components/ChannelHeader should render properly when custom status is s
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -1808,7 +1808,7 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -1964,7 +1964,7 @@ exports[`components/ChannelHeader should render properly when populated with cha
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -2218,7 +2218,7 @@ exports[`components/ChannelHeader should render shared view 1`] = `
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}
@@ -2408,7 +2408,7 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
             buttonId="channelHeaderFilesButton"
             iconComponent={
               <i
-                className="icon icon-file-document-outline"
+                className="icon icon-file-text-outline"
               />
             }
             onClick={[Function]}

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -411,7 +411,7 @@ class ChannelHeader extends React.PureComponent {
         if (rhsState === RHSStates.CHANNEL_FILES) {
             channelFilesIconClass += ' channel-header__icon--active';
         }
-        const channelFilesIcon = <i className='icon icon-file-document-outline'/>;
+        const channelFilesIcon = <i className='icon icon-file-text-outline'/>;
 
         let pinnedIconClass = 'channel-header__icon channel-header__icon--wide channel-header__icon--left';
         if (rhsState === RHSStates.PIN) {

--- a/components/no_results_indicator/no_results_indicator.tsx
+++ b/components/no_results_indicator/no_results_indicator.tsx
@@ -32,8 +32,8 @@ const iconMap: {[key in NoResultsVariant]: React.ReactNode } = {
     [NoResultsVariant.Mentions]: <MentionsIcon className='no-results__icon'/>,
     [NoResultsVariant.FlaggedPosts]: <FlagIcon className='no-results__icon'/>,
     [NoResultsVariant.PinnedPosts]: <PinIcon className='no-results__icon'/>,
-    [NoResultsVariant.ChannelFiles]: <i className='icon icon-file-document-outline no-results__icon'/>,
-    [NoResultsVariant.ChannelFilesFiltered]: <i className='icon icon-file-document-outline no-results__icon'/>,
+    [NoResultsVariant.ChannelFiles]: <i className='icon icon-file-text-outline no-results__icon'/>,
+    [NoResultsVariant.ChannelFilesFiltered]: <i className='icon icon-file-text-outline no-results__icon'/>,
 };
 
 const titleMap: {[key in NoResultsVariant]: MessageDescriptor} = {

--- a/components/search_hint/__snapshots__/search_hint.test.tsx.snap
+++ b/components/search_hint/__snapshots__/search_hint.test.tsx.snap
@@ -408,7 +408,7 @@ exports[`components/SearchHint should match snapshot, without searchType 1`] = `
       onClick={[Function]}
     >
       <i
-        className="icon icon-file-document-outline"
+        className="icon icon-file-text-outline"
       />
       <MemoizedFormattedMessage
         defaultMessage="Files"

--- a/components/search_hint/search_hint.tsx
+++ b/components/search_hint/search_hint.tsx
@@ -57,7 +57,7 @@ const SearchHint = (props: Props): JSX.Element => {
                             className={classNames({highlighted: props.highlightedIndex === 1})}
                             onClick={() => props.onSearchTypeSelected && props.onSearchTypeSelected('files')}
                         >
-                            <i className='icon icon-file-document-outline'/>
+                            <i className='icon icon-file-text-outline'/>
                             <FormattedMessage
                                 id='search_bar.usage.search_type_files'
                                 defaultMessage='Files'


### PR DESCRIPTION
#### Summary
The icon `icon-file-document-outline` was recently renamed in [Compass Icons](https://github.com/mattermost/compass-icons/commit/4b5b9f2d55fe2b1dd4c45b7ecf71fc0aff627e4b) to `icon-file-text-outline`, this PR reflects that change in the Webapp now that the Webapp is using the Compass Icons package directly.

#### Release Note
```release-note
NONE
```
