### PR TITLE
improve `ProductSwitcher` product icon rendering

### DIFF
--- a/components/global/product_switcher.tsx
+++ b/components/global/product_switcher.tsx
@@ -77,18 +77,16 @@ const MenuItemTextContainer = styled.div`
     line-height: 20px;
 `;
 
-const SwitcherNavEntry = (props: SwitcherNavEntryProps) => {
+const SwitcherNavEntry = ({icon, destination, text, active}: SwitcherNavEntryProps) => {
     return (
         <MenuItem
-            to={props.destination}
+            to={destination}
         >
-            {typeof props.icon === 'string' ? (
-                <StyledIcon glyph={props.icon}/>
-            ) : props.icon}
+            <StyledIcon glyph={icon || 'none'}/>
             <MenuItemTextContainer>
-                {props.text}
+                {text}
             </MenuItemTextContainer>
-            {props.active &&
+            {active &&
                 <Icon
                     size={16}
                     glyph='check'


### PR DESCRIPTION
#### Summary
improved and simplified the product icon rendering to a simple string or `none`
Skipping QA and UX reviews, since this currently has no impact on it.

#### Ticket Link
```
NONE
```

#### Release note
```release-note
NONE
```
