### PR TITLE
Matching text to channel sidebar header menu

### DIFF
--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -175,7 +175,7 @@ class MainMenu extends React.PureComponent {
                 })}
                 extraText={formatMessage({
                     id: 'navbar_dropdown.invitePeopleExtraText',
-                    defaultMessage: 'Add or invite people to the team',
+                    defaultMessage: 'Add people to the team',
                 })}
                 icon={this.props.mobile && <i className='fa fa-user-plus'/>}
             />

--- a/components/sidebar/add_channel_dropdown.tsx
+++ b/components/sidebar/add_channel_dropdown.tsx
@@ -41,7 +41,7 @@ class AddChannelDropdown extends React.PureComponent<Props, State> {
                     onClick={this.props.invitePeopleModal}
                     icon={<i className='icon-account-plus-outline'/>}
                     text={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.invitePeople', defaultMessage: 'Invite People'})}
-                    extraText={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.invitePeopleExtraText', defaultMessage: 'Add or invite people to team'})}
+                    extraText={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.invitePeopleExtraText', defaultMessage: 'Add people to the team'})}
                 />
                 <li className='MenuGroup menu-divider'/>
             </>

--- a/components/widgets/menu/menu_items/menu_item.scss
+++ b/components/widgets/menu/menu_items/menu_item.scss
@@ -45,7 +45,11 @@
             white-space: normal;
 
             @media (max-width: 768px) {
-                padding-left: 5px !important;
+                padding-left: 28px !important;
+
+                .mobile-main-menu & {
+                    padding-left: 36px !important;
+                }
             }
         }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3697,7 +3697,7 @@
   "navbar_dropdown.help": "Help",
   "navbar_dropdown.integrations": "Integrations",
   "navbar_dropdown.invitePeople": "Invite People",
-  "navbar_dropdown.invitePeopleExtraText": "Add or invite people to the team",
+  "navbar_dropdown.invitePeopleExtraText": "Add people to the team",
   "navbar_dropdown.join": "Join Another Team",
   "navbar_dropdown.keyboardShortcuts": "Keyboard Shortcuts",
   "navbar_dropdown.leave": "Leave Team",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4109,7 +4109,7 @@
   "sidebar_left.add_channel_dropdown.createNewChannel": "Create New Channel",
   "sidebar_left.add_channel_dropdown.dropdownAriaLabel": "Add Channel Dropdown",
   "sidebar_left.add_channel_dropdown.invitePeople": "Invite People",
-  "sidebar_left.add_channel_dropdown.invitePeopleExtraText": "Add or invite people to team",
+  "sidebar_left.add_channel_dropdown.invitePeopleExtraText": "Add people to the team",
   "sidebar_left.channel_filter.filterByUnread": "Filter by unread",
   "sidebar_left.channel_filter.showAllChannels": "Show all channels",
   "sidebar_left.channel_navigator.channelSwitcherLabel": "Channel Switcher",

--- a/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
+++ b/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
@@ -84,7 +84,7 @@ exports[`plugins/MainMenuActions should match snapshot and click plugin item for
             "type": [Function],
           }
         }
-        extraText="Add or invite people to the team"
+        extraText="Add people to the team"
         icon={false}
         id="invitePeople"
         modalId="invitation"

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -294,7 +294,6 @@
 
             span {
                 color: rgba(var(--center-channel-color-rgb), 0.9);
-                font-size: 14px;
                 white-space: nowrap;
             }
 


### PR DESCRIPTION
#### Summary
While working on https://github.com/mattermost/mattermost-webapp/pull/8569, we discovered that the "Add channel dropdown" menu with the same menu item as the channel sidebar header menu needed wording and sizing adjustments for consistency. This PR makes the necessary changes.

#### Screenshots
![image](https://user-images.githubusercontent.com/3245614/129264581-d26c7cd9-a612-4751-b33b-0c6ec7bf235c.png)

#### Release Note
```release-note
NONE
```
