### PR TITLE
[MM-37670] System console about modal missing header border

### DIFF
--- a/sass/routes/_about-modal.scss
+++ b/sass/routes/_about-modal.scss
@@ -14,7 +14,7 @@
                 align-items: center;
                 padding: 20px 25px;
                 border: none;
-                border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+                border-bottom: 1px solid rgba(var(--sys-center-channel-color-rgb), 0.08);
                 background: transparent;
                 color: inherit;
 


### PR DESCRIPTION
#### Summary
Fixes an issue where the header border in the System Console's About Mattermost modal was faded and difficult to see.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37670

#### Related Pull Requests
None
#### Screenshots
Before fix:

<img width="832" alt="Screen Shot 2021-08-05 at 9 23 07 AM" src="https://user-images.githubusercontent.com/38707101/129420478-c1e0c872-0abd-48c8-bf8d-f795d3d5e241.png">


After fix:

![after mm-37670](https://user-images.githubusercontent.com/38707101/129420463-9a36ae7e-71c2-4ff5-9a31-e2f2e17298c4.jpg)


#### Release Note

```release-note
Fixes About Mattermost modal styling
```
