### PR TITLE
[MM-37669] System console hamburger menu theming issue

### DIFF
--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -609,6 +609,11 @@
     .Menu {
         .dropdown-menu {
             overflow: auto;
+            background: var(--sys-center-channel-bg);
+
+            .MenuGroup.menu-divider {
+                background: rgba(var(--sys-center-channel-color-rgb), 0.16);
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Fixes an issue where the system console's hamburger menu was improperly themed with the user's theming instead of the system console's theming.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-37669

#### Related Pull Requests
None
#### Screenshots
Before fix:
<img width="346" alt="Screen Shot 2021-08-05 at 9 17 44 AM" src="https://user-images.githubusercontent.com/38707101/129425036-9ff43150-119e-47e2-8b52-5443d0394900.png">

After fix:
![after mm-37669](https://user-images.githubusercontent.com/38707101/129425187-36280835-4597-4182-bc4b-386c9d692d40.jpg)

#### Release Note
```release-note
Fixed system console's hamburger menu theming
```
