### PR TITLE
[MM 37561] Fix dropdown menu theming in System Console

### DIFF
--- a/components/admin_console/data_retention_settings/data_retention_settings.scss
+++ b/components/admin_console/data_retention_settings/data_retention_settings.scss
@@ -22,14 +22,6 @@
         flex-grow: 0.15;
     }
 
-    .dropdown-menu {
-        background: var(--sys-center-channel-bg);
-
-        > li > button:hover {
-            background: rgba(var(--sys-center-channel-color-rgb), 0.1);
-        }
-    }
-
     input:-webkit-autofill,
     input:-webkit-autofill:hover,
     input:-webkit-autofill:focus,

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -85,6 +85,12 @@
     }
 
     .dropdown-menu {
+        background: var(--sys-center-channel-bg);
+
+        > li > button:hover {
+            background: rgba(var(--sys-center-channel-color-rgb), 0.1);
+        }
+
         .divider {
             @include opacity(1);
         }


### PR DESCRIPTION
#### Summary
This PR fixes dropdown menus theming in the System Console. The dropdown menus now use the System theme instead of the user's theme, which may make the menus difficult to see if the user is using a Dark theme.

This PR also deletes the now-duplicate code from `/components/admin_console/data_retention_settings/data_retention_settings.scss`, which was added as a part of https://github.com/mattermost/mattermost-webapp/pull/8435.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37561

#### Related Pull Requests
None

#### Screenshots
Before fix:
![image-2021-08-02-09-48-31-333](https://user-images.githubusercontent.com/38707101/129428149-8472de48-373d-4d7f-b857-8dcc98df2abc.png)

After fix:
![after mm-37561](https://user-images.githubusercontent.com/38707101/129428306-30130f86-8f4f-4c86-919e-3850049bcd3b.jpg)


#### Release Note
```release-note
Fixed dropdown menu theming in System Console
```
