### PR TITLE
MM-37455: fix misplaced channel header info popover

### DIFF
--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -210,7 +210,10 @@ class ChannelHeader extends React.PureComponent {
             this.setState({showChannelHeaderPopover: true, leftOffset: this.headerDescriptionRef.current.offsetLeft});
         }
 
-        this.setState({topOffset: (announcementBarSize * this.props.announcementBarCount) + this.props.globalHeaderEnabled ? 40 : 0});
+        const globalHeaderOffset = this.props.globalHeaderEnabled ? 40 : 0;
+        const topOffset = (announcementBarSize * this.props.announcementBarCount) + globalHeaderOffset;
+
+        this.setState({topOffset});
     }
 
     setPopoverOverlayWidth = () => {

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -210,7 +210,7 @@ class ChannelHeader extends React.PureComponent {
             this.setState({showChannelHeaderPopover: true, leftOffset: this.headerDescriptionRef.current.offsetLeft});
         }
 
-        this.setState({topOffset: (announcementBarSize * this.props.announcementBarCount)});
+        this.setState({topOffset: (announcementBarSize * this.props.announcementBarCount) + this.props.globalHeaderEnabled ? 40 : 0});
     }
 
     setPopoverOverlayWidth = () => {


### PR DESCRIPTION
#### Summary
conditionally adds the global header height value to the channel header info `topOffset` value (if global header is enabled)

#### Ticket Link
[MM-37455](https://mattermost.atlassian.net/browse/MM-37455)

#### Screenshots
| before | after |
|---|---|
|<img width="748" alt="Screenshot 2021-08-16 at 12 22 55" src="https://user-images.githubusercontent.com/32863416/129550245-a3229f6a-ba32-4a04-a072-7c03f47a405d.png">|<img width="748" alt="Screenshot 2021-08-16 at 12 23 20" src="https://user-images.githubusercontent.com/32863416/129550263-06c5b59f-f26c-4d68-ad18-93b7f11666c4.png">|



#### Release Note
```release-note
NONE
```
