### PR TITLE
MM-37784: make integrations (backstage) take up the entire viewport

### DIFF
--- a/components/global/global_header.scss
+++ b/components/global/global_header.scss
@@ -72,5 +72,11 @@
         .product-switcher-icon {
             padding: 0 6px;
         }
+
+        .backstage {
+            position: fixed;
+            z-index: 2;
+            top: 0;
+        }
     }
 }

--- a/components/global/global_header.scss
+++ b/components/global/global_header.scss
@@ -74,9 +74,9 @@
         }
 
         .backstage {
-            position: fixed;
+            position: relative;
             z-index: 2;
-            top: 0;
+            margin-top: -40px;
         }
     }
 }


### PR DESCRIPTION
#### Summary
added a few CSS rules to make the `.backstage` class to take up the entire viewport and be layered on top of the global header.

#### Ticket Link
[MM-37784](https://mattermost.atlassian.net/browse/MM-37784)

#### Screenshots
| before | after |
|----|----|
|<img width="1306" alt="Screenshot 2021-08-16 at 14 00 18" src="https://user-images.githubusercontent.com/32863416/129560454-9b20aa95-2aa9-4a6e-8a67-5d949b411aad.png">|<img width="1306" alt="Screenshot 2021-08-16 at 14 00 25" src="https://user-images.githubusercontent.com/32863416/129560488-6ed71f61-6722-4067-a9e2-26f6e3306f9d.png">|

#### Release Note
```release-note
NONE
```
