### PR TITLE
[MM-33390] Open command in forms

### DIFF
--- a/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
+++ b/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
@@ -10,7 +10,7 @@ import {FormattedMessage} from 'react-intl';
 import {getFullName} from 'mattermost-redux/utils/user_utils';
 
 import SearchChannelWithPermissionsProvider from 'components/suggestion/search_channel_with_permissions_provider.jsx';
-import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionBox from 'components/suggestion/suggestion_box';
 import ModalSuggestionList from 'components/suggestion/modal_suggestion_list';
 
 import {placeCaretAtEnd} from 'utils/utils.jsx';

--- a/components/admin_console/user_autocomplete_setting/user_autocomplete_setting.jsx
+++ b/components/admin_console/user_autocomplete_setting/user_autocomplete_setting.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
 import Setting from 'components/admin_console/setting';
-import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionBox from 'components/suggestion/suggestion_box';
 import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 
 export default class UserAutocompleteSetting extends React.PureComponent {

--- a/components/autocomplete_selector.jsx
+++ b/components/autocomplete_selector.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionBox from 'components/suggestion/suggestion_box';
 import SuggestionList from 'components/suggestion/suggestion_list';
 
 export default class AutocompleteSelector extends React.PureComponent {

--- a/components/quick_switch_modal/quick_switch_modal.tsx
+++ b/components/quick_switch_modal/quick_switch_modal.tsx
@@ -14,7 +14,8 @@ import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
 import * as UserAgent from 'utils/user_agent';
-import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionBox from 'components/suggestion/suggestion_box';
+import SuggestionBoxComponent from 'components/suggestion/suggestion_box/suggestion_box';
 import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 import SwitchChannelProvider from 'components/suggestion/switch_channel_provider.jsx';
 import NoResultsIndicator from 'components/no_results_indicator/no_results_indicator';
@@ -53,7 +54,7 @@ type State = {
 
 export default class QuickSwitchModal extends React.PureComponent<Props, State> {
     private channelProviders: SwitchChannelProvider[];
-    private switchBox: SuggestionBox|null;
+    private switchBox: SuggestionBoxComponent|null;
 
     constructor(props: Props) {
         super(props);
@@ -83,7 +84,7 @@ export default class QuickSwitchModal extends React.PureComponent<Props, State> 
         }
     };
 
-    private setSwitchBoxRef = (input: SuggestionBox): void => {
+    private setSwitchBoxRef = (input: SuggestionBoxComponent): void => {
         this.switchBox = input;
         this.focusTextbox();
     };

--- a/components/search_bar/search_bar.tsx
+++ b/components/search_bar/search_bar.tsx
@@ -9,7 +9,8 @@ import Constants from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
 import SearchSuggestionList from 'components/suggestion/search_suggestion_list.jsx';
 import SuggestionDate from 'components/suggestion/suggestion_date.jsx';
-import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionBox from 'components/suggestion/suggestion_box';
+import SuggestionBoxComponent from 'components/suggestion/suggestion_box/suggestion_box';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 import Provider from 'components/suggestion/provider';
 
@@ -51,7 +52,7 @@ const defaultProps: Partial<Props> = {
 const SearchBar: React.FunctionComponent<Props> = (props: Props): JSX.Element => {
     const {isFocused, keepFocused, searchTerms, suggestionProviders} = props;
 
-    const searchRef = useRef<SuggestionBox>();
+    const searchRef = useRef<SuggestionBoxComponent>();
     const intl = useIntl();
 
     useEffect((): void => {
@@ -98,7 +99,7 @@ const SearchBar: React.FunctionComponent<Props> = (props: Props): JSX.Element =>
         }
     };
 
-    const getSearch = (node: SuggestionBox): void => {
+    const getSearch = (node: SuggestionBoxComponent): void => {
         searchRef.current = node;
         if (props.getFocus) {
             props.getFocus(props.handleFocus);

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies.ts
@@ -83,6 +83,7 @@ export const getStore = () => Store;
 
 import {Constants} from 'utils/constants';
 export const EXECUTE_CURRENT_COMMAND_ITEM_ID = Constants.Integrations.EXECUTE_CURRENT_COMMAND_ITEM_ID;
+export const OPEN_COMMAND_IN_MODAL_ITEM_ID = Constants.Integrations.OPEN_COMMAND_IN_MODAL_ITEM_ID;
 export const COMMAND_SUGGESTION_ERROR = Constants.Integrations.COMMAND_SUGGESTION_ERROR;
 export const COMMAND_SUGGESTION_CHANNEL = Constants.Integrations.COMMAND_SUGGESTION_CHANNEL;
 export const COMMAND_SUGGESTION_USER = Constants.Integrations.COMMAND_SUGGESTION_USER;
@@ -101,6 +102,16 @@ export const getExecuteSuggestion = (parsed: ParsedCommand): AutocompleteSuggest
         Hint: '',
         Description: 'Select this option or use ' + key + '+Enter to execute the current command.',
         IconData: EXECUTE_CURRENT_COMMAND_ITEM_ID,
+    };
+};
+
+export const getOpenInModalSuggestion = (parsed: ParsedCommand): AutocompleteSuggestion | null => {
+    return {
+        Complete: parsed.command.substring(1) + OPEN_COMMAND_IN_MODAL_ITEM_ID,
+        Suggestion: 'Open in modal',
+        Hint: '',
+        Description: 'Select this option to open the current command in a modal.',
+        IconData: OPEN_COMMAND_IN_MODAL_ITEM_ID,
     };
 };
 

--- a/components/suggestion/command_provider/command_provider.tsx
+++ b/components/suggestion/command_provider/command_provider.tsx
@@ -24,6 +24,7 @@ import {AppCommandParser} from './app_command_parser/app_command_parser';
 import {intlShim} from './app_command_parser/app_command_parser_dependencies';
 
 const EXECUTE_CURRENT_COMMAND_ITEM_ID = Constants.Integrations.EXECUTE_CURRENT_COMMAND_ITEM_ID;
+const OPEN_COMMAND_IN_MODAL_ITEM_ID = Constants.Integrations.OPEN_COMMAND_IN_MODAL_ITEM_ID;
 const COMMAND_SUGGESTION_ERROR = Constants.Integrations.COMMAND_SUGGESTION_ERROR;
 
 export class CommandSuggestion extends Suggestion {
@@ -40,12 +41,15 @@ export class CommandSuggestion extends Suggestion {
         case EXECUTE_CURRENT_COMMAND_ITEM_ID:
             symbolSpan = <span className='block mt-1'>{'↵'}</span>;
             break;
+        case OPEN_COMMAND_IN_MODAL_ITEM_ID:
+            symbolSpan = <span className='block mt-1'>{'↵'}</span>;
+            break;
         case COMMAND_SUGGESTION_ERROR:
             symbolSpan = <span>{'!'}</span>;
             break;
         }
         let icon = <div className='slash-command__icon'>{symbolSpan}</div>;
-        if (item.IconData && ![EXECUTE_CURRENT_COMMAND_ITEM_ID, COMMAND_SUGGESTION_ERROR].includes(item.IconData)) {
+        if (item.IconData && ![EXECUTE_CURRENT_COMMAND_ITEM_ID, COMMAND_SUGGESTION_ERROR, OPEN_COMMAND_IN_MODAL_ITEM_ID].includes(item.IconData)) {
             icon = (
                 <div
                     className='slash-command__icon'

--- a/components/suggestion/suggestion_box/index.js
+++ b/components/suggestion/suggestion_box/index.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {openModalFromCommand} from 'actions/apps';
+
+import SuggestionBox from './suggestion_box';
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            openModalFromCommand,
+        }, dispatch),
+    };
+}
+
+export default connect(null, mapDispatchToProps)(SuggestionBox);

--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -12,6 +12,7 @@ import * as UserAgent from 'utils/user_agent';
 import * as Utils from 'utils/utils.jsx';
 
 const EXECUTE_CURRENT_COMMAND_ITEM_ID = Constants.Integrations.EXECUTE_CURRENT_COMMAND_ITEM_ID;
+const OPEN_COMMAND_IN_MODAL_ITEM_ID = Constants.Integrations.OPEN_COMMAND_IN_MODAL_ITEM_ID;
 const KeyCodes = Constants.KeyCodes;
 
 export default class SuggestionBox extends React.PureComponent {
@@ -152,6 +153,10 @@ export default class SuggestionBox extends React.PureComponent {
          * To show suggestions even when focus is lost
          */
         forceSuggestionsWhenBlur: PropTypes.bool,
+
+        actions: PropTypes.shape({
+            openModalFromCommand: PropTypes.func.isRequired,
+        }).isRequired,
     }
 
     static defaultProps = {
@@ -450,9 +455,16 @@ export default class SuggestionBox extends React.PureComponent {
     handleCompleteWord = (term, matchedPretext, e) => {
         let fixedTerm = term;
         let finish = false;
+        let openCommandInModal = false;
         if (term.endsWith(EXECUTE_CURRENT_COMMAND_ITEM_ID)) {
             fixedTerm = term.substring(0, term.length - EXECUTE_CURRENT_COMMAND_ITEM_ID.length);
             finish = true;
+        }
+
+        if (term.endsWith(OPEN_COMMAND_IN_MODAL_ITEM_ID)) {
+            fixedTerm = term.substring(0, term.length - OPEN_COMMAND_IN_MODAL_ITEM_ID.length);
+            finish = true;
+            openCommandInModal = true;
         }
 
         if (!finish) {
@@ -475,6 +487,13 @@ export default class SuggestionBox extends React.PureComponent {
         }
 
         this.clear();
+
+        if (openCommandInModal) {
+            this.props.actions.openModalFromCommand(fixedTerm, this.props.isRHS);
+            this.inputRef.current.value = '';
+            this.handleChange({target: this.inputRef.current});
+            return false;
+        }
 
         this.inputRef.current.focus();
 

--- a/components/suggestion/suggestion_box/suggestion_box.test.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.test.jsx
@@ -6,7 +6,7 @@ import {shallow, mount} from 'enzyme';
 
 import CommandProvider from 'components/suggestion/command_provider/command_provider';
 import AtMentionProvider from 'components/suggestion/at_mention_provider/at_mention_provider.jsx';
-import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionBox from 'components/suggestion/suggestion_box/suggestion_box';
 import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 import * as Utils from 'utils/utils.jsx';
 

--- a/components/textbox/textbox.tsx
+++ b/components/textbox/textbox.tsx
@@ -16,7 +16,8 @@ import ChannelMentionProvider from 'components/suggestion/channel_mention_provid
 import AppCommandProvider from 'components/suggestion/command_provider/app_provider';
 import CommandProvider from 'components/suggestion/command_provider/command_provider';
 import EmoticonProvider from 'components/suggestion/emoticon_provider.jsx';
-import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionBox from 'components/suggestion/suggestion_box';
+import SuggestionBoxComponent from 'components/suggestion/suggestion_box/suggestion_box';
 import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 
 import * as Utils from 'utils/utils.jsx';
@@ -66,7 +67,7 @@ type Props = {
 export default class Textbox extends React.PureComponent<Props> {
     private suggestionProviders: Provider[];
     private wrapper: React.RefObject<HTMLDivElement>;
-    private message: React.RefObject<SuggestionBox>;
+    private message: React.RefObject<SuggestionBoxComponent>;
     private preview: React.RefObject<HTMLDivElement>;
 
     static defaultProps = {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2460,6 +2460,8 @@
   "apps.error.parser.multiple_equal": "Multiple `=` signs are not allowed.",
   "apps.error.parser.no_argument_pos_x": "Unable to identify argument.",
   "apps.error.parser.no_bindings": "No command bindings.",
+  "apps.error.parser.no_call": "No call found.",
+  "apps.error.parser.no_form": "No form found.",
   "apps.error.parser.no_match": "`{command}`: No matching command found in this workspace.",
   "apps.error.parser.no_slash_start": "Command must start with a `/`.",
   "apps.error.parser.unexpected_error": "Unexpected error.",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1476,6 +1476,7 @@ export const Constants = {
         OAUTH_APP: 'oauth2-apps',
         BOT: 'bots',
         EXECUTE_CURRENT_COMMAND_ITEM_ID: '_execute_current_command',
+        OPEN_COMMAND_IN_MODAL_ITEM_ID: '_open_command_in_modal',
         COMMAND_SUGGESTION_ERROR: 'error',
         COMMAND_SUGGESTION_CHANNEL: 'channel',
         COMMAND_SUGGESTION_USER: 'user',


### PR DESCRIPTION
#### Summary
This PR adds a new option to open the command as a modal. This will clear the textbox, and bring the command form and all the introduced values to a modal, so you can continue filling the parameters on the modal. Readonly, multiselect, and default values also work with this.

The "open in modal" option has been added at the end of the list of options.

Known issues:
- Dynamic selects will have as label the value (since it is what is being parsed). This may create a bad UX since when opening the modal we may see the value set as "dv1", and when we open the selector, we will see no "dv1" but "Dynamic Value 1".
- The icon is not final. Whenever the icon is ready on the Compass Icons, I will use the new one.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-33390

#### Related Pull Requests
Future PR expected on mobile to sync the App Command parser and add this feature

#### Screenshots
![Screenshot from 2021-08-16 16-30-37](https://user-images.githubusercontent.com/1933730/129580396-6cd275e4-f807-41b2-9126-a1e066812232.png)


#### Release Note
```release-note
App Commands now have an option to open them as modals.
```
