### PR TITLE
Add timezones.json to the package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "stream-browserify": "3.0.0",
         "styled-components": "5.3.0",
         "superagent": "6.1.0",
+        "timezones.json": "1.5.2",
         "tinycolor2": "1.4.2",
         "typescript": "4.3.4",
         "xregexp": "5.0.2",
@@ -37016,6 +37017,11 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/timezones.json": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/timezones.json/-/timezones.json-1.5.2.tgz",
+      "integrity": "sha512-Z+anCOAVpuJ0LcbsYl1a3D/yQNgntPzUgNTyoDgHklieiUWLec0XZM8xZ4I/r66M2yVMBfWhKftt0Rr6Fpu1/A=="
     },
     "node_modules/timm": {
       "version": "1.7.1",


### PR DESCRIPTION
This was missing from the package-lock.json in the previous PR, so it gets added automatically by `npm install` all the time

#### Release Note
```release-note
NONE
```
