### PR TITLE
MM-37542: support tooltip react components

### DIFF
--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -115,7 +115,7 @@ export default class PluginRegistry {
     // - icon - React element to use as the button's icon
     // - action - a function called when the button is clicked, passed the channel and channel member as arguments
     // - dropdown_text - string or React element shown for the dropdown button description
-    // - tooltip_text - string shown for tooltip appear on hover
+    // - tooltip_text - string or React element shown for tooltip appear on hover
     registerChannelHeaderButtonAction(icon, action, dropdownText, tooltipText) {
         const id = generateId();
 

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -125,7 +125,7 @@ export default class PluginRegistry {
             icon: resolveReactElement(icon),
             action,
             dropdownText: resolveReactElement(dropdownText),
-            tooltipText,
+            tooltipText: resolveReactElement(tooltipText),
         };
 
         store.dispatch({


### PR DESCRIPTION
#### Summary
To facilitate changing the tooltip text on playbooks depending on the context, support a React component when registering the tooltip text. This was actually already supported downstream, but wasn't correctly supported in the registration api.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-37542

#### Release Note
```release-note
Support React component in channel header tooltips registered by plugins.
```
