### PR TITLE
Automated cherry pick of #8484

### DIFF
--- a/components/convert_channel_modal/convert_channel_modal.jsx
+++ b/components/convert_channel_modal/convert_channel_modal.jsx
@@ -8,6 +8,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 import Constants from 'utils/constants';
+import {General} from 'mattermost-redux/constants';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
@@ -26,7 +27,7 @@ export default class ConvertChannelModal extends React.PureComponent {
             /**
             * Function called for converting channel to private,
             */
-            convertChannelToPrivate: PropTypes.func.isRequired,
+            updateChannelPrivacy: PropTypes.func.isRequired,
         }),
     }
 
@@ -42,7 +43,7 @@ export default class ConvertChannelModal extends React.PureComponent {
             return;
         }
 
-        actions.convertChannelToPrivate(channelId);
+        actions.updateChannelPrivacy(channelId, General.PRIVATE_CHANNEL);
         trackEvent('actions', 'convert_to_private_channel', {channel_id: channelId});
         this.onHide();
     }

--- a/components/convert_channel_modal/index.js
+++ b/components/convert_channel_modal/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {convertChannelToPrivate} from 'mattermost-redux/actions/channels';
+import {updateChannelPrivacy} from 'mattermost-redux/actions/channels';
 
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
@@ -19,7 +19,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            convertChannelToPrivate,
+            updateChannelPrivacy,
         }, dispatch),
     };
 }

--- a/packages/mattermost-redux/src/actions/channels.test.js
+++ b/packages/mattermost-redux/src/actions/channels.test.js
@@ -275,28 +275,6 @@ describe('Actions.Channels', () => {
         assert.equal(channels[channelId].type, General.PRIVATE_CHANNEL);
     });
 
-    it('convertChannelToPrivate', async () => {
-        const publicChannel = TestHelper.basicChannel;
-        nock(Client4.getChannelRoute(publicChannel.id)).
-            post('/convert').
-            reply(200, {...TestHelper.basicChannel, type: General.PRIVATE_CHANNEL});
-
-        assert.equal(TestHelper.basicChannel.type, General.OPEN_CHANNEL);
-
-        await store.dispatch(Actions.convertChannelToPrivate(TestHelper.basicChannel.id));
-
-        const updateRequest = store.getState().requests.channels.updateChannel;
-        if (updateRequest.status === RequestStatus.FAILURE) {
-            throw new Error(JSON.stringify(updateRequest.error));
-        }
-
-        const {channels} = store.getState().entities.channels;
-        const channelId = Object.keys(channels)[0];
-        assert.ok(channelId);
-        assert.ok(channels[channelId]);
-        assert.equal(channels[channelId].type, General.PRIVATE_CHANNEL);
-    });
-
     it('getChannel', async () => {
         nock(Client4.getBaseRoute()).
             get(`/channels/${TestHelper.basicChannel.id}`).

--- a/packages/mattermost-redux/src/actions/channels.ts
+++ b/packages/mattermost-redux/src/actions/channels.ts
@@ -348,37 +348,6 @@ export function updateChannelPrivacy(channelId: string, privacy: string): Action
     };
 }
 
-export function convertChannelToPrivate(channelId: string): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        dispatch({type: ChannelTypes.UPDATE_CHANNEL_REQUEST, data: null});
-
-        let convertedChannel;
-        try {
-            convertedChannel = await Client4.convertChannelToPrivate(channelId);
-        } catch (error) {
-            forceLogoutIfNecessary(error, dispatch, getState);
-
-            dispatch(batchActions([
-                {type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error},
-                logError(error),
-            ]));
-            return {error};
-        }
-
-        dispatch(batchActions([
-            {
-                type: ChannelTypes.RECEIVED_CHANNEL,
-                data: convertedChannel,
-            },
-            {
-                type: ChannelTypes.UPDATE_CHANNEL_SUCCESS,
-            },
-        ]));
-
-        return {data: convertedChannel};
-    };
-}
-
 export function updateChannelNotifyProps(userId: string, channelId: string, props: ChannelNotifyProps): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const notifyProps = {

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -1541,15 +1541,6 @@ export default class Client4 {
         );
     };
 
-    convertChannelToPrivate = (channelId: string) => {
-        this.trackEvent('api', 'api_channels_convert_to_private', {channel_id: channelId});
-
-        return this.doFetch<Channel>(
-            `${this.getChannelRoute(channelId)}/convert`,
-            {method: 'post'},
-        );
-    };
-
     updateChannelPrivacy = (channelId: string, privacy: any) => {
         this.trackEvent('api', 'api_channels_update_privacy', {channel_id: channelId, privacy});
 


### PR DESCRIPTION
Cherry pick of #8484 on cloud.

/cc  @BenCookie95

```release-note
Removing the convert channel endpoint and using /channels/{channel_id}/privacy instead
```