### PR TITLE
Moving ModalController aside the GlobalHeader

### DIFF
--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -18,7 +18,6 @@ import ShortcutsModal from 'components/shortcuts_modal.jsx';
 import SidebarRight from 'components/sidebar_right';
 import SidebarRightMenu from 'components/sidebar_right_menu';
 import ImportThemeModal from 'components/user_settings/import_theme_modal';
-import ModalController from 'components/modal_controller';
 import LegacyTeamSidebar from 'components/legacy_team_sidebar';
 import LegacySidebar from 'components/legacy_sidebar';
 import Sidebar from 'components/sidebar';
@@ -89,7 +88,6 @@ export default class ChannelController extends React.Component {
                     <ResetStatusModal/>
                     <LeavePrivateChannelModal/>
                     <ShortcutsModal isMac={Utils.isMac()}/>
-                    <ModalController/>
                 </div>
             </div>
         );

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -20,6 +20,7 @@ import {trackLoadTime} from 'actions/telemetry_actions.jsx';
 import {makeAsyncComponent} from 'components/async_load';
 import CompassThemeProvider from 'components/compass_theme_provider/compass_theme_provider';
 import GlobalHeader from 'components/global/global_header';
+import ModalController from 'components/modal_controller';
 import {HFTRoute, LoggedInHFTRoute} from 'components/header_footer_template_route';
 import IntlProvider from 'components/intl_provider';
 import NeedsTeam from 'components/needs_team';
@@ -363,6 +364,7 @@ export default class Root extends React.PureComponent {
                         to={`/${this.props.permalinkRedirectTeamName}/pl/:postid`}
                     />
                     <CompassThemeProvider theme={this.props.theme}>
+                        <ModalController/>
                         <GlobalHeader/>
                         <Switch>
                             {this.props.products?.map((product) => (


### PR DESCRIPTION
#### Summary
This is needed to show things like the Account settings in other products. If
not, the modal is activated but is only shown when you go back to Channels.

#### Ticket Link
[MM-37963](https://mattermost.atlassian.net/browse/MM-37963)

#### Release Note
```release-note
NONE
```