### PR TITLE
Fix aria label on channel switcher

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -86,14 +86,8 @@ class SwitchChannelSuggestion extends Suggestion {
             className += ' suggestion--selected';
         }
 
-        let displayName = (
-            <React.Fragment>
-                {channel.display_name}
-                <div className='mentions__fullname'>
-                    {`~${channel.name}`}
-                </div>
-            </React.Fragment>
-        );
+        let name = channel.display_name;
+        let description = '~' + channel.name;
 
         let icon;
         if (channelIsArchived) {
@@ -165,39 +159,24 @@ class SwitchChannelSuggestion extends Suggestion {
                 />
             );
 
-            let deactivated;
+            let deactivated = '';
             if (userItem.delete_at) {
                 deactivated = (' - ' + Utils.localizeMessage('channel_switch_modal.deactivated', 'Deactivated'));
             }
 
             if (teammate && teammate.is_bot) {
-                displayName = (
-                    <React.Fragment>
-                        {userItem.username}
-                        {deactivated}
-                    </React.Fragment>
-                );
+                name = userItem.username + deactivated;
+                description = '';
             } else if (channel.display_name) {
-                displayName = (
-                    <React.Fragment>
-                        {channel.display_name}
-                        <div className='mentions__fullname'>
-                            {`@${userItem.username}`}
-                            {deactivated}
-                        </div>
-                    </React.Fragment>
-                );
+                name = channel.display_name;
+                description = `@${userItem.username}` + deactivated;
             } else {
-                displayName = (
-                    <React.Fragment>
-                        {userItem.username}
-                        {deactivated}
-                    </React.Fragment>
-                );
+                name = userItem.username + deactivated;
+                description = '';
             }
         } else if (channel.type === Constants.GM_CHANNEL) {
-            // remove the slug from the option
-            displayName = channel.display_name;
+            name = channel.display_name;
+            description = '';
         }
 
         let sharedIcon = null;
@@ -221,12 +200,17 @@ class SwitchChannelSuggestion extends Suggestion {
                 }}
                 id={`switchChannel_${channel.name}`}
                 data-testid={channel.name}
-                aria-label={displayName || channel.name}
+                aria-label={name || channel.name}
                 {...Suggestion.baseProps}
             >
                 {icon}
                 <span className='suggestion-list__info_user'>
-                    {displayName}
+                    {name}
+                    {description && (
+                        <div className='mentions__fullname'>
+                            {description}
+                        </div>
+                    )}
                 </span>
                 {customStatus}
                 {sharedIcon}


### PR DESCRIPTION
#### Summary
On this version, whenever a screen reader was to read the channels in the channel switcher, would find in the aria label something like "Object". This was because we were passing a whole object to the aria label instead of the string.

This PR should solve this issue.

#### Test steps
Open the channel switcher (CTRL+K) and use a screen reader to see that the names of the channels are read out loud without any problem. Alternatively, you can check the aria labels of the div that defines each row in the list.

#### Ticket Link
None

#### Release Note
```release-note
Fix texts for screen readers on channel switcher.
```
