### PR TITLE
Fix attachment images

### DIFF
--- a/components/markdown_image_expand/markdown_image_expand.tsx
+++ b/components/markdown_image_expand/markdown_image_expand.tsx
@@ -9,7 +9,7 @@ export type Props = {
     children: React.ReactNode;
     isExpanded: boolean;
     postId: string;
-    onToggle: (isExpanded: boolean) => void;
+    onToggle?: (isExpanded: boolean) => void;
     actions: {
         toggleInlineImageVisibility: (postId: string, imageKey: string) => void;
     };
@@ -19,7 +19,7 @@ const MarkdownImageExpand: React.FC<Props> = ({children, alt, isExpanded, postId
     const {toggleInlineImageVisibility} = actions;
 
     useEffect(() => {
-        onToggle(isExpanded);
+        onToggle?.(isExpanded);
     }, [isExpanded]);
 
     const handleToggleButtonClick = () => {

--- a/components/post_view/embedded_bindings/embedded_binding/__snapshots__/embedded_binding.test.tsx.snap
+++ b/components/post_view/embedded_bindings/embedded_binding/__snapshots__/embedded_binding.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
               },
             }
           }
+          postId="post_id"
         />
       </h1>
       <div>
@@ -44,6 +45,7 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
                 }
               }
               message="some title"
+              postId="post_id"
             />
           </Connect(ShowMore)>
         </div>
@@ -85,6 +87,7 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
               },
             }
           }
+          postId="post_id"
         />
       </h1>
       <div>
@@ -104,6 +107,7 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
                 }
               }
               message="some title"
+              postId="post_id"
             />
           </Connect(ShowMore)>
         </div>
@@ -145,6 +149,7 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
               },
             }
           }
+          postId="post_id"
         />
       </h1>
       <div>
@@ -164,6 +169,7 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
                 }
               }
               message="some title"
+              postId="post_id"
             />
           </Connect(ShowMore)>
         </div>
@@ -205,6 +211,7 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
               },
             }
           }
+          postId="post_id"
         />
       </h1>
       <div>
@@ -224,6 +231,7 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
                 }
               }
               message="some title"
+              postId="post_id"
             />
           </Connect(ShowMore)>
         </div>

--- a/components/post_view/embedded_bindings/embedded_binding/__snapshots__/embedded_binding.test.tsx.snap
+++ b/components/post_view/embedded_bindings/embedded_binding/__snapshots__/embedded_binding.test.tsx.snap
@@ -37,6 +37,12 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
             text="some title"
           >
             <Connect(Markdown)
+              imageProps={
+                Object {
+                  "onImageHeightChanged": [Function],
+                  "onImageLoaded": [Function],
+                }
+              }
               message="some title"
             />
           </Connect(ShowMore)>
@@ -91,6 +97,12 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
             text="some title"
           >
             <Connect(Markdown)
+              imageProps={
+                Object {
+                  "onImageHeightChanged": [Function],
+                  "onImageLoaded": [Function],
+                }
+              }
               message="some title"
             />
           </Connect(ShowMore)>
@@ -145,6 +157,12 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
             text="some title"
           >
             <Connect(Markdown)
+              imageProps={
+                Object {
+                  "onImageHeightChanged": [Function],
+                  "onImageLoaded": [Function],
+                }
+              }
               message="some title"
             />
           </Connect(ShowMore)>
@@ -199,6 +217,12 @@ exports[`components/post_view/embedded_bindings/embedded_binding should match sn
             text="some title"
           >
             <Connect(Markdown)
+              imageProps={
+                Object {
+                  "onImageHeightChanged": [Function],
+                  "onImageLoaded": [Function],
+                }
+              }
               message="some title"
             />
           </Connect(ShowMore)>

--- a/components/post_view/embedded_bindings/embedded_binding/embedded_binding.tsx
+++ b/components/post_view/embedded_bindings/embedded_binding/embedded_binding.tsx
@@ -146,6 +146,7 @@ export default class EmbeddedBinding extends React.PureComponent<Props, State> {
                             renderer: new LinkOnlyRenderer(),
                             autolinkedUrlSchemes: [],
                         }}
+                        postId={this.props.post.id}
                     />
                 </h1>
             );
@@ -163,6 +164,7 @@ export default class EmbeddedBinding extends React.PureComponent<Props, State> {
                         message={embed.description}
                         imageProps={this.imageProps}
                         options={options}
+                        postId={this.props.post.id}
                     />
                 </ShowMore>
             );

--- a/components/post_view/embedded_bindings/embedded_binding/embedded_binding.tsx
+++ b/components/post_view/embedded_bindings/embedded_binding/embedded_binding.tsx
@@ -41,7 +41,25 @@ type Props = {
     currentRelativeTeamUrl: string;
 }
 
-export default class EmbeddedBinding extends React.PureComponent<Props> {
+type State = {
+    checkOverflow: number;
+}
+
+export default class EmbeddedBinding extends React.PureComponent<Props, State> {
+    private imageProps: Record<string, any>;
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            checkOverflow: 0,
+        };
+
+        this.imageProps = {
+            onImageLoaded: this.handleHeightReceived,
+            onImageHeightChanged: this.checkPostOverflow,
+        };
+    }
+
     fillBindings = (binding: AppBinding) => {
         const copiedBindings = JSON.parse(JSON.stringify(binding)) as AppBinding;
         cleanBinding(copiedBindings, AppBindingLocations.IN_POST);
@@ -99,6 +117,21 @@ export default class EmbeddedBinding extends React.PureComponent<Props> {
 
     handleFormattedTextClick = (e: React.MouseEvent) => Utils.handleFormattedTextClick(e, this.props.currentRelativeTeamUrl);
 
+    checkPostOverflow = () => {
+        // Increment checkOverflow to indicate change in height
+        // and recompute textContainer height at ShowMore component
+        // and see whether overflow text of show more/less is necessary or not.
+        this.setState((prevState) => {
+            return {checkOverflow: prevState.checkOverflow + 1};
+        });
+    }
+
+    handleHeightReceived = (height: number) => {
+        if (height > 0) {
+            this.checkPostOverflow();
+        }
+    };
+
     render() {
         const {embed, options} = this.props;
 
@@ -128,6 +161,7 @@ export default class EmbeddedBinding extends React.PureComponent<Props> {
                 >
                     <Markdown
                         message={embed.description}
+                        imageProps={this.imageProps}
                         options={options}
                     />
                 </ShowMore>

--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.tsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
   >
     <Connect(Markdown)
       message="pretext"
+      postId="post_id"
     />
   </div>
   <div
@@ -72,6 +73,7 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
                 }
               }
               message="short text"
+              postId="post_id"
             />
           </Connect(ShowMore)>
           <div
@@ -156,6 +158,7 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
   >
     <Connect(Markdown)
       message="pretext"
+      postId="post_id"
     />
   </div>
   <div
@@ -218,6 +221,7 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
                 }
               }
               message="short text"
+              postId="post_id"
             />
           </Connect(ShowMore)>
           <div
@@ -283,6 +287,7 @@ exports[`components/post_view/MessageAttachment should match snapshot and render
 >
   <Connect(Markdown)
     message="1234"
+    postId="post_id"
   />
 </td>
 `;
@@ -297,6 +302,7 @@ exports[`components/post_view/MessageAttachment should match snapshot when no fo
   >
     <Connect(Markdown)
       message="pretext"
+      postId="post_id"
     />
   </div>
   <div
@@ -359,6 +365,7 @@ exports[`components/post_view/MessageAttachment should match snapshot when no fo
                 }
               }
               message="short text"
+              postId="post_id"
             />
           </Connect(ShowMore)>
           <div
@@ -430,6 +437,7 @@ exports[`components/post_view/MessageAttachment should match snapshot when the a
               },
             }
           }
+          postId="post_id"
         />
       </h1>
       <div>
@@ -474,6 +482,7 @@ exports[`components/post_view/MessageAttachment should match snapshot when the a
               },
             }
           }
+          postId="post_id"
         />
       </h1>
       <div>
@@ -518,6 +527,7 @@ exports[`components/post_view/MessageAttachment should match snapshot when the a
               },
             }
           }
+          postId="post_id"
         />
       </h1>
       <div>
@@ -562,6 +572,7 @@ exports[`components/post_view/MessageAttachment should match snapshot when the f
               },
             }
           }
+          postId="post_id"
         />
       </h1>
       <div>
@@ -619,6 +630,7 @@ exports[`components/post_view/MessageAttachment should match value on getFieldsT
                 "mentionHighlight": false,
               }
             }
+            postId="post_id"
           />
         </th>
       </tr>
@@ -630,6 +642,7 @@ exports[`components/post_view/MessageAttachment should match value on getFieldsT
         >
           <Memo(Connect(Markdown))
             message="value_1"
+            postId="post_id"
           />
         </td>
       </tr>
@@ -651,6 +664,7 @@ exports[`components/post_view/MessageAttachment should match value on getFieldsT
                 "mentionHighlight": false,
               }
             }
+            postId="post_id"
           />
         </th>
       </tr>
@@ -662,6 +676,7 @@ exports[`components/post_view/MessageAttachment should match value on getFieldsT
         >
           <Memo(Connect(Markdown))
             message="value_2"
+            postId="post_id"
           />
         </td>
       </tr>

--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.tsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
             <Connect(Markdown)
               imageProps={
                 Object {
+                  "onImageHeightChanged": [Function],
                   "onImageLoaded": [Function],
                 }
               }
@@ -212,6 +213,7 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
             <Connect(Markdown)
               imageProps={
                 Object {
+                  "onImageHeightChanged": [Function],
                   "onImageLoaded": [Function],
                 }
               }
@@ -352,6 +354,7 @@ exports[`components/post_view/MessageAttachment should match snapshot when no fo
             <Connect(Markdown)
               imageProps={
                 Object {
+                  "onImageHeightChanged": [Function],
                   "onImageLoaded": [Function],
                 }
               }

--- a/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -259,6 +259,7 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                     <Markdown
                         message={field.title}
                         options={markdown}
+                        postId={this.props.postId}
                     />
                 </th>,
             );
@@ -268,7 +269,10 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                     className='attachment-field'
                     key={'attachment__field-' + i + '__' + nrTables}
                 >
-                    <Markdown message={String(field.value)}/>
+                    <Markdown
+                        message={String(field.value)}
+                        postId={this.props.postId}
+                    />
                 </td>,
             );
             rowPos += 1;
@@ -311,7 +315,10 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
             preTextClass = 'attachment--pretext';
             preText = (
                 <div className='attachment__thumb-pretext'>
-                    <Markdown message={attachment.pretext}/>
+                    <Markdown
+                        message={attachment.pretext}
+                        postId={this.props.postId}
+                    />
                 </div>
             );
         }
@@ -386,6 +393,7 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                                 renderer: new LinkOnlyRenderer(),
                                 autolinkedUrlSchemes: [],
                             }}
+                            postId={this.props.postId}
                         />
                     </h1>
                 );
@@ -404,6 +412,7 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                     <Markdown
                         message={attachment.text || ''}
                         options={options}
+                        postId={this.props.postId}
                         imageProps={this.imageProps}
                     />
                 </ShowMore>

--- a/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -77,6 +77,7 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
 
         this.imageProps = {
             onImageLoaded: this.handleHeightReceived,
+            onImageHeightChanged: this.checkPostOverflow,
         };
     }
 
@@ -108,14 +109,18 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
         }
 
         if (height > 0) {
-            // Increment checkOverflow to indicate change in height
-            // and recompute textContainer height at ShowMore component
-            // and see whether overflow text of show more/less is necessary or not.
-            this.setState((prevState) => {
-                return {checkOverflow: prevState.checkOverflow + 1};
-            });
+            this.checkPostOverflow();
         }
     };
+
+    checkPostOverflow = () => {
+        // Increment checkOverflow to indicate change in height
+        // and recompute textContainer height at ShowMore component
+        // and see whether overflow text of show more/less is necessary or not.
+        this.setState((prevState) => {
+            return {checkOverflow: prevState.checkOverflow + 1};
+        });
+    }
 
     renderPostActions = () => {
         const actions = this.props.attachment.actions;

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -132,8 +132,8 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
                     <MarkdownImage
                         className={className}
                         imageMetadata={options.imagesMetadata && options.imagesMetadata[attribs.src]}
-                        height={parseInt(height, 10)}
-                        width={parseInt(width, 10)}
+                        height={parseSize(height)}
+                        width={parseSize(width)}
                         {...attribs}
                         {...options.imageProps}
                         postId={options.postId}
@@ -162,6 +162,19 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
     });
 
     return parser.parseWithInstructions(html, isValidNode, processingInstructions);
+}
+
+function parseSize(input) {
+    if (!input) {
+        return undefined;
+    }
+
+    const parsed = parseInt(input, 10);
+    if (!parsed) {
+        return undefined;
+    }
+
+    return parsed;
 }
 
 export default messageHtmlToComponent;

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -113,6 +113,8 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
             processNode: (node) => {
                 const {
                     class: className,
+                    width,
+                    height,
                     ...attribs
                 } = node.attribs;
 
@@ -130,6 +132,8 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
                     <MarkdownImage
                         className={className}
                         imageMetadata={options.imagesMetadata && options.imagesMetadata[attribs.src]}
+                        height={parseInt(height, 10)}
+                        width={parseInt(width, 10)}
                         {...attribs}
                         {...options.imageProps}
                         postId={options.postId}

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -113,8 +113,6 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
             processNode: (node) => {
                 const {
                     class: className,
-                    width,
-                    height,
                     ...attribs
                 } = node.attribs;
 
@@ -132,8 +130,6 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
                     <MarkdownImage
                         className={className}
                         imageMetadata={options.imagesMetadata && options.imagesMetadata[attribs.src]}
-                        height={parseSize(height)}
-                        width={parseSize(width)}
                         {...attribs}
                         {...options.imageProps}
                         postId={options.postId}
@@ -162,19 +158,6 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
     });
 
     return parser.parseWithInstructions(html, isValidNode, processingInstructions);
-}
-
-function parseSize(input) {
-    if (!input) {
-        return undefined;
-    }
-
-    const parsed = parseInt(input, 10);
-    if (!parsed) {
-        return undefined;
-    }
-
-    return parsed;
 }
 
 export default messageHtmlToComponent;


### PR DESCRIPTION
#### Summary
There were some errors in markdown and attachment images (and related, in embedded bindings).
1. Attachment images were not handling the "onToggle" action. This made the "Show More" "Show Less" to still be visible and not properly working when we collapse the image.
2. Attachments (and many other markdown location) did not provide a "onImageHeightChanged" property. This would, in the end, not set the "onToggle" action, which make the attachment break.

#### Test Steps
In the Jira link you can see test steps to reproduce these issues consistently.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38003

#### Release Note
```release-note
Fix crash when markdown images are present on the message attachments and embedded bindings.
```
