### PR TITLE
[MM-37233] CRT:fix two scrollbar issue in threads view

### DIFF
--- a/components/threading/global_threads/thread_list/thread_list.scss
+++ b/components/threading/global_threads/thread_list/thread_list.scss
@@ -19,7 +19,6 @@
     }
 
     .threads {
-        overflow: auto;
         grid-area: list;
 
         .no-results__wrapper {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
CRT:fix two scrollbar issue in threads view. After increasing browser zoom to 175% or above double scrollbar starts appearing. 

#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-37233](https://mattermost.atlassian.net/browse/MM-37233)

#### Related Pull Requests
NONE

#### Screenshots
<img width="1792" alt="Screenshot 2021-08-19 at 7 46 28 PM" src="https://user-images.githubusercontent.com/16203333/130084711-1ebca12b-c9e2-490f-b70c-8c9d903ff2d4.png">


#### Release Note
```release-note
NONE
```
