### PR TITLE
Cypress/E2E: Follow up fix to finding spec files

### DIFF
--- a/e2e/generate_test_cycle.js
+++ b/e2e/generate_test_cycle.js
@@ -21,7 +21,7 @@
  *      Selected files are those not matching any of the specified stage or group.
  *   --include-group=[group]
  *      Include spec files with matching group. It can be of multiple values separated by comma.
- *      E.g. "--exclude-group='@enterprise'" will select files except @enterprise.
+ *      E.g. "--include-group='@enterprise'" will select files including @enterprise.
  *   --exclude-group=[group]
  *      Exclude spec files with matching group. It can be of multiple values separated by comma.
  *      E.g. "--exclude-group='@enterprise'" will select files except @enterprise.

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -20,7 +20,7 @@
  *      Selected files are those not matching any of the specified stage or group.
  *   --include-group=[group]
  *      Include spec files with matching group. It can be of multiple values separated by comma.
- *      E.g. "--exclude-group='@enterprise'" will select files except @enterprise.
+ *      E.g. "--include-group='@enterprise'" will select files including @enterprise.
  *   --exclude-group=[group]
  *      Exclude spec files with matching group. It can be of multiple values separated by comma.
  *      E.g. "--exclude-group='@enterprise'" will select files except @enterprise.

--- a/e2e/utils/file.js
+++ b/e2e/utils/file.js
@@ -57,7 +57,8 @@ const findFiles = (pattern) => {
             return fileOrDir;
         }).
         flat().
-        filter((f) => f.includes('spec.js'));
+        filter((file) => file.includes('spec.js')).
+        map((file) => file.replace('./', ''));
 };
 
 function getBaseTestFiles() {


### PR DESCRIPTION
#### Summary
This is minor correction to https://github.com/mattermost/mattermost-webapp/pull/8628

#### Release Note
```release-note
NONE
```
