### PR TITLE
active state for iconbuttons in global header

### DIFF
--- a/components/sidebar/sidebar_header/sidebar_header.tsx
+++ b/components/sidebar/sidebar_header/sidebar_header.tsx
@@ -86,7 +86,7 @@ const SidebarHeader: React.FC = (): JSX.Element => {
                         size='sm'
                         compact={true}
                         inverted={true}
-                        toggled={menuToggled}
+                        active={menuToggled}
                         onClick={() => {}}
                     />
                     <MainMenu id='sidebarDropdownMenu'/>

--- a/selectors/global_header.ts
+++ b/selectors/global_header.ts
@@ -1,19 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import Constants from 'utils/constants';
-import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {GlobalState} from 'types/store';
 import {getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
 import * as UserAgent from '../utils/user_agent';
 import * as Utils from '../utils/utils';
 
-const Preferences = Constants.Preferences;
-
 export function getGlobalHeaderEnabled(state: GlobalState): boolean {
     const featureFlagEnabled = getFeatureFlagValue(state, 'GlobalHeader') === 'true';
-    const userPreferenceEnabled = get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.GLOBAL_HEADER_DISPLAY, Preferences.GLOBAL_HEADER_DISPLAY_DEFAULT) === Preferences.GLOBAL_HEADER_DISPLAY_ON;
     const isMobileView = UserAgent.isMobile() || Utils.isMobile();
 
-    return !isMobileView && featureFlagEnabled && userPreferenceEnabled;
+    return !isMobileView && featureFlagEnabled;
 }


### PR DESCRIPTION
#### Summary
changed the `toggle` appearance to `active` when the menus are open.
components that are changed:
1. `ProductSwitcher`
2. `UserGuideDropdown`
3. `SidebarHeader`

The `Avatar` active styling already got handled by @nevyangelova in #8585 

#### Ticket Link
[MM-37799](https://mattermost.atlassian.net/browse/MM-37799)

#### Screenshots
|  component  |  before  |  after  |
|-----|-----|-----|
|  `ProductSwitcher`  |<img width="281" alt="Screenshot 2021-08-19 at 15 51 38" src="https://user-images.githubusercontent.com/32863416/130080997-32a0d796-aa36-4309-8d2c-18a7753f3479.png">|<img width="281" alt="Screenshot 2021-08-19 at 15 47 16" src="https://user-images.githubusercontent.com/32863416/130081019-a3b3edde-9f7d-4446-8bdb-24502fa39c9a.png">|
|  `UserGuideDropdown`  |<img width="231" alt="Screenshot 2021-08-19 at 15 52 43" src="https://user-images.githubusercontent.com/32863416/130081058-7820a16c-2f62-42fa-8d04-f23a6d609d94.png">|<img width="231" alt="Screenshot 2021-08-19 at 15 51 51" src="https://user-images.githubusercontent.com/32863416/130081081-451e4829-5c0c-422f-bbfa-c9a14f6adb35.png">
|  `SidebarHeader`  |<img width="228" alt="Screenshot 2021-08-19 at 15 53 23" src="https://user-images.githubusercontent.com/32863416/130081097-04f2d428-24e0-4e20-89e0-3427cba9317b.png">|<img width="228" alt="Screenshot 2021-08-19 at 15 52 59" src="https://user-images.githubusercontent.com/32863416/130081115-b679d4ff-7c35-4692-b06b-13b6ddca306a.png">|


#### Release Note
```release-note
NONE
```
