### PR TITLE
Added support to exclude specific emoji by short name

### DIFF
--- a/build/emoji/emoji_gen.mjs
+++ b/build/emoji/emoji_gen.mjs
@@ -141,7 +141,7 @@ const excludedEmoji = [];
 readFileSync(path.normalize(argv['excluded-emoji-file']), 'utf-8').split(/\r?\n/).forEach(function(line){
     excludedEmoji.push(line);
 });
-console.warn('The following emoji will be excluded from the webapp: ' + excludedEmoji);
+console.warn(`The following emoji will be excluded from the webapp: ${excludedEmoji}`);
 
 // Remove unwanted emoji
 const filteredEmojiJson = jsonData.filter((element) => {

--- a/build/emoji/emoji_gen.mjs
+++ b/build/emoji/emoji_gen.mjs
@@ -141,14 +141,11 @@ const excludedEmoji = [];
 readFileSync(path.normalize(argv['excluded-emoji-file']), 'utf-8').split(/\r?\n/).forEach(function(line){
     excludedEmoji.push(line);
 });
-console.log('Excluded Emoji are: ' + excludedEmoji);
+console.warn('The following emoji will be excluded from the webapp: ' + excludedEmoji);
 
 // Remove unwanted emoji
 const filteredEmojiJson = jsonData.filter((element) => {
-    if (excludedEmoji.includes(element.short_name)) {
-        return false;
-    }
-    return true;
+    return !excludedEmoji.some((e) => element.short_names.includes(e));
 });
 
 // populate skin tones as full emojis

--- a/build/emoji/emoji_gen.mjs
+++ b/build/emoji/emoji_gen.mjs
@@ -7,6 +7,17 @@
 * otherwise the file will be placed in the root of the project.
 * if you don't want to set it but for this run you can run it like:
 * $ $SERVER_ENV=<path_to_server> npm run make-emojis
+*
+* The script includes support for excluding emojis from the final set used to build the mattermost-webapp package.  To exclude specific emoji follow these steps:
+* 1. Clone https://github.com/mattermost/mattermost-webapp
+* 2. Identify the name of the emojis to be excluded.  You can find this in the Mattermost UI using the emoji picker in the channel view.
+* 3. Create a file with the name of each excluded emoji on a separate line.
+* 4. Use NPM to invoke this tool with the excluded emoji file:
+* `<path to mattermost-webapp git repo>$ npm run make-emojis -- --excluded-emoji-file ./excluded-emoji.txt`
+* 5. Build and package the modified mattermost-webapp repo
+* `<path to mattermost-webapp git repo>$ make package`
+# 6. Use the generated `mattermost-webapp.tar.gz` to overwrite the existing `<Mattermost Installation Directory>/client` folder.  Ensure the files are owned by the Mattermost service account.
+# 7. Restart Mattermost.
  */
 
 /* eslint-disable no-console */


### PR DESCRIPTION
#### Summary

In some cases we have customers wishing to remove certain emoji from our built-in set.  This script accepts a file with emoji `shortname`s and excludes them from the source files that are used to build the final `mattermost-webapp` bundle.

#### Ticket Link

No specific ticket link.

Examples:

From the `mattermost-webapp` directory, create a file with emoji shortnames, each on an individual line.  Like so:

```
flag-eg
flag-eh
flag-ta
flag-tw
```

Prior to building the whole `mattermost-webapp` project, run the following npm script, passing the file of excluded emojis:

```
mattermost-webapp$npm run make-emojis -- --excluded-emoji-file ./excluded-emoji.txt
```

Once this is complete, the whole `mattermost-webapp` build can be run, and the resulting client files will no longer have reference in the UI to the excluded emoji:

```
mattermost-webapp$ make package
```

The resulting `mattermost-webapp.tar.gz` can be uploaded to the server and extracted over top of `<INSTALL_DIR>/client`

```release-note
No release note required.  Not end-user facing.
```