### PR TITLE
Cypress:e2e/fixed category muting test case

### DIFF
--- a/e2e/cypress/integration/channel_sidebar/helpers.js
+++ b/e2e/cypress/integration/channel_sidebar/helpers.js
@@ -6,7 +6,7 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 export function clickCategoryMenuItem(categoryDisplayName, menuItemText) {
     cy.contains('.SidebarChannelGroupHeader', categoryDisplayName, {matchCase: false}).should('be.visible').within(() => {
         cy.get('.SidebarMenu').invoke('show').get('.SidebarMenu_menuButton').should('be.visible').click({force: true});
-        cy.findByRole('menu').findByText(menuItemText).should('be.visible').click();
+        cy.findByRole('menu').findByText(menuItemText).should('be.visible').click({force: true});
         cy.wait(TIMEOUTS.HALF_SEC);
     });
 }

--- a/e2e/cypress/support/ui/channel_sidebar.js
+++ b/e2e/cypress/support/ui/channel_sidebar.js
@@ -9,7 +9,7 @@ Cypress.Commands.add('uiCreateSidebarCategory', (categoryName = `category-${getR
     cy.get('.AddChannelDropdown_dropdownButton').click();
 
     // # Click the Create New Category dropdown item
-    cy.get('.AddChannelDropdown').contains('.MenuItem', 'Create New Category').click();
+    cy.get('.AddChannelDropdown').contains('.MenuItem', 'Create New Category').click({force: true});
 
     // # Fill in the category name and click Create
     cy.get('input[placeholder="Name your category"]').type(categoryName);


### PR DESCRIPTION

#### Summary

Fixed failed test case on category muting 
#### Screenshots
![image](https://user-images.githubusercontent.com/6909890/130299521-55d6120a-34c2-4f22-a12b-a66851bbe8d9.png)
#### Release Note

N/A