### PR TITLE
Revert "MM-37916: close product switcher on item click (#8594)"

### DIFF
--- a/components/global/product_switcher.tsx
+++ b/components/global/product_switcher.tsx
@@ -164,7 +164,6 @@ const ProductSwitcher = (): JSX.Element => {
                     <ProductSwitcherMenu
                         id='ProductSwitcherMenu'
                         isMessaging={currentProductID === null}
-                        onClick={handleClick}
                     />
                 </Menu>
             </MenuWrapper>

--- a/components/global/product_switcher_menu/product_switcher_menu.tsx
+++ b/components/global/product_switcher_menu/product_switcher_menu.tsx
@@ -39,7 +39,6 @@ type Props = {
     pluginMenuItems: any;
     intl: IntlShape;
     firstAdminVisitMarketplaceStatus: boolean;
-    onClick?: (event: React.MouseEvent<HTMLElement>) => void;
 };
 
 // TODO: reqrite this to a functional component
@@ -55,7 +54,7 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
     }
 
     render() {
-        const {currentUser, isMessaging, isMobile, onClick: handleClick} = this.props;
+        const {currentUser, isMessaging, isMobile} = this.props;
 
         if (!currentUser) {
             return null;
@@ -66,6 +65,7 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
 
         const {formatMessage} = this.props.intl;
 
+        // TODO: Ensure that clicking ItemLink menu items also closes the global header menu.
         return (
             <>
                 <Menu.Group>
@@ -81,7 +81,6 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                                     glyph={'application-cog'}
                                 />
                             }
-                            onClick={handleClick}
                         />
                     </SystemPermissionGate>
                     <Menu.ItemLink
@@ -95,7 +94,6 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                                 glyph={'webhook-incoming'}
                             />
                         }
-                        onClick={handleClick}
                     />
                     <TeamPermissionGate
                         teamId={this.props.teamId}
@@ -113,7 +111,6 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                                     glyph={'apps'}
                                 />
                             }
-                            onClick={handleClick}
                         />
                         <Menu.ItemExternalLink
                             id='nativeAppLink'
@@ -126,7 +123,6 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                                     glyph={'download-outline'}
                                 />
                             }
-                            onClick={handleClick}
                         />
                         <Menu.ItemToggleModalRedux
                             id='about'
@@ -139,7 +135,6 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                                     glyph={'information-outline'}
                                 />
                             }
-                            onClick={handleClick}
                         />
                     </TeamPermissionGate>
                 </Menu.Group>

--- a/components/widgets/menu/menu_items/menu_item.tsx
+++ b/components/widgets/menu/menu_items/menu_item.tsx
@@ -12,7 +12,6 @@ export default function menuItem(Component: React.ComponentType<any>) {
         id?: string;
         icon?: React.ReactNode;
         text?: React.ReactNode;
-        onClick?: (event: React.MouseEvent<HTMLElement>) => void;
     }
     class MenuItem extends React.PureComponent<Props & React.ComponentProps<typeof Component>> {
         public static defaultProps = {
@@ -44,7 +43,6 @@ export default function menuItem(Component: React.ComponentType<any>) {
                     })}
                     role='menuitem'
                     id={id}
-                    onClick={props.onClick}
                 >
                     <Component
                         text={textProp}

--- a/components/widgets/menu/menu_items/menu_item_action.test.tsx
+++ b/components/widgets/menu/menu_items/menu_item_action.test.tsx
@@ -18,7 +18,7 @@ describe('components/MenuItemAction', () => {
         expect(wrapper).toMatchInlineSnapshot(`
       <button
         className="style--none"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           className="MenuItem__primary-text"
@@ -40,7 +40,7 @@ describe('components/MenuItemAction', () => {
         expect(wrapper).toMatchInlineSnapshot(`
       <button
         className="style--none MenuItem__with-help"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           className="MenuItem__primary-text"

--- a/components/widgets/menu/menu_items/menu_item_action.tsx
+++ b/components/widgets/menu/menu_items/menu_item_action.tsx
@@ -28,11 +28,7 @@ export const MenuItemActionImpl = ({
         id={id}
         aria-label={ariaLabel}
         className={'style--none' + (extraText ? ' MenuItem__with-help' : '') + (buttonClass ? ' ' + buttonClass : '') + (isDangerous ? ' MenuItem__dangerous' : '')}
-        onClick={(event) => {
-            // stopping propagation is needed here to prevent duplicate calls to the onClick function
-            event.stopPropagation();
-            onClick(event);
-        }}
+        onClick={onClick}
     >
         {text && <span className='MenuItem__primary-text'>{text}</span>}
         {extraText && <span className='MenuItem__help-text'>{extraText}</span>}


### PR DESCRIPTION
#### Summary
This reverts #8594 since it added a bug to the existing webapp.

Adding UX and QA to check for correct restoration of previous behaviour.

#### Ticket Link
[MM-37916](https://mattermost.atlassian.net/browse/MM-37916)

Tickets reporting this bug:
[MM-38019](https://mattermost.atlassian.net/browse/MM-38019)
[MM-38056](https://mattermost.atlassian.net/browse/MM-38056)
[MM-38057](https://mattermost.atlassian.net/browse/MM-38057)

#### Related Pull Requests
#8594 

#### Release Note
```release-note
NONE
```
