### PR TITLE
Feature/mm 37916 close product switcher on item click

### DIFF
--- a/components/global/product_switcher.tsx
+++ b/components/global/product_switcher.tsx
@@ -149,6 +149,7 @@ const ProductSwitcher = (): JSX.Element => {
                     <ProductSwitcherMenu
                         id='ProductSwitcherMenu'
                         isMessaging={currentProductID === null}
+                        onClick={handleClick}
                     />
                 </Menu>
             </MenuWrapper>

--- a/components/global/product_switcher_menu/product_switcher_menu.tsx
+++ b/components/global/product_switcher_menu/product_switcher_menu.tsx
@@ -39,9 +39,10 @@ type Props = {
     pluginMenuItems: any;
     intl: IntlShape;
     firstAdminVisitMarketplaceStatus: boolean;
+    onClick?: React.MouseEventHandler<HTMLElement>;
 };
 
-// TODO: reqrite this to a functional component
+// TODO: rewrite this to a functional component
 class ProductSwitcherMenu extends React.PureComponent<Props> {
     static defaultProps = {
         teamType: '',
@@ -54,7 +55,7 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
     }
 
     render() {
-        const {currentUser, isMessaging, isMobile} = this.props;
+        const {currentUser, isMessaging, isMobile, onClick} = this.props;
 
         if (!currentUser) {
             return null;
@@ -67,8 +68,8 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
 
         // TODO: Ensure that clicking ItemLink menu items also closes the global header menu.
         return (
-            <>
-                <Menu.Group>
+            <Menu.Group>
+                <div onClick={onClick}>
                     <SystemPermissionGate permissions={Permissions.SYSCONSOLE_READ_PERMISSIONS}>
                         <Menu.ItemLink
                             id='systemConsole'
@@ -137,8 +138,8 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                             />
                         }
                     />
-                </Menu.Group>
-            </>
+                </div>
+            </Menu.Group>
         );
     }
 }

--- a/components/global/product_switcher_menu/product_switcher_menu.tsx
+++ b/components/global/product_switcher_menu/product_switcher_menu.tsx
@@ -66,7 +66,6 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
 
         const {formatMessage} = this.props.intl;
 
-        // TODO: Ensure that clicking ItemLink menu items also closes the global header menu.
         return (
             <Menu.Group>
                 <div onClick={onClick}>

--- a/components/widgets/menu/menu_group.tsx
+++ b/components/widgets/menu/menu_group.tsx
@@ -11,7 +11,7 @@ type Props = {
 }
 
 export default class MenuGroup extends React.PureComponent<Props> {
-    handleDividerClick = (e: React.MouseEvent) => {
+    handleDividerClick = (e: React.MouseEvent): void => {
         e.preventDefault();
         e.stopPropagation();
     }


### PR DESCRIPTION
#### Summary
re-adding menu closing functionality to the menu-items in the global header product switcher. This time with a different approach that does not break functionality of other menus in the webapp.

#### Ticket Link
[MM-37916](https://mattermost.atlassian.net/browse/MM-37916)

Fixes:
[MM-38019](https://mattermost.atlassian.net/browse/MM-38019)
[MM-38056](https://mattermost.atlassian.net/browse/MM-38056)
[MM-38057](https://mattermost.atlassian.net/browse/MM-38057)

#### Release Note
```release-note
NONE
```
