### PR TITLE
added a guard to check for the currentUser in `status_dropdown.tsx`

### DIFF
--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -303,7 +303,7 @@ export default class StatusDropdown extends React.PureComponent <Props, State> {
     render = (): JSX.Element => {
         const needsConfirm = this.isUserOutOfOffice() && this.props.autoResetPref === '';
         const dropdownIcon = this.renderDropdownIcon();
-        const {isTimedDNDEnabled, customStatus, isCustomStatusExpired, globalHeader} = this.props;
+        const {isTimedDNDEnabled, customStatus, isCustomStatusExpired, globalHeader, currentUser} = this.props;
         const isStatusSet = customStatus && (customStatus.text.length > 0 || customStatus.emoji.length > 0) && !isCustomStatusExpired;
 
         const setOnline = needsConfirm ? () => this.showStatusChangeConfirmation('online') : this.setOnline;
@@ -402,16 +402,16 @@ export default class StatusDropdown extends React.PureComponent <Props, State> {
                             />
                         </Menu.Header>
                     )}
-                    {globalHeader && (
+                    {globalHeader && currentUser && (
                         <Menu.Header>
                             {this.renderProfilePicture('lg')}
                             <div className={'username-wrapper'}>
-                                <Text margin={'none'}>{`${this.props.currentUser.first_name} ${this.props.currentUser.last_name}`}</Text>
+                                <Text margin={'none'}>{`${currentUser.first_name} ${currentUser.last_name}`}</Text>
                                 <Text
                                     margin={'none'}
                                     color={'disabled'}
                                 >
-                                    {'@' + this.props.currentUser.username}
+                                    {'@' + currentUser.username}
                                 </Text>
                             </div>
                         </Menu.Header>


### PR DESCRIPTION
#### Summary
this PR aims to potentially fix the "white screen of death" issue appearing in spinwick instances.

The issue first appeared after the global header got introduced in all instances.

PRs in which the error occurs (list might not be complete):
- #8645 
- #8648 
- #8651 
- #8677 
- #8678 
- #8679 

cc// @spirosoik @jgilliam17 @andrewbrown00 

#### Ticket Link
```
NONE
```

#### Release Note
```release-note
NONE
```
