### PR TITLE
[MM-37423] Webapp Custom Status: Don't show 'Custom Date and Time' for recent statuses

### DIFF
--- a/components/custom_status/custom_status_suggestion.tsx
+++ b/components/custom_status/custom_status_suggestion.tsx
@@ -5,7 +5,7 @@ import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import classNames from 'classnames';
 
-import {UserCustomStatus} from 'mattermost-redux/types/users';
+import {CustomStatusDuration, UserCustomStatus} from 'mattermost-redux/types/users';
 
 import OverlayTrigger from 'components/overlay_trigger';
 import RenderEmoji from 'components/emoji/render_emoji';
@@ -37,6 +37,7 @@ const CustomStatusSuggestion: React.FC<Props> = (props: Props) => {
             handleClear(status);
         }
     };
+    const customStatusDuration = CustomStatusDuration;
 
     const clearButton = handleClear ?
         (
@@ -82,7 +83,9 @@ const CustomStatusSuggestion: React.FC<Props> = (props: Props) => {
                     with_duration: duration,
                 })}
             />
-            {duration && (
+            {duration &&
+            duration !== customStatusDuration.CUSTOM_DATE_TIME &&
+            duration !== customStatusDuration.DATE_AND_TIME && (
                 <span className='statusSuggestion__duration'>
                     <FormattedMessage
                         id={durationValues[duration].id}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Custom Status: Don't show 'Custom Date and Time' for recent statuses

#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-37423](https://mattermost.atlassian.net/browse/MM-37423)

#### Related Pull Requests
- Has mobile changes [https://github.com/mattermost/mattermost-mobile/pull/5641](https://github.com/mattermost/mattermost-mobile/pull/5641)

#### Screenshots
<img width="1062" alt="Screenshot 2021-08-23 at 7 08 51 PM" src="https://user-images.githubusercontent.com/16203333/130567491-830d0f3e-b422-44b6-83e9-d38a4f3693d2.png">


#### Release Note
```release-note
* Remove custom date and time label from recents custom status
```
