### PR TITLE
[MM-38119] Fix class name typo

### DIFF
--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -75,57 +75,17 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
         show={true}
         text="Away"
       />
-      <SubMenuItem
+      <MenuItemAction
         ariaLabel="do not disturb. disables desktop, email and push notifications"
-        direction="right"
+        extraText="Disables all notifications"
         icon={
           <StatusDndIcon
             className="dnd--icon"
           />
         }
-        id="status-menu-dnd-timed"
-        openUp={false}
+        id="status-menu-dnd"
+        onClick={[Function]}
         show={true}
-        subMenu={
-          Array [
-            Object {
-              "direction": "right",
-              "id": "dndSubMenu-header",
-              "text": "Disable notifications until:",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-30mins",
-              "text": "30 mins",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-1hour",
-              "text": "1 hour",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-2hours",
-              "text": "2 hours",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Tomorrow",
-              "text": "Tomorrow",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Custom",
-              "text": "Custom",
-            },
-          ]
-        }
-        subMenuClass="pl-4"
         text="Do not disturb"
       />
       <MenuItemAction
@@ -329,57 +289,17 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
         show={true}
         text="Away"
       />
-      <SubMenuItem
+      <MenuItemAction
         ariaLabel="do not disturb. disables desktop, email and push notifications"
-        direction="right"
+        extraText="Disables all notifications"
         icon={
           <StatusDndIcon
             className="dnd--icon"
           />
         }
-        id="status-menu-dnd-timed"
-        openUp={false}
+        id="status-menu-dnd"
+        onClick={[Function]}
         show={true}
-        subMenu={
-          Array [
-            Object {
-              "direction": "right",
-              "id": "dndSubMenu-header",
-              "text": "Disable notifications until:",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-30mins",
-              "text": "30 mins",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-1hour",
-              "text": "1 hour",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-2hours",
-              "text": "2 hours",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Tomorrow",
-              "text": "Tomorrow",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Custom",
-              "text": "Custom",
-            },
-          ]
-        }
-        subMenuClass="pl-4"
         text="Do not disturb"
       />
       <MenuItemAction
@@ -532,57 +452,17 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
         show={true}
         text="Away"
       />
-      <SubMenuItem
+      <MenuItemAction
         ariaLabel="do not disturb. disables desktop, email and push notifications"
-        direction="right"
+        extraText="Disables all notifications"
         icon={
           <StatusDndIcon
             className="dnd--icon"
           />
         }
-        id="status-menu-dnd-timed"
-        openUp={false}
+        id="status-menu-dnd"
+        onClick={[Function]}
         show={true}
-        subMenu={
-          Array [
-            Object {
-              "direction": "right",
-              "id": "dndSubMenu-header",
-              "text": "Disable notifications until:",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-30mins",
-              "text": "30 mins",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-1hour",
-              "text": "1 hour",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-2hours",
-              "text": "2 hours",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Tomorrow",
-              "text": "Tomorrow",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Custom",
-              "text": "Custom",
-            },
-          ]
-        }
-        subMenuClass="pl-4"
         text="Do not disturb"
       />
       <MenuItemAction
@@ -735,57 +615,17 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
         show={true}
         text="Away"
       />
-      <SubMenuItem
+      <MenuItemAction
         ariaLabel="do not disturb. disables desktop, email and push notifications"
-        direction="right"
+        extraText="Disables all notifications"
         icon={
           <StatusDndIcon
             className="dnd--icon"
           />
         }
-        id="status-menu-dnd-timed"
-        openUp={false}
+        id="status-menu-dnd"
+        onClick={[Function]}
         show={true}
-        subMenu={
-          Array [
-            Object {
-              "direction": "right",
-              "id": "dndSubMenu-header",
-              "text": "Disable notifications until:",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-30mins",
-              "text": "30 mins",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-1hour",
-              "text": "1 hour",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-2hours",
-              "text": "2 hours",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Tomorrow",
-              "text": "Tomorrow",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Custom",
-              "text": "Custom",
-            },
-          ]
-        }
-        subMenuClass="pl-4"
         text="Do not disturb"
       />
       <MenuItemAction
@@ -939,57 +779,17 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
         show={true}
         text="Away"
       />
-      <SubMenuItem
+      <MenuItemAction
         ariaLabel="do not disturb. disables desktop, email and push notifications"
-        direction="right"
+        extraText="Disables all notifications"
         icon={
           <StatusDndIcon
             className="dnd--icon"
           />
         }
-        id="status-menu-dnd-timed"
-        openUp={false}
+        id="status-menu-dnd"
+        onClick={[Function]}
         show={true}
-        subMenu={
-          Array [
-            Object {
-              "direction": "right",
-              "id": "dndSubMenu-header",
-              "text": "Disable notifications until:",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-30mins",
-              "text": "30 mins",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-1hour",
-              "text": "1 hour",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-2hours",
-              "text": "2 hours",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Tomorrow",
-              "text": "Tomorrow",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Custom",
-              "text": "Custom",
-            },
-          ]
-        }
-        subMenuClass="pl-4"
         text="Do not disturb"
       />
       <MenuItemAction
@@ -1125,57 +925,17 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
         show={true}
         text="Away"
       />
-      <SubMenuItem
+      <MenuItemAction
         ariaLabel="do not disturb. disables desktop, email and push notifications"
-        direction="right"
+        extraText="Disables all notifications"
         icon={
           <StatusDndIcon
             className="dnd--icon"
           />
         }
-        id="status-menu-dnd-timed"
-        openUp={false}
+        id="status-menu-dnd"
+        onClick={[Function]}
         show={true}
-        subMenu={
-          Array [
-            Object {
-              "direction": "right",
-              "id": "dndSubMenu-header",
-              "text": "Disable notifications until:",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-30mins",
-              "text": "30 mins",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-1hour",
-              "text": "1 hour",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-2hours",
-              "text": "2 hours",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Tomorrow",
-              "text": "Tomorrow",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Custom",
-              "text": "Custom",
-            },
-          ]
-        }
-        subMenuClass="pl-4"
         text="Do not disturb"
       />
       <MenuItemAction
@@ -1307,57 +1067,17 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
         show={true}
         text="Away"
       />
-      <SubMenuItem
+      <MenuItemAction
         ariaLabel="do not disturb. disables desktop, email and push notifications"
-        direction="right"
+        extraText="Disables all notifications"
         icon={
           <StatusDndIcon
             className="dnd--icon"
           />
         }
-        id="status-menu-dnd-timed"
-        openUp={false}
+        id="status-menu-dnd"
+        onClick={[Function]}
         show={true}
-        subMenu={
-          Array [
-            Object {
-              "direction": "right",
-              "id": "dndSubMenu-header",
-              "text": "Disable notifications until:",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-30mins",
-              "text": "30 mins",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-1hour",
-              "text": "1 hour",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-2hours",
-              "text": "2 hours",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Tomorrow",
-              "text": "Tomorrow",
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "id": "dndTime-Custom",
-              "text": "Custom",
-            },
-          ]
-        }
-        subMenuClass="pl-4"
         text="Do not disturb"
       />
       <MenuItemAction

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -330,26 +330,26 @@ export default class StatusDropdown extends React.PureComponent <Props, State> {
         const customStatusComponent = this.renderCustomStatus(isStatusSet);
 
         let timedDND = (
-            <Menu.ItemSubMenu
-                subMenu={dndSubMenuItems}
+            <Menu.ItemAction
+                onClick={setDndUntimed}
                 ariaLabel={`${localizeMessage('status_dropdown.set_dnd', 'Do not disturb').toLowerCase()}. ${localizeMessage('status_dropdown.set_dnd.extra', 'Disables desktop, email and push notifications').toLowerCase()}`}
                 text={localizeMessage('status_dropdown.set_dnd', 'Do not disturb')}
+                extraText={localizeMessage('status_dropdown.set_dnd.extra', 'Disables all notifications')}
                 icon={<StatusDndIcon className={'dnd--icon'}/>}
-                direction={globalHeader ? 'left' : 'right'}
-                openUp={this.state.openUp}
-                id={'status-menu-dnd-timed'}
+                id={'status-menu-dnd'}
             />
         );
 
         if (isTimedDNDEnabled) {
             timedDND = (
-                <Menu.ItemAction
-                    onClick={setDndUntimed}
+                <Menu.ItemSubMenu
+                    subMenu={dndSubMenuItems}
                     ariaLabel={`${localizeMessage('status_dropdown.set_dnd', 'Do not disturb').toLowerCase()}. ${localizeMessage('status_dropdown.set_dnd.extra', 'Disables desktop, email and push notifications').toLowerCase()}`}
                     text={localizeMessage('status_dropdown.set_dnd', 'Do not disturb')}
-                    extraText={localizeMessage('status_dropdown.set_dnd.extra', 'Disables all notifications')}
                     icon={<StatusDndIcon className={'dnd--icon'}/>}
-                    id={'status-menu-dnd'}
+                    direction={globalHeader ? 'left' : 'right'}
+                    openUp={this.state.openUp}
+                    id={'status-menu-dnd-timed'}
                 />
             );
         }

--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -659,7 +659,7 @@
             min-width: 240px;
             margin: 4px 0 0 6px;
 
-            .Submenu {
+            .SubMenu {
                 margin: -4px 0 0 -4px;
             }
         }


### PR DESCRIPTION
#### Summary
Small fix: DND submenu is too far from parent menu to mouse over to (submenu disappears before getting to it) as a result of margins not being overridden as intended due to a classname typo. This PR fixes that typo and corrects the DND submenu issue.

Update: Turns out the conditional for TimedDND feature flag was reversed, so the submenu was only showing when it's feature flag was disabled. Added a commit to this review to fix the conditional.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38119

#### Screenshots
Before:

![image](https://user-images.githubusercontent.com/3245614/130630747-f23bbf2c-8d0e-4888-abad-5ee74418f948.png)

After:

![image](https://user-images.githubusercontent.com/3245614/130655554-7f0d2c76-8eb7-4996-934b-3be1f1f202e0.png)

#### Release Note
```release-note
NONE
```
