### PR TITLE
[MM-37859] Fix product switcher menu items

### DIFF
--- a/components/global/product_switcher_menu/product_switcher_menu.tsx
+++ b/components/global/product_switcher_menu/product_switcher_menu.tsx
@@ -115,33 +115,33 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                             }
                             onClick={handleClick}
                         />
-                        <Menu.ItemExternalLink
-                            id='nativeAppLink'
-                            show={this.props.appDownloadLink && !UserAgent.isMobileApp()}
-                            url={useSafeUrl(this.props.appDownloadLink)}
-                            text={formatMessage({id: 'navbar_dropdown.nativeApps', defaultMessage: 'Download Apps'})}
-                            icon={
-                                <Icon
-                                    size={16}
-                                    glyph={'download-outline'}
-                                />
-                            }
-                            onClick={handleClick}
-                        />
-                        <Menu.ItemToggleModalRedux
-                            id='about'
-                            modalId={ModalIdentifiers.ABOUT}
-                            dialogType={AboutBuildModal}
-                            text={formatMessage({id: 'navbar_dropdown.about', defaultMessage: 'About {appTitle}'}, {appTitle: this.props.siteName})}
-                            icon={
-                                <Icon
-                                    size={16}
-                                    glyph={'information-outline'}
-                                />
-                            }
-                            onClick={handleClick}
-                        />
                     </TeamPermissionGate>
+                    <Menu.ItemExternalLink
+                        id='nativeAppLink'
+                        show={this.props.appDownloadLink && !UserAgent.isMobileApp()}
+                        url={useSafeUrl(this.props.appDownloadLink)}
+                        text={formatMessage({id: 'navbar_dropdown.nativeApps', defaultMessage: 'Download Apps'})}
+                        icon={
+                            <Icon
+                                size={16}
+                                glyph={'download-outline'}
+                            />
+                        }
+                        onClick={handleClick}
+                    />
+                    <Menu.ItemToggleModalRedux
+                        id='about'
+                        modalId={ModalIdentifiers.ABOUT}
+                        dialogType={AboutBuildModal}
+                        text={formatMessage({id: 'navbar_dropdown.about', defaultMessage: 'About {appTitle}'}, {appTitle: this.props.siteName})}
+                        icon={
+                            <Icon
+                                size={16}
+                                glyph={'information-outline'}
+                            />
+                        }
+                        onClick={handleClick}
+                    />
                 </Menu.Group>
             </>
         );

--- a/components/global/product_switcher_menu/product_switcher_menu.tsx
+++ b/components/global/product_switcher_menu/product_switcher_menu.tsx
@@ -124,7 +124,6 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                                 glyph={'download-outline'}
                             />
                         }
-                        onClick={handleClick}
                     />
                     <Menu.ItemToggleModalRedux
                         id='about'
@@ -137,7 +136,6 @@ class ProductSwitcherMenu extends React.PureComponent<Props> {
                                 glyph={'information-outline'}
                             />
                         }
-                        onClick={handleClick}
                     />
                 </Menu.Group>
             </>

--- a/components/widgets/menu/menu_items/menu_item_external_link.test.tsx
+++ b/components/widgets/menu/menu_items/menu_item_external_link.test.tsx
@@ -1,28 +1,29 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
-import {shallow} from 'enzyme';
+import React from "react";
+import { shallow } from "enzyme";
 
-import {MenuItemExternalLinkImpl} from './menu_item_external_link';
+import { MenuItemExternalLinkImpl } from "./menu_item_external_link";
 
-describe('components/MenuItemExternalLink', () => {
-    test('should match snapshot', () => {
-        const wrapper = shallow(
-            <MenuItemExternalLinkImpl
-                url='http://test.com'
-                text='Whatever'
-            />,
-        );
+describe("components/MenuItemExternalLink", () => {
+  test("should match snapshot", () => {
+    const wrapper = shallow(
+      <MenuItemExternalLinkImpl url="http://test.com" text="Whatever" />
+    );
 
-        expect(wrapper).toMatchInlineSnapshot(`
-<a
-  href="http://test.com"
-  rel="noopener noreferrer"
-  target="_blank"
->
-  Whatever
-</a>
-`);
-    });
+    expect(wrapper).toMatchInlineSnapshot(`
+      <a
+        href="http://test.com"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <span
+          className="MenuItem__primary-text"
+        >
+          Whatever
+        </span>
+      </a>
+    `);
+  });
 });

--- a/components/widgets/menu/menu_items/menu_item_external_link.test.tsx
+++ b/components/widgets/menu/menu_items/menu_item_external_link.test.tsx
@@ -1,18 +1,21 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from "react";
-import { shallow } from "enzyme";
+import React from 'react';
+import {shallow} from 'enzyme';
 
-import { MenuItemExternalLinkImpl } from "./menu_item_external_link";
+import {MenuItemExternalLinkImpl} from './menu_item_external_link';
 
-describe("components/MenuItemExternalLink", () => {
-  test("should match snapshot", () => {
-    const wrapper = shallow(
-      <MenuItemExternalLinkImpl url="http://test.com" text="Whatever" />
-    );
+describe('components/MenuItemExternalLink', () => {
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <MenuItemExternalLinkImpl
+                url='http://test.com'
+                text='Whatever'
+            />,
+        );
 
-    expect(wrapper).toMatchInlineSnapshot(`
+        expect(wrapper).toMatchInlineSnapshot(`
       <a
         href="http://test.com"
         rel="noopener noreferrer"
@@ -25,5 +28,5 @@ describe("components/MenuItemExternalLink", () => {
         </span>
       </a>
     `);
-  });
+    });
 });

--- a/components/widgets/menu/menu_items/menu_item_external_link.tsx
+++ b/components/widgets/menu/menu_items/menu_item_external_link.tsx
@@ -17,7 +17,9 @@ export const MenuItemExternalLinkImpl: React.FC<Props> = ({url, text, onClick}: 
         href={url}
         onClick={onClick}
     >
-        {text}
+        <span className='MenuItem__primary-text'>
+            {text}
+        </span>
     </a>
 );
 


### PR DESCRIPTION
#### Summary
The 'Download' and 'About' menu items were inadvertently added to the `Permissions.SYSCONSOLE_WRITE_PLUGINS` permissions gate when added during the Global Header push. This PR moves them back out so that they are accessible by all users and not just select admins.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37859

#### Release Note
```release-note
NONE
```
