### PR TITLE
MM-38121 Do not overwrite current team's thread mention count on websocket reconnect

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -165,9 +165,6 @@ function reconnectWebSocket() {
     initialize();
 }
 
-window.closeWS = close;
-window.connectWS = reconnect;
-
 const pluginReconnectHandlers = {};
 
 export function registerPluginReconnectHandler(pluginId, handler) {

--- a/packages/mattermost-redux/src/actions/teams.ts
+++ b/packages/mattermost-redux/src/actions/teams.ts
@@ -79,7 +79,7 @@ export function getMyTeams(): ActionFunc {
 // The argument skipCurrentTeam is a (not ideal) workaround for CRT mention counts. Unread mentions are stored in the reducer per
 // team but we do not track unread mentions for DMs/GMs independently. This results in a bit of funky logic and edge case bugs
 // that need workarounds like this. In the future we should fix the root cause with better APIs and redux state.
-export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam: boolean): ActionFunc {
+export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam = false): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         let unreads;
         try {

--- a/packages/mattermost-redux/src/actions/teams.ts
+++ b/packages/mattermost-redux/src/actions/teams.ts
@@ -76,14 +76,39 @@ export function getMyTeams(): ActionFunc {
     });
 }
 
-export function getMyTeamUnreads(collapsedThreads: boolean): ActionFunc {
-    return bindClientFunc({
-        clientFunc: Client4.getMyTeamUnreads,
-        onSuccess: TeamTypes.RECEIVED_MY_TEAM_UNREADS,
-        params: [
-            collapsedThreads,
-        ],
-    });
+// The argument skipCurrentTeam is a (not ideal) workaround for CRT mention counts. Unread mentions are stored in the reducer per
+// team but we do not track unread mentions for DMs/GMs independently. This results in a bit of funky logic and edge case bugs
+// that need workarounds like this. In the future we should fix the root cause with better APIs and redux state.
+export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam: boolean): ActionFunc {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        let unreads;
+        try {
+            unreads = await Client4.getMyTeamUnreads(collapsedThreads);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch, getState);
+            dispatch(logError(error));
+            return {error};
+        }
+
+        if (skipCurrentTeam) {
+            const currentTeamId = getCurrentTeamId(getState());
+            if (currentTeamId) {
+                const index = unreads.findIndex((member) => member.team_id === currentTeamId);
+                if (index >= 0) {
+                    unreads.splice(index, 1);
+                }
+            }
+        }
+
+        dispatch(
+            {
+                type: TeamTypes.RECEIVED_MY_TEAM_UNREADS,
+                data: unreads,
+            },
+        );
+
+        return {data: unreads};
+    };
 }
 
 export function getTeam(teamId: string): ActionFunc {


### PR DESCRIPTION
#### Summary
Do not overwrite current team's thread mention count on websocket reconnect and fetch threads again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38121

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fix re-connecting to the websocket causing thread mentions to be cleared in the UI with collapsed reply threads enabled.
```
