### PR TITLE
[MM-38130] Rename channel preferences tooltip and modal to settings

### DIFF
--- a/actions/command.test.js
+++ b/actions/command.test.js
@@ -172,7 +172,7 @@ describe('executeCommand', () => {
             expect(store.getActions()).toEqual([
                 {
                     type: ActionTypes.MODAL_OPEN,
-                    dialogProps: {isContentChannelPreferences: true},
+                    dialogProps: {isContentProductSettings: true},
                     dialogType: UserSettingsModal,
                     modalId: 'user_settings',
                 },

--- a/actions/command.ts
+++ b/actions/command.ts
@@ -101,7 +101,7 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
             break;
         }
         case '/settings':
-            dispatch(openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentChannelPreferences: true}}));
+            dispatch(openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}}));
             return {data: true};
         case '/collapse':
         case '/expand':

--- a/components/global/settings_button/settings_button.tsx
+++ b/components/global/settings_button/settings_button.tsx
@@ -20,10 +20,10 @@ type Props = {
 
 const SettingsButton = (props: Props): JSX.Element | null => {
     const tooltip = (
-        <Tooltip id='channelPreferences'>
+        <Tooltip id='productSettings'>
             <FormattedMessage
-                id='channel_header.channelPreferences'
-                defaultMessage='Channel Preferences'
+                id='global_header.productSettings'
+                defaultMessage='Settings'
             />
         </Tooltip>
     );

--- a/components/global/settings_button/settings_button.tsx
+++ b/components/global/settings_button/settings_button.tsx
@@ -39,11 +39,11 @@ const SettingsButton = (props: Props): JSX.Element | null => {
                 size={'sm'}
                 icon={'settings-outline'}
                 onClick={(): void => {
-                    props.actions.openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentChannelPreferences: true}});
+                    props.actions.openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}});
                 }}
                 inverted={true}
                 compact={true}
-                aria-label='Select to opens the settings modal.' // proper wording and translation needed
+                aria-label='Select to open the settings modal.' // proper wording and translation needed
             />
         </OverlayTrigger>
     );

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -102,7 +102,7 @@ class MainMenu extends React.PureComponent {
     handleKeyDown = (e) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey && isKeyPressed(e, Constants.KeyCodes.A)) {
             e.preventDefault();
-            this.props.actions.openModal({ModalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentChannelPreferences: true}});
+            this.props.actions.openModal({ModalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}});
         }
     }
 
@@ -335,7 +335,7 @@ class MainMenu extends React.PureComponent {
                         id='accountSettings'
                         modalId={ModalIdentifiers.USER_SETTINGS}
                         dialogType={UserSettingsModal}
-                        dialogProps={{isContentChannelPreferences: true}}
+                        dialogProps={{isContentProductSettings: true}}
                         text={formatMessage({id: 'navbar_dropdown.accountSettings', defaultMessage: 'Account Settings'})}
                         icon={this.props.mobile && <i className='fa fa-cog'/>}
                     />

--- a/components/next_steps_view/steps/setup_preferences_step/setup_preferences_step.tsx
+++ b/components/next_steps_view/steps/setup_preferences_step/setup_preferences_step.tsx
@@ -33,7 +33,7 @@ export default function SetupPreferencesStep(props: StepComponentProps) {
             dialogType: UserSettingsModal,
             dialogProps: {
                 onExit: onFinish,
-                dialogProps: {isContentChannelPreferences: true},
+                dialogProps: {isContentProductSettings: true},
             },
         }));
     };

--- a/components/profile_popover/profile_popover.tsx
+++ b/components/profile_popover/profile_popover.tsx
@@ -228,7 +228,7 @@ ProfilePopoverState
         this.props.actions.openModal({
             modalId: ModalIdentifiers.USER_SETTINGS,
             dialogType: UserSettingsModal,
-            dialogProps: {isContentChannelPreferences: false},
+            dialogProps: {isContentProductSettings: false},
         });
         this.handleCloseModals();
     };

--- a/components/sidebar/legacy_sidebar_header/dropdown/sidebar_header_dropdown.tsx
+++ b/components/sidebar/legacy_sidebar_header/dropdown/sidebar_header_dropdown.tsx
@@ -45,7 +45,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent<Props> {
     handleKeyDown = (e: KeyboardEvent) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey && isKeyPressed(e, Constants.KeyCodes.A)) {
             e.preventDefault();
-            this.props.actions.openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentChannelPreferences: true}});
+            this.props.actions.openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}});
         }
     }
 

--- a/components/sidebar/sidebar_header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/sidebar/sidebar_header/dropdown/sidebar_header_dropdown.jsx
@@ -55,7 +55,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent {
     handleKeyDown = (e) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey && isKeyPressed(e, Constants.KeyCodes.A)) {
             e.preventDefault();
-            this.props.actions.openModal({ModalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentChannelPreferences: true}});
+            this.props.actions.openModal({ModalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}});
         }
     }
 

--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
         accessibilityLabel="Account Settings"
         dialogProps={
           Object {
-            "isContentChannelPreferences": false,
+            "isContentProductSettings": false,
           }
         }
         dialogType={
@@ -396,7 +396,7 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
         accessibilityLabel="Account Settings"
         dialogProps={
           Object {
-            "isContentChannelPreferences": false,
+            "isContentProductSettings": false,
           }
         }
         dialogType={
@@ -599,7 +599,7 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
         accessibilityLabel="Account Settings"
         dialogProps={
           Object {
-            "isContentChannelPreferences": false,
+            "isContentProductSettings": false,
           }
         }
         dialogType={
@@ -802,7 +802,7 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
         accessibilityLabel="Account Settings"
         dialogProps={
           Object {
-            "isContentChannelPreferences": false,
+            "isContentProductSettings": false,
           }
         }
         dialogType={
@@ -1006,7 +1006,7 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
         accessibilityLabel="Account Settings"
         dialogProps={
           Object {
-            "isContentChannelPreferences": false,
+            "isContentProductSettings": false,
           }
         }
         dialogType={
@@ -1192,7 +1192,7 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
         accessibilityLabel="Account Settings"
         dialogProps={
           Object {
-            "isContentChannelPreferences": false,
+            "isContentProductSettings": false,
           }
         }
         dialogType={
@@ -1374,7 +1374,7 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
         accessibilityLabel="Account Settings"
         dialogProps={
           Object {
-            "isContentChannelPreferences": false,
+            "isContentProductSettings": false,
           }
         }
         dialogType={

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -456,7 +456,7 @@ export default class StatusDropdown extends React.PureComponent <Props, State> {
                             accessibilityLabel='Account Settings'
                             modalId={ModalIdentifiers.USER_SETTINGS}
                             dialogType={UserSettingsModal}
-                            dialogProps={{isContentChannelPreferences: false}}
+                            dialogProps={{isContentProductSettings: false}}
                             text={localizeMessage('navbar_dropdown.accountSettings', 'Account Settings')}
                             icon={globalHeader ?
                                 <Icon

--- a/components/user_settings/modal/user_settings_modal.tsx
+++ b/components/user_settings/modal/user_settings_modal.tsx
@@ -78,7 +78,7 @@ export type Props = {
     intl: IntlShape;
     collapsedThreads: boolean;
     globalHeaderEnabled: boolean;
-    isContentChannelPreferences: boolean;
+    isContentProductSettings: boolean;
     actions: {
         openModal: (params: {modalId: string; dialogType: any}) => void;
         sendVerificationEmail: (email: string) => Promise<{
@@ -114,7 +114,7 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
         super(props);
 
         this.state = {
-            active_tab: props.isContentChannelPreferences ? 'notifications' : 'profile',
+            active_tab: props.isContentProductSettings ? 'notifications' : 'profile',
             active_section: '',
             showConfirmModal: false,
             enforceFocus: true,
@@ -191,7 +191,7 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
     // called after the dialog is fully hidden and faded out
     handleHidden = () => {
         this.setState({
-            active_tab: this.props.isContentChannelPreferences ? 'notifications' : 'profile',
+            active_tab: this.props.isContentProductSettings ? 'notifications' : 'profile',
             active_section: '',
         });
         this.props.onHide();
@@ -302,7 +302,7 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
         }
         const tabs = [];
         if (this.props.globalHeaderEnabled) {
-            if (this.props.isContentChannelPreferences) {
+            if (this.props.isContentProductSettings) {
                 tabs.push({name: 'notifications', uiName: formatMessage(holders.notifications), icon: 'icon fa fa-exclamation-circle', iconTitle: Utils.localizeMessage('user.settings.notifications.icon', 'Notification Settings Icon')});
                 tabs.push({name: 'display', uiName: formatMessage(holders.display), icon: 'icon fa fa-eye', iconTitle: Utils.localizeMessage('user.settings.display.icon', 'Display Settings Icon')});
                 tabs.push({name: 'sidebar', uiName: formatMessage(holders.sidebar), icon: 'icon fa fa-columns', iconTitle: Utils.localizeMessage('user.settings.sidebar.icon', 'Sidebar Settings Icon')});
@@ -339,10 +339,10 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
                         componentClass='h1'
                         id='accountSettingsModalLabel'
                     >
-                        {this.props.globalHeaderEnabled && this.props.isContentChannelPreferences ? (
+                        {this.props.globalHeaderEnabled && this.props.isContentProductSettings ? (
                             <FormattedMessage
-                                id='channel_header.channelPreferences'
-                                defaultMessage='Channel Preferences'
+                                id='global_header.productSettings'
+                                defaultMessage='Settings'
                             />
                         ) : (
                             <FormattedMessage

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3176,6 +3176,7 @@
   "get_public_link_modal.title": "Copy Public Link",
   "gif_picker.gfycat": "Search Gfycat",
   "global_header.open": "Open...",
+  "global_header.productSettings": "Settings",
   "globalThreads.heading": "Followed threads",
   "globalThreads.noThreads.subtitle": "Any threads you are mentioned in or have participated in will show here along with any threads you have followed.",
   "globalThreads.noThreads.title": "No followed threads yet",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2622,7 +2622,6 @@
   "channel_header.channelFiles": "Channel files",
   "channel_header.channelHasGuests": "This channel has guests",
   "channel_header.channelMembers": "Members",
-  "channel_header.channelPreferences": "Channel Preferences",
   "channel_header.convert": "Convert to Private Channel",
   "channel_header.delete": "Archive Channel",
   "channel_header.directchannel.you": "{displayname} (you) ",

--- a/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
+++ b/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
@@ -25,7 +25,7 @@ exports[`plugins/MainMenuActions should match snapshot and click plugin item for
     <MenuItemToggleModalRedux
       dialogProps={
         Object {
-          "isContentChannelPreferences": true,
+          "isContentProductSettings": true,
         }
       }
       dialogType={


### PR DESCRIPTION
#### Summary
This PR changes the tooltip text of the gear icon button and resulting modal from "Channel Preferences" to "Settings" to help avoid confusion between the button being used for settings for the Channel product or settings for the currently active channel ... includes translation id and string. The resulting Modal's title is also changing to "Settings".

Also, updated a variable name from `isContentChannelPreference` to `isContentProductSettings` for consistency.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38130

#### Screenshots
![image](https://user-images.githubusercontent.com/3245614/130667386-83f9aa72-7586-43f9-883c-9eae8e1cbf33.png)
![image](https://user-images.githubusercontent.com/3245614/130674364-e764793f-f0b9-4092-9520-6e5b415bd6cf.png)


#### Release Note
```release-note
NONE
```
