### PR TITLE
[MM-38049] Fix permalink preview username spacing

### DIFF
--- a/sass/components/_post-right.scss
+++ b/sass/components/_post-right.scss
@@ -142,6 +142,10 @@
                 max-height: 200px;
             }
         }
+
+        .post-preview .post__img {
+            width: 24px;
+        }
     }
 
     hr {


### PR DESCRIPTION
#### Summary
This PR fixes a spacing issue where the username in permalink previews is misaligned in the RHS.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38049

#### Related Pull Requests
None

#### Screenshots
Before fix:
![Screenshot 2021-08-24 161945](https://user-images.githubusercontent.com/38707101/130702329-138f95f5-b9e3-4913-aa22-96748effd3f4.jpg)



After fix:
![Screenshot 2021-08-24 161842](https://user-images.githubusercontent.com/38707101/130702201-b5f92c9c-a9b4-4424-92ef-47d397da007e.jpg)

#### Release Note
```release-note
Fixed permalink preview misalignment when viewed in RHS
```
