### PR TITLE
Promoting hungarian and english australian

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -296,7 +296,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 2,
-                  "text": "English Australian",
+                  "text": "English Australian (Beta)",
                   "value": "en-AU",
                 },
                 Object {
@@ -316,7 +316,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 6,
-                  "text": "Magyar",
+                  "text": "Magyar (Beta)",
                   "value": "hu",
                 },
                 Object {
@@ -422,7 +422,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 2,
-                  "text": "English Australian",
+                  "text": "English Australian (Beta)",
                   "value": "en-AU",
                 },
                 Object {
@@ -442,7 +442,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 6,
-                  "text": "Magyar",
+                  "text": "Magyar (Beta)",
                   "value": "hu",
                 },
                 Object {

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -291,7 +291,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 1,
-                  "text": "English",
+                  "text": "English (US)",
                   "value": "en",
                 },
                 Object {
@@ -417,7 +417,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 1,
-                  "text": "English",
+                  "text": "English (US)",
                   "value": "en",
                 },
                 Object {

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -291,12 +291,12 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 1,
-                  "text": "English",
+                  "text": "English (US)",
                   "value": "en",
                 },
                 Object {
                   "order": 2,
-                  "text": "English (Australian)",
+                  "text": "English (Australia)",
                   "value": "en-AU",
                 },
                 Object {
@@ -417,12 +417,12 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 1,
-                  "text": "English",
+                  "text": "English (US)",
                   "value": "en",
                 },
                 Object {
                   "order": 2,
-                  "text": "English (Australian)",
+                  "text": "English (Australia)",
                   "value": "en-AU",
                 },
                 Object {

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -296,7 +296,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 2,
-                  "text": "English Australian (Beta)",
+                  "text": "English Australian",
                   "value": "en-AU",
                 },
                 Object {
@@ -316,7 +316,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 6,
-                  "text": "Magyar (Beta)",
+                  "text": "Magyar",
                   "value": "hu",
                 },
                 Object {

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -422,7 +422,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 2,
-                  "text": "English Australian (Beta)",
+                  "text": "English Australian",
                   "value": "en-AU",
                 },
                 Object {
@@ -442,7 +442,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 6,
-                  "text": "Magyar (Beta)",
+                  "text": "Magyar",
                   "value": "hu",
                 },
                 Object {

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -291,7 +291,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 1,
-                  "text": "English (US)",
+                  "text": "English",
                   "value": "en",
                 },
                 Object {
@@ -417,7 +417,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 1,
-                  "text": "English (US)",
+                  "text": "English",
                   "value": "en",
                 },
                 Object {

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -296,7 +296,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 2,
-                  "text": "English Australian",
+                  "text": "English (Australian)",
                   "value": "en-AU",
                 },
                 Object {
@@ -422,7 +422,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 2,
-                  "text": "English Australian",
+                  "text": "English (Australian)",
                   "value": "en-AU",
                 },
                 Object {

--- a/components/user_settings/display/__snapshots__/user_settings_display.test.tsx.snap
+++ b/components/user_settings/display/__snapshots__/user_settings_display.test.tsx.snap
@@ -244,7 +244,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -506,7 +506,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -768,7 +768,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1158,7 +1158,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1420,7 +1420,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1700,7 +1700,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1900,7 +1900,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2100,7 +2100,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2300,7 +2300,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2512,7 +2512,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2712,7 +2712,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English"
+        describe="English (US)"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)

--- a/components/user_settings/display/__snapshots__/user_settings_display.test.tsx.snap
+++ b/components/user_settings/display/__snapshots__/user_settings_display.test.tsx.snap
@@ -244,7 +244,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -506,7 +506,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -768,7 +768,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1158,7 +1158,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1420,7 +1420,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1700,7 +1700,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -1900,7 +1900,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2100,7 +2100,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2300,7 +2300,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2512,7 +2512,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)
@@ -2712,7 +2712,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
     </div>
     <div>
       <SettingItemMin
-        describe="English (US)"
+        describe="English"
         section="languages"
         title={
           <Memo(MemoizedFormattedMessage)

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -42,7 +42,7 @@ const languages = {
     },
     'en-AU': {
         value: 'en-AU',
-        name: 'English Australian',
+        name: 'English (Australian)',
         order: 2,
         url: enAU,
     },

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -36,7 +36,7 @@ const languages = {
     },
     en: {
         value: 'en',
-        name: 'English',
+        name: 'English (US)',
         order: 1,
         url: '',
     },

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -42,7 +42,7 @@ const languages = {
     },
     'en-AU': {
         value: 'en-AU',
-        name: 'English Australian (Beta)',
+        name: 'English Australian',
         order: 2,
         url: enAU,
     },
@@ -66,7 +66,7 @@ const languages = {
     },
     hu: {
         value: 'hu',
-        name: 'Magyar (Beta)',
+        name: 'Magyar',
         order: 6,
         url: hu,
     },

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -42,7 +42,7 @@ const languages = {
     },
     'en-AU': {
         value: 'en-AU',
-        name: 'English (Australian)',
+        name: 'English (Australia)',
         order: 2,
         url: enAU,
     },


### PR DESCRIPTION
#### Summary
The maintainers for English-Australian and Hungarian reached for more than 3 months a full translation. These languages don't need a beta tag anymore #### Related Pull Requests
None
#### Screenshots
#### Release Note
```

```
```release-note
Hungarian and English-Australian are now official languages. 
```