### PR TITLE
[MM-38085] - fixing focussed search field background color

### DIFF
--- a/components/global/global_header.scss
+++ b/components/global/global_header.scss
@@ -180,7 +180,7 @@
     }
 
     &:focus-within {
-        background: var(--sidebar-text);
+        background: var(--center-channel-bg);
 
         .search__font-icon,
         .input-clear-x {

--- a/components/global/global_header.scss
+++ b/components/global/global_header.scss
@@ -162,6 +162,7 @@
 
         &::placeholder {
             color: rgba(var(--global-header-text-rgb), 0.64);
+            opacity: 1;
         }
     }
 


### PR DESCRIPTION
#### Summary
fixes focussed searchbar background color.

It was using the `--sidebar-text` variable, which led to an unreadable search field.
It now uses `--center-channel-bg` as mentioned in [this thread](https://community-daily.mattermost.com/core/pl/1148ypnr33nzzfj3dwxrbwuaue).

#### Ticket Link
[MM-38085](https://mattermost.atlassian.net/browse/MM-38085)

#### Screenshots

##### light theme (Quartz)
|  before  |  after  |
|-----|-----|
|<img width="439" alt="Screenshot 2021-08-27 at 16 13 37" src="https://user-images.githubusercontent.com/32863416/131141502-ed612a17-146c-44a5-953c-47673a5c54a4.png">|<img width="439" alt="Screenshot 2021-08-27 at 16 12 29" src="https://user-images.githubusercontent.com/32863416/131141584-32ceca0b-97a7-4f81-8353-74335f0c6108.png">|

##### dark theme (Onyx)
|  before  |  after  |
|-----|-----|
|<img width="439" alt="Screenshot 2021-08-27 at 16 13 21" src="https://user-images.githubusercontent.com/32863416/131141605-d54a50e3-456f-4fa1-b216-9b9d0606ccaf.png">|<img width="439" alt="Screenshot 2021-08-27 at 16 13 37" src="https://user-images.githubusercontent.com/32863416/131141623-50bce1c1-2f4d-42bc-b032-58b404c581d2.png">|

#### Release Note
```release-note
NONE
```
