### PR TITLE
Update compass-icons to v0.1.8 for new product icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@formatjs/intl-pluralrules": "4.0.6",
         "@formatjs/intl-relativetimeformat": "6.2.3",
         "@mattermost/compass-components": "0.2.9",
-        "@mattermost/compass-icons": "0.1.6",
+        "@mattermost/compass-icons": "0.1.8",
         "@stripe/react-stripe-js": "1.1.2",
         "@stripe/stripe-js": "1.9.0",
         "@types/country-list": "2.1.0",
@@ -4441,9 +4441,9 @@
       }
     },
     "node_modules/@mattermost/compass-icons": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.6.tgz",
-      "integrity": "sha512-UTDlv244fFtw9PTppN77S1APv+uzv7bOQMwTWEQhmsFZPcIbCtioZPXqOwWJVRjSwZ6GJ/TH0wlamJvgW55HFw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.8.tgz",
+      "integrity": "sha512-678nlW1uVHkVtQHP740+Mb1vm7e2bDMPPp1IKj8fHHFWxKbeOD38QRAbq7C9KmPviB5eE4GeBx7DXFD/pbcYPw==",
       "dependencies": {
         "esm": "^3.2.25",
         "fontello-batch-cli": "^4.0.0",
@@ -43230,9 +43230,9 @@
       }
     },
     "@mattermost/compass-icons": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.6.tgz",
-      "integrity": "sha512-UTDlv244fFtw9PTppN77S1APv+uzv7bOQMwTWEQhmsFZPcIbCtioZPXqOwWJVRjSwZ6GJ/TH0wlamJvgW55HFw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.8.tgz",
+      "integrity": "sha512-678nlW1uVHkVtQHP740+Mb1vm7e2bDMPPp1IKj8fHHFWxKbeOD38QRAbq7C9KmPviB5eE4GeBx7DXFD/pbcYPw==",
       "requires": {
         "esm": "^3.2.25",
         "fontello-batch-cli": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@formatjs/intl-pluralrules": "4.0.6",
     "@formatjs/intl-relativetimeformat": "6.2.3",
     "@mattermost/compass-components": "0.2.9",
-    "@mattermost/compass-icons": "0.1.6",
+    "@mattermost/compass-icons": "0.1.8",
     "@stripe/react-stripe-js": "1.1.2",
     "@stripe/stripe-js": "1.9.0",
     "@types/country-list": "2.1.0",


### PR DESCRIPTION
#### Summary
This PR updates the `@mattermost/compass-icons` package to get the updated product icons.

#### Screenshots
![image](https://user-images.githubusercontent.com/3245614/131205511-f92532ec-ba43-4def-8e91-898e65cf2a83.png)

#### Release Note
```release-note
NONE
```
