### PR TITLE
Fix JS error on joining missing channel as sysadmin

### DIFF
--- a/components/channel_layout/channel_identifier_router/actions.ts
+++ b/components/channel_layout/channel_identifier_router/actions.ts
@@ -174,7 +174,7 @@ export function goToChannelByChannelName(match: Match, history: History): Action
             const user = getCurrentUser(getState());
             const isSystemAdmin = Utils.isSystemAdmin(user?.roles);
             if (isSystemAdmin) {
-                if (channel.type === Constants.PRIVATE_CHANNEL) {
+                if (channel && channel.type === Constants.PRIVATE_CHANNEL) {
                     const joinPromptResult = await dispatch(joinPrivateChannelPrompt(teamObj, channel));
                     if ('data' in joinPromptResult && !joinPromptResult.data.join) {
                         return {data: undefined};

--- a/components/channel_layout/channel_identifier_router/actions.ts
+++ b/components/channel_layout/channel_identifier_router/actions.ts
@@ -174,7 +174,7 @@ export function goToChannelByChannelName(match: Match, history: History): Action
             const user = getCurrentUser(getState());
             const isSystemAdmin = Utils.isSystemAdmin(user?.roles);
             if (isSystemAdmin) {
-                if (channel && channel.type === Constants.PRIVATE_CHANNEL) {
+                if (channel?.type === Constants.PRIVATE_CHANNEL) {
                     const joinPromptResult = await dispatch(joinPrivateChannelPrompt(teamObj, channel));
                     if ('data' in joinPromptResult && !joinPromptResult.data.join) {
                         return {data: undefined};


### PR DESCRIPTION
#### Summary

PR fixes a `Cannot read property 'type' of undefined` error that could happen if the channel couldn't be found when joining as sysadmin.

#### Ticket

https://mattermost.atlassian.net/browse/MM-38198

#### Release Note

```release-note
Fixed an issue on joining a missing channel as sysadmin.
```

#### GitHub Issue

https://github.com/mattermost/mattermost-server/issues/18284