### PR TITLE
[MM-38189] - removed `Open...` from the product switcher menu

### DIFF
--- a/components/global/product_switcher.tsx
+++ b/components/global/product_switcher.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import React, {useRef, useState} from 'react';
-import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -30,14 +29,6 @@ const ProductSwitcherContainer = styled.nav`
     > * + * {
         margin-left: 12px;
     }
-`;
-
-const SwitcherMenuDescriptiveText = styled.div`
-    height: 32px;
-    padding-left: 20px;
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 32px;
 `;
 
 const MenuItem = styled(Link)`
@@ -147,12 +138,6 @@ const ProductSwitcher = (): JSX.Element => {
                     className={'product-switcher-menu'}
                     ariaLabel={'switcherOpen'}
                 >
-                    <SwitcherMenuDescriptiveText>
-                        <FormattedMessage
-                            defaultMessage='Open...'
-                            id='global_header.open'
-                        />
-                    </SwitcherMenuDescriptiveText>
                     <SwitcherNavEntry
                         destination={'/'}
                         icon={'product-channels'}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3181,7 +3181,6 @@
   "get_public_link_modal.help": "The link below allows anyone to see this file without being registered on this server.",
   "get_public_link_modal.title": "Copy Public Link",
   "gif_picker.gfycat": "Search Gfycat",
-  "global_header.open": "Open...",
   "global_header.productSettings": "Settings",
   "globalThreads.heading": "Followed threads",
   "globalThreads.noThreads.subtitle": "Any threads you are mentioned in or have participated in will show here along with any threads you have followed.",


### PR DESCRIPTION
#### Summary
remove the first "headline" entry from the product switcher: `Open ...` since it did create some misunderstanding among users.

#### Ticket Link
[MM-38189](https://mattermost.atlassian.net/browse/MM-38189)

#### Release Note
```release-note
NONE
```
