### PR TITLE
Global header: make opening of account settings modal backward compatible when global header is disabled

### DIFF
--- a/actions/command.test.js
+++ b/actions/command.test.js
@@ -172,7 +172,7 @@ describe('executeCommand', () => {
             expect(store.getActions()).toEqual([
                 {
                     type: ActionTypes.MODAL_OPEN,
-                    dialogProps: {isContentProductSettings: true},
+                    dialogProps: {isContentProductSettings: false},
                     dialogType: UserSettingsModal,
                     modalId: 'user_settings',
                 },

--- a/actions/command.ts
+++ b/actions/command.ts
@@ -19,6 +19,7 @@ import {DoAppCallResult} from 'types/apps';
 import {openModal} from 'actions/views/modals';
 import * as GlobalActions from 'actions/global_actions';
 import * as PostActions from 'actions/post_actions.jsx';
+import {getGlobalHeaderEnabled} from 'selectors/global_header';
 
 import {isUrlSafe, getSiteURL} from 'utils/url';
 import {localizeMessage, getUserIdFromChannelName, localizeAndFormatMessage} from 'utils/utils.jsx';
@@ -101,7 +102,13 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
             break;
         }
         case '/settings':
-            dispatch(openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}}));
+            dispatch(openModal({
+                modalId: ModalIdentifiers.USER_SETTINGS,
+                dialogType: UserSettingsModal,
+                dialogProps: {
+                    isContentProductSettings: getGlobalHeaderEnabled(state),
+                },
+            }));
             return {data: true};
         case '/collapse':
         case '/expand':

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -102,7 +102,13 @@ class MainMenu extends React.PureComponent {
     handleKeyDown = (e) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey && isKeyPressed(e, Constants.KeyCodes.A)) {
             e.preventDefault();
-            this.props.actions.openModal({ModalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}});
+            this.props.actions.openModal({
+                ModalId: ModalIdentifiers.USER_SETTINGS,
+                dialogType: UserSettingsModal,
+                dialogProps: {
+                    isContentProductSettings: this.props.globalHeaderEnabled,
+                },
+            });
         }
     }
 
@@ -335,7 +341,7 @@ class MainMenu extends React.PureComponent {
                         id='accountSettings'
                         modalId={ModalIdentifiers.USER_SETTINGS}
                         dialogType={UserSettingsModal}
-                        dialogProps={{isContentProductSettings: true}}
+                        dialogProps={{isContentProductSettings: this.props.globalHeaderEnabled}}
                         text={formatMessage({id: 'navbar_dropdown.accountSettings', defaultMessage: 'Account Settings'})}
                         icon={this.props.mobile && <i className='fa fa-cog'/>}
                     />

--- a/components/sidebar/legacy_sidebar_header/dropdown/index.ts
+++ b/components/sidebar/legacy_sidebar_header/dropdown/index.ts
@@ -12,6 +12,7 @@ import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {openModal} from 'actions/views/modals';
+import {getGlobalHeaderEnabled} from 'selectors/global_header';
 
 import {Preferences, TutorialSteps} from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
@@ -28,6 +29,7 @@ function mapStateToProps(state: GlobalState) {
         teamDescription: currentTeam.description,
         teamDisplayName: currentTeam.display_name,
         teamId: currentTeam.id,
+        globalHeaderEnabled: getGlobalHeaderEnabled(state),
         showTutorialTip,
     };
 }

--- a/components/sidebar/legacy_sidebar_header/dropdown/sidebar_header_dropdown.tsx
+++ b/components/sidebar/legacy_sidebar_header/dropdown/sidebar_header_dropdown.tsx
@@ -24,6 +24,7 @@ type Props = {
     teamDisplayName: string;
     teamId: string;
     currentUser: UserProfile;
+    globalHeaderEnabled: boolean;
     showTutorialTip: boolean;
     actions: Actions;
 }
@@ -45,7 +46,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent<Props> {
     handleKeyDown = (e: KeyboardEvent) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey && isKeyPressed(e, Constants.KeyCodes.A)) {
             e.preventDefault();
-            this.props.actions.openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}});
+            this.props.actions.openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: this.props.globalHeaderEnabled}});
         }
     }
 

--- a/components/sidebar/sidebar_header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/sidebar/sidebar_header/dropdown/sidebar_header_dropdown.jsx
@@ -55,7 +55,13 @@ export default class SidebarHeaderDropdown extends React.PureComponent {
     handleKeyDown = (e) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey && isKeyPressed(e, Constants.KeyCodes.A)) {
             e.preventDefault();
-            this.props.actions.openModal({ModalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}});
+            this.props.actions.openModal({
+                ModalId: ModalIdentifiers.USER_SETTINGS,
+                dialogType: UserSettingsModal,
+                dialogProps: {
+                    isContentProductSettings: this.props.globalHeaderEnabled,
+                },
+            });
         }
     }
 

--- a/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
+++ b/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
@@ -25,7 +25,7 @@ exports[`plugins/MainMenuActions should match snapshot and click plugin item for
     <MenuItemToggleModalRedux
       dialogProps={
         Object {
-          "isContentProductSettings": true,
+          "isContentProductSettings": undefined,
         }
       }
       dialogType={


### PR DESCRIPTION
#### Summary
Make opening of account settings modal backward compatible when global header is disabled. Maybe support until the global header is fully released which is when related feature flag is removed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38235

#### Release Note
```release-note
NONE
```
