### PR TITLE
MM-37603: click on code should not open the thread

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -20,7 +20,7 @@ import PostPreHeader from 'components/post_view/post_pre_header';
 import ThreadFooter from 'components/threading/channel_threads/thread_footer';
 
 // When adding clickable targets within a root post, please add to/maintain the selector below
-const isEligibleForClick = makeIsEligibleForClick('.post-image__column, .embed-responsive-item, .attachment');
+const isEligibleForClick = makeIsEligibleForClick('.post-image__column, .embed-responsive-item, .attachment, .hljs, code');
 
 export default class Post extends React.PureComponent {
     static propTypes = {

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -19,7 +19,8 @@ import PostContext from 'components/post_view/post_context';
 import PostPreHeader from 'components/post_view/post_pre_header';
 import ThreadFooter from 'components/threading/channel_threads/thread_footer';
 
-// When adding clickable targets within a root post, please add to/maintain the selector below
+// When adding clickable targets within a root post to exclude from post's on click to open thread,
+// please add to/maintain the selector below
 const isEligibleForClick = makeIsEligibleForClick('.post-image__column, .embed-responsive-item, .attachment, .hljs, code');
 
 export default class Post extends React.PureComponent {

--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -212,6 +212,7 @@ h6.markdown__heading {
         border: 1px solid rgba(v(center-channel-color-rgb), 0.2);
         margin: 5px 0;
         border-radius: 0.25em;
+        cursor: default;
         font-size: 13px;
         overflow-x: auto;
         visibility: visible;
@@ -255,6 +256,7 @@ h6.markdown__heading {
 
     .codespan__pre-wrap {
         code {
+            cursor: default;
             white-space: pre-wrap;
         }
     }

--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -212,7 +212,7 @@ h6.markdown__heading {
         border: 1px solid rgba(v(center-channel-color-rgb), 0.2);
         margin: 5px 0;
         border-radius: 0.25em;
-        cursor: default;
+        cursor: auto;
         font-size: 13px;
         overflow-x: auto;
         visibility: visible;
@@ -256,7 +256,7 @@ h6.markdown__heading {
 
     .codespan__pre-wrap {
         code {
-            cursor: default;
+            cursor: auto;
             white-space: pre-wrap;
         }
     }


### PR DESCRIPTION
#### Summary

Removes the click to open thread functionality when clicking or
trying to select text in a code block or in-line code.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37603

#### Release Note

```release-note
NONE
```
