### PR TITLE
MM-37957: fixes overlapping separators in thread

### DIFF
--- a/sass/components/_post-right.scss
+++ b/sass/components/_post-right.scss
@@ -13,13 +13,6 @@
         position: relative;
 
         .post {
-            &.same--root {
-                &.same--user {
-                    padding-top: 0;
-                    padding-bottom: 0;
-                }
-            }
-
             &:hover {
                 & + .Separator {
                     .separator__hr {
@@ -36,14 +29,6 @@
                         }
                     }
                 }
-            }
-        }
-
-        .Separator {
-            padding-top: 15px;
-
-            & + .post {
-                padding-top: 20px;
             }
         }
     }


### PR DESCRIPTION
#### Summary

Timestamps and or new messages line was overlapping the text message
making it impossible to read, this commit fixes that.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37957

#### Release Note

```release-note
NONE
```
