### PR TITLE
[MM-37708] - changed font-family to Open Sans on popover title

### DIFF
--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -174,7 +174,10 @@
         > span {
             display: flex;
             justify-content: space-between;
-            font-family: 'Open Sans', sans-serif;
+
+            .user-popover__username {
+                font-family: 'Open Sans', sans-serif;
+            }
         }
     }
 

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "utf-8";
 
 @import 'compass/css3/transition';
 
@@ -174,6 +174,7 @@
         > span {
             display: flex;
             justify-content: space-between;
+            font-family: 'Open Sans', sans-serif;
         }
     }
 

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -175,9 +175,10 @@
             display: flex;
             justify-content: space-between;
 
-            .user-popover__username {
-                font-family: 'Open Sans', sans-serif;
-            }
+        }
+
+        .user-popover__username {
+            font-family: 'Open Sans', sans-serif;
         }
     }
 

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -174,7 +174,6 @@
         > span {
             display: flex;
             justify-content: space-between;
-
         }
 
         .user-popover__username {


### PR DESCRIPTION
#### Summary
change the user-profile popover username font-family from `Metropolis` to `Open Sans`

#### Ticket Link
[MM-37708](https://mattermost.atlassian.net/browse/MM-37708)

#### Screenshots
|  before  |  after  |
|------|------|
|<img width="134" alt="Screenshot 2021-08-31 at 12 39 45" src="https://user-images.githubusercontent.com/32863416/131488545-3964764e-a17b-4e49-8334-fe4d54eaa03f.png">|<img width="157" alt="Screenshot 2021-08-31 at 12 39 22" src="https://user-images.githubusercontent.com/32863416/131488569-43f54578-33c6-4b8e-8dd0-f22762b63670.png">|

#### Release Note
```release-note
NONE
```
