### PR TITLE
[MM-38209] - removed propagation stop on handler function

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -161,7 +161,6 @@ export default class Post extends React.PureComponent {
 
     handleCommentClick = (e) => {
         e.preventDefault();
-        e.stopPropagation();
 
         const post = this.props.post;
         if (!post) {


### PR DESCRIPTION
#### Summary
dotmenu on post is now closing correctly when clicking `Reply`.

@koox00 , @deanwhillier and @jgilliam17 please be extra thorough when checking for other menu items, since I had to remove a event propagation and I cannot tell if that might have side-effects.

#### Ticket Link
[MM-38209](https://mattermost.atlassian.net/browse/MM-38209)

#### Release Note
```release-note
NONE
```
