### PR TITLE
[MM-38241] Use DOMParser to parse tables from clipboard

### DIFF
--- a/e2e/cypress/integration/messaging/post_html_table_spec.js
+++ b/e2e/cypress/integration/messaging/post_html_table_spec.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @messaging
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('Post HTML', () => {
+    before(() => {
+        // # Create new team and new user and visit Town Square channel
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+
+    it('Pasting HTML table in message box should not trigger CSP violation', () => {
+        cy.document().then(($document) => {
+            $document.addEventListener('securitypolicyviolation', () => {
+                throw new Error('should not have triggered violation');
+            });
+        });
+
+        // # Paste HTML data from clipboard to the message box.
+        cy.get('#create_post').trigger('paste', {clipboardData: {
+            items: [1],
+            types: ['text/html'],
+            getData: () => '<table><img src="null" onerror="alert(\'xss\')" /></table>',
+        }}).wait(TIMEOUTS.TEN_SEC);
+    });
+});

--- a/utils/paste.tsx
+++ b/utils/paste.tsx
@@ -3,9 +3,7 @@
 import {splitMessageBasedOnCaretPosition} from 'utils/post_utils';
 
 export function parseTable(html: string): HTMLTableElement | null {
-    const el = document.createElement('div');
-    el.innerHTML = html;
-    return el.querySelector('table');
+    return new DOMParser().parseFromString(html, 'text/html').querySelector('table');
 }
 
 export function getTable(clipboardData: DataTransfer): HTMLTableElement | null {


### PR DESCRIPTION
#### Summary

We start making use of [`DOMParser`](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser) to parse html tables from clipboard.  
I am assuming creating a parser is an efficient operation. Let me know if we should cache it or something like that.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38241

#### Release Note

```release-note
NONE
```
