### PR TITLE
MM-38159 - Fix license checks in System Console for Starter License

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2396,7 +2396,7 @@ const AdminDefinition = {
             title: t('admin.sidebar.announcement'),
             title_default: 'Announcement Banner',
             isHidden: it.any(
-                it.not(it.licensedForFeature('Announcement')),
+                it.not(it.licensed),
                 it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.SITE.ANNOUNCEMENT_BANNER)),
             ),
             schema: {
@@ -2466,7 +2466,7 @@ const AdminDefinition = {
             title: t('admin.sidebar.announcement'),
             title_default: 'Announcement Banner',
             isHidden: it.any(
-                it.licensedForFeature('Announcement'),
+                it.licensed,
                 it.not(it.enterpriseReady),
             ),
             schema: {
@@ -5513,7 +5513,7 @@ const AdminDefinition = {
             title: t('admin.sidebar.complianceMonitoring'),
             title_default: 'Compliance Monitoring',
             isHidden: it.any(
-                it.not(it.licensedForFeature('Compliance')),
+                it.not(it.licensed),
                 it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.COMPLIANCE.COMPLIANCE_MONITORING)),
             ),
             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.COMPLIANCE.COMPLIANCE_MONITORING)),

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2396,7 +2396,7 @@ const AdminDefinition = {
             title: t('admin.sidebar.announcement'),
             title_default: 'Announcement Banner',
             isHidden: it.any(
-                it.not(it.licensed),
+                it.not(it.licensedForFeature('Announcement')),
                 it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.SITE.ANNOUNCEMENT_BANNER)),
             ),
             schema: {
@@ -2466,7 +2466,7 @@ const AdminDefinition = {
             title: t('admin.sidebar.announcement'),
             title_default: 'Announcement Banner',
             isHidden: it.any(
-                it.licensed,
+                it.licensedForFeature('Announcement'),
                 it.not(it.enterpriseReady),
             ),
             schema: {
@@ -5513,7 +5513,7 @@ const AdminDefinition = {
             title: t('admin.sidebar.complianceMonitoring'),
             title_default: 'Compliance Monitoring',
             isHidden: it.any(
-                it.not(it.licensed),
+                it.not(it.licensedForFeature('Compliance')),
                 it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.COMPLIANCE.COMPLIANCE_MONITORING)),
             ),
             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.COMPLIANCE.COMPLIANCE_MONITORING)),

--- a/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
+++ b/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
@@ -2364,6 +2364,34 @@ exports[`components/AdminSidebar should match snapshot, with license (without an
             />
           </AdminSidebarCategory>
           <AdminSidebarCategory
+            definitionKey="site"
+            icon="fa-cogs"
+            key="site"
+            parentLink="/admin_console"
+            sectionClass=""
+            title={
+              <Memo(MemoizedFormattedMessage)
+                defaultMessage="Site Configuration"
+                id="admin.sidebar.site"
+              />
+            }
+          >
+            <AdminSidebarSection
+              definitionKey="site.announcement_banner_feature_discovery"
+              key="site.announcement_banner_feature_discovery"
+              name="site_config/announcement_banner"
+              parentLink=""
+              subsection={false}
+              tag=""
+              title={
+                <Memo(MemoizedFormattedMessage)
+                  defaultMessage="Announcement Banner"
+                  id="admin.sidebar.announcement"
+                />
+              }
+            />
+          </AdminSidebarCategory>
+          <AdminSidebarCategory
             definitionKey="authentication"
             icon="fa-shield"
             key="authentication"

--- a/components/admin_console/admin_sidebar/admin_sidebar.test.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.test.jsx
@@ -249,6 +249,7 @@ describe('components/AdminSidebar', () => {
                 CustomPermissionsSchemes: 'true',
                 OpenId: 'true',
                 GuestAccounts: 'true',
+                Announcement: 'true',
             },
             config: {
                 ExperimentalSettings: {


### PR DESCRIPTION
#### Summary

Features below were only checking for the existence of a license in System Console (assuming it would be available for both E10/E20). However, in Cloud Starter, there is a license present but these features should not be available:

- Announcement Banner
- Compliance Monitoring

This PR changes it so it checks for the actual Feature Flags in the license.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38159

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
