### PR TITLE
fixing show more button for message previews

### DIFF
--- a/components/post_view/post_message_preview/__snapshots__/post_message_preview.test.tsx.snap
+++ b/components/post_view/post_message_preview/__snapshots__/post_message_preview.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`PostMessagePreview should render correctly 1`] = `
       </div>
     </div>
     <Connect(PostMessageView)
-      maxHeight={100}
+      maxHeight={105}
       overflowType="ellipsis"
       post={
         Object {

--- a/components/post_view/post_message_preview/post_message_preview.tsx
+++ b/components/post_view/post_message_preview/post_message_preview.tsx
@@ -70,7 +70,7 @@ const PostMessagePreview = (props: Props) => {
                 <PostMessageView
                     post={previewPost}
                     overflowType='ellipsis'
-                    maxHeight={100}
+                    maxHeight={105}
                 />
 
                 <div className='post__preview-footer'>

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1860,6 +1860,7 @@
             text-overflow: ellipsis;
             white-space: nowrap;
         }
+
         .post-preview-collapse__show-more-button {
             padding: 0;
             border: none;

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1856,7 +1856,7 @@
             display: -webkit-box;
             overflow: hidden;
             -webkit-box-orient: vertical;
-            -webkit-line-clamp: 5;
+            -webkit-line-clamp: 4;
             text-overflow: ellipsis;
             white-space: nowrap;
         }

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1856,15 +1856,13 @@
             display: -webkit-box;
             overflow: hidden;
             -webkit-box-orient: vertical;
-            -webkit-line-clamp: 5;
+            -webkit-line-clamp: 4;
             text-overflow: ellipsis;
             white-space: nowrap;
         }
-
         .post-preview-collapse__show-more-button {
             padding: 0;
             border: none;
-            margin-top: 10px;
             background: none;
             font-size: 12px;
         }

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1856,7 +1856,7 @@
             display: -webkit-box;
             overflow: hidden;
             -webkit-box-orient: vertical;
-            -webkit-line-clamp: 4;
+            -webkit-line-clamp: 5;
             text-overflow: ellipsis;
             white-space: nowrap;
         }


### PR DESCRIPTION
#### Summary
The show more indicator was showing when it wasn't needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38158

#### Screenshots
![Screen Shot 2021-09-01 at 4 12 07 PM](https://user-images.githubusercontent.com/14115924/131738378-9a36619d-f880-473c-8e50-3c72fc1a97f0.png)
![Screen Shot 2021-09-01 at 4 12 24 PM](https://user-images.githubusercontent.com/14115924/131738399-5c1607ea-bb70-4402-99ef-719dd70eb32f.png)


#### Release Note
```release-note
NONE
```
