### PR TITLE
Update binding filter to accept bindings with a form with a call but no call

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/__snapshots__/apps.test.ts.snap
+++ b/packages/mattermost-redux/src/reducers/entities/__snapshots__/apps.test.ts.snap
@@ -8,7 +8,6 @@ Array [
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "label": "a",
         "location": "/post_menu/locA",
       },
@@ -21,7 +20,6 @@ Array [
       Object {
         "app_id": "2",
         "call": Object {},
-        "form": undefined,
         "label": "a",
         "location": "/post_menu/locA",
       },
@@ -34,7 +32,6 @@ Array [
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "icon": "icon",
         "label": "b",
         "location": "/channel_header/locB",
@@ -48,7 +45,6 @@ Array [
       Object {
         "app_id": "2",
         "call": Object {},
-        "form": undefined,
         "icon": "icon",
         "label": "c",
         "location": "/channel_header/locC",
@@ -62,7 +58,6 @@ Array [
       Object {
         "app_id": "3",
         "call": Object {},
-        "form": undefined,
         "label": "c",
         "location": "/command/locC",
       },
@@ -80,14 +75,12 @@ Array [
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "label": "a",
         "location": "/post_menu/locA",
       },
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "label": "a",
         "location": "/post_menu/locB",
       },
@@ -100,7 +93,6 @@ Array [
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "icon": "icon",
         "label": "b",
         "location": "/channel_header/locB",
@@ -117,13 +109,10 @@ Array [
           Object {
             "app_id": "3",
             "call": Object {},
-            "form": undefined,
             "label": "c2",
             "location": "/command/locC/subC2",
           },
         ],
-        "call": undefined,
-        "form": undefined,
         "label": "c",
         "location": "/command/locC",
       },
@@ -139,20 +128,17 @@ Array [
           Object {
             "app_id": "2",
             "call": Object {},
-            "form": undefined,
             "label": "c1",
             "location": "/command/locC/subC1",
           },
           Object {
             "app_id": "2",
             "call": Object {},
-            "form": undefined,
             "label": "c2",
             "location": "/command/locC/subC2",
           },
         ],
         "call": Object {},
-        "form": undefined,
         "label": "c",
         "location": "/command/locC",
       },
@@ -170,7 +156,6 @@ Array [
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "label": "a",
         "location": "/post_menu/locB",
       },
@@ -183,14 +168,12 @@ Array [
       Object {
         "app_id": "2",
         "call": Object {},
-        "form": undefined,
         "label": "a",
         "location": "/post_menu/locA",
       },
       Object {
         "app_id": "2",
         "call": Object {},
-        "form": undefined,
         "label": "b",
         "location": "/post_menu/locB",
       },
@@ -203,7 +186,6 @@ Array [
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "icon": "icon",
         "label": "b",
         "location": "/channel_header/locB",
@@ -217,7 +199,6 @@ Array [
       Object {
         "app_id": "3",
         "call": Object {},
-        "form": undefined,
         "label": "c",
         "location": "/command/locC",
       },
@@ -235,7 +216,6 @@ Array [
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "label": "a",
         "location": "/post_menu/locA",
       },
@@ -248,7 +228,6 @@ Array [
       Object {
         "app_id": "2",
         "call": Object {},
-        "form": undefined,
         "label": "a",
         "location": "/post_menu/locA",
       },
@@ -261,7 +240,6 @@ Array [
       Object {
         "app_id": "1",
         "call": Object {},
-        "form": undefined,
         "icon": "icon",
         "label": "b",
         "location": "/channel_header/locB",
@@ -275,7 +253,6 @@ Array [
       Object {
         "app_id": "3",
         "call": Object {},
-        "form": undefined,
         "label": "c",
         "location": "/command/locC",
       },

--- a/packages/mattermost-redux/src/utils/apps.test.ts
+++ b/packages/mattermost-redux/src/utils/apps.test.ts
@@ -296,6 +296,42 @@ describe('Apps Utils', () => {
             cleanBinding(inBinding, '');
             expect(inBinding).toEqual(outBinding);
         });
+        test('Do not filter bindings with no call but with a form with a call', () => {
+            const inBinding = {
+                app_id: 'appID',
+                location: 'loc1',
+                bindings: [
+                    {
+                        location: 'loc2',
+                        form: {
+                            call: {
+                                path: 'url',
+                            },
+                        },
+                    } as AppBinding,
+                ],
+            } as AppBinding;
+
+            const outBinding = {
+                app_id: 'appID',
+                location: 'loc1',
+                bindings: [
+                    {
+                        app_id: 'appID',
+                        location: 'loc1/loc2',
+                        label: 'loc2',
+                        form: {
+                            call: {
+                                path: 'url',
+                            },
+                        },
+                    },
+                ],
+            } as AppBinding;
+
+            cleanBinding(inBinding, '');
+            expect(inBinding).toEqual(outBinding);
+        });
     });
     describe('cleanForm', () => {
         test('no field filter on names', () => {

--- a/packages/mattermost-redux/src/utils/apps.ts
+++ b/packages/mattermost-redux/src/utils/apps.ts
@@ -17,13 +17,13 @@ function cleanBindingRec(binding: AppBinding, topLocation: string, depth: number
     const usedLabels: {[label: string]: boolean} = {};
     binding.bindings?.forEach((b, i) => {
         // Inheritance and defaults
-        if (!b.call) {
+        if (!b.call && binding.call) {
             b.call = binding.call;
         }
 
         if (b.form) {
             cleanForm(b.form);
-        } else {
+        } else if (binding.form) {
             b.form = binding.form;
         }
 
@@ -64,6 +64,13 @@ function cleanBindingRec(binding: AppBinding, topLocation: string, depth: number
             }
             break;
         }
+        case AppBindingLocations.IN_POST: {
+            if (usedLabels[b.label]) {
+                toRemove.unshift(i);
+                return;
+            }
+            break;
+        }
         }
 
         if (b.bindings?.length) {
@@ -76,7 +83,7 @@ function cleanBindingRec(binding: AppBinding, topLocation: string, depth: number
             }
         } else {
             // Remove leaves without a call
-            if (!b.call) {
+            if (!b.call && !b.form?.call) {
                 toRemove.unshift(i);
                 return;
             }


### PR DESCRIPTION
#### Summary
We are currently removing all bindings that have no call object. But a binding with a form that has a call should also be valid.

This PR cover that, and piggybacks some minor aesthethic changes removes the repeated options on in post bindings on cleanup.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33824

#### Related Pull Requests
This change will be piggybacked on mobile on this PR: https://github.com/mattermost/mattermost-mobile/pull/5655

#### Screenshots
None

#### Release Note
```release-note
NONE
```
