### PR TITLE
Fixes "property.roles" of undefined

### DIFF
--- a/components/global/user_guide_dropdown/index.ts
+++ b/components/global/user_guide_dropdown/index.ts
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {unhideNextSteps} from 'actions/views/next_steps';
@@ -12,21 +13,32 @@ import {GlobalState} from 'types/store';
 
 import {
     showOnboarding,
-    showNextStepsTips,
-    showNextSteps,
+    showNextStepsTips as showNextStepsTipsSelector,
+    showNextSteps as showNextStepsSelector,
 } from 'components/next_steps_view/steps';
 
 import UserGuideDropdown from './user_guide_dropdown';
 
 function mapStateToProps(state: GlobalState) {
     const {HelpLink, ReportAProblemLink, EnableAskCommunityLink} = getConfig(state);
+
+    let showNextSteps = false;
+    let showNextStepsTips = false;
+    let showGettingStarted = false;
+
+    if (getCurrentUser(state)) {
+        showNextStepsTips = showNextStepsTipsSelector(state);
+        showNextSteps = showNextStepsSelector(state);
+        showGettingStarted = showOnboarding(state);
+    }
+
     return {
         helpLink: HelpLink || '',
         reportAProblemLink: ReportAProblemLink || '',
         enableAskCommunityLink: EnableAskCommunityLink || '',
-        showGettingStarted: showOnboarding(state),
-        showNextStepsTips: showNextStepsTips(state),
-        showNextSteps: showNextSteps(state),
+        showGettingStarted,
+        showNextStepsTips,
+        showNextSteps,
     };
 }
 


### PR DESCRIPTION
#### Summary

A logged out user with global header enabled would crash for the root
URL. This was happening because we assumed current user exists when
querying on whether to show or not the tutorials or getting started
page.

This commit fixes that by defaulting those values to false and
guarding on current user.

#### Release Note

```release-note
NONE
```
