### PR TITLE
Bugfix - roles error with global header enabled

### DIFF
--- a/components/global/global_header.tsx
+++ b/components/global/global_header.tsx
@@ -21,7 +21,7 @@ import SavedPostsButton from './saved_posts_button/saved_posts_button';
 import SettingsButton from './settings_button';
 import SettingsTip from './settings_tip';
 
-import {useCurrentProductId, useProducts, useShowTutorialStep} from './hooks';
+import {useCurrentProductId, useIsLoggedIn, useProducts, useShowTutorialStep} from './hooks';
 
 import './global_header.scss';
 
@@ -78,6 +78,7 @@ const RightControls = styled.div`
 
 const GlobalHeader = (): JSX.Element | null => {
     const enabled = useSelector(getGlobalHeaderEnabled);
+    const isLoggedIn = useIsLoggedIn();
     const products = useProducts();
     const currentProductID = useCurrentProductId(products);
     const showSettingsTip = useShowTutorialStep(TutorialSteps.SETTINGS);
@@ -94,7 +95,7 @@ const GlobalHeader = (): JSX.Element | null => {
         };
     }, [enabled]);
 
-    if (!enabled) {
+    if (!enabled || !isLoggedIn) {
         return null;
     }
 

--- a/components/global/hooks.tsx
+++ b/components/global/hooks.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {UserProfile} from 'mattermost-redux/types/users';
 import {MutableRefObject, useEffect, useRef} from 'react';
 import {useSelector} from 'react-redux';
 import {useLocation} from 'react-router';
@@ -11,6 +10,7 @@ import {ProductComponent} from 'types/store/plugins';
 import {getBasePath} from 'utils/url';
 import {Preferences} from 'utils/constants';
 
+import {UserProfile} from 'mattermost-redux/types/users';
 import {getCurrentUser, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 

--- a/components/global/hooks.tsx
+++ b/components/global/hooks.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {UserProfile} from 'mattermost-redux/types/users';
 import {MutableRefObject, useEffect, useRef} from 'react';
 import {useSelector} from 'react-redux';
 import {useLocation} from 'react-router';
@@ -10,7 +11,7 @@ import {ProductComponent} from 'types/store/plugins';
 import {getBasePath} from 'utils/url';
 import {Preferences} from 'utils/constants';
 
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUser, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 
 import {isModalOpen} from 'selectors/views/modals';
@@ -64,6 +65,10 @@ export const useShowTutorialStep = (stepToShow: number): boolean => {
     const step = useSelector<GlobalState, number>(boundGetInt);
 
     return step === stepToShow;
+};
+
+export const useIsLoggedIn = (): boolean => {
+    return Boolean(useSelector<GlobalState, UserProfile>(getCurrentUser));
 };
 
 /**

--- a/components/global/user_guide_dropdown/index.ts
+++ b/components/global/user_guide_dropdown/index.ts
@@ -5,7 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {unhideNextSteps} from 'actions/views/next_steps';
@@ -13,32 +12,21 @@ import {GlobalState} from 'types/store';
 
 import {
     showOnboarding,
-    showNextStepsTips as showNextStepsTipsSelector,
-    showNextSteps as showNextStepsSelector,
+    showNextStepsTips,
+    showNextSteps,
 } from 'components/next_steps_view/steps';
 
 import UserGuideDropdown from './user_guide_dropdown';
 
 function mapStateToProps(state: GlobalState) {
     const {HelpLink, ReportAProblemLink, EnableAskCommunityLink} = getConfig(state);
-
-    let showNextSteps = false;
-    let showNextStepsTips = false;
-    let showGettingStarted = false;
-
-    if (getCurrentUser(state)) {
-        showNextStepsTips = showNextStepsTipsSelector(state);
-        showNextSteps = showNextStepsSelector(state);
-        showGettingStarted = showOnboarding(state);
-    }
-
     return {
         helpLink: HelpLink || '',
         reportAProblemLink: ReportAProblemLink || '',
         enableAskCommunityLink: EnableAskCommunityLink || '',
-        showGettingStarted,
-        showNextStepsTips,
-        showNextSteps,
+        showGettingStarted: showOnboarding(state),
+        showNextStepsTips: showNextStepsTips(state),
+        showNextSteps: showNextSteps(state),
     };
 }
 

--- a/components/next_steps_view/steps.ts
+++ b/components/next_steps_view/steps.ts
@@ -98,10 +98,9 @@ export const isFirstAdmin = createSelector(
     (state: GlobalState) => getCurrentUser(state),
     (state: GlobalState) => getUsers(state),
     (currentUser, users) => {
-        if (currentUser && !currentUser.roles.includes('system_admin')) {
+        if (!currentUser.roles.includes('system_admin')) {
             return false;
         }
-
         const userIds = Object.keys(users);
         for (const userId of userIds) {
             const user = users[userId];
@@ -119,10 +118,6 @@ export const getSteps = createSelector(
     (state: GlobalState) => getCurrentUser(state),
     (state: GlobalState) => isFirstAdmin(state),
     (currentUser, firstAdmin) => {
-        if (!currentUser) {
-            return Steps.filter((step) => step.visible);
-        }
-
         const roles = firstAdmin ? `first_admin ${currentUser.roles}` : currentUser.roles;
         return Steps.filter((step) =>
             isStepForUser(step, roles) && step.visible,
@@ -189,10 +184,6 @@ export const nextStepsNotFinished = createSelector(
     (state: GlobalState) => isFirstAdmin(state),
     (state: GlobalState) => getSteps(state),
     (stepPreferences, currentUser, firstAdmin, mySteps) => {
-        if (!currentUser) {
-            return true;
-        }
-
         const roles = firstAdmin ? `first_admin ${currentUser.roles}` : currentUser.roles;
         const checkPref = (step: StepType) => stepPreferences.some((pref) => (pref.name === step.id && pref.value === 'true') || !isStepForUser(step, roles));
         return !mySteps.every(checkPref);


### PR DESCRIPTION
#### Summary
in the last days we had some problems with our test-servers not showing a login screen because of a javascript error. In the global header we were accessing the currently logged in user (although there was none) and that resulted in breaking the application.

The root cause for this is that the global header is rendering regardless if a user is logged in pr not. Re-arranging the components in `root.jsx` did not really work out due to our current routing structure. 

the solution for now is to prevent rendering of the global header inside the global header component, by utilizing a new hook `useIsLoggedIn`.

this PR also reverts changes made in #8781 and #8791 

#### Ticket Link
```
NONE
```

#### Release Note
```release-note
NONE
```
