### PR TITLE
[MM-38420] Fix root message being equal

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/channels/message_counts.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/channels/message_counts.test.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import {updateMessageCount} from './message_counts';
+
+describe('reducers.entities.channels', () => {
+    describe('updateMessageCounts', () => {
+        it('root and total should be different if there are threads', () => {
+            const state = {
+                myid: {
+                    total: 0,
+                    root: 0,
+                },
+            };
+            const channel = {
+                id: 'myid',
+                total_msg_count_root: 1,
+                total_msg_count: 5,
+            };
+            const results = updateMessageCount(state, channel);
+            assert.equal(results.myid.root, 1);
+            assert.equal(results.myid.total, 5);
+        });
+    });
+});

--- a/packages/mattermost-redux/src/reducers/entities/channels/message_counts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/channels/message_counts.ts
@@ -78,7 +78,7 @@ export default function messageCounts(state: RelationOneToOne<Channel, ChannelMe
     }
 }
 
-function updateMessageCount(state: RelationOneToOne<Channel, ChannelMessageCount>, channel: ServerChannel) {
+export function updateMessageCount(state: RelationOneToOne<Channel, ChannelMessageCount>, channel: ServerChannel) {
     const existing = state[channel.id];
     if (
         existing &&
@@ -91,7 +91,7 @@ function updateMessageCount(state: RelationOneToOne<Channel, ChannelMessageCount
     return {
         ...state,
         [channel.id]: {
-            root: channel.total_msg_count,
+            root: channel.total_msg_count_root,
             total: channel.total_msg_count,
         },
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

fixes count of root posts should not be equal to the total posts if there are threads. See [discussion](https://community-daily.mattermost.com/core/pl/ynhi4n6w6pyztec8qrnzjdqpwr)

#### Ticket Link

[MM-38420](https://mattermost.atlassian.net/browse/MM-38420)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
