### PR TITLE
[MM-37694] - fixing getting started colors

### DIFF
--- a/components/sidebar/sidebar_next_steps/sidebar_next_steps.scss
+++ b/components/sidebar/sidebar_next_steps/sidebar_next_steps.scss
@@ -26,7 +26,7 @@
             left: -2px;
             width: 4px;
             height: 100%;
-            background: rgb(var(--sidebar-text-active-border));
+            background: var(--sidebar-text-active-border);
             border-radius: 4px;
             content: '';
         }

--- a/components/sidebar/sidebar_next_steps/sidebar_next_steps.scss
+++ b/components/sidebar/sidebar_next_steps/sidebar_next_steps.scss
@@ -14,11 +14,11 @@
     transition: 0.2s ease-in-out;
 
     &:hover:not(.active) {
-        background-color: rgba(var(--button-color-rgb), 0.08);
+        background-color: var(--sidebar-text-hover-bg);
     }
 
     &.active {
-        background-color: var(--sidebar-text-hover-bg);
+        background-color: rgba(var(--sidebar-text-rgb), 0.08);
 
         &::before {
             position: absolute;
@@ -26,7 +26,7 @@
             left: -2px;
             width: 4px;
             height: 100%;
-            background: var(--sidebar-text-active-border);
+            background: rgb(var(--sidebar-text-active-border));
             border-radius: 4px;
             content: '';
         }

--- a/components/sidebar/sidebar_next_steps/sidebar_next_steps.scss
+++ b/components/sidebar/sidebar_next_steps/sidebar_next_steps.scss
@@ -26,7 +26,7 @@
             left: -2px;
             width: 4px;
             height: 100%;
-            background: var(--sidebar-text-active-border);
+            background: rgb(var(--sidebar-text-active-border-rgb));
             border-radius: 4px;
             content: '';
         }


### PR DESCRIPTION
#### Summary
this fixes the colors for the getting started indicator element in the bottom of the left sidebar.

#### Ticket Link
[MM-37694](https://mattermost.atlassian.net/browse/MM-37694)

#### Screenshots

|  |  before  |  after  |
|-----|-----|-----|
|  hover  |<img width="255" alt="Screenshot 2021-09-08 at 14 34 08" src="https://user-images.githubusercontent.com/32863416/132510010-6ca19cd2-f230-4eb1-a776-8e59fcbf38d0.png">|<img width="255" alt="Screenshot 2021-09-08 at 14 29 29" src="https://user-images.githubusercontent.com/32863416/132509769-60284f07-4a05-4058-af67-4ff363b9fbdc.png">
|  active  |<img width="255" alt="Screenshot 2021-09-08 at 14 34 13" src="https://user-images.githubusercontent.com/32863416/132510045-db3d90f9-7568-482e-b7d2-26e9f6cee42b.png">|<img width="255" alt="Screenshot 2021-09-08 at 14 29 39" src="https://user-images.githubusercontent.com/32863416/132509819-68860db5-726b-44f8-8a9f-1beadc00edcc.png">

#### Release Note
```release-note
NONE
```
