### PR TITLE
extends the `Screenshots` section in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,13 @@ List all PRs related to resolving a ticket. For instance, if you submitted a PR 
 #### Screenshots
 <!--
 If the PR includes UI changes, include screenshots/GIFs.
+
+For an easier comparison of before and after a table (template below) can be used
+
+|  before  |  after  |
+|----|----|
+| <insert before screenshot here> | <insert after screenshot here> |
+
 -->
 
 #### Release Note

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ List all PRs related to resolving a ticket. For instance, if you submitted a PR 
 <!--
 If the PR includes UI changes, include screenshots/GIFs.
 
-For an easier comparison of before and after a table (template below) can be used
+For an easier comparison of UI changes a table (template below) can be used.
 
 |  before  |  after  |
 |----|----|


### PR DESCRIPTION
#### Summary
I am using comparison tables a lot in my PRs and therefore I am constantly typing them out by hand. 
This PR aims to provide a template to copy/paste in the `Screenshots` section of our current PR template for convenience. 

#### Ticket Link
no ticket has been filed for this.

#### Release Note
```release-note
NONE
```
