### PR TITLE
[MM-38280] Fixing doc link for permalinks

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2553,7 +2553,8 @@ const AdminDefinition = {
                         label: t('admin.customization.enablePermalinkPreviewsTitle'),
                         label_default: 'Enable message link previews:',
                         help_text: t('admin.customization.enablePermalinkPreviewsDesc'),
-                        help_text_default: 'When enabled, links to Mattermost messages will generate a preview for any users that have access to the original message. Please review our [documentation](https://docs.mattermost.com/messaging/sharing-messages.html) for details.',
+                        help_text_default: 'When enabled, links to Mattermost messages will generate a preview for any users that have access to the original message. Please review our [documentation](!https://docs.mattermost.com/messaging/sharing-messages.html) for details.',
+                        help_text_markdown: true,
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.POSTS)),
                     },
                     {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -609,7 +609,7 @@
   "admin.customization.enableLatexTitle": "Enable Latex Rendering:",
   "admin.customization.enableLinkPreviewsDesc": "Display a preview of website content, image links and YouTube links below the message when available. The server must be connected to the internet and have access through the firewall (if applicable) to the websites from which previews are expected. Users can disable these previews from Account Settings > Display > Website Link Previews.",
   "admin.customization.enableLinkPreviewsTitle": "Enable website link previews:",
-  "admin.customization.enablePermalinkPreviewsDesc": "When enabled, links to Mattermost messages will generate a preview for any users that have access to the original message. Please review our [documentation](https://docs.mattermost.com/messaging/sharing-messages.html) for details.",
+  "admin.customization.enablePermalinkPreviewsDesc": "When enabled, links to Mattermost messages will generate a preview for any users that have access to the original message. Please review our [documentation](!https://docs.mattermost.com/messaging/sharing-messages.html) for details.",
   "admin.customization.enablePermalinkPreviewsTitle": "Enable message link previews:",
   "admin.customization.enableSVGsDesc": "Enable previews for SVG file attachments and allow them to appear in messages.",
   "admin.customization.enableSVGsTitle": "Enable SVGs:",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -609,7 +609,7 @@
   "admin.customization.enableLatexTitle": "Enable LaTeX Rendering:",
   "admin.customization.enableLinkPreviewsDesc": "Display a preview of website content, image links and YouTube links below the message when available. The server must be connected to the internet and have access through the firewall (if applicable) to the websites from which previews are expected. Users can disable these previews from Account Settings > Display > Website Link Previews.",
   "admin.customization.enableLinkPreviewsTitle": "Enable website link previews:",
-  "admin.customization.enablePermalinkPreviewsDesc": "When enabled, links to Mattermost messages will generate a preview for any users that have access to the original message. Please review our [documentation](https://docs.mattermost.com/messaging/sharing-messages.html) for details.",
+  "admin.customization.enablePermalinkPreviewsDesc": "When enabled, links to Mattermost messages will generate a preview for any users that have access to the original message. Please review our [documentation](!https://docs.mattermost.com/messaging/sharing-messages.html) for details.",
   "admin.customization.enablePermalinkPreviewsTitle": "Enable message link previews:",
   "admin.customization.enableSVGsDesc": "Enable previews for SVG file attachments and allow them to appear in messages.",
   "admin.customization.enableSVGsTitle": "Enable SVGs:",


### PR DESCRIPTION
#### Summary
Fixing link for docs

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38280

#### Screenshots
![Screen Shot 2021-09-08 at 2 26 21 PM](https://user-images.githubusercontent.com/14115924/132564508-92cb5324-e498-41a5-b138-633bb9eab216.png)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
