### PR TITLE
[MM-38427] - Start Trial option showing in Daily

### DIFF
--- a/components/widgets/menu/menu_items/menu_start_trial.test.tsx
+++ b/components/widgets/menu/menu_items/menu_start_trial.test.tsx
@@ -12,19 +12,22 @@ import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 import MenuStartTrial from './menu_start_trial';
 
 describe('components/widgets/menu/menu_items/menu_start_trial', () => {
-    const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
     const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
 
     beforeEach(() => {
-        useSelectorMock.mockClear();
         useDispatchMock.mockClear();
     });
 
     const mockStore = configureStore();
 
-    test('should render when prevTrialLicense is not licensed', () => {
+    test('should render when no trial license has ever been used and there is no license currently loaded', () => {
         const state = {
             entities: {
+                general: {
+                    license: {
+                        IsLicensed: 'false',
+                    },
+                },
                 admin: {
                     prevTrialLicense: {
                         IsLicensed: 'false',
@@ -39,12 +42,39 @@ describe('components/widgets/menu/menu_items/menu_start_trial', () => {
         expect(wrapper.find('button').exists()).toEqual(true);
     });
 
-    test('should render null when prevTrialLicense was licensed', () => {
+    test('should render null when prevTrialLicense was used and there is no license currently loaded', () => {
         const state = {
             entities: {
+                general: {
+                    license: {
+                        IsLicensed: 'false',
+                    },
+                },
                 admin: {
                     prevTrialLicense: {
                         IsLicensed: 'true',
+                    },
+                },
+            },
+        };
+        const store = mockStore(state);
+        const dummyDispatch = jest.fn();
+        useDispatchMock.mockReturnValue(dummyDispatch);
+        const wrapper = mountWithIntl(<reactRedux.Provider store={store}><MenuStartTrial id='startTrial'/></reactRedux.Provider>);
+        expect(wrapper.find('button').exists()).toEqual(false);
+    });
+
+    test('should render null when no trial license has ever been used but there is a license currently loaded', () => {
+        const state = {
+            entities: {
+                general: {
+                    license: {
+                        IsLicensed: 'true',
+                    },
+                },
+                admin: {
+                    prevTrialLicense: {
+                        IsLicensed: 'false',
                     },
                 },
             },

--- a/components/widgets/menu/menu_items/menu_start_trial.tsx
+++ b/components/widgets/menu/menu_items/menu_start_trial.tsx
@@ -39,7 +39,7 @@ const MenuStartTrial = (props: Props): JSX.Element | null => {
     const isCurrentLicensed = currentLicense?.IsLicensed;
 
     // Show this CTA if the instance is currently not licensed and has never had a trial license loaded before
-    const show = (isCurrentLicensed !== undefined && isCurrentLicensed !== 'true') && (isPrevLicensed !== undefined && isPrevLicensed !== 'true');
+    const show = (isCurrentLicensed === 'false') && (isPrevLicensed === 'false');
 
     if (!show) {
         return null;

--- a/components/widgets/menu/menu_items/menu_start_trial.tsx
+++ b/components/widgets/menu/menu_items/menu_start_trial.tsx
@@ -9,6 +9,7 @@ import {ModalIdentifiers} from 'utils/constants';
 import {openModal} from 'actions/views/modals';
 import StartTrialModal from 'components/start_trial_modal';
 import {getPrevTrialLicense} from 'mattermost-redux/actions/admin';
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {GlobalState} from 'mattermost-redux/types/store';
 
 import './menu_item.scss';
@@ -33,8 +34,12 @@ const MenuStartTrial = (props: Props): JSX.Element | null => {
     };
 
     const prevTrialLicense = useSelector((state: GlobalState) => state.entities.admin.prevTrialLicense);
-    const isLicensed = prevTrialLicense?.IsLicensed;
-    const show = isLicensed !== undefined && isLicensed !== 'true';
+    const currentLicense = useSelector(getLicense);
+    const isPrevLicensed = prevTrialLicense?.IsLicensed;
+    const isCurrentLicensed = currentLicense?.IsLicensed;
+
+    // Show this CTA if the instance is currently not licensed and has never had a trial license loaded before
+    const show = (isCurrentLicensed !== undefined && isCurrentLicensed !== 'true') && (isPrevLicensed !== undefined && isPrevLicensed !== 'true');
 
     if (!show) {
         return null;


### PR DESCRIPTION
#### Summary
This PR takes care of an edge case where if the instance has never had a trial license used and currently has a non trial license loaded, the CTA shows up. This PR ensures that the CTA doesn't show in such a scenario.

#### Ticket Link
[MM-38427](https://mattermost.atlassian.net/browse/MM-38427)


#### Release Note
```release-note
NONE

```
