### PR TITLE
match invite members button space with other lhs spacing

### DIFF
--- a/components/sidebar/invite_members_button.tsx
+++ b/components/sidebar/invite_members_button.tsx
@@ -17,7 +17,11 @@ import TeamPermissionGate from 'components/permissions_gates/team_permission_gat
 
 import {ModalIdentifiers} from 'utils/constants';
 
-const InviteMembersButton: React.FC = (): JSX.Element => {
+type Props = {
+    className?: string;
+}
+
+const InviteMembersButton: React.FC<Props> = (props: Props): JSX.Element => {
     const intl = useIntl();
 
     const currentTeamId = useSelector(getCurrentTeamId);
@@ -30,7 +34,7 @@ const InviteMembersButton: React.FC = (): JSX.Element => {
             <ToggleModalButtonRedux
                 accessibilityLabel={intl.formatMessage({id: 'sidebar_left.inviteUsers', defaultMessage: 'Invite Users'})}
                 id='introTextInvite'
-                className='intro-links color--link cursor--pointer'
+                className={`intro-links color--link cursor--pointer${props.className ? ` ${props.className}` : ''}`}
                 modalId={ModalIdentifiers.INVITATION}
                 dialogType={InvitationModal}
             >

--- a/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
+++ b/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
@@ -267,7 +267,9 @@ exports[`components/sidebar/sidebar_category should match snapshot when sorting 
   >
     <Component />
   </Connect(Droppable)>
-  <InviteMembersButton />
+  <InviteMembersButton
+    className="followingSibling"
+  />
 </div>
 `;
 
@@ -338,7 +340,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when sorting 
     </OverlayTrigger>
   </SidebarCategoryHeader>
   <div
-    className="SidebarChannelGroup_content"
+    className="SidebarChannelGroup_content hasFollowingSibling"
   >
     <ul
       className="NavGroupContent"
@@ -377,7 +379,9 @@ exports[`components/sidebar/sidebar_category should match snapshot when the cate
   >
     <Component />
   </Connect(Droppable)>
-  <InviteMembersButton />
+  <InviteMembersButton
+    className="followingSibling"
+  />
 </div>
 `;
 
@@ -448,7 +452,7 @@ exports[`components/sidebar/sidebar_category should match snapshot when the cate
     </OverlayTrigger>
   </SidebarCategoryHeader>
   <div
-    className="SidebarChannelGroup_content"
+    className="SidebarChannelGroup_content hasFollowingSibling"
   >
     <ul
       className="NavGroupContent"

--- a/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -336,7 +336,7 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                 disableInteractiveElementBlocking={true}
             >
                 {(provided, snapshot) => {
-                    const inviteMembersButton = category.type === 'direct_messages' ? <InviteMembersButton/> : null;
+                    const inviteMembersButton = category.type === 'direct_messages' ? <InviteMembersButton className='followingSibling'/> : null;
                     return (
                         <div
                             className={classNames('SidebarChannelGroup a11y__section', {
@@ -377,7 +377,11 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                                                 {directMessagesModalButton}
                                                 {categoryMenu}
                                             </SidebarCategoryHeader>
-                                            <div className='SidebarChannelGroup_content'>
+                                            <div
+                                                className={classNames('SidebarChannelGroup_content', {
+                                                    hasFollowingSibling: category.type === CategoryTypes.DIRECT_MESSAGES,
+                                                })}
+                                            >
                                                 <ul
                                                     role='list'
                                                     className='NavGroupContent'

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -709,6 +709,7 @@
 
     .SidebarChannelNavigator_inviteMembersLhsButton {
         display: flex;
+        padding: 6px 0;
         margin-left: 15px;
         color: rgba(var(--sidebar-text-rgb), 0.72);
         line-height: 20px;
@@ -895,9 +896,20 @@
     //     }
     // }
 
-    .SidebarChannelGroup.capture .SidebarChannelGroup_content {
-        padding-bottom: 14px;
-        margin-bottom: 0;
+    .SidebarChannelGroup.capture {
+        .SidebarChannelGroup_content {
+            padding-bottom: 14px;
+            margin-bottom: 0;
+
+            &.hasFollowingSibling {
+                padding-bottom: 0;
+            }
+        }
+
+        .followingSibling {
+            padding-bottom: 14px;
+            margin-bottom: 0;
+        }
     }
 
     .SidebarChannelGroupHeader_addButton {
@@ -955,9 +967,27 @@
     .SidebarChannelGroup_content {
         min-height: 2px;
         margin-bottom: 14px;
+
+        &.hasFollowingSibling {
+            margin-bottom: 0;
+        }
+    }
+
+    .followingSibling {
+        min-height: 2px;
+        margin-bottom: 14px;
     }
 
     .SidebarChannelGroup.a11y--active .SidebarChannelGroup_content {
+        padding-bottom: 14px;
+        margin-bottom: 0;
+
+        &.hasFollowingSibling {
+            padding-bottom: 0;
+        }
+    }
+
+    .SidebarChannelGroup.a11y--active .followingSibling {
         padding-bottom: 14px;
         margin-bottom: 0;
     }


### PR DESCRIPTION
#### Summary
Fix whitespace of left hand side invite members button to match other left hand side items.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38466

#### Related Pull Requests
none

#### Screenshots

before:
![lhs-button-after](https://user-images.githubusercontent.com/13738432/132876879-b07a9e57-fb83-4fa8-bcac-229d2d95aa0b.png)

after:
![lhs-button-after](https://user-images.githubusercontent.com/13738432/132876901-2dcc2ac2-681b-4549-8eb3-55453d337291.png)


#### Release Note

```release-note
Fix whitespace of left hand side invite members button to match other left hand side items.
```
