### PR TITLE
Fixes overlap of Date separator in RHS

### DIFF
--- a/sass/components/_post-right.scss
+++ b/sass/components/_post-right.scss
@@ -31,6 +31,14 @@
                 }
             }
         }
+
+        .Separator {
+            padding-top: 15px;
+
+            & + .post {
+                padding-top: 20px;
+            }
+        }
     }
 
     .help__format-text {


### PR DESCRIPTION
#### Summary

Fixes date separators paddings in RHS.

#### Ticket Link

https://community-daily.mattermost.com/core/pl/uyxg37po4bypxrmzm5n64ua7ma

#### Screenshots

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/3829551/133066854-c33c38b5-5bbd-41ee-a91c-2604c5782765.png) | ![image](https://user-images.githubusercontent.com/3829551/133066772-e26df3d6-9860-4068-aa30-f85d1eb0f360.png) |

#### Release Note

```release-note
NONE
```
