### PR TITLE
[MM-38216] Add multiteam mentions and saved posts

### DIFF
--- a/actions/views/rhs.ts
+++ b/actions/views/rhs.ts
@@ -142,7 +142,7 @@ export function performSearch(terms: string, isMentionSearch?: boolean) {
         const userTimezone = getUserTimezone(getState(), userId);
         const userCurrentTimezone = getUserCurrentTimezone(userTimezone);
         const timezoneOffset = ((userCurrentTimezone && (userCurrentTimezone.length > 0)) ? getUtcOffsetForTimeZone(userCurrentTimezone) : getBrowserUtcOffset()) * 60;
-        const messagesPromise = dispatch(searchPostsWithParams(teamId, {terms, is_or_search: Boolean(isMentionSearch), include_deleted_channels: viewArchivedChannels, time_zone_offset: timezoneOffset, page: 0, per_page: 20}));
+        const messagesPromise = dispatch(searchPostsWithParams(isMentionSearch ? '' : teamId, {terms, is_or_search: Boolean(isMentionSearch), include_deleted_channels: viewArchivedChannels, time_zone_offset: timezoneOffset, page: 0, per_page: 20}));
         const filesPromise = dispatch(searchFilesWithParams(teamId, {terms: termsWithExtensionsFilters, is_or_search: Boolean(isMentionSearch), include_deleted_channels: viewArchivedChannels, time_zone_offset: timezoneOffset, page: 0, per_page: 20}));
         return Promise.all([filesPromise, messagesPromise]);
     };

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -112,6 +112,13 @@ export default class SearchResultsItem extends React.PureComponent {
          * Is the search results item from the pinned posts list.
          */
         isPinnedPosts: PropTypes.bool,
+
+        channelTeamName: PropTypes.string,
+
+        /**
+         * Is this a post that we can directly reply to?
+         */
+        canReply: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -214,7 +221,7 @@ export default class SearchResultsItem extends React.PureComponent {
     }
 
     render() {
-        const {post, channelIsArchived} = this.props;
+        const {post, channelIsArchived, channelTeamName, canReply} = this.props;
         const channelName = this.getChannelName();
 
         let overrideUsername;
@@ -318,14 +325,16 @@ export default class SearchResultsItem extends React.PureComponent {
                         isReadOnly={channelIsArchived || null}
                     />
                     {flagContent}
-                    <CommentIcon
-                        location={Locations.SEARCH}
-                        handleCommentClick={this.handleFocusRHSClick}
-                        commentCount={this.props.replyCount}
-                        postId={post.id}
-                        searchStyle={'search-item__comment'}
-                        extraClass={this.props.replyCount ? 'icon--visible' : ''}
-                    />
+                    {canReply &&
+                        <CommentIcon
+                            location={Locations.SEARCH}
+                            handleCommentClick={this.handleFocusRHSClick}
+                            commentCount={this.props.replyCount}
+                            postId={post.id}
+                            searchStyle={'search-item__comment'}
+                            extraClass={this.props.replyCount ? 'icon--visible' : ''}
+                        />
+                    }
                     <a
                         href='#'
                         onClick={this.handleJumpClick}
@@ -386,6 +395,11 @@ export default class SearchResultsItem extends React.PureComponent {
                                     id='search_item.channelArchived'
                                     defaultMessage='Archived'
                                 />
+                            </span>
+                        }
+                        {Boolean(channelTeamName) &&
+                            <span className='search-team__name'>
+                                {' | ' + channelTeamName}
                             </span>
                         }
                     </div>

--- a/packages/mattermost-redux/src/actions/search.ts
+++ b/packages/mattermost-redux/src/actions/search.ts
@@ -201,13 +201,12 @@ export function getFlaggedPosts(): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const userId = getCurrentUserId(state);
-        const teamId = getCurrentTeamId(state);
 
         dispatch({type: SearchTypes.SEARCH_FLAGGED_POSTS_REQUEST});
 
         let posts;
         try {
-            posts = await Client4.getFlaggedPosts(userId, '', teamId);
+            posts = await Client4.getFlaggedPosts(userId, '');
 
             await Promise.all([getProfilesAndStatusesForPosts(posts.posts, dispatch, getState) as any, dispatch(getMissingChannelsFromPosts(posts.posts)) as any]);
         } catch (error) {

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -1992,11 +1992,11 @@ export default class Client4 {
         );
     };
 
-    getFlaggedPosts = (userId: string, channelId = '', teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
-        this.trackEvent('api', 'api_posts_get_flagged', {team_id: teamId});
+    getFlaggedPosts = (userId: string, channelId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+        this.trackEvent('api', 'api_posts_get_flagged');
 
         return this.doFetch<PostList>(
-            `${this.getUserRoute(userId)}/posts/flagged${buildQueryString({channel_id: channelId, team_id: teamId, page, per_page: perPage})}`,
+            `${this.getUserRoute(userId)}/posts/flagged${buildQueryString({channel_id: channelId, page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
@@ -2064,8 +2064,13 @@ export default class Client4 {
     searchPostsWithParams = (teamId: string, params: any) => {
         this.trackEvent('api', 'api_posts_search', {team_id: teamId});
 
+        let route = `${this.getPostsRoute()}/search`;
+        if (teamId) {
+            route = `${this.getTeamRoute(teamId)}/posts/search`;
+        }
+
         return this.doFetch<PostSearchResults>(
-            `${this.getTeamRoute(teamId)}/posts/search`,
+            route,
             {method: 'post', body: JSON.stringify(params)},
         );
     };

--- a/sass/components/_search.scss
+++ b/sass/components/_search.scss
@@ -248,6 +248,12 @@
             opacity: 0.5;
         }
 
+        .search-team__name {
+            font-size: 12px;
+            font-weight: 400;
+            opacity: 0.5;
+        }
+
         .post-pre-header__icons-container {
             width: 53px; // If the width of post__img changes, this needs to be adjusted accordingly
             padding-right: 10px; // If the padding of post__img changes, this needs to be adjusted accordingly


### PR DESCRIPTION
#### Summary
Previously, channel mentions and saved posts only showed you the results for the current team. This PR makes it possible to show for several teams.

Saved posts should work fine with any server version.
Multiteam mentions require changes in the server, which are in this PR: https://github.com/mattermost/mattermost-server/pull/18371

This PR would open the path to allow multi-team search. We just need to clarify how do we specify the team or all teams in the search query.

Known issues:
- Long names are not cut. They show in multiple lines. You can see the current behaviour in a screenshot.
- Technically is possible to open a thread from a different team, but I worry about the unexpected implications this may bring. Therefore, I removed the reply button from any post that is not in the current team.
- The component used to render the posts is used in many places (search results, mention results, pinned posts results and saved posts, if I am not mistaken). Therefore, right now any of those will always show the name of the team. This is specially redundant in pinned posts. Depending on the design, it is simple to solve, but I am waiting for a design answer.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38216

(Also related) https://mattermost.atlassian.net/browse/MM-8459

#### Related Pull Requests
Server: https://github.com/mattermost/mattermost-server/pull/18371

#### Screenshots
![Screenshot from 2021-09-13 13-17-08](https://user-images.githubusercontent.com/1933730/133076011-31d0728d-8019-4061-a8e8-a1de2731393f.png)
![Screenshot from 2021-09-13 13-17-21](https://user-images.githubusercontent.com/1933730/133076022-2dc299c3-ff23-4792-ab5b-12ce4ef4da01.png)

With and without reply button
![Screenshot from 2021-09-13 13-31-00](https://user-images.githubusercontent.com/1933730/133076152-e977aaeb-a8e9-4e9e-ada6-2dd463c185fd.png)
![Screenshot from 2021-09-13 13-30-31](https://user-images.githubusercontent.com/1933730/133076169-df2ea8dc-e566-48d7-9445-b45d11a80d03.png)

Long name error
![Screenshot from 2021-09-13 13-21-13](https://user-images.githubusercontent.com/1933730/133076191-e904a976-1b4c-422f-831f-9347c5754a3c.png)



#### Release Note
```release-note
Recent mentions and saved posts now show across all teams.
```
