### PR TITLE
MM-24370 Remove manual focus change from cancel button 

### DIFF
--- a/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
+++ b/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
@@ -256,7 +256,6 @@ exports[`components/NewChannelModal should match snapshot, display only private 
         <button
           className="btn btn-link"
           id="cancelNewChannel"
-          onBlur={[Function]}
           onClick={[MockFunction]}
           type="button"
         >
@@ -538,7 +537,6 @@ exports[`components/NewChannelModal should match snapshot, display only public c
         <button
           className="btn btn-link"
           id="cancelNewChannel"
-          onBlur={[Function]}
           onClick={[MockFunction]}
           type="button"
         >
@@ -860,7 +858,6 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
         <button
           className="btn btn-link"
           id="cancelNewChannel"
-          onBlur={[Function]}
           onClick={[MockFunction]}
           type="button"
         >
@@ -1182,7 +1179,6 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
         <button
           className="btn btn-link"
           id="cancelNewChannel"
-          onBlur={[Function]}
           onClick={[MockFunction]}
           type="button"
         >
@@ -1513,7 +1509,6 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
         <button
           className="btn btn-link"
           id="cancelNewChannel"
-          onBlur={[Function]}
           onClick={[MockFunction]}
           type="button"
         >
@@ -1849,7 +1844,6 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
         <button
           className="btn btn-link"
           id="cancelNewChannel"
-          onBlur={[Function]}
           onClick={[MockFunction]}
           type="button"
         >
@@ -2171,7 +2165,6 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
         <button
           className="btn btn-link"
           id="cancelNewChannel"
-          onBlur={[Function]}
           onClick={[MockFunction]}
           type="button"
         >

--- a/components/new_channel_modal/index.js
+++ b/components/new_channel_modal/index.js
@@ -5,14 +5,12 @@ import {connect} from 'react-redux';
 
 import {Preferences} from 'mattermost-redux/constants';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 import NewChannelModal from './new_channel_modal.jsx';
 
 function mapStateToProps(state) {
     return {
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
-        currentTeamId: getCurrentTeamId(state),
     };
 }
 

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -441,7 +441,6 @@ export default class NewChannelModal extends React.PureComponent {
                                 type='button'
                                 className='btn btn-link'
                                 onClick={this.props.onModalDismissed}
-                                onBlur={() => document.getElementById('newChannelName').focus()}
                             >
                                 <FormattedMessage
                                     id='channel_modal.cancel'

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -23,11 +23,6 @@ export default class NewChannelModal extends React.PureComponent {
         show: PropTypes.bool.isRequired,
 
         /**
-         * Id of the active team
-         */
-        currentTeamId: PropTypes.string.isRequired,
-
-        /**
          * The type of channel to create, 'O' or 'P'
          */
         channelType: PropTypes.string.isRequired,

--- a/components/new_channel_modal/new_channel_modal.test.jsx
+++ b/components/new_channel_modal/new_channel_modal.test.jsx
@@ -19,7 +19,6 @@ describe('components/NewChannelModal', () => {
     const baseProps = {
         show: true,
         channelType: Constants.OPEN_CHANNEL,
-        currentTeamId: 'test_team_id',
         channelData,
         canCreatePublicChannel: true,
         canCreatePrivateChannel: true,


### PR DESCRIPTION
Looking back at the diffs, we might have had some logic in this modal to manually control focus, but it was mostly removed a while back with only this `onBlur` left over. Without it, react-bootstrap's automatic focus trapping seems to work fine to keep the keyboard focus within the modal when tabbing around.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24370

#### Release Note
```release-note
Fixed keyboard focus within New Channel modal
```