### PR TITLE
MM-38140 - show only enterprise for professional upgrade

### DIFF
--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -224,7 +224,13 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
             if (products[key].billing_scheme === BillingSchemes.FLAT_FEE) {
                 flatFeeProducts.push(tempEl);
             } else {
+
+                // only show enterprise to customers upgrading from professional
+                if (currentProduct.sku === 'cloud-professional') {
+                    return;
+                }
                 userBasedProducts.push(tempEl);
+
             }
         });
 
@@ -527,7 +533,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                 </div>
                 <div className='RHS'>
                     <div className='price-container'>
-                        {(this.props.products && Object.keys(this.props.products).length > 1) &&
+                        {(this.props.products && Object.keys(this.props.products).length > 1 && this.state.currentProduct.sku !== 'cloud-professional') &&
                             <div className='select-plan'>
                                 <div className='title'>
                                     <FormattedMessage

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -224,10 +224,6 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
             if (products[key].billing_scheme === BillingSchemes.FLAT_FEE) {
                 flatFeeProducts.push(tempEl);
             } else {
-                // only show enterprise to customers upgrading from professional
-                if (currentProduct.sku === 'cloud-professional') {
-                    return;
-                }
                 userBasedProducts.push(tempEl);
             }
         });
@@ -237,11 +233,11 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
             if (currentProduct.billing_scheme === BillingSchemes.PER_SEAT) {
                 flatFeeProducts = [];
                 userBasedProducts = userBasedProducts.filter((option: RadioGroupOption) => {
-                    return option.price >= currentProduct.price_per_seat;
+                    return option.price > currentProduct.price_per_seat;
                 });
             } else {
                 flatFeeProducts = flatFeeProducts.filter((option: RadioGroupOption) => {
-                    return option.price >= currentProduct.price_per_seat;
+                    return option.price > currentProduct.price_per_seat;
                 });
             }
         }
@@ -255,15 +251,28 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
             />
         );
 
+        if (options.length <= 1) {
+            return null;
+        }
+
         return (
-            <div className='plans-list'>
-                <RadioButtonGroup
-                    id='list-plans-radio-buttons'
-                    values={options!}
-                    value={this.state.selectedProduct?.id as string}
-                    sideLegend={{matchVal: currentProduct.id as string, text: sideLegendTitle}}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => this.onPlanSelected(e)}
-                />
+            <div className='select-plan'>
+                <div className='title'>
+                    <FormattedMessage
+                        id='cloud_subscribe.select_plan'
+                        defaultMessage='Select a plan'
+                    />
+                    {this.comparePlan}
+                </div>
+                <div className='plans-list'>
+                    <RadioButtonGroup
+                        id='list-plans-radio-buttons'
+                        values={options!}
+                        value={this.state.selectedProduct?.id as string}
+                        sideLegend={{matchVal: currentProduct.id as string, text: sideLegendTitle}}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => this.onPlanSelected(e)}
+                    />
+                </div>
             </div>
         );
     }
@@ -531,18 +540,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                 </div>
                 <div className='RHS'>
                     <div className='price-container'>
-                        {(this.props.products && Object.keys(this.props.products).length > 1 && this.state.currentProduct?.sku !== 'cloud-professional') &&
-                            <div className='select-plan'>
-                                <div className='title'>
-                                    <FormattedMessage
-                                        id='cloud_subscribe.select_plan'
-                                        defaultMessage='Select a plan'
-                                    />
-                                    {this.comparePlan}
-                                </div>
-                                {this.listPlans()}
-                            </div>
-                        }
+                        {this.listPlans()}
                         <div className='bold-text'>
                             {this.state.selectedProduct?.name || ''}
                         </div>

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -224,13 +224,11 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
             if (products[key].billing_scheme === BillingSchemes.FLAT_FEE) {
                 flatFeeProducts.push(tempEl);
             } else {
-
                 // only show enterprise to customers upgrading from professional
                 if (currentProduct.sku === 'cloud-professional') {
                     return;
                 }
                 userBasedProducts.push(tempEl);
-
             }
         });
 

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -203,7 +203,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
         this.setState({selectedProduct: selectedPlan});
     }
 
-    listPlans = (): JSX.Element => {
+    listPlans = (): JSX.Element | null => {
         const products = this.props.products!;
         const currentProduct = this.state.currentProduct!;
 

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -531,7 +531,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                 </div>
                 <div className='RHS'>
                     <div className='price-container'>
-                        {(this.props.products && Object.keys(this.props.products).length > 1 && this.state.currentProduct.sku !== 'cloud-professional') &&
+                        {(this.props.products && Object.keys(this.props.products).length > 1 && this.state.currentProduct?.sku !== 'cloud-professional') &&
                             <div className='select-plan'>
                                 <div className='title'>
                                     <FormattedMessage


### PR DESCRIPTION
#### Summary
When a customer is upgrading to Enterprise from professional, we want to only show the Enterprise option.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38140

#### Related Pull Requests
none

#### Screenshots
|  before  |  after  |
|----|----|
| 
<img width="1523" alt="Captura de pantalla 2021-09-14 a las 9 27 30" src="https://user-images.githubusercontent.com/10082627/133215307-5456e839-bd82-48bf-b150-897f5d8321d4.png">
 | 
<img width="1598" alt="Captura de pantalla 2021-09-14 a las 9 27 09" src="https://user-images.githubusercontent.com/10082627/133215369-d4ef542c-694a-47dc-9cdf-35f91b23347a.png">
 |

#### Release Note
```release-note
NONE
```
