### PR TITLE
[MM-38274] Implement registerMessageWillBeUpdatedHook

### DIFF
--- a/actions/hooks.js
+++ b/actions/hooks.js
@@ -62,3 +62,30 @@ export function runSlashCommandWillBePostedHooks(originalMessage, originalArgs) 
         return {data: {message, args}};
     };
 }
+
+export function runMessageWillBeUpdatedHooks(newPost, oldPost) {
+    return async (dispatch, getState) => {
+        const hooks = getState().plugins.components.MessageWillBeUpdated;
+        if (!hooks || hooks.length === 0) {
+            return {data: newPost};
+        }
+
+        let post = newPost;
+
+        for (const hook of hooks) {
+            const result = await hook.hook(post, oldPost); // eslint-disable-line no-await-in-loop
+
+            if (result) {
+                if (result.error) {
+                    return {
+                        error: result.error,
+                    };
+                }
+
+                post = result.post;
+            }
+        }
+
+        return {data: post};
+    };
+}

--- a/actions/hooks.test.js
+++ b/actions/hooks.test.js
@@ -4,7 +4,7 @@
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import {runMessageWillBePostedHooks, runSlashCommandWillBePostedHooks} from './hooks';
+import {runMessageWillBePostedHooks, runMessageWillBeUpdatedHooks, runSlashCommandWillBePostedHooks} from './hooks';
 
 const mockStore = configureStore([thunk]);
 
@@ -334,5 +334,165 @@ describe('runSlashCommandWillBePostedHooks', () => {
         expect(hook1).toHaveBeenCalledWith(message, args);
         expect(hook2).toHaveBeenCalled();
         expect(hook2).toHaveBeenCalledWith(message, args);
+    });
+});
+
+describe('runMessageWillBeUpdatedHooks', () => {
+    test('should do nothing when no hooks are registered', async () => {
+        const store = mockStore({
+            plugins: {
+                components: {},
+            },
+        });
+
+        const oldPost = {message: 'test'};
+        const newPost = {message: 'edited'};
+
+        const result = await store.dispatch(runMessageWillBeUpdatedHooks(newPost, oldPost));
+
+        expect(result).toEqual({data: newPost});
+    });
+
+    test('should pass the post through every hook', async () => {
+        const hook1 = jest.fn((post) => ({post}));
+        const hook2 = jest.fn((post) => ({post}));
+        const hook3 = jest.fn((post) => ({post}));
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBeUpdated: [
+                        {hook: hook1},
+                        {hook: hook2},
+                        {hook: hook3},
+                    ],
+                },
+            },
+        });
+
+        const oldPost = {message: 'test'};
+        const newPost = {message: 'edited'};
+
+        const result = await store.dispatch(runMessageWillBeUpdatedHooks(newPost, oldPost));
+
+        expect(result).toEqual({data: newPost});
+        expect(hook1).toHaveBeenCalledWith(newPost, oldPost);
+        expect(hook2).toHaveBeenCalledWith(newPost, oldPost);
+        expect(hook3).toHaveBeenCalledWith(newPost, oldPost);
+    });
+
+    test('should return an error when a hook rejects the post', async () => {
+        const hook1 = jest.fn((post) => ({post}));
+        const hook2 = jest.fn(() => ({error: {message: 'an error occurred'}}));
+        const hook3 = jest.fn((post) => ({post}));
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBeUpdated: [
+                        {hook: hook1},
+                        {hook: hook2},
+                        {hook: hook3},
+                    ],
+                },
+            },
+        });
+
+        const oldPost = {message: 'test'};
+        const newPost = {message: 'edited'};
+
+        const result = await store.dispatch(runMessageWillBeUpdatedHooks(newPost, oldPost));
+
+        expect(result).toEqual({error: {message: 'an error occurred'}});
+        expect(hook1).toHaveBeenCalledWith(newPost, oldPost);
+        expect(hook2).toHaveBeenCalledWith(newPost, oldPost);
+        expect(hook3).not.toHaveBeenCalled();
+    });
+
+    test('should pass the result of each hook to the next', async () => {
+        const hook1 = jest.fn((post) => ({post: {...post, message: post.message + 'a'}}));
+        const hook2 = jest.fn((post) => ({post: {...post, message: post.message + 'b'}}));
+        const hook3 = jest.fn((post) => ({post: {...post, message: post.message + 'c'}}));
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBeUpdated: [
+                        {hook: hook1},
+                        {hook: hook2},
+                        {hook: hook3},
+                    ],
+                },
+            },
+        });
+
+        const oldPost = {message: 'test'};
+        const newPost = {message: 'edited'};
+
+        const result = await store.dispatch(runMessageWillBeUpdatedHooks(newPost, oldPost));
+
+        expect(result).toEqual({data: {message: 'editedabc'}});
+        expect(hook1).toHaveBeenCalledWith(newPost, oldPost);
+        expect(hook2).toHaveBeenCalled();
+        expect(hook2).not.toHaveBeenCalledWith(newPost, oldPost);
+        expect(hook3).toHaveBeenCalled();
+        expect(hook3).not.toHaveBeenCalledWith(newPost, oldPost);
+    });
+
+    test('should wait for async hooks', async () => {
+        jest.useFakeTimers();
+
+        const hook = jest.fn((post) => {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    resolve({post: {...post, message: post.message + 'async'}});
+                }, 100);
+
+                jest.runOnlyPendingTimers();
+            });
+        });
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBeUpdated: [
+                        {hook},
+                    ],
+                },
+            },
+        });
+
+        const oldPost = {message: 'test'};
+        const newPost = {message: 'edited'};
+
+        const result = await store.dispatch(runMessageWillBeUpdatedHooks(newPost, oldPost));
+
+        expect(result).toEqual({data: {message: 'editedasync'}});
+        expect(hook).toHaveBeenCalledWith(newPost, oldPost);
+    });
+
+    test('should assume post is unchanged if a hook returns undefined', async () => {
+        const hook1 = jest.fn();
+        const hook2 = jest.fn((post) => ({post: {...post, message: post.message + 'b'}}));
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBeUpdated: [
+                        {hook: hook1},
+                        {hook: hook2},
+                    ],
+                },
+            },
+        });
+        const oldPost = {message: 'test'};
+        const newPost = {message: 'edited'};
+
+        const result = await store.dispatch(runMessageWillBeUpdatedHooks(newPost, oldPost));
+
+        expect(result).toEqual({data: {message: 'editedb'}});
+        expect(hook1).toHaveBeenCalledWith(newPost, oldPost);
+        expect(hook2).toHaveBeenCalled();
+        expect(hook2).toHaveBeenCalledWith(newPost, oldPost);
     });
 });

--- a/components/edit_post_modal/edit_post_modal.test.tsx
+++ b/components/edit_post_modal/edit_post_modal.test.tsx
@@ -79,6 +79,7 @@ const defaultProps = {
         hideEditPostModal: jest.fn(),
         openModal: jest.fn(),
         setShowPreview: jest.fn(),
+        runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
     },
 };
 
@@ -97,6 +98,7 @@ function createEditPost(
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         },
     }: Props,
 ) {
@@ -141,7 +143,7 @@ describe('components/EditPostModal', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('should not call openModal on empty edited message but with attachment', () => {
+    it('should not call openModal on empty edited message but with attachment', async () => {
         global.scrollTo = jest.fn();
         const actions = {
             editPost: jest.fn((data) => (Promise.resolve(data))),
@@ -149,6 +151,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         const editingPost = {
             postId: '123',
@@ -164,7 +167,7 @@ describe('components/EditPostModal', () => {
         const wrapper = shallowWithIntl(createEditPost({...defaultProps, actions, editingPost}));
         const instance = wrapper.instance() as EditPostModalClass;
         wrapper.setState({editText: ''});
-        instance.handleEdit();
+        await instance.handleEdit();
 
         expect(actions.openModal).not.toHaveBeenCalled();
         expect(actions.addMessageIntoHistory).toBeCalled();
@@ -179,6 +182,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         const wrapper = shallowWithIntl(createEditPost({...defaultProps, actions}));
 
@@ -186,13 +190,12 @@ describe('components/EditPostModal', () => {
         expect(actions.editPost).not.toBeCalled();
 
         wrapper.setState({editText: 'new message'});
-        wrapper.find('.btn-primary').simulate('click');
+        await wrapper.find('.btn-primary').simulate('click');
 
         await Promise.resolve();
         expect(actions.addMessageIntoHistory).toBeCalledWith('new message');
         expect(actions.editPost).toBeCalledWith({
-            id: defaultProps.editingPost.post.id,
-            channel_id: defaultProps.editingPost.post.channel_id,
+            ...defaultPost,
             message: 'new message',
         });
         expect(actions.hideEditPostModal).toBeCalled();
@@ -223,11 +226,11 @@ describe('components/EditPostModal', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('should set the errorClass to animate when try to edit with an error', () => {
+    it('should set the errorClass to animate when try to edit with an error', async () => {
         const wrapper = shallowWithIntl(createEditPost({...defaultProps}));
         wrapper.setState({postError: 'Test error message'});
         expect((wrapper.state() as EditPostModalState).errorClass).toBe(null);
-        (wrapper.instance() as EditPostModalClass).handleEdit();
+        await (wrapper.instance() as EditPostModalClass).handleEdit();
         expect((wrapper.state() as EditPostModalState).errorClass).toBe('animation--highlight');
         jest.runOnlyPendingTimers();
         expect((wrapper.state() as EditPostModalState).errorClass).toBe(null);
@@ -302,6 +305,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
 
         const wrapper = shallowWithIntl(createEditPost({...defaultProps, actions}));
@@ -313,20 +317,21 @@ describe('components/EditPostModal', () => {
         expect(actions.setShowPreview).toHaveBeenCalledWith(false);
     });
 
-    it('should close without saving when post text is not changed', () => {
+    it('should close without saving when post text is not changed', async () => {
         const actions = {
             editPost: jest.fn((data) => (Promise.resolve(data))),
             addMessageIntoHistory: jest.fn(),
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         const wrapper = shallowWithIntl(createEditPost({...defaultProps, actions}));
         const instance = wrapper.instance() as EditPostModalClass;
 
         expect(actions.hideEditPostModal).not.toBeCalled();
 
-        instance.handleEdit();
+        await instance.handleEdit();
 
         expect(actions.addMessageIntoHistory).not.toBeCalled();
         expect(actions.editPost).not.toBeCalled();
@@ -340,6 +345,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         let wrapper = shallowWithIntl(createEditPost({...defaultProps, actions}));
         let instance = wrapper.instance() as EditPostModalClass;
@@ -347,7 +353,7 @@ describe('components/EditPostModal', () => {
         expect(actions.hideEditPostModal).not.toBeCalled();
 
         wrapper.setState({editText: ''});
-        instance.handleEdit();
+        await instance.handleEdit();
 
         expect(actions.hideEditPostModal).toBeCalled();
         expect(actions.openModal).toHaveBeenCalledWith({
@@ -386,6 +392,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         global.scrollTo = jest.fn();
         const wrapper = shallowWithIntl(createEditPost({...defaultProps, actions}));
@@ -415,6 +422,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         const editingPost = {
             show: false,
@@ -451,6 +459,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         const wrapper = shallowWithIntl(createEditPost({...defaultProps, actions}));
         const instance = wrapper.instance() as EditPostModalClass;
@@ -710,6 +719,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         const wrapper = shallowWithIntl(
             createEditPost({...defaultProps, actions, canEditPost: false}),
@@ -738,6 +748,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
             setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn((newPost: Post) => Promise.resolve({data: newPost})),
         };
         const wrapper = shallowWithIntl(
             createEditPost({...defaultProps, actions, canDeletePost: false}),
@@ -865,5 +876,43 @@ describe('components/EditPostModal', () => {
             onSelect(e);
         }
         expect(setSelectionRangeFn).toHaveBeenCalledWith(8, 13);
+    });
+
+    it('should show error when hooks returns one', async () => {
+        const err = 'an error occurred';
+        const actions = {
+            editPost: jest.fn((data) => (Promise.resolve(data))),
+            addMessageIntoHistory: jest.fn(),
+            hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
+            setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn(() => Promise.resolve({error: err})),
+        };
+        const wrapper = shallowWithIntl(createEditPost({...defaultProps, actions}));
+        const instance = wrapper.instance() as EditPostModalClass;
+
+        await instance.handleEdit();
+
+        expect(actions.runMessageWillBeUpdatedHooks).toBeCalled();
+        expect((wrapper.state() as EditPostModalState).postError).toBe(err);
+    });
+
+    it('should call editPost with data returned by hook', async () => {
+        const newPost = {message: 'edited'};
+        const actions = {
+            editPost: jest.fn((data) => (Promise.resolve(data))),
+            addMessageIntoHistory: jest.fn(),
+            hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
+            setShowPreview: jest.fn(),
+            runMessageWillBeUpdatedHooks: jest.fn(() => Promise.resolve({data: newPost})),
+        };
+        const wrapper = shallowWithIntl(createEditPost({...defaultProps, actions}));
+        const instance = wrapper.instance() as EditPostModalClass;
+
+        await instance.handleEdit();
+
+        expect(actions.runMessageWillBeUpdatedHooks).toBeCalled();
+        expect(actions.editPost).toHaveBeenCalledWith(newPost);
     });
 });

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -19,6 +19,7 @@ import {showPreviewOnEditPostModal} from 'selectors/views/textbox';
 import {hideEditPostModal} from 'actions/post_actions';
 import {editPost} from 'actions/views/posts';
 import {getEditingPost} from 'selectors/posts';
+import {runMessageWillBeUpdatedHooks} from 'actions/hooks';
 import Constants from 'utils/constants';
 
 import EditPostModal from './edit_post_modal';
@@ -64,6 +65,7 @@ function mapDispatchToProps(dispatch) {
             hideEditPostModal,
             openModal,
             setShowPreview: setShowPreviewOnEditPostModal,
+            runMessageWillBeUpdatedHooks,
         }, dispatch),
     };
 }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -739,4 +739,31 @@ export default class PluginRegistry {
 
         return id;
     }
+
+    // Register a hook that will be called when a message is updated by the user before it
+    // is sent to the server. Accepts a function that receives the post as an argument.
+    //
+    // To reject a post, return an object containing an error such as
+    //     {error: {message: 'Rejected'}}
+    // To modify or allow the post without modification, return an object containing the post
+    // such as
+    //     {post: {...}}
+    //
+    // If the hook function is asynchronous, the message will not be sent to the server
+    // until the hook returns.
+    registerMessageWillBeUpdatedHook(hook) {
+        const id = generateId();
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
+            name: 'MessageWillBeUpdated',
+            data: {
+                id,
+                pluginId: this.id,
+                hook,
+            },
+        });
+
+        return id;
+    }
 }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -740,7 +740,7 @@ export default class PluginRegistry {
         return id;
     }
 
-    // Register a hook that will be called when a message is updated by the user before it
+    // Register a hook that will be called when a message is edited by the user before it
     // is sent to the server. Accepts a function that receives the post as an argument.
     //
     // To reject a post, return an object containing an error such as


### PR DESCRIPTION
#### Summary

PR adds a new `registerMessageWillBeUpdatedHook(newPost, oldPost)` to intercept edited messages before sending them to the server.

This was surprisingly missing given we offer similar functionality server-side and it was posing certain limitations: for example, this was brought up by a user that is currently implementing an e2e encryption plugin which needs a way to manipulate messages before they hit the server, whether they are new or updated.

#### Ticket

https://mattermost.atlassian.net/browse/MM-38274

#### Release Note

```release-note
Added new registerMessageWillBeUpdatedHook(newPost, oldPost) client-side plugin hook to intercept edited messages.
```