### PR TITLE
[MM-36551] - improvements to post edit indicator

### DIFF
--- a/components/markdown/__snapshots__/markdown.test.tsx.snap
+++ b/components/markdown/__snapshots__/markdown.test.tsx.snap
@@ -3,6 +3,10 @@
 exports[`components/Markdown should not render markdown when formatting is disabled 1`] = `
 <span>
   This _is_ some **Markdown**
+  <PostEditedIndicator
+    editedAt={0}
+    postId=""
+  />
 </span>
 `;
 

--- a/components/markdown/markdown.tsx
+++ b/components/markdown/markdown.tsx
@@ -10,6 +10,7 @@ import {Dictionary} from 'mattermost-redux/types/utilities';
 import messageHtmlToComponent from 'utils/message_html_to_component';
 import EmojiMap from 'utils/emoji_map';
 import {ChannelNamesMap, TextFormattingOptions, formatText, MentionKey} from 'utils/text_formatting';
+import PostEditedIndicator from '../post_view/post_edited_indicator/post_edited_indicator';
 
 type Props = {
 
@@ -100,6 +101,11 @@ type Props = {
      */
     postId?: string;
 
+    /**
+     * When the post is edited this is the timestamp it happened at
+     */
+    editedAt?: number;
+
     channelId?: string;
 
     /**
@@ -116,11 +122,21 @@ export default class Markdown extends React.PureComponent<Props> {
         proxyImages: true,
         imagesMetadata: {},
         postId: '', // Needed to avoid proptypes console errors for cases like channel header, which doesn't have a proper value
+        editedAt: 0,
     }
 
     render() {
+        const {postId, editedAt, message} = this.props;
         if (!this.props.enableFormatting) {
-            return <span>{this.props.message}</span>;
+            return (
+                <span>
+                    {this.props.message}
+                    <PostEditedIndicator
+                        postId={postId}
+                        editedAt={editedAt}
+                    />
+                </span>
+            );
         }
 
         const options = Object.assign({
@@ -133,9 +149,11 @@ export default class Markdown extends React.PureComponent<Props> {
             team: this.props.team,
             minimumHashtagLength: this.props.minimumHashtagLength,
             managedResourcePaths: this.props.managedResourcePaths,
+            editedAt,
         }, this.props.options);
 
-        const htmlFormattedText = formatText(this.props.message, options, this.props.emojiMap);
+        const htmlFormattedText = formatText(message, options, this.props.emojiMap, postId);
+
         return messageHtmlToComponent(htmlFormattedText, this.props.isRHS, {
             imageProps: this.props.imageProps,
             imagesMetadata: this.props.imagesMetadata,
@@ -145,6 +163,7 @@ export default class Markdown extends React.PureComponent<Props> {
             postType: this.props.postType,
             mentionHighlight: this.props.options.mentionHighlight,
             disableGroupHighlight: this.props.options.disableGroupHighlight,
+            editedAt,
         });
     }
 }

--- a/components/markdown/markdown.tsx
+++ b/components/markdown/markdown.tsx
@@ -150,9 +150,10 @@ export default class Markdown extends React.PureComponent<Props> {
             minimumHashtagLength: this.props.minimumHashtagLength,
             managedResourcePaths: this.props.managedResourcePaths,
             editedAt,
+            postId,
         }, this.props.options);
 
-        const htmlFormattedText = formatText(message, options, this.props.emojiMap, postId);
+        const htmlFormattedText = formatText(message, options, this.props.emojiMap);
 
         return messageHtmlToComponent(htmlFormattedText, this.props.isRHS, {
             imageProps: this.props.imageProps,

--- a/components/post_markdown/__snapshots__/post_markdown.test.tsx.snap
+++ b/components/post_markdown/__snapshots__/post_markdown.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`components/PostMarkdown plugin hooks can build upon other hook message 
       },
     }
   }
+  editedAt={0}
   imageProps={Object {}}
   imagesMetadata={Object {}}
   isRHS={false}
@@ -29,6 +30,7 @@ exports[`components/PostMarkdown plugin hooks can build upon other hook message 
   options={
     Object {
       "disableGroupHighlight": false,
+      "editedAt": null,
       "mentionHighlight": true,
     }
   }
@@ -46,6 +48,7 @@ exports[`components/PostMarkdown plugin hooks can overwrite other hooks messages
       },
     }
   }
+  editedAt={0}
   imageProps={Object {}}
   imagesMetadata={Object {}}
   isRHS={false}
@@ -66,6 +69,7 @@ exports[`components/PostMarkdown plugin hooks can overwrite other hooks messages
   options={
     Object {
       "disableGroupHighlight": false,
+      "editedAt": null,
       "mentionHighlight": true,
     }
   }
@@ -76,6 +80,7 @@ exports[`components/PostMarkdown plugin hooks can overwrite other hooks messages
 
 exports[`components/PostMarkdown should correctly pass postId down 1`] = `
 <Connect(Markdown)
+  editedAt={0}
   imageProps={Object {}}
   imagesMetadata={Object {}}
   isRHS={false}
@@ -96,6 +101,7 @@ exports[`components/PostMarkdown should correctly pass postId down 1`] = `
   options={
     Object {
       "disableGroupHighlight": false,
+      "editedAt": null,
       "mentionHighlight": true,
     }
   }
@@ -168,6 +174,7 @@ exports[`components/PostMarkdown should render properly with a post 1`] = `
       },
     }
   }
+  editedAt={0}
   imageProps={Object {}}
   imagesMetadata={Object {}}
   isRHS={false}
@@ -188,6 +195,7 @@ exports[`components/PostMarkdown should render properly with a post 1`] = `
   options={
     Object {
       "disableGroupHighlight": false,
+      "editedAt": null,
       "mentionHighlight": true,
     }
   }
@@ -198,6 +206,7 @@ exports[`components/PostMarkdown should render properly with a post 1`] = `
 
 exports[`components/PostMarkdown should render properly with an empty post 1`] = `
 <Connect(Markdown)
+  editedAt={0}
   imageProps={Object {}}
   imagesMetadata={Object {}}
   isRHS={false}
@@ -218,6 +227,7 @@ exports[`components/PostMarkdown should render properly with an empty post 1`] =
   options={
     Object {
       "disableGroupHighlight": false,
+      "editedAt": null,
       "mentionHighlight": true,
     }
   }
@@ -228,6 +238,7 @@ exports[`components/PostMarkdown should render properly with an empty post 1`] =
 
 exports[`components/PostMarkdown should render properly without group highlight on a post 1`] = `
 <Connect(Markdown)
+  editedAt={0}
   imageProps={Object {}}
   imagesMetadata={Object {}}
   isRHS={false}
@@ -248,6 +259,7 @@ exports[`components/PostMarkdown should render properly without group highlight 
   options={
     Object {
       "disableGroupHighlight": true,
+      "editedAt": null,
       "mentionHighlight": true,
     }
   }
@@ -258,6 +270,7 @@ exports[`components/PostMarkdown should render properly without group highlight 
 
 exports[`components/PostMarkdown should render properly without highlight a post 1`] = `
 <Connect(Markdown)
+  editedAt={0}
   imageProps={Object {}}
   imagesMetadata={Object {}}
   isRHS={false}
@@ -278,6 +291,7 @@ exports[`components/PostMarkdown should render properly without highlight a post
   options={
     Object {
       "disableGroupHighlight": false,
+      "editedAt": null,
       "mentionHighlight": true,
     }
   }

--- a/components/post_markdown/__snapshots__/post_markdown.test.tsx.snap
+++ b/components/post_markdown/__snapshots__/post_markdown.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`components/PostMarkdown plugin hooks can build upon other hook message 
   options={
     Object {
       "disableGroupHighlight": false,
-      "editedAt": null,
+      "editedAt": 0,
       "mentionHighlight": true,
     }
   }
@@ -69,7 +69,7 @@ exports[`components/PostMarkdown plugin hooks can overwrite other hooks messages
   options={
     Object {
       "disableGroupHighlight": false,
-      "editedAt": null,
+      "editedAt": 0,
       "mentionHighlight": true,
     }
   }
@@ -101,7 +101,7 @@ exports[`components/PostMarkdown should correctly pass postId down 1`] = `
   options={
     Object {
       "disableGroupHighlight": false,
-      "editedAt": null,
+      "editedAt": 0,
       "mentionHighlight": true,
     }
   }
@@ -195,7 +195,7 @@ exports[`components/PostMarkdown should render properly with a post 1`] = `
   options={
     Object {
       "disableGroupHighlight": false,
-      "editedAt": null,
+      "editedAt": 0,
       "mentionHighlight": true,
     }
   }
@@ -227,7 +227,7 @@ exports[`components/PostMarkdown should render properly with an empty post 1`] =
   options={
     Object {
       "disableGroupHighlight": false,
-      "editedAt": null,
+      "editedAt": 0,
       "mentionHighlight": true,
     }
   }
@@ -259,7 +259,7 @@ exports[`components/PostMarkdown should render properly without group highlight 
   options={
     Object {
       "disableGroupHighlight": true,
-      "editedAt": null,
+      "editedAt": 0,
       "mentionHighlight": true,
     }
   }
@@ -291,7 +291,7 @@ exports[`components/PostMarkdown should render properly without highlight a post
   options={
     Object {
       "disableGroupHighlight": false,
-      "editedAt": null,
+      "editedAt": 0,
       "mentionHighlight": true,
     }
   }

--- a/components/post_markdown/post_markdown.tsx
+++ b/components/post_markdown/post_markdown.tsx
@@ -59,7 +59,7 @@ export default class PostMarkdown extends React.PureComponent<Props> {
     };
 
     getOptions = memoize(
-        (disableGroupHighlight: boolean, options?: TextFormattingOptions, mentionHighlight?: boolean, editedAt?: number) => {
+        (options?: TextFormattingOptions, disableGroupHighlight?: boolean, mentionHighlight?: boolean, editedAt?: number) => {
             return {
                 ...options,
                 disableGroupHighlight,
@@ -95,8 +95,8 @@ export default class PostMarkdown extends React.PureComponent<Props> {
         }
 
         const options = this.getOptions(
-            post?.props?.disable_group_highlight === true, // eslint-disable-line camelcase
             this.props.options,
+            post?.props?.disable_group_highlight === true, // eslint-disable-line camelcase
             mentionHighlight,
             post?.edit_at,
         );
@@ -111,9 +111,9 @@ export default class PostMarkdown extends React.PureComponent<Props> {
                 options={options}
                 channelNamesMap={channelNamesMap}
                 hasPluginTooltips={this.props.hasPluginTooltips}
-                imagesMetadata={this.props.post && this.props.post.metadata && this.props.post.metadata.images}
-                postId={this.props.post && this.props.post.id}
-                editedAt={this.props.post && this.props.post.edit_at}
+                imagesMetadata={this.props.post?.metadata?.images}
+                postId={this.props.post?.id}
+                editedAt={this.props.post?.edit_at}
             />
         );
     }

--- a/components/post_markdown/post_markdown.tsx
+++ b/components/post_markdown/post_markdown.tsx
@@ -59,11 +59,12 @@ export default class PostMarkdown extends React.PureComponent<Props> {
     };
 
     getOptions = memoize(
-        (options: TextFormattingOptions | undefined, disableGroupHighlight: boolean, mentionHighlight: boolean | undefined) => {
+        (options: TextFormattingOptions | undefined, disableGroupHighlight: boolean, mentionHighlight: boolean | undefined, editedAt: number | null) => {
             return {
                 ...options,
                 disableGroupHighlight,
                 mentionHighlight,
+                editedAt,
             };
         })
 
@@ -97,6 +98,7 @@ export default class PostMarkdown extends React.PureComponent<Props> {
             this.props.options,
             post?.props?.disable_group_highlight === true, // eslint-disable-line camelcase
             mentionHighlight,
+            post?.edit_at || null,
         );
 
         return (
@@ -111,6 +113,7 @@ export default class PostMarkdown extends React.PureComponent<Props> {
                 hasPluginTooltips={this.props.hasPluginTooltips}
                 imagesMetadata={this.props.post && this.props.post.metadata && this.props.post.metadata.images}
                 postId={this.props.post && this.props.post.id}
+                editedAt={this.props.post && this.props.post.edit_at}
             />
         );
     }

--- a/components/post_markdown/post_markdown.tsx
+++ b/components/post_markdown/post_markdown.tsx
@@ -59,7 +59,7 @@ export default class PostMarkdown extends React.PureComponent<Props> {
     };
 
     getOptions = memoize(
-        (options: TextFormattingOptions | undefined, disableGroupHighlight: boolean, mentionHighlight: boolean | undefined, editedAt: number | null) => {
+        (disableGroupHighlight: boolean, options?: TextFormattingOptions, mentionHighlight?: boolean, editedAt?: number) => {
             return {
                 ...options,
                 disableGroupHighlight,
@@ -95,10 +95,10 @@ export default class PostMarkdown extends React.PureComponent<Props> {
         }
 
         const options = this.getOptions(
-            this.props.options,
             post?.props?.disable_group_highlight === true, // eslint-disable-line camelcase
+            this.props.options,
             mentionHighlight,
-            post?.edit_at || null,
+            post?.edit_at,
         );
 
         return (

--- a/components/post_view/post_edited_indicator/post_edited_indicator.tsx
+++ b/components/post_view/post_edited_indicator/post_edited_indicator.tsx
@@ -10,11 +10,11 @@ import {isSameDay, isWithinLastWeek, isYesterday} from '../../../utils/datetime'
 import OverlayTrigger from '../../overlay_trigger';
 
 interface Props {
-    postId?: string | null;
+    postId?: string;
     editedAt?: number;
 }
 
-const PostEditedIndicator = ({postId = null, editedAt = 0}: Props): JSX.Element | null => {
+const PostEditedIndicator = ({postId, editedAt = 0}: Props): JSX.Element | null => {
     if (!postId || editedAt === 0) {
         return null;
     }

--- a/components/post_view/post_edited_indicator/post_edited_indicator.tsx
+++ b/components/post_view/post_edited_indicator/post_edited_indicator.tsx
@@ -38,7 +38,7 @@ const PostEditedIndicator = ({postId, editedAt = 0}: Props): JSX.Element | null 
         date = formatDate(editedDate, {month: 'long', day: 'numeric'});
     }
 
-    const time = formatTime(editedDate, {hour: '2-digit', minute: '2-digit'});
+    const time = formatTime(editedDate, {hour: 'numeric', minute: '2-digit'});
 
     const editedText = formatMessage({
         id: 'post_message_view.edited',

--- a/components/post_view/post_edited_indicator/post_edited_indicator.tsx
+++ b/components/post_view/post_edited_indicator/post_edited_indicator.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import Icon from '@mattermost/compass-components/foundations/icon/Icon';
+
+interface Props {
+    postId?: string | null;
+    editedAt?: number;
+}
+
+const PostEditedIndicator = ({postId = null, editedAt = 0}: Props): JSX.Element | null => {
+    return postId && editedAt > 0 ? (
+        <span
+            id={`postEdited_${postId}`}
+            className='post-edited__indicator'
+            data-post-id={postId}
+            data-edited-at={editedAt}
+        >
+            <Icon
+                glyph={'pencil-outline'}
+                size={10}
+            />
+            <FormattedMessage
+                id='post_message_view.edited'
+                defaultMessage='Edited'
+            />
+        </span>
+    ) : null;
+};
+
+export default PostEditedIndicator;

--- a/components/post_view/post_edited_indicator/post_edited_indicator.tsx
+++ b/components/post_view/post_edited_indicator/post_edited_indicator.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const PostEditedIndicator = ({postId = null, editedAt = 0}: Props): JSX.Element | null => {
-    return postId && editedAt > 0 ? (
+    return !postId || editedAt === 0 ? null : (
         <span
             id={`postEdited_${postId}`}
             className='post-edited__indicator'
@@ -27,7 +27,7 @@ const PostEditedIndicator = ({postId = null, editedAt = 0}: Props): JSX.Element 
                 defaultMessage='Edited'
             />
         </span>
-    ) : null;
+    );
 };
 
 export default PostEditedIndicator;

--- a/components/post_view/post_edited_indicator/post_edited_indicator.tsx
+++ b/components/post_view/post_edited_indicator/post_edited_indicator.tsx
@@ -2,8 +2,12 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {Tooltip} from 'react-bootstrap';
+import {useIntl} from 'react-intl';
 import Icon from '@mattermost/compass-components/foundations/icon/Icon';
+
+import {isSameDay, isWithinLastWeek, isYesterday} from '../../../utils/datetime';
+import OverlayTrigger from '../../overlay_trigger';
 
 interface Props {
     postId?: string | null;
@@ -11,22 +15,73 @@ interface Props {
 }
 
 const PostEditedIndicator = ({postId = null, editedAt = 0}: Props): JSX.Element | null => {
-    return !postId || editedAt === 0 ? null : (
-        <span
-            id={`postEdited_${postId}`}
-            className='post-edited__indicator'
-            data-post-id={postId}
-            data-edited-at={editedAt}
+    if (!postId || editedAt === 0) {
+        return null;
+    }
+
+    const {formatMessage, formatDate, formatTime} = useIntl();
+    const editedDate = new Date(editedAt);
+
+    let date;
+    switch (true) {
+    case isSameDay(editedDate):
+        date = formatMessage({id: 'datetime.today', defaultMessage: 'today '});
+        break;
+    case isYesterday(editedDate):
+        date = formatMessage({id: 'datetime.yesterday', defaultMessage: 'yesterday '});
+        break;
+    case isWithinLastWeek(editedDate):
+        date = formatDate(editedDate, {weekday: 'long'});
+        break;
+    case !isWithinLastWeek(editedDate):
+    default:
+        date = formatDate(editedDate, {month: 'long', day: 'numeric'});
+    }
+
+    const time = formatTime(editedDate, {hour: '2-digit', minute: '2-digit'});
+
+    const editedText = formatMessage({
+        id: 'post_message_view.edited',
+        defaultMessage: 'Edited',
+    });
+
+    const formattedTime = formatMessage({
+        id: 'timestamp.datetime',
+        defaultMessage: '{relativeOrDate} at {time}',
+    },
+    {
+        relativeOrDate: date,
+        time,
+    });
+
+    const tooltip = (
+        <Tooltip
+            id={`edited-post-tooltip_${postId}`}
+            className='hidden-xs'
         >
-            <Icon
-                glyph={'pencil-outline'}
-                size={10}
-            />
-            <FormattedMessage
-                id='post_message_view.edited'
-                defaultMessage='Edited'
-            />
-        </span>
+            {`${editedText} ${formattedTime}`}
+        </Tooltip>
+    );
+
+    return !postId || editedAt === 0 ? null : (
+        <OverlayTrigger
+            delayShow={250}
+            placement='top'
+            overlay={tooltip}
+        >
+            <span
+                id={`postEdited_${postId}`}
+                className='post-edited__indicator'
+                data-post-id={postId}
+                data-edited-at={editedAt}
+            >
+                <Icon
+                    glyph={'pencil-outline'}
+                    size={10}
+                />
+                {editedText}
+            </span>
+        </OverlayTrigger>
     );
 };
 

--- a/components/post_view/post_message_view/__snapshots__/post_message_view.test.tsx.snap
+++ b/components/post_view/post_message_view/__snapshots__/post_message_view.test.tsx.snap
@@ -171,33 +171,12 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
       }
     />
   </div>
-  <span
-    className="post-edited__indicator"
-    id="postEdited_post_id"
-  >
-    <MemoizedFormattedMessage
-      defaultMessage="(edited)"
-      id="post_message_view.edited"
-    />
-  </span>
   <Connect(Pluggable)
     onHeightChange={[Function]}
     pluggableName="PostMessageAttachment"
     postId="post_id"
   />
 </Connect(ShowMore)>
-`;
-
-exports[`components/post_view/PostAttachment should match snapshot, on edited post 2`] = `
-<span
-  className="post-edited__indicator"
-  id="postEdited_post_id"
->
-  <Memo(MemoizedFormattedMessage)
-    defaultMessage="(edited)"
-    id="post_message_view.edited"
-  />
-</span>
 `;
 
 exports[`components/post_view/PostAttachment should match snapshot, on ephemeral post 1`] = `

--- a/components/post_view/post_message_view/post_message_view.test.tsx
+++ b/components/post_view/post_message_view/post_message_view.test.tsx
@@ -62,10 +62,8 @@ describe('components/post_view/PostAttachment', () => {
     test('should match snapshot, on edited post', () => {
         const props = {...baseProps, post: {...post, edit_at: 1}};
         const wrapper = shallow(<PostMessageView {...props}/>);
-        const instance = wrapper.instance() as PostMessageView;
 
         expect(wrapper).toMatchSnapshot();
-        expect(instance.renderEditedIndicator()).toMatchSnapshot();
     });
 
     test('should match snapshot, on ephemeral post', () => {

--- a/components/post_view/post_message_view/post_message_view.tsx
+++ b/components/post_view/post_message_view/post_message_view.tsx
@@ -9,7 +9,6 @@ import {Post} from 'mattermost-redux/types/posts';
 
 import {Theme} from 'mattermost-redux/types/themes';
 
-import * as PostUtils from 'utils/post_utils';
 import * as Utils from 'utils/utils';
 
 import PostMarkdown from 'components/post_markdown';
@@ -90,24 +89,6 @@ export default class PostMessageView extends React.PureComponent<Props, State> {
         );
     }
 
-    renderEditedIndicator() {
-        if (!PostUtils.isEdited(this.props.post)) {
-            return null;
-        }
-
-        return (
-            <span
-                id={`postEdited_${this.props.post.id}`}
-                className='post-edited__indicator'
-            >
-                <FormattedMessage
-                    id='post_message_view.edited'
-                    defaultMessage='(edited)'
-                />
-            </span>
-        );
-    }
-
     handleFormattedTextClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) =>
         Utils.handleFormattedTextClick(e, this.props.currentRelativeTeamUrl);
 
@@ -180,7 +161,6 @@ export default class PostMessageView extends React.PureComponent<Props, State> {
                         mentionKeys={[]}
                     />
                 </div>
-                {this.renderEditedIndicator()}
                 <Pluggable
                     pluggableName='PostMessageAttachment'
                     postId={post.id}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2888,6 +2888,8 @@
   "date_separator.today": "Today",
   "date_separator.tomorrow": "Tomorrow",
   "date_separator.yesterday": "Yesterday",
+  "datetime.today": "today",
+  "datetime.yesterday": "yesterday",
   "deactivate_member_modal.deactivate": "Deactivate",
   "deactivate_member_modal.desc": "This action deactivates {username}. They will be logged out and not have access to any teams or channels on this system.\n",
   "deactivate_member_modal.desc.confirm": " Are you sure you want to deactivate {username}?",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3890,7 +3890,7 @@
   "post_info.unpin": "Unpin from Channel",
   "post_info.unread": "Mark as Unread",
   "post_message_preview.channel": "Originally posted in ~{channel}",
-  "post_message_view.edited": "(edited)",
+  "post_message_view.edited": "Edited",
   "post_pre_header.flagged": "Saved",
   "post_pre_header.pinned": "Pinned",
   "post.ariaLabel.attachment": ", 1 attachment",

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1059,15 +1059,13 @@
     }
 
     .post-edited__indicator {
+        margin-left: 8px;
+        color: rgba(var(--center-channel-color-rgb), 0.56);
         font-size: 11px;
         -webkit-user-select: none; /* Chrome all / Safari all */
         -moz-user-select: none;    /* Firefox all */
         -ms-user-select: none;     /* IE 10+ */
         user-select: none;
-
-        color: rgba(var(--center-channel-color-rgb), 0.56);
-
-        margin-left: 8px;
 
         // remove when the icon is replaced
         // @see https://mattermost.atlassian.net/browse/MM-38500

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1059,6 +1059,7 @@
     }
 
     .post-edited__indicator {
+        display: inline-block;
         color: rgba(var(--center-channel-color-rgb), 0.56);
         font-size: 11px;
         font-style: italic;

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1067,12 +1067,6 @@
         -ms-user-select: none;     /* IE 10+ */
         user-select: none;
 
-        // remove when the icon is replaced
-        // @see https://mattermost.atlassian.net/browse/MM-38500
-        > i::before {
-            direction: rtl;
-        }
-
         > span {
             font-style: italic;
         }

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1059,16 +1059,16 @@
     }
 
     .post-edited__indicator {
-        margin-left: 8px;
         color: rgba(var(--center-channel-color-rgb), 0.56);
         font-size: 11px;
+        font-style: italic;
         -webkit-user-select: none; /* Chrome all / Safari all */
         -moz-user-select: none;    /* Firefox all */
         -ms-user-select: none;     /* IE 10+ */
         user-select: none;
 
-        > span {
-            font-style: italic;
+        > i {
+            margin-right: 2px;
         }
     }
 

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1059,13 +1059,25 @@
     }
 
     .post-edited__indicator {
-        @include opacity(0.6);
-
-        font-size: 0.87em;
+        font-size: 11px;
         -webkit-user-select: none; /* Chrome all / Safari all */
         -moz-user-select: none;    /* Firefox all */
         -ms-user-select: none;     /* IE 10+ */
         user-select: none;
+
+        color: rgba(var(--center-channel-color-rgb), 0.56);
+
+        margin-left: 8px;
+
+        // remove when the icon is replaced
+        // @see https://mattermost.atlassian.net/browse/MM-38500
+        > i::before {
+            direction: rtl;
+        }
+
+        > span {
+            font-style: italic;
+        }
     }
 
     .emoticon {

--- a/utils/datetime.ts
+++ b/utils/datetime.ts
@@ -24,9 +24,7 @@ export function isWithin(
     truncateEndpoints = shouldTruncate.get(unit) || false,
 ): boolean {
     const diff = getDiff(a, b, timeZone, unit, truncateEndpoints);
-    return threshold >= 0 ?
-        diff <= threshold && diff >= 0 :
-        diff >= threshold && diff <= 0;
+    return threshold >= 0 ? diff <= threshold && diff >= 0 : diff >= threshold && diff <= 0;
 }
 
 export function isEqual(
@@ -55,28 +53,32 @@ export function getDiff(
         momentB.tz(timeZone);
     }
 
-    return truncateEndpoints ?
-        momentA.startOf(unit).diff(momentB.startOf(unit), unit) :
-        momentA.diff(b, unit, true);
+    return truncateEndpoints ? momentA.startOf(unit).diff(momentB.startOf(unit), unit) : momentA.diff(b, unit, true);
 }
 
-export function isSameDay(a: Date, b: Date = new Date()) {
+export function isSameDay(a: Date, b: Date = new Date()): boolean {
     return a.getDate() === b.getDate() && isSameMonth(a, b);
 }
 
-export function isSameMonth(a: Date, b: Date = new Date()) {
+export function isWithinLastWeek(a: Date): boolean {
+    return moment(a).isAfter(
+        moment().subtract(6, 'days').startOf('day'),
+    );
+}
+
+export function isSameMonth(a: Date, b: Date = new Date()): boolean {
     return a.getMonth() === b.getMonth() && isSameYear(a, b);
 }
 
-export function isSameYear(a: Date, b: Date = new Date()) {
+export function isSameYear(a: Date, b: Date = new Date()): boolean {
     return a.getFullYear() === b.getFullYear();
 }
 
-export function isToday(date: Date) {
+export function isToday(date: Date): boolean {
     return isSameDay(date);
 }
 
-export function isYesterday(date: Date) {
+export function isYesterday(date: Date): boolean {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
 

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -52,7 +52,7 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
         },
         {
             replaceChildren: false,
-            shouldProcessNode: (node) => node.type === 'tag' && node.name === 'span' && node.attribs.id && node.attribs.id === `postEdited_${options.postId}`,
+            shouldProcessNode: (node) => node.type === 'tag' && node.name === 'span' && node.attribs['data-edited-post-id'] && node.attribs['data-edited-post-id'] === options.postId,
             processNode: () => (
                 <PostEditedIndicator
                     key={options.postId}

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -9,6 +9,7 @@ import LatexBlock from 'components/latex_block';
 import LinkTooltip from 'components/link_tooltip/link_tooltip';
 import MarkdownImage from 'components/markdown_image';
 import PostEmoji from 'components/post_emoji';
+import PostEditedIndicator from 'components/post_view/post_edited_indicator/post_edited_indicator';
 
 /*
  * Converts HTML to React components using html-to-react.
@@ -49,6 +50,17 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
                 return React.createElement('input', {...node.attribs});
             },
         },
+        {
+            replaceChildren: false,
+            shouldProcessNode: (node) => node.type === 'tag' && node.name === 'span' && node.attribs.id && node.attribs.id === `postEdited_${options.postId}`,
+            processNode: () => (
+                <PostEditedIndicator
+                    key={options.postId}
+                    postId={options.postId}
+                    editedAt={options.editedAt}
+                />
+            ),
+        },
     ];
 
     if (options.hasPluginTooltips) {
@@ -68,6 +80,7 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
             },
         });
     }
+
     if (!('mentions' in options) || options.mentions) {
         const mentionHighlight = 'mentionHighlight' in options ? options.mentionHighlight : true;
         const disableGroupHighlight = 'disableGroupHighlight' in options ? options.disableGroupHighlight === true : false;

--- a/utils/text_formatting.tsx
+++ b/utils/text_formatting.tsx
@@ -198,6 +198,7 @@ export function formatText(
     text: string,
     inputOptions: TextFormattingOptions = DEFAULT_OPTIONS,
     emojiMap: EmojiMap,
+    postId = '',
 ): string {
     if (!text) {
         return '';
@@ -260,6 +261,16 @@ export function formatText(
 
     if (htmlEmojiPattern.test(output.trim())) {
         output = `<span class="all-emoji">${output.trim()}</span>`;
+    }
+
+    if (postId) {
+        // unwrap the output from an enclosing p tag and add a span that will serve as a
+        // palceholder for `messageToHtmlComponent` function later on
+        if (output.startsWith('<p>') && output.endsWith('</p>')) {
+            output = `${output.slice(0, -4)}<span id='postEdited_${postId}'>(edited)</span></p>`;
+        } else {
+            output += `<span id='postEdited_${postId}'>(edited)</span>`;
+        }
     }
 
     return output;

--- a/utils/text_formatting.tsx
+++ b/utils/text_formatting.tsx
@@ -53,108 +53,109 @@ export type Team = {
     name: string;
     displayName: string;
 };
+
 interface TextFormattingOptionsBase {
 
     /**
-   * If specified, this word is highlighted in the resulting html.
-   *
-   * Defaults to nothing.
-   */
+     * If specified, this word is highlighted in the resulting html.
+     *
+     * Defaults to nothing.
+     */
     searchTerm: string;
 
     /**
-   * If specified, an array of words that will be highlighted.
-   *
-   * If both this and `searchTerm` are specified, this takes precedence.
-   *
-   * Defaults to nothing.
-   */
+     * If specified, an array of words that will be highlighted.
+     *
+     * If both this and `searchTerm` are specified, this takes precedence.
+     *
+     * Defaults to nothing.
+     */
     searchMatches: string[];
 
     searchPatterns: SearchPattern[];
 
     /**
-   * Specifies whether or not to highlight mentions of the current user.
-   *
-   * Defaults to `true`.
-   */
+     * Specifies whether or not to highlight mentions of the current user.
+     *
+     * Defaults to `true`.
+     */
     mentionHighlight: boolean;
 
     /**
-   * Specifies whether or not to display group mentions as blue links.
-   *
-   * Defaults to `false`.
-   */
+     * Specifies whether or not to display group mentions as blue links.
+     *
+     * Defaults to `false`.
+     */
     disableGroupHighlight: boolean;
 
     /**
-   * A list of mention keys for the current user to highlight.
-   */
+     * A list of mention keys for the current user to highlight.
+     */
     mentionKeys: MentionKey[];
 
     /**
-   * Specifies whether or not to remove newlines.
-   *
-   * Defaults to `false`.
-   */
+     * Specifies whether or not to remove newlines.
+     *
+     * Defaults to `false`.
+     */
     singleline: boolean;
 
     /**
-   * Enables emoticon parsing with a data-emoticon attribute.
-   *
-   * Defaults to `true`.
-   */
+     * Enables emoticon parsing with a data-emoticon attribute.
+     *
+     * Defaults to `true`.
+     */
     emoticons: boolean;
 
     /**
-   * Enables markdown parsing.
-   *
-   * Defaults to `true`.
-   */
+     * Enables markdown parsing.
+     *
+     * Defaults to `true`.
+     */
     markdown: boolean;
 
     /**
-   * The origin of this Mattermost instance.
-   *
-   * If provided, links to channels and posts will be replaced with internal
-   * links that can be handled by a special click handler.
-   */
+     * The origin of this Mattermost instance.
+     *
+     * If provided, links to channels and posts will be replaced with internal
+     * links that can be handled by a special click handler.
+     */
     siteURL: string;
 
     /**
-   * Whether or not to render at mentions into spans with a data-mention attribute.
-   *
-   * Defaults to `false`.
-   */
+     * Whether or not to render at mentions into spans with a data-mention attribute.
+     *
+     * Defaults to `false`.
+     */
     atMentions: boolean;
 
     /**
-   * An object mapping channel display names to channels.
-   *
-   * If provided, ~channel mentions will be replaced with links to the relevant channel.
-   */
+     * An object mapping channel display names to channels.
+     *
+     * If provided, ~channel mentions will be replaced with links to the relevant channel.
+     */
     channelNamesMap: ChannelNamesMap;
 
     /**
-   * The current team.
-   */
+     * The current team.
+     */
     team: Team;
 
     /**
-   * If specified, images are proxied.
-   *
-   * Defaults to `false`.
-   */
+     * If specified, images are proxied.
+     *
+     * Defaults to `false`.
+     */
     proxyImages: boolean;
 
     /**
-   * An array of url schemes that will be allowed for autolinking.
-   *
-   * Defaults to autolinking with any url scheme.
-   */
+     * An array of url schemes that will be allowed for autolinking.
+     *
+     * Defaults to autolinking with any url scheme.
+     */
     autolinkedUrlSchemes: string[];
 
-    /*
+    /**
      * An array of paths on the server that are managed by another server. Any path provided will be treated as an
      * external link that will not by handled by react-router.
      *
@@ -163,18 +164,24 @@ interface TextFormattingOptionsBase {
     managedResourcePaths: string[];
 
     /**
-   * A custom renderer object to use in the formatWithRenderer function.
-   *
-   * Defaults to empty.
-   */
+     * A custom renderer object to use in the formatWithRenderer function.
+     *
+     * Defaults to empty.
+     */
     renderer: Renderer;
 
     /**
-   * Minimum number of characters in a hashtag.
-   *
-   * Defaults to `3`.
-   */
+     * Minimum number of characters in a hashtag.
+     *
+     * Defaults to `3`.
+     */
     minimumHashtagLength: number;
+
+    /**
+     * the timestamp on which the post was last edited
+     */
+    editedAt: number;
+    postId: string;
 }
 
 export type TextFormattingOptions = Partial<TextFormattingOptionsBase>;
@@ -188,6 +195,8 @@ const DEFAULT_OPTIONS: TextFormattingOptions = {
     atMentions: false,
     minimumHashtagLength: 3,
     proxyImages: false,
+    editedAt: 0,
+    postId: '',
 };
 
 // pattern to detect the existence of a Chinese, Japanese, or Korean character in a string
@@ -198,7 +207,6 @@ export function formatText(
     text: string,
     inputOptions: TextFormattingOptions = DEFAULT_OPTIONS,
     emojiMap: EmojiMap,
-    postId = '',
 ): string {
     if (!text) {
         return '';
@@ -224,29 +232,29 @@ export function formatText(
         output = Markdown.format(output, options, emojiMap);
         if (output.includes('class="markdown-inline-img"')) {
             const replacer = (match: string) => {
-            /*
-            * remove p tag to allow other divs to be nested,
-            * which allows markdown images to open preview window
-            */
+                /*
+                 * remove p tag to allow other divs to be nested,
+                 * which allows markdown images to open preview window
+                 */
                 return match === '<p>' ? '<div class="markdown-inline-img__container">' : '</div>';
             };
 
             /*
-            * Fix for MM-22267 - replace any carriage-return (\r), line-feed (\n) or cr-lf (\r\n) occurences
-            * in enclosing `<p>` tags with `<br/>` breaks to show correct line-breaks in the UI
-            *
-            * the Markdown.format function removes all duplicate line-breaks beforehand, so it is safe to just
-            * replace occurrences which are not followed by opening <p> tags to prevent duplicate line-breaks
-            *
-            * @link to regex101.com: https://regex101.com/r/iPZ02c/1
-            */
+             * Fix for MM-22267 - replace any carriage-return (\r), line-feed (\n) or cr-lf (\r\n) occurences
+             * in enclosing `<p>` tags with `<br/>` breaks to show correct line-breaks in the UI
+             *
+             * the Markdown.format function removes all duplicate line-breaks beforehand, so it is safe to just
+             * replace occurrences which are not followed by opening <p> tags to prevent duplicate line-breaks
+             *
+             * @link to regex101.com: https://regex101.com/r/iPZ02c/1
+             */
             output = output.replace(/[\r\n]+(?!(<p>))/g, '<br/>');
 
             /*
-            * the replacer is not ideal, since it replaces every occurence with a new div
-            * It would be better to more accurately match only the element in question
-            * and replace it with an inlione-version
-            */
+             * the replacer is not ideal, since it replaces every occurence with a new div
+             * It would be better to more accurately match only the element in question
+             * and replace it with an inlione-version
+             */
             output = output.replace(/<p>|<\/p>/g, replacer);
         }
     } else {
@@ -263,13 +271,13 @@ export function formatText(
         output = `<span class="all-emoji">${output.trim()}</span>`;
     }
 
-    if (postId) {
-        // unwrap the output from an enclosing p tag and add a span that will serve as a
+    if (options.postId) {
+        // unwrap the output from the closing p tag and add a span that will serve as a
         // palceholder for `messageToHtmlComponent` function later on
-        if (output.startsWith('<p>') && output.endsWith('</p>')) {
-            output = `${output.slice(0, -4)}<span id='postEdited_${postId}'>(edited)</span></p>`;
+        if (output.endsWith('</p>')) {
+            output = `${output.slice(0, -4)}<span data-edited-post-id='${options.postId}'></span></p>`;
         } else {
-            output += `<span id='postEdited_${postId}'>(edited)</span>`;
+            output += `<span data-edited-post-id='${options.postId}'></span>`;
         }
     }
 

--- a/utils/text_formatting.tsx
+++ b/utils/text_formatting.tsx
@@ -275,9 +275,9 @@ export function formatText(
         // unwrap the output from the closing p tag and add a span that will serve as a
         // palceholder for `messageToHtmlComponent` function later on
         if (output.endsWith('</p>')) {
-            output = `${output.slice(0, -4)}<span data-edited-post-id='${options.postId}'></span></p>`;
+            output = `${output.slice(0, -4)} <span data-edited-post-id='${options.postId}'></span></p>`;
         } else {
-            output += `<span data-edited-post-id='${options.postId}'></span>`;
+            output += ` <span data-edited-post-id='${options.postId}'></span>`;
         }
     }
 


### PR DESCRIPTION
#### Summary
According to the [designs](https://www.figma.com/file/fVLSLjGls2d2LUvCqk2JMS/MM-29137-Message-Editing?node-id=630%3A240624) this PR moves the edit-indicator on posts inline and adds some more functionality in the form of a popover which holds information on when the post was last edited.

For this purpose I had to extend 2 functions that are responsible for rendering: `formatText` and `messageHtmlToComponent`, since the rendering of posts differs quite a bit depending on the content. Those are being called from the `Markdown` component (first `formatText` and afterwards `messageHtmlToComponent`).

**changes to `formatText`:**
I essentially remove a wrapping `<p>` tag if it exists and append an empty `<span>` with an id. The format of the id is `postEdited_${postId}`. This makes the span id unique and can be replaced by the second following function: `messageHtmlToComponent`. In order to do this I added a new optional parameter to the function: `postId` with the default value of `''`.

**changes to `messageHtmlToComponent`:**
The only thing that needed to be added here was a new processing instruction to be handled by the `html-to-react` parser. It processes all `<span>` with a matching Id (the one I set from the `formatText` function and replaces it with a new `PostEditIndicator` component.

The matching condition is:
```typescript
node.type === 'tag' && node.name === 'span' && node.attribs.id && node.attribs.id === `postEdited_${options.postId}`
```

To make this possible I added a new property to the `options` object: `editedAt`, which is being set from the post property `post.edit_at`.

**UI changes**
the edit indicator is now rendered as a combination of a pencil-icon and the text `Edited` according to the designs.

**EDIT:**
addition of an `OverlayTrigger` integrating a more detailed text about the edit date:

|  edited ...  |  today  |  yesterday  |  within last week  |  more than 1 week ago  |
|-----|-----|-----|-----|-----|
|   |<img width="317" alt="Screenshot 2021-09-15 at 17 21 25" src="https://user-images.githubusercontent.com/32863416/133462424-d8ef2e9a-9d66-4667-88e5-68a2e9a2df8c.png">|<img width="317" alt="Screenshot 2021-09-15 at 17 19 02" src="https://user-images.githubusercontent.com/32863416/133462501-174fe746-2713-4b4b-8a61-091fa9dd4089.png">|<img width="317" alt="Screenshot 2021-09-15 at 17 19 48" src="https://user-images.githubusercontent.com/32863416/133462534-507be91f-71dc-472d-b744-f70dcbf199c2.png">|<img width="317" alt="Screenshot 2021-09-15 at 17 20 32" src="https://user-images.githubusercontent.com/32863416/133462563-f9473256-9dd8-4349-937e-b1121503ca50.png">|

#### Ticket Link
[MM-36551](https://mattermost.atlassian.net/browse/MM-36551)

#### Related Pull Requests
- Has mobile changes: TBD

#### Screenshots
|  type  |  before  |  after  |
|----|----|----|
|  normal post  |<img width="995" alt="Screenshot 2021-09-14 at 15 24 30" src="https://user-images.githubusercontent.com/32863416/133265781-92f3d1ae-a15c-4c40-86fb-422fa5650075.png">|<img width="995" alt="Screenshot 2021-09-14 at 15 22 16" src="https://user-images.githubusercontent.com/32863416/133265819-03c9214e-e115-4518-bec6-1d766e7d4f67.png">|
|  markdown table  |<img width="368" alt="Screenshot 2021-09-14 at 15 24 38" src="https://user-images.githubusercontent.com/32863416/133265858-34cbc17b-20e0-46a3-9080-af2ce05a7d05.png">|<img width="373" alt="Screenshot 2021-09-14 at 15 22 32" src="https://user-images.githubusercontent.com/32863416/133265880-ed12326f-c941-4efc-a85a-0c158c8365fc.png">|

#### Release Note
```release-note
Changed the UI of the edit-indicator of posts and moved it inline
```
