### PR TITLE
fix input background

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -400,6 +400,10 @@
 
         &.prewritten {
             background: rgba(var(--button-bg-rgb), 0.08);
+
+            .custom-textarea {
+                background: var(--center-channel-bg);
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix compose message textbox background to match center channel background color when the around_input treatment is given, instead of taking on the highlight color.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38361

#### Related Pull Requests
None

#### Screenshots
before:
![before](https://user-images.githubusercontent.com/13738432/133654508-53a2364c-e116-4e2d-bab9-b43469014b8f.png)

after:
![after](https://user-images.githubusercontent.com/13738432/133654522-54d9e608-055f-42d7-9ab5-dbbb55e637b3.png)


#### Release Note

```release-note
NONE
```
