### PR TITLE
MM-38260: Enabled the team list and team details system console pages in team edition build.

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -510,7 +510,6 @@ const AdminDefinition = {
             title: t('admin.sidebar.teams'),
             title_default: 'Teams',
             isHidden: it.any(
-                it.not(it.licensedForFeature('LDAPGroups')),
                 it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.TEAMS)),
             ),
             schema: {

--- a/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
+++ b/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
@@ -545,6 +545,20 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
               }
             />
             <AdminSidebarSection
+              definitionKey="user_management.teams"
+              key="user_management.teams"
+              name="user_management/teams"
+              parentLink=""
+              subsection={false}
+              tag=""
+              title={
+                <Memo(MemoizedFormattedMessage)
+                  defaultMessage="Teams"
+                  id="admin.sidebar.teams"
+                />
+              }
+            />
+            <AdminSidebarSection
               definitionKey="user_management.permissions"
               key="user_management.permissions"
               name="user_management/permissions/"

--- a/components/admin_console/team_channel_settings/team/details/__snapshots__/team_details.test.jsx.snap
+++ b/components/admin_console/team_channel_settings/team/details/__snapshots__/team_details.test.jsx.snap
@@ -77,33 +77,6 @@ exports[`admin_console/team_channel_settings/team/TeamDetails should match snaps
         onToggle={[Function]}
         syncChecked={false}
       />
-      <TeamGroups
-        groups={
-          Array [
-            Object {
-              "display_name": "DN",
-              "id": "123",
-              "member_count": 3,
-            },
-          ]
-        }
-        onAddCallback={[Function]}
-        onGroupRemoved={[Function]}
-        removedGroups={Array []}
-        setNewGroupRole={[Function]}
-        syncChecked={false}
-        team={
-          Object {
-            "allow_open_invite": false,
-            "allowed_domains": "",
-            "delete_at": 0,
-            "display_name": "team",
-            "group_constrained": false,
-            "id": "123",
-          }
-        }
-        totalGroups={1}
-      />
       <Connect(TeamMembers)
         onAddCallback={[Function]}
         onRemoveCallback={[Function]}

--- a/components/admin_console/team_channel_settings/team/details/__snapshots__/team_modes.test.jsx.snap
+++ b/components/admin_console/team_channel_settings/team/details/__snapshots__/team_modes.test.jsx.snap
@@ -15,13 +15,6 @@ exports[`admin_console/team_channel_settings/team/TeamModes should match snapsho
     <div
       className="group-teams-and-channels--body"
     >
-      <SyncGroupsToggle
-        allAllowedChecked={false}
-        allowedDomains=""
-        allowedDomainsChecked={true}
-        onToggle={[MockFunction]}
-        syncChecked={false}
-      />
       <AllowAllToggle
         allAllowedChecked={false}
         allowedDomains=""

--- a/components/admin_console/team_channel_settings/team/details/index.js
+++ b/components/admin_console/team_channel_settings/team/details/index.js
@@ -27,12 +27,14 @@ function mapStateToProps(state, props) {
     const groups = getGroupsAssociatedToTeam(state, teamID);
     const allGroups = getAllGroups(state, teamID);
     const totalGroups = groups.length;
+    const isLicensedForLDAPGroups = state.entities.general.license.LDAPGroups === 'true';
     return {
         team,
         groups,
         totalGroups,
         allGroups,
         teamID,
+        isLicensedForLDAPGroups,
     };
 }
 

--- a/components/admin_console/team_channel_settings/team/details/team_details.jsx
+++ b/components/admin_console/team_channel_settings/team/details/team_details.jsx
@@ -33,6 +33,7 @@ export default class TeamDetails extends React.PureComponent {
         groups: PropTypes.arrayOf(PropTypes.object),
         allGroups: PropTypes.object.isRequired,
         isDisabled: PropTypes.bool,
+        isLicensedForLDAPGroups: PropTypes.bool,
         actions: PropTypes.shape({
             setNavigationBlocked: PropTypes.func.isRequired,
             getTeam: PropTypes.func.isRequired,
@@ -414,7 +415,7 @@ export default class TeamDetails extends React.PureComponent {
     };
 
     render = () => {
-        const {team} = this.props;
+        const {team, isLicensedForLDAPGroups} = this.props;
         const {totalGroups, saving, saveNeeded, serverError, groups, allAllowedChecked, allowedDomainsChecked, allowedDomains, syncChecked, showRemoveConfirmation, usersToRemoveCount, isLocalArchived, showArchiveConfirmModal} = this.state;
         const missingGroup = (og) => !groups.find((g) => g.id === og.id);
         const removedGroups = this.props.groups.filter(missingGroup);
@@ -435,19 +436,22 @@ export default class TeamDetails extends React.PureComponent {
                     syncChecked={syncChecked}
                     onToggle={this.setToggles}
                     isDisabled={this.props.isDisabled}
+                    isLicensedForLDAPGroups={isLicensedForLDAPGroups}
                 />
 
-                <TeamGroups
-                    syncChecked={syncChecked}
-                    team={team}
-                    groups={groups}
-                    removedGroups={removedGroups}
-                    totalGroups={totalGroups}
-                    onAddCallback={this.handleGroupChange}
-                    onGroupRemoved={this.handleGroupRemoved}
-                    setNewGroupRole={this.setNewGroupRole}
-                    isDisabled={this.props.isDisabled}
-                />
+                {isLicensedForLDAPGroups &&
+                    <TeamGroups
+                        syncChecked={syncChecked}
+                        team={team}
+                        groups={groups}
+                        removedGroups={removedGroups}
+                        totalGroups={totalGroups}
+                        onAddCallback={this.handleGroupChange}
+                        onGroupRemoved={this.handleGroupRemoved}
+                        setNewGroupRole={this.setNewGroupRole}
+                        isDisabled={this.props.isDisabled}
+                    />
+                }
 
                 {!syncChecked &&
                     <TeamMembers

--- a/components/admin_console/team_channel_settings/team/details/team_modes.jsx
+++ b/components/admin_console/team_channel_settings/team/details/team_modes.jsx
@@ -118,7 +118,7 @@ AllowedDomainsToggle.propTypes = {
     isDisabled: PropTypes.bool,
 };
 
-export const TeamModes = ({allAllowedChecked, syncChecked, allowedDomains, allowedDomainsChecked, onToggle, isDisabled}) => (
+export const TeamModes = ({allAllowedChecked, syncChecked, allowedDomains, allowedDomainsChecked, onToggle, isDisabled, isLicensedForLDAPGroups}) => (
     <AdminPanel
         id='team_manage'
         titleId={t('admin.team_settings.team_detail.manageTitle')}
@@ -128,14 +128,16 @@ export const TeamModes = ({allAllowedChecked, syncChecked, allowedDomains, allow
     >
         <div className='group-teams-and-channels'>
             <div className='group-teams-and-channels--body'>
-                <SyncGroupsToggle
-                    allAllowedChecked={allAllowedChecked}
-                    allowedDomainsChecked={allowedDomainsChecked}
-                    allowedDomains={allowedDomains}
-                    syncChecked={syncChecked}
-                    onToggle={onToggle}
-                    isDisabled={isDisabled}
-                />
+                {isLicensedForLDAPGroups &&
+                    <SyncGroupsToggle
+                        allAllowedChecked={allAllowedChecked}
+                        allowedDomainsChecked={allowedDomainsChecked}
+                        allowedDomains={allowedDomains}
+                        syncChecked={syncChecked}
+                        onToggle={onToggle}
+                        isDisabled={isDisabled}
+                    />
+                }
                 <AllowAllToggle
                     allAllowedChecked={allAllowedChecked}
                     allowedDomainsChecked={allowedDomainsChecked}
@@ -163,4 +165,5 @@ TeamModes.propTypes = {
     onToggle: PropTypes.func.isRequired,
     allowedDomains: PropTypes.string.isRequired,
     isDisabled: PropTypes.bool,
+    isLicensedForLDAPGroups: PropTypes.bool,
 };

--- a/components/admin_console/team_channel_settings/team/list/__snapshots__/team_list.test.tsx.snap
+++ b/components/admin_console/team_channel_settings/team/list/__snapshots__/team_list.test.tsx.snap
@@ -44,7 +44,6 @@ exports[`admin_console/team_channel_settings/team/TeamList should match snapshot
             "keys": Array [
               "allow_open_invite",
               "invite_only",
-              "group_constrained",
             ],
             "name": <Memo(MemoizedFormattedMessage)
               defaultMessage="Management"
@@ -55,13 +54,6 @@ exports[`admin_console/team_channel_settings/team/TeamList should match snapshot
                 "name": <Memo(MemoizedFormattedMessage)
                   defaultMessage="Anyone Can Join"
                   id="admin.team_settings.team_row.managementMethod.anyoneCanJoin"
-                />,
-                "value": false,
-              },
-              "group_constrained": Object {
-                "name": <Memo(MemoizedFormattedMessage)
-                  defaultMessage="Group Sync"
-                  id="admin.team_settings.team_row.managementMethod.groupSync"
                 />,
                 "value": false,
               },
@@ -200,7 +192,6 @@ exports[`admin_console/team_channel_settings/team/TeamList should match snapshot
             "keys": Array [
               "allow_open_invite",
               "invite_only",
-              "group_constrained",
             ],
             "name": <Memo(MemoizedFormattedMessage)
               defaultMessage="Management"
@@ -211,13 +202,6 @@ exports[`admin_console/team_channel_settings/team/TeamList should match snapshot
                 "name": <Memo(MemoizedFormattedMessage)
                   defaultMessage="Anyone Can Join"
                   id="admin.team_settings.team_row.managementMethod.anyoneCanJoin"
-                />,
-                "value": false,
-              },
-              "group_constrained": Object {
-                "name": <Memo(MemoizedFormattedMessage)
-                  defaultMessage="Group Sync"
-                  id="admin.team_settings.team_row.managementMethod.groupSync"
                 />,
                 "value": false,
               },

--- a/components/admin_console/team_channel_settings/team/list/index.ts
+++ b/components/admin_console/team_channel_settings/team/list/index.ts
@@ -31,6 +31,7 @@ function mapStateToProps(state: GlobalState) {
     return {
         data: getSortedListOfTeams(state),
         total: state.entities.teams.totalCount || 0,
+        isLicensedForLDAPGroups: state.entities.general.license.LDAPGroups === 'true',
     };
 }
 

--- a/components/admin_console/team_channel_settings/team/list/team_list.tsx
+++ b/components/admin_console/team_channel_settings/team/list/team_list.tsx
@@ -29,6 +29,7 @@ type Props = {
         searchTeams(term: string, opts: TeamSearchOpts): Promise<{data: TeamsWithCount}>;
         getData(page: number, size: number): void;
     };
+    isLicensedForLDAPGroups?: boolean;
 }
 
 type State = {
@@ -117,13 +118,19 @@ export default class TeamList extends React.PureComponent<Props, State> {
     onFilter = ({management}: FilterOptions) => {
         const filters: TeamSearchOpts = {};
 
+        let groupConstrained;
+
         const {
-            group_constrained: {value: groupConstrained},
             allow_open_invite: {value: allowOpenInvite},
             invite_only: {value: inviteOnly},
         } = management.values;
 
-        const filtersList = [allowOpenInvite, inviteOnly, groupConstrained];
+        const filtersList = [allowOpenInvite, inviteOnly];
+
+        if (this.props.isLicensedForLDAPGroups) {
+            groupConstrained = management.values.group_constrained.value;
+            filtersList.push(groupConstrained);
+        }
 
         // If all filters or no filters do nothing
         if (filtersList.includes(false) && filtersList.includes(true)) {
@@ -278,6 +285,7 @@ export default class TeamList extends React.PureComponent<Props, State> {
         const rows = this.getRows();
         const columns = this.getColumns();
         const {startCount, endCount, total} = this.getPaginationProps();
+        const {isLicensedForLDAPGroups} = this.props;
 
         let placeholderEmpty = (
             <FormattedMessage
@@ -295,7 +303,28 @@ export default class TeamList extends React.PureComponent<Props, State> {
             );
         }
 
-        const filterOptions = {
+        type Value = {
+            name: JSX.Element;
+            value: boolean;
+        };
+
+        type Management = {
+            name: JSX.Element;
+            values: Values;
+            keys: string[];
+        };
+
+        type FilterOptions = {
+            management: Management;
+        };
+
+        type Values = {
+            allow_open_invite: Value;
+            invite_only: Value;
+            group_constrained?: Value;
+        };
+
+        const filterOptions: FilterOptions = {
             management: {
                 name: (
                     <FormattedMessage
@@ -322,19 +351,23 @@ export default class TeamList extends React.PureComponent<Props, State> {
                         ),
                         value: false,
                     },
-                    group_constrained: {
-                        name: (
-                            <FormattedMessage
-                                id='admin.team_settings.team_row.managementMethod.groupSync'
-                                defaultMessage='Group Sync'
-                            />
-                        ),
-                        value: false,
-                    },
                 },
-                keys: ['allow_open_invite', 'invite_only', 'group_constrained'],
+                keys: ['allow_open_invite', 'invite_only'],
             },
         };
+
+        if (isLicensedForLDAPGroups) {
+            filterOptions.management.values.group_constrained = {
+                name: (
+                    <FormattedMessage
+                        id='admin.team_settings.team_row.managementMethod.groupSync'
+                        defaultMessage='Group Sync'
+                    />
+                ),
+                value: false,
+            };
+            filterOptions.management.keys.push('group_constrained');
+        }
 
         const filterProps = {
             options: filterOptions,

--- a/components/post_view/post_message_preview/__snapshots__/post_message_preview.test.tsx.snap
+++ b/components/post_view/post_message_preview/__snapshots__/post_message_preview.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`PostMessagePreview should not render bot icon 1`] = `
       </div>
     </div>
     <Connect(PostMessageView)
-      maxHeight={100}
+      maxHeight={105}
       overflowType="ellipsis"
       post={
         Object {
@@ -149,7 +149,7 @@ exports[`PostMessagePreview should render bot icon 1`] = `
       </div>
     </div>
     <Connect(PostMessageView)
-      maxHeight={100}
+      maxHeight={105}
       overflowType="ellipsis"
       post={
         Object {


### PR DESCRIPTION
#### Summary

Enabled the team list and team details system console pages in team edition build.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38260

#### Screenshots

<img width="1208" alt="Screen Shot 2021-09-16 at 4 13 19 PM" src="https://user-images.githubusercontent.com/1149597/133679570-36d43423-b481-4f47-afc7-fbcad7948efe.png">
<img width="1208" alt="Screen Shot 2021-09-16 at 4 13 30 PM" src="https://user-images.githubusercontent.com/1149597/133679575-46203fc1-181a-4818-9758-ec5befc00154.png">
<img width="1207" alt="Screen Shot 2021-09-16 at 4 13 40 PM" src="https://user-images.githubusercontent.com/1149597/133679576-4c8aab10-f51b-4587-8455-691027151d6b.png">

#### Release Note

```release-note
Enabled the team list and team details system console pages in team edition build.
```
