### PR TITLE
[MM-38630] Don't error if there is no pathName defined on the message

### DIFF
--- a/utils/browser_history.jsx
+++ b/utils/browser_history.jsx
@@ -16,8 +16,10 @@ window.addEventListener('message', ({origin, data: {type, message = {}} = {}} = 
 
     switch (type) {
     case 'browser-history-push-return': {
-        const {pathName} = message;
-        b.push(pathName);
+        if (message.pathName) {
+            const {pathName} = message;
+            b.push(pathName);
+        }
         break;
     }
     }


### PR DESCRIPTION
#### Summary
desktop is sending an event back to the webapp and sometimes is not defined properly, while it gets fixed this should prevent errors from happening.

#### Ticket Link

[MM-38630](https://mattermost.atlassian.net/browse/MM-38630), [community report](https://community-daily.mattermost.com/core/pl/z6g57troxbyitgsdee5jsoster)

#### Related Pull Requests

https://github.com/mattermost/mattermost-webapp/pull/8522

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
