### PR TITLE
MM-38579: fix town-square being always read-only

### DIFF
--- a/components/create_comment/index.ts
+++ b/components/create_comment/index.ts
@@ -80,7 +80,7 @@ function makeMapStateToProps() {
             codeBlockOnCtrlEnter: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'code_block_ctrl_enter', true),
             ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
             createPostErrorId: err.server_error_id,
-            readOnlyChannel: !isCurrentUserSystemAdmin(state) && channel.name === Constants.DEFAULT_CHANNEL,
+            readOnlyChannel: false,
             enableConfirmNotificationsToChannel,
             enableEmojiPicker,
             enableGifPicker,

--- a/components/create_post/index.ts
+++ b/components/create_post/index.ts
@@ -112,7 +112,7 @@ function makeMapStateToProps() {
             latestReplyablePostId,
             locale: getCurrentLocale(state),
             currentUsersLatestPost: getCurrentUsersLatestPost(state, ''),
-            readOnlyChannel: ownProps.readOnlyChannel || (!isCurrentUserSystemAdmin(state) && currentChannel.name === Constants.DEFAULT_CHANNEL),
+            readOnlyChannel: ownProps.readOnlyChannel,
             canUploadFiles: canUploadFiles(config),
             enableEmojiPicker,
             enableGifPicker,


### PR DESCRIPTION
#### Summary
A recent change to remove the experimental town square feature make town square permanently read-only for non system admins. (We don't notice on community since we were used to this setting being enabled).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38579?filter=15018

#### Release Note
```release-note
NONE
```
