### PR TITLE
[MM-38468] - Webapp/System Console: Check if help text about customized Support Email is still accurate with the removal of tutorial screen

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1942,7 +1942,7 @@ const AdminDefinition = {
                         label: t('admin.support.emailTitle'),
                         label_default: 'Support Email:',
                         help_text: t('admin.support.emailHelp'),
-                        help_text_default: 'Email address displayed on email notifications and during tutorial for end users to ask support questions.',
+                        help_text_default: 'Email address displayed on email notifications.',
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.CUSTOMIZATION)),
                     },
                     {

--- a/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
+++ b/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
@@ -142,7 +142,7 @@ describe('Customization', () => {
         cy.findByTestId('SupportSettings.SupportEmailinput').should('have.value', origConfig.SupportSettings.SupportEmail);
 
         // * Verify that the help text is visible and matches text content
-        cy.findByTestId('SupportSettings.SupportEmailhelp-text').find('span').should('be.visible').and('have.text', 'Email address displayed on email notifications and during tutorial for end users to ask support questions.');
+        cy.findByTestId('SupportSettings.SupportEmailhelp-text').find('span').should('be.visible').and('have.text', 'Email address displayed on email notifications.');
 
         const newEmail = 'support@example.com';
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2105,7 +2105,7 @@
   "admin.sql.traceTitle": "SQL Statement Logging: ",
   "admin.support.aboutDesc": "The URL for the About link on the Mattermost login and sign-up pages. If this field is empty, the About link is hidden from users.",
   "admin.support.aboutTitle": "About Link:",
-  "admin.support.emailHelp": "Email address displayed on email notifications and during tutorial for end users to ask support questions.",
+  "admin.support.emailHelp": "Email address displayed on email notifications.",
   "admin.support.emailTitle": "Support Email:",
   "admin.support.enableAskCommunityDesc": "When true, \"Ask the community\" link appears on the Mattermost user interface and Main Menu, which allows users to join the Mattermost Community to ask questions and help others troubleshoot issues. When false, the link is hidden from users.",
   "admin.support.enableAskCommunityTitle": "Enable Ask Community Link:",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -2105,7 +2105,7 @@
   "admin.sql.traceTitle": "SQL Statement Logging: ",
   "admin.support.aboutDesc": "The URL for the About link on the Mattermost login and sign-up pages. If this field is empty, the About link is hidden from users.",
   "admin.support.aboutTitle": "About Link:",
-  "admin.support.emailHelp": "Email address displayed on email notifications.",
+  "admin.support.emailHelp": "Email address displayed on email notifications and during tutorial for end users to ask support questions.",
   "admin.support.emailTitle": "Support Email:",
   "admin.support.enableAskCommunityDesc": "When true, 'Ask the community' link appears on the Mattermost user interface and Main Menu, which allows users to join the Mattermost Community to ask questions and help others troubleshoot issues. When false, the link is hidden from users.",
   "admin.support.enableAskCommunityTitle": "Enable Ask Community Link:",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -2105,7 +2105,7 @@
   "admin.sql.traceTitle": "SQL Statement Logging: ",
   "admin.support.aboutDesc": "The URL for the About link on the Mattermost login and sign-up pages. If this field is empty, the About link is hidden from users.",
   "admin.support.aboutTitle": "About Link:",
-  "admin.support.emailHelp": "Email address displayed on email notifications and during tutorial for end users to ask support questions.",
+  "admin.support.emailHelp": "Email address displayed on email notifications.",
   "admin.support.emailTitle": "Support Email:",
   "admin.support.enableAskCommunityDesc": "When true, 'Ask the community' link appears on the Mattermost user interface and Main Menu, which allows users to join the Mattermost Community to ask questions and help others troubleshoot issues. When false, the link is hidden from users.",
   "admin.support.enableAskCommunityTitle": "Enable Ask Community Link:",


### PR DESCRIPTION
#### Summary
This PR updates text on the support email description in the console

#### Ticket Link
[MM-38468](https://mattermost.atlassian.net/browse/MM-38468)

```release-note
NONE

```
