### PR TITLE
Improve memoization of makeCombineUserActivityPosts

### DIFF
--- a/packages/mattermost-redux/src/utils/post_list.test.js
+++ b/packages/mattermost-redux/src/utils/post_list.test.js
@@ -766,7 +766,7 @@ describe('makeCombineUserActivityPosts', () => {
             expect(combineUserActivityPosts.recomputations()).toBe(1);
         });
 
-        test('should recalculate if any post changes, but should return the same results if possible', () => {
+        test('should not recalculate if an unrelated post changes', () => {
             const combineUserActivityPosts = makeCombineUserActivityPosts();
 
             let state = initialState;
@@ -788,10 +788,20 @@ describe('makeCombineUserActivityPosts', () => {
                     },
                 },
             };
-            let result = combineUserActivityPosts(state, initialPostIds);
+            const result = combineUserActivityPosts(state, initialPostIds);
 
-            expect(combineUserActivityPosts.recomputations()).toBe(2);
+            // The selector didn't recalculate so the result didn't change
+            expect(combineUserActivityPosts.recomputations()).toBe(1);
             expect(result).toBe(initialResult);
+        });
+
+        test('should return the same result when a post changes in a way that doesn\'t affect the result', () => {
+            const combineUserActivityPosts = makeCombineUserActivityPosts();
+
+            let state = initialState;
+            const initialResult = combineUserActivityPosts(state, initialPostIds);
+
+            expect(combineUserActivityPosts.recomputations()).toBe(1);
 
             // One of the posts was updated, but post type didn't change
             state = {
@@ -807,9 +817,10 @@ describe('makeCombineUserActivityPosts', () => {
                     },
                 },
             };
-            result = combineUserActivityPosts(state, initialPostIds);
+            let result = combineUserActivityPosts(state, initialPostIds);
 
-            expect(combineUserActivityPosts.recomputations()).toBe(3);
+            // The selector recalculated but is still returning the same array
+            expect(combineUserActivityPosts.recomputations()).toBe(2);
             expect(result).toBe(initialResult);
 
             // One of the posts changed type
@@ -828,7 +839,8 @@ describe('makeCombineUserActivityPosts', () => {
             };
             result = combineUserActivityPosts(state, initialPostIds);
 
-            expect(combineUserActivityPosts.recomputations()).toBe(4);
+            // The selector recalculated, and the result changed
+            expect(combineUserActivityPosts.recomputations()).toBe(3);
             expect(result).not.toBe(initialResult);
         });
     });

--- a/packages/mattermost-redux/src/utils/post_list.ts
+++ b/packages/mattermost-redux/src/utils/post_list.ts
@@ -127,10 +127,12 @@ export function makeFilterPostsAndAddSeparators() {
 }
 
 export function makeCombineUserActivityPosts() {
+    const getPostsForIds = makeGetPostsForIds();
+
     return createIdsSelector(
         'makeCombineUserActivityPosts',
         (state: GlobalState, postIds: string[]) => postIds,
-        (state) => state.entities.posts.posts,
+        (state: GlobalState, postIds: string[]) => getPostsForIds(state, postIds),
         (postIds, posts) => {
             let lastPostIsUserActivity = false;
             let combinedCount = 0;
@@ -150,7 +152,7 @@ export function makeCombineUserActivityPosts() {
                     continue;
                 }
 
-                const post = posts[postId];
+                const post = posts[i];
                 const postIsUserActivity = isUserActivityPost(post.type);
 
                 if (postIsUserActivity && lastPostIsUserActivity && combinedCount < MAX_COMBINED_SYSTEM_POSTS) {


### PR DESCRIPTION
A small performance improvement I came across while working on https://mattermost.atlassian.net/browse/MM-28338. `makeGetPostsForIds` has some extra memoization that lets us work with a subset of posts a bit easier.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28338

#### Release Note
```release-note
Slightly improved performance around rendering of system messages
```
