### PR TITLE
Mm 38326 getting started position

### DIFF
--- a/components/global/global_header.scss
+++ b/components/global/global_header.scss
@@ -79,10 +79,6 @@
             z-index: 20;
             top: 0;
 
-            body.announcement-bar--fixed & {
-                height: 100%;
-            }
-
             .sidebar-right-container {
                 height: 100%;
             }

--- a/components/global/global_header.scss
+++ b/components/global/global_header.scss
@@ -38,15 +38,18 @@
 
             // adjust height of team sidebar
             height: calc(100% - 40px);
+
             body.announcement-bar--fixed & {
                 height: calc(100% - 80px);
             }
+
             border-right: solid 1px rgba(var(--center-channel-color-rgb), 0.08);
         }
 
         // adjust height of sidebar to account for GH
         #SidebarContainer {
             height: calc(100% - 40px);
+
             body.announcement-bar--fixed & {
                 height: calc(100% - 80px);
             }
@@ -75,6 +78,7 @@
         #sidebar-right {
             z-index: 20;
             top: 0;
+
             body.announcement-bar--fixed & {
                 height: 100%;
             }

--- a/components/global/global_header.scss
+++ b/components/global/global_header.scss
@@ -38,12 +38,18 @@
 
             // adjust height of team sidebar
             height: calc(100% - 40px);
+            body.announcement-bar--fixed & {
+                height: calc(100% - 80px);
+            }
             border-right: solid 1px rgba(var(--center-channel-color-rgb), 0.08);
         }
 
         // adjust height of sidebar to account for GH
         #SidebarContainer {
             height: calc(100% - 40px);
+            body.announcement-bar--fixed & {
+                height: calc(100% - 80px);
+            }
         }
 
         #lhsNavigator {
@@ -69,6 +75,9 @@
         #sidebar-right {
             z-index: 20;
             top: 0;
+            body.announcement-bar--fixed & {
+                height: 100%;
+            }
 
             .sidebar-right-container {
                 height: 100%;


### PR DESCRIPTION
#### Summary
Fix some lhs sidebar & team sidebar height issues when both the global header and the announcement bar are enabled. In the CWS linked spinwick, users should see the announcement bar from the free trial, enabling testing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38326

#### Related Pull Requests

#### Screenshots
before:
![after](https://user-images.githubusercontent.com/13738432/134078406-a2307b6f-ba30-4d2e-9865-11e4b2175121.png)


after:
![before](https://user-images.githubusercontent.com/13738432/134078393-d74febdc-939c-4430-bdb7-795f9d997ae8.png)


#### Release Note
```release-note
NONE
```
