### PR TITLE
This allows the emoji picker to be shown outside the context of a team

### DIFF
--- a/components/emoji_picker/components/emoji_picker_preview.jsx
+++ b/components/emoji_picker/components/emoji_picker_preview.jsx
@@ -22,6 +22,9 @@ export default class EmojiPickerPreview extends React.PureComponent {
         if (!this.props.customEmojisEnabled) {
             return null;
         }
+        if (!this.props.currentTeamName) {
+            return null;
+        }
         return (
             <AnyTeamPermissionGate permissions={[Permissions.CREATE_EMOJIS]}>
                 <div className='emoji-picker__custom'>

--- a/components/emoji_picker/index.js
+++ b/components/emoji_picker/index.js
@@ -20,7 +20,7 @@ function mapStateToProps(state) {
         emojiMap: getEmojiMap(state),
         recentEmojis: getRecentEmojis(state),
         userSkinTone: getUserSkinTone(state),
-        currentTeamName: currentTeam.name,
+        currentTeamName: currentTeam ? currentTeam.name : '',
     };
 }
 


### PR DESCRIPTION
#### Summary
This allows the emoji picker to be shown outside the context of a team. This is needed for example to show the emoji picker when you are in boards, where the team is not part of the context (for now).

#### Ticket Link
mattermost/focalboard#1286

#### Release Note
```release-note
NONE
```