### PR TITLE
always show playbooks card

### DIFF
--- a/components/next_steps_view/__snapshots__/next_steps_view.test.tsx.snap
+++ b/components/next_steps_view/__snapshots__/next_steps_view.test.tsx.snap
@@ -106,7 +106,6 @@ exports[`components/next_steps_view should match snapshot 1`] = `
     animating={false}
     currentUserId="user_id"
     globalHeaderEnabled={true}
-    isCloud={false}
     isFirstAdmin={true}
     savePreferences={[MockFunction]}
     setShowNextStepsView={[MockFunction]}

--- a/components/next_steps_view/next_steps_tips.tsx
+++ b/components/next_steps_view/next_steps_tips.tsx
@@ -141,7 +141,7 @@ export default function NextStepsTips(props: Props) {
                         </h4>
                         <FormattedMessage
                             id='next_steps_view.tips.resolveIncidents.text'
-                            defaultMessage='Resolve incidents faster with Mattermost Incident Collaboration.'
+                            defaultMessage='Resolve incidents faster with Mattermost Playbooks.'
                         />
                         <button
                             className='NextStepsView__button NextStepsView__finishButton primary'

--- a/components/next_steps_view/next_steps_tips.tsx
+++ b/components/next_steps_view/next_steps_tips.tsx
@@ -50,7 +50,6 @@ type Props = {
     currentUserId: string;
     isFirstAdmin: boolean;
     team: Team;
-    isCloud: boolean;
     globalHeaderEnabled: boolean;
     stopAnimating: () => void;
     savePreferences: (userId: string, preferences: PreferenceType[]) => void;
@@ -129,34 +128,32 @@ export default function NextStepsTips(props: Props) {
                         </button>
                     </div>
                 </Card>
-                {props.isCloud && (
-                    <Card expanded={true}>
-                        <div className='Card__body'>
-                            <div className='Card__image'>
-                                <IncidentsSvg/>
-                            </div>
-                            <h4>
-                                <FormattedMessage
-                                    id='next_steps_view.tips.resolveIncidents'
-                                    defaultMessage='Resolve incidents faster'
-                                />
-                            </h4>
-                            <FormattedMessage
-                                id='next_steps_view.tips.resolveIncidents.text'
-                                defaultMessage='Resolve incidents faster with Mattermost Incident Collaboration.'
-                            />
-                            <button
-                                className='NextStepsView__button NextStepsView__finishButton primary'
-                                onClick={() => openIncidentsPlugin(props.isFirstAdmin, props.team)}
-                            >
-                                <FormattedMessage
-                                    id='next_steps_view.tips.resolveIncidents.button'
-                                    defaultMessage='Open playbooks'
-                                />
-                            </button>
+                <Card expanded={true}>
+                    <div className='Card__body'>
+                        <div className='Card__image'>
+                            <IncidentsSvg/>
                         </div>
-                    </Card>
-                )}
+                        <h4>
+                            <FormattedMessage
+                                id='next_steps_view.tips.resolveIncidents'
+                                defaultMessage='Resolve incidents faster'
+                            />
+                        </h4>
+                        <FormattedMessage
+                            id='next_steps_view.tips.resolveIncidents.text'
+                            defaultMessage='Resolve incidents faster with Mattermost Incident Collaboration.'
+                        />
+                        <button
+                            className='NextStepsView__button NextStepsView__finishButton primary'
+                            onClick={() => openIncidentsPlugin(props.isFirstAdmin, props.team)}
+                        >
+                            <FormattedMessage
+                                id='next_steps_view.tips.resolveIncidents.button'
+                                defaultMessage='Open playbooks'
+                            />
+                        </button>
+                    </div>
+                </Card>
             </>
         );
     } else if (!Utils.isMobile() && !props.isFirstAdmin) {

--- a/components/next_steps_view/next_steps_view.tsx
+++ b/components/next_steps_view/next_steps_view.tsx
@@ -349,7 +349,6 @@ export default class NextStepsView extends React.PureComponent<Props, State> {
                         currentUserId={this.props.currentUser.id}
                         setShowNextStepsView={this.props.actions.setShowNextStepsView}
                         team={this.props.team}
-                        isCloud={this.props.isCloud}
                         globalHeaderEnabled={this.props.globalHeaderEnabled}
                     />
                 </>}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3800,7 +3800,7 @@
   "next_steps_view.tips.manageWorkspace.text": "Visit the system console to manage users, teams, and plugins",
   "next_steps_view.tips.resolveIncidents": "Resolve incidents faster",
   "next_steps_view.tips.resolveIncidents.button": "Open playbooks",
-  "next_steps_view.tips.resolveIncidents.text": "Resolve incidents faster with Mattermost Incident Collaboration.",
+  "next_steps_view.tips.resolveIncidents.text": "Resolve incidents faster with Mattermost Playbooks.",
   "next_steps_view.tips.viewMembers": "View team members",
   "next_steps_view.tipsAndNextSteps": "Tips & Next Steps",
   "next_steps_view.titles.completeProfile": "Complete your profile",


### PR DESCRIPTION
#### Summary
Always display playbooks card.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38064

#### Screenshots
before:
<img width="1007" alt="Screen Shot 2021-08-20 at 4 26 46 PM" src="https://user-images.githubusercontent.com/13738432/134200511-1c7a748c-3024-449d-b52d-e9713b656a4e.png">


after:
![after](https://user-images.githubusercontent.com/13738432/134200399-5fdab69a-ee2c-4189-aabc-7320cd04ca9b.png)


#### Release Note

```release-note
Always show Tips & Next Steps Playabooks card.
```
