### PR TITLE
[MM-37746] Allow copying of emoji names & aliases

### DIFF
--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -598,6 +598,8 @@
 
     .emoji-picker__preview-image-label-box {
         .emoji-picker__preview-name {
+            @include user-select(text);
+
             display: inline-block;
             overflow: hidden;
             max-width: 120px;


### PR DESCRIPTION
#### Summary
Emoji names and aliases aren't currently selectable, so not easily copied. Even if occluded, triple-click, etc, can select the entire line.

#### Ticket Link
Helps mitigate [Mattermost Server issue #18430](https://github.com/mattermost/mattermost-server/issues/18430)/[JIRA MM-37746](https://mattermost.atlassian.net/browse/MM-37746).

#### Screenshots
|  before  |  after  |
|---|---|
| ![image](https://user-images.githubusercontent.com/28617290/134265666-e5d92d76-2792-4fe6-95aa-fcdca1abcd97.png) | ![image](https://user-images.githubusercontent.com/28617290/134265747-6064e700-02d9-44ac-bb4a-69fe2ba87fe7.png) |

#### Release Note
```release-note
Allow selection of names & aliases in the emoji picker.
```
