### PR TITLE
[MM-38578] - fix for rhs bottom spacing issue

### DIFF
--- a/sass/components/_post-right.scss
+++ b/sass/components/_post-right.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "utf-8";
 
 .post-right__container,
 .ThreadViewer {
@@ -205,10 +205,10 @@
 }
 
 .post-right__container {
-    height: 100%;
+    flex: 1;
 
     .ThreadViewer {
-        height: 100%;
+        flex: 1;
     }
 }
 


### PR DESCRIPTION
#### Summary
this PR fixes a spacing issue that occured in community daily (in the desktopapp) when opening a thread-view in the RHS.
The "Add comment" button was hidden in the overflow.

#### Ticket Link
[MM-38578](https://mattermost.atlassian.net/browse/MM-38578)

#### Release Note
```release-note
NONE
```
