### PR TITLE
[MM 38105] Bug fix: apply theme in root component instead of needs team component

### DIFF
--- a/components/needs_team/index.ts
+++ b/components/needs_team/index.ts
@@ -8,7 +8,7 @@ import {withRouter} from 'react-router-dom';
 import {fetchMyChannelsAndMembers, viewChannel} from 'mattermost-redux/actions/channels';
 import {getMyTeamUnreads, getTeamByName, selectTeam} from 'mattermost-redux/actions/teams';
 import {getGroups, getAllGroupsAssociatedToChannelsInTeam, getAllGroupsAssociatedToTeam, getGroupsByUserId} from 'mattermost-redux/actions/groups';
-import {getTheme, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
@@ -42,7 +42,6 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     return {
         license,
         collapsedThreads: isCollapsedThreadsEnabled(state),
-        theme: getTheme(state),
         mfaRequired: checkIfMFARequired(currentUser, license, config, ownProps.match.url),
         currentUser,
         currentTeamId: getCurrentTeamId(state),

--- a/components/needs_team/needs_team.test.tsx
+++ b/components/needs_team/needs_team.test.tsx
@@ -27,9 +27,7 @@ jest.mock('actions/post_actions.jsx', () => ({
 }));
 
 jest.mock('utils/utils', () => ({
-    applyTheme: jest.fn(),
     localizeMessage: jest.fn(),
-    areObjectsEqual: jest.fn(),
     isGuest: jest.fn(),
     makeIsEligibleForClick: jest.fn(),
 }));
@@ -103,7 +101,6 @@ describe('components/needs_team', () => {
         currentUser: {
             id: 'test',
         },
-        theme: {},
         mfaRequired: false,
         match,
         teamsList,

--- a/components/needs_team/needs_team.tsx
+++ b/components/needs_team/needs_team.tsx
@@ -73,7 +73,6 @@ type Props = {
         push(path: string): void;
     };
     teamsList: Team[];
-    theme: any;
     collapsedThreads: ReturnType<typeof isCollapsedThreadsEnabled>;
     plugins?: any;
     selectedThreadId: string | null;

--- a/components/needs_team/needs_team.tsx
+++ b/components/needs_team/needs_team.tsx
@@ -154,10 +154,6 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props) {
-        const {theme} = this.props;
-        if (!Utils.areObjectsEqual(prevProps.theme, theme)) {
-            Utils.applyTheme(theme);
-        }
         if (this.props.match.params.team !== prevProps.match.params.team) {
             if (this.state.team) {
                 this.initTeam(this.state.team);

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -230,6 +230,9 @@ export default class Root extends React.PureComponent {
     }
 
     componentDidUpdate(prevProps) {
+        if (!Utils.areObjectsEqual(prevProps.theme, this.props.theme)) {
+            Utils.applyTheme(this.props.theme);
+        }
         if (this.props.location.pathname === '/') {
             if (this.props.noAccounts) {
                 prevProps.history.push('/signup_user_complete');

--- a/components/root/root.test.jsx
+++ b/components/root/root.test.jsx
@@ -36,6 +36,7 @@ jest.mock('utils/utils', () => ({
     enableDevModeFeatures: jest.fn(),
     applyTheme: jest.fn(),
     makeIsEligibleForClick: jest.fn(),
+    areObjectsEqual: jest.fn(),
 }));
 
 jest.mock('mattermost-redux/actions/general', () => ({
@@ -48,6 +49,7 @@ describe('components/Root', () => {
         telemetryId: '1234ab',
         noAccounts: false,
         showTermsOfService: false,
+        theme: {},
         actions: {
             loadMeAndConfig: async () => [{}, {}, {data: true}], // eslint-disable-line no-empty-function
         },


### PR DESCRIPTION
#### Summary
When using a single theme for all teams that isn't the default team (Denim), logging out and in again incorrectly applies the default theme (Denim) until the browser is refreshed, at which point the correct theme is applied. This does not happen when using per-team themes.

For some reason, the `NeedsTeam` component that handles applying the users selected theme when it changes, is not updated following initialization to trigger applying the users theme when sharing a single theme across all teams but it is updated if using per-team themes. In both cases, the users selected theme is correctly passed as a prop to the `NeedsTeam` component.

I spent a fair amount of time trying to track down why this is happening, but didn't get very far so left the exploration to another day. Since we now use the theme in the `Root` component, I elected to move the logic that applies the theme when its prop value changes to the `Root` component, which is always updating when the theme changes regardless of theme type. The Root component is already responsible for applying the default theme when not logged in or when user preferences are loaded when logged in after refreshing, so I didn't see this approach as being a problem.

NOTE: This was not a recent regression and was also happening before the recent system theme updates for v6.0. I did not spend more time trying to determine how far back this bug goes though, so I'm not even sure if it is a regression or not.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38105

#### Release Note
```release-note
NONE
```
