### PR TITLE
MM-38311 - invite people button to bottom of menu

### DIFF
--- a/components/sidebar/add_channel_dropdown.tsx
+++ b/components/sidebar/add_channel_dropdown.tsx
@@ -62,7 +62,7 @@ class AddChannelDropdown extends React.PureComponent<Props, State> {
         const {intl, canCreateChannel, canJoinPublicChannel} = this.props;
 
         const invitePeople = (
-            <>
+            <Menu.Group>
                 <Menu.ItemAction
                     id='invitePeople'
                     onClick={this.props.invitePeopleModal}
@@ -70,8 +70,7 @@ class AddChannelDropdown extends React.PureComponent<Props, State> {
                     text={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.invitePeople', defaultMessage: 'Invite People'})}
                     extraText={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.invitePeopleExtraText', defaultMessage: 'Add people to the team'})}
                 />
-                <li className='MenuGroup menu-divider'/>
-            </>
+            </Menu.Group>
         );
 
         let joinPublicChannel;
@@ -123,12 +122,12 @@ class AddChannelDropdown extends React.PureComponent<Props, State> {
         return (
             <>
                 <Menu.Group>
-                    {invitePeople}
                     {joinPublicChannel}
                     {createChannel}
                     {createDirectMessage}
                 </Menu.Group>
                 {createCategory}
+                {invitePeople}
             </>
         );
     }


### PR DESCRIPTION
#### Summary
this PR adds the necessary changes to move the invite users button to the bottom of the menu of the plus menu button channels.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38311

#### Related Pull Requests

#### Screenshots
Before:

<img width="474" alt="Captura de pantalla 2021-09-22 a las 19 07 49" src="https://user-images.githubusercontent.com/10082627/134389573-cfb0cf41-6a1a-4310-99bf-1a98463900ca.png">

After:
<img width="840" alt="Captura de pantalla 2021-09-22 a las 19 04 33" src="https://user-images.githubusercontent.com/10082627/134389614-4b362ea6-deae-4ead-a3aa-5685118a0eb7.png">


#### Release Note

```release-note
NONE
```
