### PR TITLE
MM-38678 - fix theme colour bug

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -260,7 +260,6 @@
             white-space: nowrap;
 
             .name {
-                color: $white;
                 font-weight: 600;
             }
 


### PR DESCRIPTION
#### Summary
This PR fixes a bug where a css selector with higher specificity was directly applying white to the channel name in the notification preferences modal for that channel. The overriding colour has been removed to allow the channel name to inherit the themed colour from it's parent.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38678

#### Screenshots
|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/3245614/134390491-246a3753-4166-4c83-b11e-fdab682a07f2.png) | ![image](https://user-images.githubusercontent.com/3245614/134390364-acbdb567-4cfe-428b-ab72-448f6ea4879e.png) |

#### Release Note
```release-note
NONE
```
