### PR TITLE
Bug fix: Product Switcher button icon size increase

### DIFF
--- a/components/global/product_switcher.tsx
+++ b/components/global/product_switcher.tsx
@@ -33,6 +33,23 @@ const ProductSwitcherContainer = styled.nav`
     }
 `;
 
+const ProductSwitcherButton = styled(IconButton).attrs(() => ({
+    icon: 'products',
+    size: 'sm',
+
+    // we currently need this, since not passing a onClick handler is disabling the IconButton
+    // this is a known issue and is being tracked by UI platform team
+    // TODO@UI: remove the onClick, when it is not a mandatory prop anymore
+    onClick: () => {},
+    inverted: true,
+    compact: true,
+}))`
+    > i::before {
+        font-size: 20px;
+        letter-spacing: 20px;
+    }
+`;
+
 const MenuItem = styled(Link)`
     && {
         text-decoration: none;
@@ -125,17 +142,8 @@ const ProductSwitcher = (): JSX.Element => {
                 open={switcherOpen}
             >
                 <ProductSwitcherContainer onClick={handleClick}>
-                    <IconButton
-                        icon={'products'}
-                        size={'sm'}
-
-                        // we currently need this, since not passing a onClick handler is disabling the IconButton
-                        // this is a known issue and is being tracked by UI platform team
-                        // TODO@UI: remove the onClick, when it is not a mandatory prop anymore
-                        onClick={() => {}}
-                        compact={true}
+                    <ProductSwitcherButton
                         active={switcherOpen}
-                        inverted={true}
                         aria-label='Select to open product switch menu.'
                     />
                     <ProductSwitcherTip/>


### PR DESCRIPTION
#### Summary
Given the prominence of the product switcher button and challenges with rendering the 9 square grid icon at such a small size, we are increasing the icon size for this single use case. This corrects a rendering challenge of the icon on non-retina screens and especially on Linux.

See conversation here for context and details: https://community-daily.mattermost.com/core/pl/yk3u6xqoqbddjnz79qjieqcwfw

#### Screenshots
|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/3245614/134529333-cef42c9a-28ee-4ed9-aaf3-e4e813ae285a.png) ![image](https://user-images.githubusercontent.com/3245614/134530124-e77b4b59-2b37-4948-92fd-a43c8872f3be.png)| ![image](https://user-images.githubusercontent.com/3245614/134529398-fbb3f800-4dba-440b-918b-7f4eecc960ed.png) ![image](https://user-images.githubusercontent.com/3245614/134530693-d58d171f-4440-466f-a454-e32173a763fb.png) |

#### Release Note
```release-note
NONE
```
