### PR TITLE
Highlight invite_members_button until user interacts with it

### DIFF
--- a/components/sidebar/__snapshots__/invite_members_button.test.tsx.snap
+++ b/components/sidebar/__snapshots__/invite_members_button.test.tsx.snap
@@ -13,7 +13,10 @@ exports[`components/sidebar/invite_members_button should match snapshot 1`] = `
     }
   }
 >
-  <InviteMembersButton>
+  <InviteMembersButton
+    onClick={[MockFunction]}
+    touchedInviteMembersButton={false}
+  >
     <Connect(TeamPermissionGate)
       permissions={
         Array [
@@ -49,6 +52,7 @@ exports[`components/sidebar/invite_members_button should match snapshot 1`] = `
           }
           id="introTextInvite"
           modalId="invitation"
+          onClick={[MockFunction]}
         >
           <injectIntl(ModalToggleButtonRedux)
             accessibilityLabel="Invite Users"
@@ -69,6 +73,7 @@ exports[`components/sidebar/invite_members_button should match snapshot 1`] = `
             }
             id="introTextInvite"
             modalId="invitation"
+            onClick={[MockFunction]}
           >
             <ModalToggleButtonRedux
               accessibilityLabel="Invite Users"
@@ -126,6 +131,7 @@ exports[`components/sidebar/invite_members_button should match snapshot 1`] = `
                 }
               }
               modalId="invitation"
+              onClick={[MockFunction]}
             >
               <button
                 aria-label="Invite Users dialog"
@@ -136,7 +142,7 @@ exports[`components/sidebar/invite_members_button should match snapshot 1`] = `
               >
                 <li
                   aria-label="Invite Members"
-                  className="SidebarChannelNavigator_inviteMembersLhsButton"
+                  className="SidebarChannelNavigator_inviteMembersLhsButton SidebarChannelNavigator_inviteMembersLhsButton--untouched"
                 >
                   <i
                     className="icon-plus-box"

--- a/components/sidebar/invite_members_button.test.tsx
+++ b/components/sidebar/invite_members_button.test.tsx
@@ -49,6 +49,11 @@ describe('components/sidebar/invite_members_button', () => {
         },
     };
 
+    const props = {
+        onClick: jest.fn(),
+        touchedInviteMembersButton: false,
+    };
+
     const mockStore = configureStore();
     const store = mockStore(state);
     jest.spyOn(teams, 'getCurrentTeamId').mockReturnValue('team_id2sss');
@@ -56,7 +61,7 @@ describe('components/sidebar/invite_members_button', () => {
     test('should match snapshot', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
-                <InviteMembersButton/>
+                <InviteMembersButton {...props}/>
             </Provider>,
         );
 
@@ -78,7 +83,7 @@ describe('components/sidebar/invite_members_button', () => {
 
         const wrapper = mountWithIntl(
             <Provider store={store}>
-                <InviteMembersButton/>
+                <InviteMembersButton {...props}/>
             </Provider>,
         );
         expect(wrapper.find('i').exists()).toBeFalsy();

--- a/components/sidebar/invite_members_button.test.tsx
+++ b/components/sidebar/invite_members_button.test.tsx
@@ -6,12 +6,13 @@ import React from 'react';
 import {Provider} from 'react-redux';
 import configureStore from 'redux-mock-store';
 
+import thunk from 'redux-thunk';
+
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
 import InviteMembersButton from 'components/sidebar/invite_members_button';
 
 import * as teams from 'mattermost-redux/selectors/entities/teams';
-import thunk from 'redux-thunk';
 
 describe('components/sidebar/invite_members_button', () => {
     // required state to mount using the provider
@@ -94,29 +95,29 @@ describe('components/sidebar/invite_members_button', () => {
         const mock = jest.fn();
         const wrapper = mountWithIntl(
             <Provider store={store}>
-                <InviteMembersButton {...{...props, onClick: mock}} />
+                <InviteMembersButton {...{...props, onClick: mock}}/>
             </Provider>,
         );
         expect(mock).not.toHaveBeenCalled();
-        wrapper.find('i').simulate('click')
+        wrapper.find('i').simulate('click');
         expect(mock).toHaveBeenCalled();
     });
 
     test('should not have untouched ui when component has been touched', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
-                <InviteMembersButton {...{...props, touchedInviteMembersButton: true}} />
+                <InviteMembersButton {...{...props, touchedInviteMembersButton: true}}/>
             </Provider>,
         );
-        expect(wrapper.find('li').prop('className')).not.toContain('untouched')
+        expect(wrapper.find('li').prop('className')).not.toContain('untouched');
     });
 
     test('should have untouched ui when component has not been touched', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
-                <InviteMembersButton {...props} />
+                <InviteMembersButton {...props}/>
             </Provider>,
         );
-        expect(wrapper.find('li').prop('className')).toContain('untouched')
+        expect(wrapper.find('li').prop('className')).toContain('untouched');
     });
 });

--- a/components/sidebar/invite_members_button.test.tsx
+++ b/components/sidebar/invite_members_button.test.tsx
@@ -11,6 +11,7 @@ import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 import InviteMembersButton from 'components/sidebar/invite_members_button';
 
 import * as teams from 'mattermost-redux/selectors/entities/teams';
+import thunk from 'redux-thunk';
 
 describe('components/sidebar/invite_members_button', () => {
     // required state to mount using the provider
@@ -54,7 +55,7 @@ describe('components/sidebar/invite_members_button', () => {
         touchedInviteMembersButton: false,
     };
 
-    const mockStore = configureStore();
+    const mockStore = configureStore([thunk]);
     const store = mockStore(state);
     jest.spyOn(teams, 'getCurrentTeamId').mockReturnValue('team_id2sss');
 
@@ -87,5 +88,35 @@ describe('components/sidebar/invite_members_button', () => {
             </Provider>,
         );
         expect(wrapper.find('i').exists()).toBeFalsy();
+    });
+
+    test('should should fire onClick prop on click', () => {
+        const mock = jest.fn();
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <InviteMembersButton {...{...props, onClick: mock}} />
+            </Provider>,
+        );
+        expect(mock).not.toHaveBeenCalled();
+        wrapper.find('i').simulate('click')
+        expect(mock).toHaveBeenCalled();
+    });
+
+    test('should not have untouched ui when component has been touched', () => {
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <InviteMembersButton {...{...props, touchedInviteMembersButton: true}} />
+            </Provider>,
+        );
+        expect(wrapper.find('li').prop('className')).not.toContain('untouched')
+    });
+
+    test('should have untouched ui when component has not been touched', () => {
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <InviteMembersButton {...props} />
+            </Provider>,
+        );
+        expect(wrapper.find('li').prop('className')).toContain('untouched')
     });
 });

--- a/components/sidebar/invite_members_button.tsx
+++ b/components/sidebar/invite_members_button.tsx
@@ -18,13 +18,20 @@ import TeamPermissionGate from 'components/permissions_gates/team_permission_gat
 import {ModalIdentifiers} from 'utils/constants';
 
 type Props = {
+    touchedInviteMembersButton: boolean;
     className?: string;
+    onClick: () => void;
 }
 
 const InviteMembersButton: React.FC<Props> = (props: Props): JSX.Element => {
     const intl = useIntl();
 
     const currentTeamId = useSelector(getCurrentTeamId);
+    let buttonClass = 'SidebarChannelNavigator_inviteMembersLhsButton';
+
+    if (!props.touchedInviteMembersButton) {
+        buttonClass += ' SidebarChannelNavigator_inviteMembersLhsButton--untouched';
+    }
 
     return (
         <TeamPermissionGate
@@ -37,9 +44,10 @@ const InviteMembersButton: React.FC<Props> = (props: Props): JSX.Element => {
                 className={`intro-links color--link cursor--pointer${props.className ? ` ${props.className}` : ''}`}
                 modalId={ModalIdentifiers.INVITATION}
                 dialogType={InvitationModal}
+                onClick={props.onClick}
             >
                 <li
-                    className='SidebarChannelNavigator_inviteMembersLhsButton'
+                    className={buttonClass}
                     aria-label={intl.formatMessage({id: 'sidebar_left.sidebar_channel_navigator.inviteUsers', defaultMessage: 'Invite Members'})}
                 >
                     <i className='icon-plus-box'/>

--- a/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
+++ b/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
@@ -269,6 +269,8 @@ exports[`components/sidebar/sidebar_category should match snapshot when sorting 
   </Connect(Droppable)>
   <InviteMembersButton
     className="followingSibling"
+    onClick={[Function]}
+    touchedInviteMembersButton={false}
   />
 </div>
 `;
@@ -397,6 +399,8 @@ exports[`components/sidebar/sidebar_category should match snapshot when the cate
   </Connect(Droppable)>
   <InviteMembersButton
     className="followingSibling"
+    onClick={[Function]}
+    touchedInviteMembersButton={false}
   />
 </div>
 `;

--- a/components/sidebar/sidebar_category/index.ts
+++ b/components/sidebar/sidebar_category/index.ts
@@ -6,7 +6,11 @@ import {bindActionCreators, Dispatch} from 'redux';
 
 import {setCategoryCollapsed, setCategorySorting} from 'mattermost-redux/actions/channel_categories';
 import {GenericAction} from 'mattermost-redux/types/actions';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {ChannelCategory} from 'mattermost-redux/types/channel_categories';
+import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {Preferences, Touched} from 'utils/constants';
 
 import {getDraggingState, makeGetFilteredChannelIdsForCategory} from 'selectors/views/channel_sidebar';
 import {GlobalState} from 'types/store';
@@ -24,6 +28,8 @@ function makeMapStateToProps() {
         return {
             channelIds: getChannelIdsForCategory(state, ownProps.category),
             draggingState: getDraggingState(state),
+            touchedInviteMembersButton: getBool(state, Preferences.TOUCHED, Touched.INVITE_MEMBERS),
+            currentUserId: getCurrentUserId(state),
         };
     };
 }
@@ -33,6 +39,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
         actions: bindActionCreators({
             setCategoryCollapsed,
             setCategorySorting,
+            savePreferences,
         }, dispatch),
     };
 }

--- a/components/sidebar/sidebar_category/sidebar_category.test.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category.test.tsx
@@ -31,9 +31,12 @@ describe('components/sidebar/sidebar_category', () => {
         isNewCategory: false,
         isDisabled: false,
         limitVisibleDMsGMs: 10000,
+        touchedInviteMembersButton: false,
+        currentUserId: '',
         actions: {
             setCategoryCollapsed: jest.fn(),
             setCategorySorting: jest.fn(),
+            savePreferences: jest.fn(),
         },
     };
 

--- a/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -9,11 +9,12 @@ import classNames from 'classnames';
 
 import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
 import {ChannelCategory, CategorySorting} from 'mattermost-redux/types/channel_categories';
+import {PreferenceType} from 'mattermost-redux/types/preferences';
 import {localizeMessage} from 'mattermost-redux/utils/i18n_utils';
 import {trackEvent} from 'actions/telemetry_actions';
 import OverlayTrigger from 'components/overlay_trigger';
 import {DraggingState} from 'types/store';
-import Constants, {A11yCustomEventTypes, DraggingStateTypes, DraggingStates} from 'utils/constants';
+import Constants, {A11yCustomEventTypes, DraggingStateTypes, DraggingStates, Preferences, Touched} from 'utils/constants';
 import {t} from 'utils/i18n';
 import {isKeyPressed} from 'utils/utils';
 import SidebarChannel from '../sidebar_channel';
@@ -35,9 +36,12 @@ type Props = {
     getChannelRef: (channelId: string) => HTMLLIElement | undefined;
     isNewCategory: boolean;
     draggingState: DraggingState;
+    currentUserId: string;
+    touchedInviteMembersButton: boolean;
     actions: {
         setCategoryCollapsed: (categoryId: string, collapsed: boolean) => void;
         setCategorySorting: (categoryId: string, sorting: CategorySorting) => void;
+        savePreferences: (userId: string, preferences: PreferenceType[]) => void;
     };
 };
 
@@ -338,7 +342,27 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                 disableInteractiveElementBlocking={true}
             >
                 {(provided, snapshot) => {
-                    const inviteMembersButton = category.type === 'direct_messages' ? <InviteMembersButton className='followingSibling'/> : null;
+                    let inviteMembersButton = null;
+                    if (category.type === 'direct_messages') {
+                        inviteMembersButton = (
+                            <InviteMembersButton
+                                className='followingSibling'
+                                touchedInviteMembersButton={this.props.touchedInviteMembersButton}
+                                onClick={() => {
+                                    this.props.actions.savePreferences(
+                                        this.props.currentUserId,
+                                        [{
+                                            category: Preferences.TOUCHED,
+                                            user_id: this.props.currentUserId,
+                                            name: Touched.INVITE_MEMBERS,
+                                            value: 'true',
+                                        }],
+                                    );
+                                }}
+                            />
+                        );
+                    }
+
                     return (
                         <div
                             className={classNames('SidebarChannelGroup a11y__section', {

--- a/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -349,15 +349,17 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                                 className='followingSibling'
                                 touchedInviteMembersButton={this.props.touchedInviteMembersButton}
                                 onClick={() => {
-                                    this.props.actions.savePreferences(
-                                        this.props.currentUserId,
-                                        [{
-                                            category: Preferences.TOUCHED,
-                                            user_id: this.props.currentUserId,
-                                            name: Touched.INVITE_MEMBERS,
-                                            value: 'true',
-                                        }],
-                                    );
+                                    if (!this.props.touchedInviteMembersButton) {
+                                        this.props.actions.savePreferences(
+                                            this.props.currentUserId,
+                                            [{
+                                                category: Preferences.TOUCHED,
+                                                user_id: this.props.currentUserId,
+                                                name: Touched.INVITE_MEMBERS,
+                                                value: 'true',
+                                            }],
+                                        );
+                                    }
                                 }}
                             />
                         );

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -728,6 +728,15 @@
         &:hover {
             color: var(--sidebar-text);
         }
+
+        &--untouched {
+            color: var(--sidebar-unread-text);
+            font-weight: $font-weight--semibold;
+
+            i::before {
+                font-weight: $font-weight--semibold;
+            }
+        }
     }
 
     #introTextInvite {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -109,6 +109,14 @@ export const Preferences = {
     ADMIN_CLOUD_UPGRADE_PANEL: 'admin_cloud_upgrade_panel',
     CATEGORY_EMOJI: 'emoji',
     EMOJI_SKINTONE: 'emoji_skintone',
+
+    // For one off things that have a special, attention-grabbing UI until you interact with them
+    TOUCHED: 'touched',
+};
+
+// For one off things that have a special, attention-grabbing UI until you interact with them
+export const Touched = {
+    INVITE_MEMBERS: 'invite_members',
 };
 
 export const TrialPeriodDays = {


### PR DESCRIPTION
#### Summary
Invite members button is highlighted until the user interacts with it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38803 , but first intended to be included with
https://mattermost.atlassian.net/browse/MM-38258

#### Screenshots
![invite-members-highlighted](https://user-images.githubusercontent.com/13738432/134583453-ceb67b18-4809-4ac7-8da3-9b930988a18d.png)

#### Release Note
No release note; this has not been released and was intended to be part of the invite members button when we established that as the A/B test winner.

```release-note
NONE
```
