### PR TITLE
MM-36932: always call reconnect callback

### DIFF
--- a/client/websocket_client.tsx
+++ b/client/websocket_client.tsx
@@ -86,7 +86,7 @@ export default class WebSocketClient {
 
             if (this.connectFailCount > 0) {
                 console.log('websocket re-established connection'); //eslint-disable-line no-console
-                if (!reliableWebSockets && this.reconnectCallback) {
+                if (this.reconnectCallback) {
                     this.reconnectCallback();
                 }
             } else if (this.firstConnectCallback) {


### PR DESCRIPTION
#### Summary

Upon websocket reconnect we are missing messages, this commit attempts
to fix that by always calling reconnectCallback regardless on whether
reliableWebSockets is enabled or not.

Some more info:
We keep track of websocket connection status on redux,
which is getting set to false onerror, and set true upon reconnect,
with reliable websockets enabled it didn't got set to true upon reconnection,
since `reconnectCallback` was responsible for that.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36932

#### Release Note

```release-note
NONE
```
