### PR TITLE
[MM-38854] - remove extra space from message when no edit indicator is present

### DIFF
--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -54,16 +54,21 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
         {
             replaceChildren: false,
             shouldProcessNode: (node) => node.type === 'tag' && node.name === 'span' && node.attribs['data-edited-post-id'] && node.attribs['data-edited-post-id'] === options.postId,
-            processNode: () => (
-                <>
-                    {' '}
+            processNode: () => {
+                const indicator = (
                     <PostEditedIndicator
                         key={options.postId}
                         postId={options.postId}
                         editedAt={options.editedAt}
                     />
-                </>
-            ),
+                );
+                return indicator ? (
+                    <>
+                        {' '}
+                        {indicator}
+                    </>
+                ) : null;
+            },
         },
     ];
 

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -55,11 +55,14 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
             replaceChildren: false,
             shouldProcessNode: (node) => node.type === 'tag' && node.name === 'span' && node.attribs['data-edited-post-id'] && node.attribs['data-edited-post-id'] === options.postId,
             processNode: () => (
-                <PostEditedIndicator
-                    key={options.postId}
-                    postId={options.postId}
-                    editedAt={options.editedAt}
-                />
+                <>
+                    {' '}
+                    <PostEditedIndicator
+                        key={options.postId}
+                        postId={options.postId}
+                        editedAt={options.editedAt}
+                    />
+                </>
             ),
         },
     ];

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -55,17 +55,14 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
             replaceChildren: false,
             shouldProcessNode: (node) => node.type === 'tag' && node.name === 'span' && node.attribs['data-edited-post-id'] && node.attribs['data-edited-post-id'] === options.postId,
             processNode: () => {
-                const indicator = (
-                    <PostEditedIndicator
-                        key={options.postId}
-                        postId={options.postId}
-                        editedAt={options.editedAt}
-                    />
-                );
-                return indicator ? (
+                return options.postId && options.editedAt > 0 ? (
                     <>
                         {' '}
-                        {indicator}
+                        <PostEditedIndicator
+                            key={options.postId}
+                            postId={options.postId}
+                            editedAt={options.editedAt}
+                        />
                     </>
                 ) : null;
             },

--- a/utils/text_formatting.tsx
+++ b/utils/text_formatting.tsx
@@ -275,9 +275,9 @@ export function formatText(
         // unwrap the output from the closing p tag and add a span that will serve as a
         // palceholder for `messageToHtmlComponent` function later on
         if (output.endsWith('</p>')) {
-            output = `${output.slice(0, -4)} <span data-edited-post-id='${options.postId}'></span></p>`;
+            output = `${output.slice(0, -4)}<span data-edited-post-id='${options.postId}'></span></p>`;
         } else {
-            output += ` <span data-edited-post-id='${options.postId}'></span>`;
+            output += `<span data-edited-post-id='${options.postId}'></span>`;
         }
     }
 


### PR DESCRIPTION
#### Summary
this PR removes an extra whitespace from messages, when no edit indicator is being rendered. This led to several failing cypress tests.

#### Ticket Link
[MM-38854](https://mattermost.atlassian.net/browse/MM-38854)

#### Release Note
```release-note
NONE
```
