### PR TITLE
[MM-35700] Accept drag and dropping on a thread view

### DIFF
--- a/components/create_comment/create_comment.tsx
+++ b/components/create_comment/create_comment.tsx
@@ -238,6 +238,7 @@ type Props = {
     channelMemberCountsByGroup: ChannelMemberCountsByGroup;
     onHeightChange?: (height: number, maxHeight: number) => void;
     focusOnMount?: boolean;
+    isThreadView?: boolean;
 }
 
 type State = {
@@ -1249,7 +1250,7 @@ class CreateComment extends React.PureComponent<Props, State> {
                     onUploadProgress={this.handleUploadProgress}
                     rootId={this.props.rootId}
                     channelId={this.props.channelId}
-                    postType='comment'
+                    postType={this.props.isThreadView ? 'thread' : 'comment'}
                 />
             );
         }

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -180,6 +180,8 @@ export class FileUpload extends PureComponent {
             this.registerDragEvents('.row.main', '.center-file-overlay');
         } else if (this.props.postType === 'comment') {
             this.registerDragEvents('.post-right__container', '.right-file-overlay');
+        } else if (this.props.postType === 'thread') {
+            this.registerDragEvents('.ThreadPane', '.right-file-overlay');
         }
 
         document.addEventListener('paste', this.pasteUpload);

--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -35,6 +35,7 @@ import Header from 'components/widgets/header';
 import LoadingScreen from 'components/loading_screen';
 import NoResultsIndicator from 'components/no_results_indicator';
 import NextStepsView from 'components/next_steps_view';
+import FileUploadOverlay from 'components/file_upload_overlay';
 
 import {useThreadRouting} from '../hooks';
 import ChatIllustration from '../common/chat_illustration';
@@ -162,6 +163,7 @@ const GlobalThreads = () => {
                         <ThreadPane
                             thread={selectedThread}
                         >
+                            <FileUploadOverlay overlayType='right'/>
                             <ThreadViewer
                                 rootPostId={selectedThread.id}
                                 useRelativeTimestamp={true}

--- a/components/threading/virtualized_thread_viewer/create_comment.tsx
+++ b/components/threading/virtualized_thread_viewer/create_comment.tsx
@@ -22,6 +22,7 @@ type Props = {
     teammate?: UserProfile;
     threadId: string;
     latestPostId: $ID<Post>;
+    isThreadView?: boolean;
 };
 
 const CreateComment = forwardRef<HTMLDivElement, Props>(({
@@ -35,6 +36,7 @@ const CreateComment = forwardRef<HTMLDivElement, Props>(({
     teammate,
     threadId,
     latestPostId,
+    isThreadView,
 }: Props, ref) => {
     if (channelType === Constants.DM_CHANNEL && teammate?.delete_at) {
         return (
@@ -76,6 +78,7 @@ const CreateComment = forwardRef<HTMLDivElement, Props>(({
                 onHeightChange={onHeightChange}
                 rootDeleted={isDeleted}
                 rootId={threadId}
+                isThreadView={isThreadView}
             />
         </div>
     );

--- a/components/threading/virtualized_thread_viewer/virtualized_thread_viewer.tsx
+++ b/components/threading/virtualized_thread_viewer/virtualized_thread_viewer.tsx
@@ -315,6 +315,7 @@ class ThreadViewerVirtualized extends PureComponent<Props, State> {
                         ref={this.postCreateContainerRef}
                         teammate={this.props.directTeammate}
                         threadId={this.props.selected.id}
+                        isThreadView={true}
                     />
                 )}
             </>


### PR DESCRIPTION
#### Summary

Allow users to drag and drop files on a thread while on the CRT Panel

#### Ticket Link

[MM-35700](https://mattermost.atlassian.net/browse/MM-35700)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed drag and drop files on a thread while on CRT Panel
```
