### PR TITLE
[MM-38850] - only render "recent" divider in quick switch modal

### DIFF
--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -206,28 +206,18 @@ export default class SuggestionList extends React.PureComponent {
             items.push(this.renderNoResults());
         }
 
-        const sortedItems = clonedItems.sort((itemA, itemB) => {
-            if (!itemA.type) {
-                return 1;
-            }
-            if (!itemB.type) {
-                return -1;
-            }
-            return itemA.type.localeCompare(itemB.type);
-        });
-
-        let lastType;
-        for (let i = 0; i < sortedItems.length; i++) {
-            const item = sortedItems[i];
+        let dividerRendered = false;
+        for (let i = 0; i < this.props.items.length; i++) {
+            const item = this.props.items[i];
             const term = this.props.terms[i];
             const isSelection = term === this.props.selection;
 
             // ReactComponent names need to be upper case when used in JSX
             const Component = this.props.components[i];
 
-            if (this.props.renderDividers && item.type !== lastType) {
+            if (!dividerRendered && item.type === 'mention.recent.channels') {
                 items.push(this.renderDivider(item.type));
-                lastType = item.type;
+                dividerRendered = true;
             }
 
             if (item.loading) {
@@ -243,7 +233,7 @@ export default class SuggestionList extends React.PureComponent {
                 <Component
                     key={term}
                     ref={(ref) => this.itemRefs.set(term, ref)}
-                    item={sortedItems[i]}
+                    item={this.props.items[i]}
                     term={term}
                     matchedPretext={this.props.matchedPretext[i]}
                     isSelection={isSelection}


### PR DESCRIPTION
#### Summary
due to some misunderstanding and a regression coming in by another PR the `SuggestionList` inside the quick switch modal was rendering type-dividers for the returned results.

I had a PR open for fixing it (#8963), but since I did not have all information on channel request/sorting logic within it and the number of commits that were already in that PR it was easier to provide a new PR for a fix.

#### Ticket Link
[MM-38850](https://mattermost.atlassian.net/browse/MM-38850)

#### Screenshots

**showing recent channels with divider**
<img width="636" alt="Screenshot 2021-09-28 at 16 48 36" src="https://user-images.githubusercontent.com/32863416/135111090-78b5e55a-adb8-41a6-9f99-1f9d9603dcce.png">

**after typing the results have no divider**
<img width="635" alt="Screenshot 2021-09-28 at 16 48 44" src="https://user-images.githubusercontent.com/32863416/135111172-6122adc8-16a3-4b74-8caa-d79c4959d294.png">

#### Release Note
```release-note
NONE
```
