### PR TITLE
MM-38539 Only rehydrate drafts from localStorage on first load

### DIFF
--- a/actions/storage.js
+++ b/actions/storage.js
@@ -83,7 +83,7 @@ export function actionOnItemsWithPrefix(prefix, action) {
 }
 
 // Temporary action to manually rehydrate drafts from localStorage.
-function rehydrateDrafts() {
+export function rehydrateDrafts() {
     return (dispatch) => {
         const actions = [];
 
@@ -138,7 +138,7 @@ export function storageRehydrate(incoming, persistor) {
                 data: storage,
             });
         });
-        dispatch(rehydrateDrafts());
+
         persistor.resume();
         return {data: true};
     };

--- a/store/index.js
+++ b/store/index.js
@@ -12,7 +12,7 @@ import {General, RequestStatus} from 'mattermost-redux/constants';
 import configureServiceStore from 'mattermost-redux/store';
 import reduxInitialState from 'mattermost-redux/store/initial_state';
 
-import {storageRehydrate} from 'actions/storage';
+import {storageRehydrate, rehydrateDrafts} from 'actions/storage';
 import {clearUserCookie} from 'actions/views/cookie';
 import appReducer from 'reducers';
 import {ActionTypes} from 'utils/constants';
@@ -76,6 +76,7 @@ export default function configureStore(initialState) {
                     }
                 }).then(() => {
                     storageRehydrate(restoredState, persistor)(store.dispatch, store.getState);
+                    store.dispatch(rehydrateDrafts());
                 });
 
                 observable.subscribe({
@@ -85,6 +86,7 @@ export default function configureStore(initialState) {
 
                             var statePartial = {};
                             statePartial[keyspace] = args.newValue;
+
                             storageRehydrate(statePartial, persistor)(store.dispatch, store.getState);
                         }
                     },


### PR DESCRIPTION
#### Summary
Companion PR to #8978. Draft rehydration was occurring on any change to localforage when it was only required on first load. This had a side effect for multiple tabs on the same desktop app or browser causing a lot of unnecessary hydration resulting in high CPU usage.

@jgilliam17 for testing can you make sure drafts still persist correctly after refresh and channel switch? Particularly when typing quickly and immediately reloading the page.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38539

#### Release Note
```release-note
Performance improvements for draft storage with multiple tabs open
```
