### PR TITLE
[MM-38536] Stop needs_team from trying to join a team with a reserved name

### DIFF
--- a/components/needs_team/needs_team.tsx
+++ b/components/needs_team/needs_team.tsx
@@ -204,6 +204,11 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
     }
 
     joinTeam = async (props: Props, firstLoad = false) => {
+        // skip reserved teams
+        if (Constants.RESERVED_TEAM_NAMES.includes(props.match.params.team)) {
+            return;
+        }
+
         const {data: team} = await this.props.actions.getTeamByName(props.match.params.team);
         if (team && team.delete_at === 0) {
             const {error} = await props.actions.addUserToTeam(team.id, props.currentUser && props.currentUser.id);


### PR DESCRIPTION
#### Summary
This PR stops the `needs_team` component from trying to go to a team with a reserved name. This is a workaround for the issue seen on the Desktop App when the server enables/disables/upgrades a plugin like Boards or Playbooks where it uses the base route instead of the `/plugins` route.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38536

#### Release Note
```release-note
NONE
```
