### PR TITLE
[MM-38833] - Font within CC field is not consistent with other fields in payment form

### DIFF
--- a/components/payment_form/card_input.tsx
+++ b/components/payment_form/card_input.tsx
@@ -14,7 +14,7 @@ const CARD_ELEMENT_OPTIONS = {
     hidePostalCode: true,
     style: {
         base: {
-            fontFamily: 'Open Sans',
+            fontFamily: "'Open Sans', sans-serif",
             fontSize: '14px',
             opacity: '0.5',
             fontSmoothing: 'antialiased',


### PR DESCRIPTION
#### Summary
This PR updates the font in the CC field on the purchase modal to Open Sans

#### Ticket Link
[MM-38833](https://mattermost.atlassian.net/browse/MM-38833)

#### Related Pull Requests
https://github.com/mattermost/customer-web-server/pull/569

#### Screenshots
Before
---
<img width="1261" alt="Screenshot 2021-09-29 at 11 49 57" src="https://user-images.githubusercontent.com/28563179/135237048-d3c178b8-80d2-4d48-a48b-b308acd28cb7.png">


After
---
<img width="1285" alt="Screenshot 2021-09-29 at 11 50 30" src="https://user-images.githubusercontent.com/28563179/135237087-6f1eeff5-0c4e-45dc-bd08-91136e1b391a.png">


#### Release Note
```release-note
NONE

```
