### PR TITLE
fixes failing cypress tests because of `accessibilityLabel` renaming

### DIFF
--- a/components/widgets/menu/menu_items/menu_item_toggle_modal_redux.tsx
+++ b/components/widgets/menu/menu_items/menu_item_toggle_modal_redux.tsx
@@ -17,17 +17,17 @@ type Props = {
     dialogProps?: Dictionary<any>;
     extraText?: string;
     text?: React.ReactNode;
-    ariaLabel?: string;
+    accessibilityLabel?: string;
     className?: string;
     children?: React.ReactNode;
     sibling?: React.ReactNode;
     showUnread?: boolean;
 }
 
-export const MenuItemToggleModalReduxImpl: React.FC<Props> = ({modalId, dialogType, dialogProps, text, ariaLabel, extraText, children, className, sibling, showUnread}: Props) => (
+export const MenuItemToggleModalReduxImpl: React.FC<Props> = ({modalId, dialogType, dialogProps, text, accessibilityLabel, extraText, children, className, sibling, showUnread}: Props) => (
     <>
         <ToggleModalButtonRedux
-            accessibilityLabel={ariaLabel}
+            accessibilityLabel={accessibilityLabel}
             modalId={modalId}
             dialogType={dialogType}
             dialogProps={dialogProps}


### PR DESCRIPTION
#### Summary
renames prop `ariaLabel` back to `accessibilityLabel`. The change was unintended and this should now fix the failing cypres stests.

#### Ticket Link
no ticket was issued for this

#### Related Pull Requests
PR introducing this bug: #8921 

#### Release Note
```release-note
NONE
```
