### PR TITLE
Fixes fetching threads upon ws reconnection

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -213,8 +213,11 @@ export function reconnect(includeWebSocket = true) {
         }
         StatusActions.loadStatusesForChannelAndSidebar();
 
-        dispatch(TeamActions.getMyTeamUnreads(isCollapsedThreadsEnabled(state), true));
-        dispatch(fetchThreads(currentUserId, currentTeamId, {unread: true, perPage: 200}));
+        const crtEnabled = isCollapsedThreadsEnabled(state);
+        dispatch(TeamActions.getMyTeamUnreads(crtEnabled, true));
+        if (crtEnabled) {
+            dispatch(fetchThreads(currentUserId, currentTeamId, {unread: true, perPage: 200}));
+        }
     }
 
     if (state.websocket.lastDisconnectAt) {


### PR DESCRIPTION
#### Summary

When a websocket reconnect occurs and the `reconnectCallback` gets called,
we should only fetch user threads if CRT is enabled for the user.

#### Release Note

```release-note
NONE
```
