### PR TITLE
[MM-38836] - Try Enterprise for free option missing spacing in mobile webview

### DIFF
--- a/components/widgets/menu/menu_items/menu_item.scss
+++ b/components/widgets/menu/menu_items/menu_item.scss
@@ -171,7 +171,7 @@
             padding: 3px 0;
             border: none;
             background-color: transparent;
-            color: var(--button-bg);
+            color: var(--link-color);
             font-style: normal;
             font-weight: 600;
         }

--- a/components/widgets/menu/menu_items/menu_item.scss
+++ b/components/widgets/menu/menu_items/menu_item.scss
@@ -157,6 +157,9 @@
     }
 
     .MenuStartTrial {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
         padding: 8px;
         padding-left: 16px;
         margin: 8px;


### PR DESCRIPTION
#### Summary
Makes the Try Enterprise CTA responsive

#### Ticket Link
[MM-38836](https://mattermost.atlassian.net/browse/MM-38836)

#### Screenshots

Before
---
<img width="710" alt="Screen Shot 2021-09-23 at 9 26 11 PM" src="https://user-images.githubusercontent.com/28563179/135264526-c65a2730-09cb-402f-83a6-162584086b3f.png">


After
---
<img width="628" alt="Screenshot 2021-09-29 at 14 33 09" src="https://user-images.githubusercontent.com/28563179/135263819-0af34a55-bcb0-4578-809f-70d54b402d09.png">


#### Release Note

```release-note
NONE

```
