### PR TITLE
docker/build: push image to the testing repository and refactor the fetches of the dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,22 +232,26 @@ jobs:
   build-docker:
     working_directory: ~/mattermost/
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:stable
     steps:
       - attach_workspace:
           at: ~/mattermost/
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.7
       - run:
           command: |
             export TAG="${CIRCLE_SHA1:0:7}"
 
-            git clone https://github.com/mattermost/mattermost-server.git
+            mkdir -p ./docker-build
+            cd ./docker-build
+            wget https://raw.githubusercontent.com/mattermost/mattermost-server/master/build/Dockerfile
+            wget https://raw.githubusercontent.com/mattermost/mattermost-server/master/build/entrypoint.sh
 
-            cd mattermost-server
-            export MM_PACKAGE=https://pr-builds.mattermost.com/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}/mattermost-enterprise-linux-amd64.tar.gz
-            docker build --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mattermost-enterprise-edition:${TAG} build
+            export DOCKER_CLI_EXPERIMENTAL=enabled
             echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
-            docker push mattermost/mattermost-enterprise-edition:${TAG}
+            export MM_PACKAGE=https://pr-builds.mattermost.com/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}/mattermost-enterprise-linux-amd64.tar.gz
+            # Pushing the images to two places to not break anything, but the `mattermost/mattermost-enterprise-edition` will be removed soon.
+            docker buildx build --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mattermost-enterprise-edition:${TAG} -t mattermost/mm-ee-test:${TAG} .
 
 workflows:
   version: 2


### PR DESCRIPTION
#### Summary
This is the initial work to cleanup the docker repositories and push images tot he official repositories (`mattermost/mattermost-enterprise-edition` / `mattermost/mattermost-team-edition`) only official releases and not testing/prs images

the testing/prs images will be pushed to `mattermost/mm-te-test` and `mattermost/mm-ee-test`

to avoid any breaks for now we will push to both places, after we make sure everything is clean and correct we will do a follow up to remove the push to `mattermost/mattermost-enterprise-edition`

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/DOPS-632

#### Related Pull Requests

Server: https://github.com/mattermost/mattermost-server/pull/18488
enterprise: https://github.com/mattermost/enterprise/pull/1073
Matterwick: https://github.com/mattermost/matterwick/pull/30

#### Release Note

```release-note
NONE
```

cc @amyblais 