### PR TITLE
MM-T1805 No infinite loading spinner on Select Team page

### DIFF
--- a/e2e/cypress/integration/multi_team_and_dm/multi_team_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/multi_team_spec.js
@@ -12,7 +12,7 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 // Stage: @prod
 // Group: @multi_team_and_dm
 
-describe('Send a DM', () => {
+describe('Multi-Team + DMs', () => {
     let userA; // Member of team A and B
     let userB; // Member of team A and B
     let userC; // Member of team A
@@ -52,9 +52,6 @@ describe('Send a DM', () => {
     beforeEach(() => {
         // # Log in to Team A with an account that has joined multiple teams.
         cy.apiLogin(userA);
-
-        // # On an account on two teams, view Team A
-        cy.visit(offTopicUrlA);
     });
 
     it('MM-T433 Switch teams', () => {
@@ -146,5 +143,10 @@ describe('Send a DM', () => {
         cy.get(`#${teamA.name}TeamButton`).should('be.visible').within(() => {
             cy.get('.badge').should('not.exist');
         });
+    });
+
+    it('MM-T1805 No infinite loading spinner on Select Team page', () => {
+        cy.visit('/select_team');
+        cy.get('.loading-screen').should('not.exist');
     });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Check 'No infinite loading spinner on Select Team page'

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/mattermost-server/issues/18178


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
