### PR TITLE
[MM-38430] - Onboarding invite shows limits that no longer apply-2

### DIFF
--- a/components/next_steps_view/steps/invite_members_step/invite_members_step.test.tsx
+++ b/components/next_steps_view/steps/invite_members_step/invite_members_step.test.tsx
@@ -148,6 +148,11 @@ describe('components/next_steps_view/steps/invite_members_step', () => {
                 is_paid_tier: 'false',
             },
         };
+
+        const nonCloudProps = {
+            ...baseProps,
+            subscriptionStats: null, // in non cloud instances, the subscription stats in redux state remain null
+        };
         const paidTierwrapper: ReactWrapper<any, any, any> = mountWithIntl(
             <InviteMembersStep {...paidTierProps}/>,
         );
@@ -156,7 +161,12 @@ describe('components/next_steps_view/steps/invite_members_step', () => {
             <InviteMembersStep {...freeTierProps}/>,
         );
 
+        const nonCloudWrapper: ReactWrapper<any, any, any> = mountWithIntl(
+            <InviteMembersStep {...nonCloudProps}/>,
+        );
+
         expect(paidTierwrapper.find('.InviteMembersStep__emailInvitations').find('span').at(1).text()).toEqual('You can invite team members using a space or comma between addresses');
         expect(freeTierWrapper.find('.InviteMembersStep__emailInvitations').find('span').at(1).text()).toEqual('You can invite up to 5 team members using a space or comma between addresses');
+        expect(nonCloudWrapper.find('.InviteMembersStep__emailInvitations').find('span').at(1).text()).toEqual('You can invite team members using a space or comma between addresses');
     });
 });

--- a/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
+++ b/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
@@ -36,7 +36,7 @@ type Props = StepComponentProps & {
         sendEmailInvitesToTeamGracefully: (teamId: string, emails: string[]) => Promise<{ data: TeamInviteWithError[]; error: ServerError }>;
         regenerateTeamInviteId: (teamId: string) => void;
     };
-    subscriptionStats: SubscriptionStats;
+    subscriptionStats: SubscriptionStats | null;
     intl: IntlShape;
     isCloud: boolean;
     downloadAppsAsNextStep: boolean;
@@ -278,20 +278,25 @@ class InviteMembersStep extends React.PureComponent<Props, State> {
 
     render(): JSX.Element {
         const linkBtn = this.props.isAdmin ? <UpgradeLink telemetryInfo='click_upgrade_invite_members_step'/> : <NotifyLink/>;
-        const subtitle = this.props?.subscriptionStats?.is_paid_tier === 'true' ? (
+        let subtitle = (
             <FormattedMessage
                 id='next_steps_view.invite_members_step.youCanInvite'
                 defaultMessage='You can invite team members using a space or comma between addresses'
             />
-        ) : (
-            <FormattedMessage
-                id='next_steps_view.invite_members_step.youCanInviteUpTo'
-                defaultMessage='You can invite up to {members} team members using a space or comma between addresses'
-                values={{
-                    members: this.props?.subscriptionStats?.remaining_seats,
-                }}
-            />
         );
+
+        if (this.props?.subscriptionStats?.is_paid_tier === 'false') {
+            subtitle = (
+                <FormattedMessage
+                    id='next_steps_view.invite_members_step.youCanInviteUpTo'
+                    defaultMessage='You can invite up to {members} team members using a space or comma between addresses'
+                    values={{
+                        members: this.props?.subscriptionStats?.remaining_seats,
+                    }}
+                />
+            );
+        }
+
         let finishMessage = (
             <FormattedMessage
                 id='next_steps_view.invite_members_step.finish'


### PR DESCRIPTION
#### Summary
This PR updates the invitation card subtitle in the onboarding to show correct text depending on whether the cloud subscription is paid or not. It also makes sure there's a default text for other instances (non-cloud)

It is an update of this PR https://github.com/mattermost/mattermost-webapp/pull/8944

#### Ticket Link
[MM-38430](https://mattermost.atlassian.net/browse/MM-38430)


#### Release Note

```release-note
NONE

```
