### PR TITLE
MM-38294 Show browse channels with global header disabled and A/B tests enabled

### DIFF
--- a/components/sidebar/channel_navigator/channel_navigator.test.tsx
+++ b/components/sidebar/channel_navigator/channel_navigator.test.tsx
@@ -56,4 +56,11 @@ describe('Components/ChannelNavigator', () => {
         const wrapper = shallow(<ChannelNavigator {...props}/>);
         expect(wrapper.find(AddChannelDropdown).length).toBe(0);
     });
+
+    it('should show AddChannelDropdown when there is an active A/B treatment and the global header is disabled', () => {
+        props.addChannelButton = AddChannelButtonTreatments.BY_TEAM_NAME;
+        props.globalHeaderEnabled = false;
+        const wrapper = shallow(<ChannelNavigator {...props}/>);
+        expect(wrapper.find(AddChannelDropdown).length).toBe(1);
+    });
 });

--- a/components/sidebar/channel_navigator/channel_navigator.tsx
+++ b/components/sidebar/channel_navigator/channel_navigator.tsx
@@ -134,7 +134,11 @@ export default class ChannelNavigator extends React.PureComponent<Props> {
         );
 
         let addChannelDropdown = null;
-        if (!this.props.addChannelButton || this.props.addChannelButton === AddChannelButtonTreatments.NONE) {
+        if (
+            !this.props.addChannelButton ||
+            this.props.addChannelButton === AddChannelButtonTreatments.NONE ||
+            (this.props.addChannelButton === AddChannelButtonTreatments.BY_TEAM_NAME && !this.props.globalHeaderEnabled)
+        ) {
             addChannelDropdown = (
                 <AddChannelDropdown
                     showNewChannelModal={this.props.showNewChannelModal}


### PR DESCRIPTION
I don't know if this is only something we'll hit on community-daily, but we seem to have hit an unfortunate combination of feature flags and A/B tests there that make it so that the dropdown is missing

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38294

#### Screenshots
Without the global header:
![Screen Shot 2021-09-29 at 10 45 45 AM](https://user-images.githubusercontent.com/3277310/135292546-ef99b08e-5efb-42a5-b290-f1f0d7d271b3.png)

With the global header:
![Screen Shot 2021-09-29 at 10 44 55 AM](https://user-images.githubusercontent.com/3277310/135292571-28c62b85-5fb8-4ec7-89af-0f0357e9adae.png)

#### Release Note
```release-note
NONE
```
