### PR TITLE
[MM-38868] Fixes do not disturb submenu item not taking full width

### DIFF
--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -42,7 +42,13 @@
 
 #status-menu-dnd-timed_menuitem {
     .SubMenuItem.MenuItem {
-        width: 100%;
+        flex-grow: 1;
+    }
+    .SubMenuItemContainer{
+        &:hover,
+        &:focus {
+            background-color: unset;
+        }
     }
 }
 

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -40,6 +40,12 @@
     }
 }
 
+#status-menu-dnd-timed_menuitem {
+    .SubMenuItem.MenuItem {
+        width: 100%;
+    }
+}
+
 .custom_status__row {
     position: relative;
     height: auto;

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -44,7 +44,8 @@
     .SubMenuItem.MenuItem {
         flex-grow: 1;
     }
-    .SubMenuItemContainer{
+
+    .SubMenuItemContainer {
         &:hover,
         &:focus {
             background-color: unset;


### PR DESCRIPTION
#### Summary
Do not disturb submenu item not taking full width
(Note: we need to enable TimeDND feature flag)
<img width="1530" alt="Screenshot 2021-09-30 at 2 49 38 PM" src="https://user-images.githubusercontent.com/16203333/135425183-da3e3b16-2f55-4df6-a7eb-52c92f9e8b6b.png">



#### Ticket Link
Fixes [https://mattermost.atlassian.net/browse/MM-38868](https://mattermost.atlassian.net/browse/MM-38868)

#### Related Pull Requests
NONE

#### Screenshots
|  before  |  after  |
|----|----|
| ![image-20210927-235911](https://user-images.githubusercontent.com/16203333/135425382-ec7885a0-e627-43e0-9e89-1764c643dd2c.png) | <img width="572" alt="Screenshot 2021-09-30 at 2 47 44 PM" src="https://user-images.githubusercontent.com/16203333/135425275-a188f481-ccae-443a-8295-c4c9dfde1687.png"> |

#### Release Note
```release-note
* UI: Fixes Do not disturb submenu item not taking full width
```
