### PR TITLE
 MM-38540 - set consistent hover state for invite members button

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -740,7 +740,11 @@
     }
 
     #introTextInvite {
-        margin-top: -2px;
+        display: flex;
+        width: 100%;
+        &:hover {
+            background-color: var(--sidebar-text-hover-bg);
+        }
     }
 
     .SidebarChannelNavigator_inviteUsersSticky {

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -725,10 +725,6 @@
             margin-left: 5px;
         }
 
-        &:hover {
-            color: var(--sidebar-text);
-        }
-
         &--untouched {
             color: var(--sidebar-unread-text);
             font-weight: $font-weight--semibold;

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -742,6 +742,7 @@
     #introTextInvite {
         display: flex;
         width: 100%;
+
         &:hover {
             background-color: var(--sidebar-text-hover-bg);
         }


### PR DESCRIPTION
#### Summary
This PR adds the css changes to make the LHS invite members button to behave consistently on the hover event with the chat members DM links.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38540


#### Screenshots
Before:
<img width="941" alt="Captura de pantalla 2021-09-30 a las 19 20 46" src="https://user-images.githubusercontent.com/10082627/135501761-95cf856f-2b60-4f61-9124-0b58ba6bb761.png">



After:
<img width="1057" alt="Captura de pantalla 2021-09-30 a las 19 20 20" src="https://user-images.githubusercontent.com/10082627/135501781-fb619de2-724f-4c2b-80f3-6cebccc4b422.png">




#### Release Note
```release-note
NONE
```
