### PR TITLE
Cypress/E2E: Update tests related to edit indicator

### DIFF
--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -10,8 +10,6 @@
 // Stage: @prod
 // Group: @account_setting
 
-import {getRandomId} from '../../../utils';
-
 describe('Account Settings', () => {
     before(() => {
         // # Login as new user and visit off-topic
@@ -34,8 +32,8 @@ describe('Account Settings', () => {
 function verifyLineBreaksRemainIntact(display) {
     cy.uiChangeMessageDisplaySetting(display);
 
-    const firstLine = `First line ${getRandomId()}`;
-    const secondLine = `Text after ${getRandomId()}`;
+    const firstLine = 'First line';
+    const secondLine = 'Second line';
 
     // # Enter in text
     cy.get('#post_textbox').
@@ -48,8 +46,8 @@ function verifyLineBreaksRemainIntact(display) {
     cy.getLastPostId().then((postId) => {
         const postMessageTextId = `#postMessageText_${postId}`;
 
-        // * Verify HTML still includes new line
-        cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine}</p>`);
+        // * Verify text still includes new line
+        cy.get(postMessageTextId).should('have.text', `${firstLine}\n${secondLine}`);
 
         // # click dot menu button
         cy.clickPostDotMenu(postId);
@@ -58,17 +56,18 @@ function verifyLineBreaksRemainIntact(display) {
         cy.get(`#edit_post_${postId}`).scrollIntoView().should('be.visible').click();
 
         // # Add ",edited" to the text
-        cy.get('#edit_textbox').type(',edited');
+        const editMessage = ',edited';
+        cy.get('#edit_textbox').type(editMessage);
 
         // # Save
-        cy.get('#editButton').click();
+        cy.uiSave();
 
-        // * Verify HTML includes newline and the edit
-        cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine},edited</p>`);
+        // * Verify posted message includes newline, edit message and "Edited" indicator
+        cy.get(postMessageTextId).should('have.text', `${firstLine}\n${secondLine}${editMessage} Edited`);
 
-        // * Post should have (edited)
+        // * Post should have "Edited"
         cy.get(`#postEdited_${postId}`).
             should('be.visible').
-            should('contain', '(edited)');
+            should('contain', 'Edited');
     });
 }

--- a/e2e/cypress/integration/keyboard_shortcuts/keyboard_shortcuts_2_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/keyboard_shortcuts_2_spec.js
@@ -43,7 +43,7 @@ describe('Keyboard Shortcuts', () => {
         cy.get('#post_textbox').cmdOrCtrlShortcut('/');
 
         // # Verify that the 'Keyboard Shortcuts' modal is open
-        cy.get('#shortcutsModalLabel').should('be.visible');
+        modalShouldOpen();
 
         // # Verify that the 'Keyboard Shortcuts' modal displays the CTRL/CMD+U shortcut
         cy.get('.section').eq(2).within(() => {
@@ -64,7 +64,7 @@ describe('Keyboard Shortcuts', () => {
 
         // # Type /shortcuts
         cy.get('#post_textbox').clear().type('/shortcuts{enter}');
-        cy.get('#shortcutsModalLabel').should('be.visible');
+        modalShouldOpen();
 
         // # Close the 'Keyboard Shortcuts' modal using the x button
         cy.get('.modal-header button.close').should('have.attr', 'aria-label', 'Close').click();
@@ -132,10 +132,10 @@ describe('Keyboard Shortcuts', () => {
         });
 
         cy.getLastPostId().then((postId) => {
-            // * Post should have (edited)
+            // * Post should have "Edited"
             cy.get(`#postEdited_${postId}`).
                 should('be.visible').
-                should('contain', '(edited)');
+                should('contain', 'Edited');
         });
     });
 
@@ -200,7 +200,11 @@ describe('Keyboard Shortcuts', () => {
         // # Click "Keyboard shortcuts" at help menu
         cy.uiOpenHelpMenu('Keyboard shortcuts');
 
-        const name = isMac() ? /Keyboard Shortcuts ⌘ \// : /Keyboard Shortcuts Ctrl \//;
-        cy.findByRole('dialog', {name}).should('be.visible');
+        modalShouldOpen();
     });
 });
+
+function modalShouldOpen() {
+    const name = isMac() ? /Keyboard Shortcuts ⌘ \// : /Keyboard Shortcuts Ctrl \//;
+    cy.findByRole('dialog', {name}).should('be.visible');
+}

--- a/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -496,12 +496,12 @@ describe('Messaging', () => {
             // * Close the modal
             cy.get('#editButton', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible').click();
 
-            // # Verify that last post does not contain (edited)
-            cy.get(`#postMessageText_${postId}`).should('contain', message1).and('not.contain', '(edited)');
+            // # Verify that last post does not contain "Edited"
+            cy.get(`#postMessageText_${postId}`).should('contain', message1).and('not.contain', 'Edited');
         });
     });
 
-    it('MM-T2140 Edited message displays edits and `(edited)` in center and RHS', () => {
+    it('MM-T2140 Edited message displays edits and "Edited" in center and RHS', () => {
         // # Mobile app
         cy.viewport('iphone-6');
 
@@ -524,18 +524,18 @@ describe('Messaging', () => {
         });
 
         cy.getLastPostId().then((postId) => {
-            // # Verify that the posted message contains (edited)
+            // # Verify that the posted message contains "Edited"
             cy.get(`#post_${postId}`).within((el) => {
-                cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
             });
 
             // # Open the RHS panel
             cy.clickPostCommentIcon(postId);
 
-            // # Verify that the updated post message in RHS contains (edited)
+            // # Verify that the updated post message in RHS contains "Edited"
             cy.get('#rhsContainer').should('be.visible').within(() => {
                 cy.get(`#rhsPost_${postId}`).within((el) => {
-                    cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                    cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
                 });
             });
         });
@@ -568,15 +568,15 @@ describe('Messaging', () => {
         });
 
         cy.getLastPostId().then((postId) => {
-            // # Verify that the posted message contains (edited)
+            // # Verify that the posted message contains "Edited"
             cy.get(`#post_${postId}`).within((el) => {
-                cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
             });
 
-            // # Verify that the updated post message in RHS contains (edited)
+            // # Verify that the updated post message in RHS contains "Edited"
             cy.get('#rhsContainer').should('be.visible').within(() => {
                 cy.get(`#rhsPost_${postId}`).within((el) => {
-                    cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                    cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
                 });
             });
         });
@@ -643,8 +643,8 @@ describe('Messaging', () => {
                 // # Verify that the message is in a code block
                 cy.wrap(el).find('.post-code.post-code--wrap').should('have.text', 'test update');
 
-                // # Verify that the updated post contains '(edited)'
-                cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                // # Verify that the updated post contains 'Edited'
+                cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
             });
         });
     });
@@ -668,16 +668,16 @@ describe('Messaging', () => {
         });
 
         cy.getLastPostId().then((postId) => {
-            // # Verify that the updated post contains '(edited)'
+            // # Verify that the updated post contains 'Edited'
             cy.get(`#post_${postId}`).within((el) => {
                 // # Verify that the updated post contains updated message
                 cy.wrap(el).findByText(message2).should('be.visible');
-                cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
             });
         });
     });
 
-    it('MM-T2145 Other user sees `(edited)`', () => {
+    it('MM-T2145 Other user sees "Edited"', () => {
         // # Post message
         cy.get('#post_textbox').type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
@@ -699,9 +699,9 @@ describe('Messaging', () => {
         cy.apiLogin(otherUser);
 
         cy.getLastPostId().then((postId) => {
-            // # Verify that the updated post contains '(edited)'
+            // # Verify that the updated post contains 'Edited'
             cy.get(`#post_${postId}`).within((el) => {
-                cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
             });
 
             // # Reply to the message
@@ -709,9 +709,9 @@ describe('Messaging', () => {
             cy.clickPostCommentIcon(postId);
 
             cy.get('#rhsContainer').should('be.visible').within(() => {
-                // # Verify that the updated post in RHS contains '(edited)'
+                // # Verify that the updated post in RHS contains 'Edited'
                 cy.get(`#rhsPost_${postId}`).within((el) => {
-                    cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                    cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
                 });
             });
         });
@@ -738,11 +738,11 @@ describe('Messaging', () => {
             cy.get('#edit_textbox', {timeout: TIMEOUTS.FIVE_SEC}).invoke('val', '').type(message2).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
             // * Post appears in RHS search results, displays Pinned badge
-            cy.get(`#searchResult_${postId}`).findByText('(edited)').should('exist');
+            cy.get(`#searchResult_${postId}`).findByText('Edited').should('exist');
 
-            // # Verify that the updated post contains '(edited)'
+            // # Verify that the updated post contains 'Edited'
             cy.get(`#post_${postId}`).within((el) => {
-                cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
             });
 
             // # Close the modal
@@ -778,10 +778,10 @@ describe('Messaging', () => {
             cy.get('#editButton', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible').click();
         });
 
-        // # Verify tha the updated post contians '(edited)'
+        // # Verify tha the updated post contains 'Edited'
         cy.getLastPostId().then((postId) => {
             cy.get(`#post_${postId}`).within((el) => {
-                cy.wrap(el).find('.post-edited__indicator').should('have.text', '(edited)');
+                cy.wrap(el).find('.post-edited__indicator').should('have.text', 'Edited');
             });
         });
     });

--- a/e2e/cypress/integration/messaging/direct_message_spec.js
+++ b/e2e/cypress/integration/messaging/direct_message_spec.js
@@ -70,10 +70,10 @@ describe('Direct Message', () => {
             cy.get('#edit_textbox').should('have.text', originalMessage).type(' World{enter}');
             cy.get('#editPostModal').should('not.exist');
 
-            // * Verify that last post does contain (edited)
+            // * Verify that last post does contain "Edited"
             cy.getLastPostId().then((postId) => {
                 const postEdited = `#postEdited_${postId}`;
-                cy.get(postEdited).should('be.visible');
+                cy.get(postEdited).should('be.visible').and('have.text', 'Edited');
             });
         }).apiLogout().wait(TIMEOUTS.HALF_SEC);
 
@@ -93,7 +93,7 @@ describe('Direct Message', () => {
                 const postEdited = `#postEdited_${postId}`;
 
                 // * Check the post and verify that it contains new edited message.
-                cy.get(postText).should('have.text', editedMessage);
+                cy.get(postText).should('have.text', `${editedMessage} Edited`);
                 cy.get(postEdited).should('be.visible');
             });
         }).apiLogout().wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
@@ -87,7 +87,7 @@ describe('Permalink message edit', () => {
         cy.wait(TIMEOUTS.FIVE_SEC).url().should('include', `/${team.name}/channels/town-square`).and('not.include', `/${permalinkId}`);
 
         // * Verify edited post
-        cy.get(`#postMessageText_${permalinkId}`).should('have.text', text);
-        cy.get(`#postEdited_${permalinkId}`).should('have.text', '(edited)');
+        cy.get(`#postMessageText_${permalinkId}`).should('have.text', `${text} Edited`);
+        cy.get(`#postEdited_${permalinkId}`).should('have.text', 'Edited');
     }
 });

--- a/e2e/cypress/integration/messaging/strikethrough_spec.js
+++ b/e2e/cypress/integration/messaging/strikethrough_spec.js
@@ -15,8 +15,8 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 describe('Messaging', () => {
     before(() => {
         // # Login as test user and visit off-topic
-        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
-            cy.visit(`/${team.name}/channels/off-topic`);
+        cy.apiInitSetup({loginAfter: true}).then(({offTopicUrl}) => {
+            cy.visit(offTopicUrl);
         });
     });
 
@@ -60,13 +60,14 @@ describe('Messaging', () => {
         cy.get('#suggestionList').should('not.exist');
 
         // # Save the changes
-        cy.get('#editButton').click({force: true});
+        cy.uiSave();
 
         cy.getLastPostId().then((postId) => {
-            // * Message strikedthrough should be the same message we posted
-            cy.get(`#postMessageText_${postId}`).find('del').should('contain', message).
-                and('have.css', 'text-decoration', 'line-through solid rgb(63, 67, 80)');
-            cy.get(`#postEdited_${postId}`).should('be.visible').and('have.text', '(edited)');
+            // * Strikethrough message should be the same message we posted
+            cy.get(`#postMessageText_${postId}`).
+                should('have.text', `${message} Edited`).
+                find('del').
+                should('contain', message);
         });
     });
 });

--- a/e2e/cypress/integration/messaging/typing_should_show_up_when_editing_spec.js
+++ b/e2e/cypress/integration/messaging/typing_should_show_up_when_editing_spec.js
@@ -13,8 +13,8 @@
 describe('Messaging', () => {
     before(() => {
         // # Login as test user and visit off-topic channel
-        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
-            cy.visit(`/${team.name}/channels/off-topic`);
+        cy.apiInitSetup({loginAfter: true}).then(({offTopicUrl}) => {
+            cy.visit(offTopicUrl);
         });
     });
 
@@ -29,11 +29,11 @@ describe('Messaging', () => {
         cy.get('#edit_textbox').type(' and test post 2').should('have.text', 'test post 1 and test post 2');
 
         // # Click on the save button to edit the post
-        cy.get('#editButton').click();
+        cy.uiSave();
 
         // # Get the last post and check that none of the text was cut off after being edited
         cy.getLastPostId().then((postId) => {
-            cy.get(`#postMessageText_${postId}`).should('have.text', 'test post 1 and test post 2');
+            cy.get(`#postMessageText_${postId}`).should('have.text', 'test post 1 and test post 2 Edited');
         });
     });
 });


### PR DESCRIPTION
#### Summary
Failed tests introduced by https://github.com/mattermost/mattermost-webapp/pull/8851

Test report - https://automation-dashboard.vercel.app/cycles/726450d3-2515-48ec-bae7-ceb55a246d35

Note: MM-T1239 is known product bug - https://mattermost.atlassian.net/browse/MM-38971

#### Screenshots (some)
<img width="586" alt="Screen Shot 2021-10-01 at 6 24 12 AM" src="https://user-images.githubusercontent.com/5334504/135547477-c89a64f8-ba67-4e2b-a766-adb53ffad050.png">
<img width="669" alt="Screen Shot 2021-10-01 at 6 24 53 AM" src="https://user-images.githubusercontent.com/5334504/135547479-5c99bf07-37c7-4c64-889f-0f35801b1d55.png">
<img width="527" alt="Screen Shot 2021-10-01 at 7 49 18 AM" src="https://user-images.githubusercontent.com/5334504/135547482-589fbf4f-305d-42aa-8367-27ef95df289f.png">
<img width="541" alt="Screen Shot 2021-10-01 at 8 16 36 AM" src="https://user-images.githubusercontent.com/5334504/135547487-68dbd880-373b-44da-9a70-7604e3f82884.png">
<img width="307" alt="Screen Shot 2021-10-01 at 8 18 20 AM" src="https://user-images.githubusercontent.com/5334504/135547488-b7760e2d-367b-4487-9aeb-40120957e397.png">

#### Release Note
```release-note
NONE
```
