### PR TITLE
MM-38908: Handle /:team/_playbooks/:playbookId/run

### DIFF
--- a/components/channel_layout/center_channel/center_channel.tsx
+++ b/components/channel_layout/center_channel/center_channel.tsx
@@ -11,6 +11,7 @@ import LoadingScreen from 'components/loading_screen';
 import PermalinkView from 'components/permalink_view';
 import ChannelHeaderMobile from 'components/channel_header_mobile';
 import ChannelIdentifierRouter from 'components/channel_layout/channel_identifier_router';
+import PlaybookRunner from 'components/channel_layout/playbook_runner';
 import {makeAsyncComponent} from 'components/async_load';
 const LazyGlobalThreads = makeAsyncComponent(
     React.lazy(() => import('components/threading/global_threads')),
@@ -115,6 +116,11 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
                             path='/:team/:path(channels|messages)/:identifier/:postid?'
                             component={ChannelIdentifierRouter}
                         />
+                        <Route
+                            path='/:team/_playbooks/:playbookId/run'
+                        >
+                            <PlaybookRunner/>
+                        </Route>
                         {isCollapsedThreadsEnabled ? (
                             <Route
                                 path='/:team/threads/:threadIdentifier?'

--- a/components/channel_layout/playbook_runner.tsx
+++ b/components/channel_layout/playbook_runner.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useEffect} from 'react';
+import {AnyAction, Dispatch} from 'redux';
+import {useDispatch, useSelector} from 'react-redux';
+import {useRouteMatch} from 'react-router-dom';
+
+import {getChannelByName} from 'mattermost-redux/selectors/entities/channels';
+import {Client4} from 'mattermost-redux/client';
+import {IntegrationTypes} from 'mattermost-redux/action_types';
+import {Channel} from 'mattermost-redux/types/channels';
+import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
+import {generateId} from 'mattermost-redux/utils/helpers';
+
+import {switchToChannel} from 'actions/views/channel';
+import {getLastViewedChannelNameByTeamName} from 'selectors/local_storage';
+import {GlobalState} from 'types/store';
+
+interface MatchParams {
+    team: string;
+    playbookId: string;
+}
+
+const PlaybookRunner = () => {
+    const match = useRouteMatch<MatchParams>();
+    const dispatch = useDispatch();
+
+    const teamName = match.params.team;
+    const playbookId = match.params.playbookId;
+
+    const team = useSelector((state: GlobalState) => getTeamByName(state, teamName));
+
+    const lastViewedChannelName = useSelector((state: GlobalState) => getLastViewedChannelNameByTeamName(state, teamName));
+    const lastViewedChannel = useSelector((state: GlobalState) => getChannelByName(state, lastViewedChannelName));
+
+    useEffect(() => {
+        const switchToChannelAndStartRun = async () => {
+            const channelToSwitchTo = lastViewedChannel ?? await Client4.getChannelByName(team?.id || '', 'town-square');
+
+            dispatch(switchToChannel(channelToSwitchTo));
+            dispatch(startPlaybookRunById(channelToSwitchTo, team?.id || '', playbookId));
+        };
+
+        switchToChannelAndStartRun();
+    }, []);
+
+    return null;
+};
+
+function startPlaybookRunById(currentChannel: Channel, teamId: string, playbookId: string) {
+    return async (dispatch: Dispatch<AnyAction>) => {
+        // Generate a unique id for the command and send it to Playbooks
+        const clientId = generateId();
+        dispatch({type: 'playbooks_set_client_id', clientId});
+
+        const command = `/playbook run-playbook ${playbookId} ${clientId}`;
+
+        const args = {
+            channel_id: currentChannel.id,
+            team_id: teamId,
+        };
+
+        try {
+            const data = await Client4.executeCommand(command, args);
+            dispatch({type: IntegrationTypes.RECEIVED_DIALOG_TRIGGER_ID, data: data?.trigger_id});
+        } catch (error) {
+            console.error(error); //eslint-disable-line no-console
+        }
+    };
+}
+
+export default PlaybookRunner;


### PR DESCRIPTION
#### Summary
Navigating to `/:team/_playbooks/:playbookId/run` will switch to the last viewed channel in the team, defaulting to Town Square, and then will execute the `/playbook run-playbook` command, effectively rendering an interactive dialog to run the playbook.

This is needed to support the Run button in the Playbooks product, fixing a bug in the desktop where the app successfully changes the tab to Channels but still renders the interactive dialog in the Playbooks tab.

The video below shows the use-case: the user is in team `eligendi`, then goes to the Playbooks tab and opens a Playbook in team `minus`, when clicking on the Run button, the desktop app focuses the Channels tab, where the user is redirected to the last channel viewed in the playbook team (in this case `neque` in the team `minus`) and opens the interactive dialog. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38908

#### Related Pull Requests
- Playbooks PR: https://github.com/mattermost/mattermost-plugin-playbooks/pull/780

#### Screenshots
https://user-images.githubusercontent.com/3924815/135624556-f38d661e-e7a1-41a7-bea6-930e78227689.mp4

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
