### PR TITLE
[MM-35202] Enable require setting are enabled before installing demo plugin

### DIFF
--- a/e2e/cypress/integration/plugins/upgrade_spec.js
+++ b/e2e/cypress/integration/plugins/upgrade_spec.js
@@ -34,6 +34,17 @@ describe('Plugin remains enabled when upgraded', () => {
     });
 
     it('MM-T40 Plugin remains enabled when upgraded', () => {
+        // # Set plugin settings
+        const newSettings = {
+            ServiceSettings: {
+                EnableGifPicker: true,
+            },
+            FileSettings: {
+                EnablePublicLink: true,
+            },
+        };
+        cy.apiUpdateConfig(newSettings);
+
         // * Upload Demo plugin from the browser
         const mimeType = 'application/gzip';
         cy.fixture(demoPluginOld.filename, 'binary').


### PR DESCRIPTION
#### Summary
The demo plugin has some required settings defined in https://github.com/mattermost/mattermost-plugin-demo/blob/b04ab557a22d2d5bd83a7f5e1caed91d4b83f58b/plugin.json#L135-L142. The e2e test needs to ensure these are enabled before trying to install the plugin.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35202

#### Release Note
```release-note
NONE
```
