### PR TITLE
[MM-36883] Show ephemeral message as centre post even if CRT is enabled

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -4,6 +4,7 @@
 import {ChannelTypes, GeneralTypes, PostTypes, UserTypes, ThreadTypes} from 'mattermost-redux/action_types';
 
 import {Posts} from 'mattermost-redux/constants';
+import {PostTypes as PostConstant} from 'utils/constants';
 
 import {GenericAction} from 'mattermost-redux/types/actions';
 import {
@@ -402,7 +403,7 @@ export function postsInChannel(state: Dictionary<PostOrderBlock[]> = {}, action:
     case PostTypes.RECEIVED_NEW_POST: {
         const post = action.data as Post;
 
-        if (action.features?.crtEnabled && post.root_id) {
+        if (action.features?.crtEnabled && post.root_id && post.type !== PostConstant.EPHEMERAL) {
             return state;
         }
 


### PR DESCRIPTION
#### Summary
When CRT is enabled ephemeral message were rendering only in RHS without any indication on centre post, this change will add ephemeral message in centre channel as well

#### Ticket Link
[https://mattermost.atlassian.net/browse/MM-36883](https://mattermost.atlassian.net/browse/MM-36883)

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="1792" alt="Screenshot 2021-10-04 at 2 03 27 PM" src="https://user-images.githubusercontent.com/16203333/135819270-940724f1-acd1-4a5c-985c-813a59ce671e.png"> | <img width="1792" alt="Screenshot 2021-10-04 at 2 02 29 PM" src="https://user-images.githubusercontent.com/16203333/135819345-ce8bef4f-4f46-4f42-8678-ae90e753d519.png"> |

#### Release Note
```release-note
* Show ephemeral message as centre post even if CRT is enabled
```
