### PR TITLE
[MM-20402] Migrate 'components/mfa/mfa_controller' to TypeScript

### DIFF
--- a/components/mfa/mfa_controller/index.ts
+++ b/components/mfa/mfa_controller/index.ts
@@ -5,9 +5,11 @@ import {connect} from 'react-redux';
 
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
-import MFAController from './mfa_controller.jsx';
+import {GlobalState} from 'types/store';
 
-function mapStateToProps(state) {
+import MFAController from './mfa_controller';
+
+function mapStateToProps(state: GlobalState) {
     const license = getLicense(state);
     const config = getConfig(state);
 

--- a/components/mfa/mfa_controller/mfa_controller.tsx
+++ b/components/mfa/mfa_controller/mfa_controller.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {Route, Switch} from 'react-router-dom';
+import {Route, Switch, RouteComponentProps} from 'react-router-dom';
 
 import {emitUserLoggedOutEvent} from 'actions/global_actions';
 import logoImage from 'images/logo.png';
@@ -14,27 +13,60 @@ import LogoutIcon from 'components/widgets/icons/fa_logout_icon';
 import Setup from '../setup';
 import Confirm from '../confirm';
 
-export default class MFAController extends React.PureComponent {
-    componentDidMount() {
+type Location = {
+    search: string;
+}
+
+type Props = {
+    location: Location;
+    children: React.ReactNode;
+    mfa: boolean;
+    enableMultifactorAuthentication: boolean;
+    enforceMultifactorAuthentication: boolean;
+
+    /*
+     * Object from react-router
+     */
+    match: {
+        url: string;
+    };
+}
+
+type State = {
+    enforceMultifactorAuthentication?: boolean;
+}
+
+export default class MFAController extends React.PureComponent<Props & RouteComponentProps> {
+    public constructor(props: Props & RouteComponentProps) {
+        super(props);
+
+        this.state = {enforceMultifactorAuthentication: props.enableMultifactorAuthentication};
+    }
+
+    public componentDidMount(): void {
         document.body.classList.add('sticky');
-        document.getElementById('root').classList.add('container-fluid');
+        document.getElementById('root')!.classList.add('container-fluid');
 
         if (!this.props.enableMultifactorAuthentication) {
             this.props.history.push('/');
         }
     }
 
-    componentWillUnmount() {
+    public componentWillUnmount(): void {
         document.body.classList.remove('sticky');
-        document.getElementById('root').classList.remove('container-fluid');
+        document.getElementById('root')!.classList.remove('container-fluid');
     }
 
-    handleOnClick = (e) => {
+    public handleOnClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
         e.preventDefault();
         emitUserLoggedOutEvent('/login');
     }
 
-    render() {
+    public updateParent = (state: State): void => {
+        this.setState(state);
+    };
+
+    public render(): JSX.Element {
         let backButton;
         if (this.props.mfa && this.props.enforceMultifactorAuthentication) {
             backButton = (
@@ -105,18 +137,3 @@ export default class MFAController extends React.PureComponent {
         );
     }
 }
-
-MFAController.propTypes = {
-    location: PropTypes.object.isRequired,
-    children: PropTypes.node,
-    mfa: PropTypes.bool.isRequired,
-    enableMultifactorAuthentication: PropTypes.bool.isRequired,
-    enforceMultifactorAuthentication: PropTypes.bool.isRequired,
-
-    /*
-     * Object from react-router
-     */
-    match: PropTypes.shape({
-        url: PropTypes.string.isRequired,
-    }).isRequired,
-};

--- a/components/mfa/mfa_controller/mfa_controller.tsx
+++ b/components/mfa/mfa_controller/mfa_controller.tsx
@@ -19,7 +19,7 @@ type Location = {
 
 type Props = {
     location: Location;
-    children: React.ReactNode;
+    children?: React.ReactNode;
     mfa: boolean;
     enableMultifactorAuthentication: boolean;
     enforceMultifactorAuthentication: boolean;
@@ -36,7 +36,7 @@ type State = {
     enforceMultifactorAuthentication?: boolean;
 }
 
-export default class MFAController extends React.PureComponent<Props & RouteComponentProps> {
+export default class MFAController extends React.PureComponent<Props & RouteComponentProps, State> {
     public constructor(props: Props & RouteComponentProps) {
         super(props);
 

--- a/components/mfa/mfa_controller/mfa_controller.tsx
+++ b/components/mfa/mfa_controller/mfa_controller.tsx
@@ -33,7 +33,7 @@ type Props = {
 }
 
 type State = {
-    enforceMultifactorAuthentication?: boolean;
+    enforceMultifactorAuthentication: boolean;
 }
 
 export default class MFAController extends React.PureComponent<Props & RouteComponentProps, State> {

--- a/components/mfa/setup/setup.tsx
+++ b/components/mfa/setup/setup.tsx
@@ -12,7 +12,22 @@ import {t} from 'utils/i18n.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 import LocalizedInput from 'components/localized_input/localized_input';
 
+type MFAControllerState = {
+    enforceMultifactorAuthentication?: boolean;
+};
+
 type Props = {
+
+    /*
+     * Object containing enforceMultifactorAuthentication
+     */
+    state: MFAControllerState;
+
+    /*
+     * Function that updates parent component with state props
+     */
+    updateParent: (state: MFAControllerState) => void;
+
     currentUser: UserProfile;
     siteName?: string;
     enforceMultifactorAuthentication: boolean;
@@ -56,7 +71,7 @@ export default class Setup extends React.PureComponent<Props, State> {
         this.input = React.createRef();
     }
 
-    public componentDidMount() {
+    public componentDidMount(): void {
         const user = this.props.currentUser;
         if (!user || user.mfa_active) {
             this.props.history.push('/');
@@ -78,7 +93,7 @@ export default class Setup extends React.PureComponent<Props, State> {
         });
     }
 
-    submit = (e: React.FormEvent<HTMLFormElement>) => {
+    submit = (e: React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault();
         const code = this.input?.current?.value.replace(/\s/g, '');
         if (!code || code.length === 0) {
@@ -107,7 +122,7 @@ export default class Setup extends React.PureComponent<Props, State> {
         });
     }
 
-    public render() {
+    public render(): JSX.Element {
         let formClass = 'form-group';
         let errorContent;
         if (this.state.error) {

--- a/components/mfa/setup/setup.tsx
+++ b/components/mfa/setup/setup.tsx
@@ -13,7 +13,7 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx'
 import LocalizedInput from 'components/localized_input/localized_input';
 
 type MFAControllerState = {
-    enforceMultifactorAuthentication?: boolean;
+    enforceMultifactorAuthentication: boolean;
 };
 
 type Props = {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This migrates the `mfa/mfa_controller` component in the webapp to TypeScript. The trickiest part was the `state` and `updateParent` props that are passed to `setup` and `confirm` components. I've used the `create_team` component as a reference to solve this problem, creating a state prop for the mfa/mfa_controller component and an equivalent mfa_controller state type for the setup component.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA: https://mattermost.atlassian.net/browse/MM-20402

<!--#### Related Pull Requests
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
- Has server changes (please link here)
- Has mobile changes (please link here)
-->

<!--
#### Screenshots
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

<!--
#### Release Note
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
```release-note

```
-->
