### PR TITLE
MM-39033 Revert change to More DMs modal for new users

### DIFF
--- a/components/more_direct_channels/list/index.ts
+++ b/components/more_direct_channels/list/index.ts
@@ -105,7 +105,7 @@ export function makeGetOptions(): (state: GlobalState, users: UserProfile[], val
 
             // Only show the 20 most recent DMs and GMs when no search term has been entered. If a search term has been
             // entered, `users` is expected to have already been filtered by it
-            if (!isSearch) {
+            if (!isSearch && recents.length > 0) {
                 return recents.slice(0, 20);
             }
 


### PR DESCRIPTION
I accidentally made it so that new users would see an empty DM modal instead of a list of all users alphabetically before they had any DMs opened. This fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39033

#### Screenshots
Before:
![Screen Shot 2021-10-04 at 10 24 32 AM](https://user-images.githubusercontent.com/3277310/135872921-ed674a4d-18a6-4340-80df-807e2ff05fe0.png)
After:
![Screen Shot 2021-10-04 at 10 46 47 AM](https://user-images.githubusercontent.com/3277310/135872940-712c1a62-16a0-44bb-885f-34fd046c3099.png)

#### Release Note
```release-note
NONE
```
