### PR TITLE
MM-39034 Fix 'no results found' string in More DMs modal

### DIFF
--- a/components/multiselect/__snapshots__/multiselect.test.tsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.tsx.snap
@@ -169,6 +169,7 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
       }
       page={0}
       perPage={5}
+      query=""
     />
     <div
       className="multi-select__help"
@@ -350,6 +351,7 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
       }
       page={1}
       perPage={5}
+      query=""
     />
     <div
       className="multi-select__help"

--- a/components/multiselect/multiselect.tsx
+++ b/components/multiselect/multiselect.tsx
@@ -409,6 +409,7 @@ export default class MultiSelect<T extends Value> extends React.PureComponent<Pr
                     onAdd={this.onAdd}
                     onSelect={this.onSelect}
                     loading={this.props.loading}
+                    query={this.state.input}
                     selectedItemRef={this.props.selectedItemRef}
                 />
             );


### PR DESCRIPTION
When a related modal was updated in #7172 and we changed the message from "No items found" to "No results found for **whatever**", we forgot to pass in the search query, so it just displayed "No results found for ****"

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39034

#### Screenshots
![Screen Shot 2021-10-04 at 11 02 34 AM](https://user-images.githubusercontent.com/3277310/135875354-5023682f-b595-4fc0-92a1-be7268af86d3.png)

#### Release Note
```release-note
Fixed "No results found" string in Direct Messages modal
```
