### PR TITLE
Cypress/E2E: Fix some prod messaging tests

### DIFF
--- a/e2e/cypress/integration/messaging/channel_and_posts_links_spec.js
+++ b/e2e/cypress/integration/messaging/channel_and_posts_links_spec.js
@@ -10,6 +10,8 @@
 // Stage: @prod
 // Group: @messaging
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 describe('Message permalink', () => {
     let testTeam;
     let testChannel;
@@ -87,7 +89,7 @@ describe('Message permalink', () => {
         cy.visit(`/${testTeam.name}/channels/off-topic`);
 
         // # Clear then type ~ and prefix of channel name
-        cy.get('#post_textbox').should('be.visible').clear().type('~' + publicChannelName.substring(0, 3));
+        cy.get('#post_textbox').should('be.visible').clear().type('~' + publicChannelName.substring(0, 3)).wait(TIMEOUTS.HALF_SEC);
 
         // * Verify that the item is displayed or not as expected.
         cy.get('#suggestionList').should('be.visible').within(() => {
@@ -109,7 +111,7 @@ describe('Message permalink', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Clear then type ~ and prefix of channel name
-        cy.get('#post_textbox').should('be.visible').clear().type(`~${testChannel.display_name}`);
+        cy.get('#post_textbox').should('be.visible').clear().type(`~${testChannel.display_name}`).wait(TIMEOUTS.HALF_SEC);
 
         // * Verify that the item is displayed or not as expected.
         cy.get('#suggestionList').within(() => {

--- a/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
@@ -58,7 +58,7 @@ describe('Permalink message edit', () => {
             const editedText = `edited - ${searchWord}`;
 
             // # Add new text in edit box
-            cy.get('#edit_textbox').should('be.visible').type('any').clear().type(editedText);
+            cy.get('#edit_textbox').should('be.visible').type('any').clear({force: true}).type(editedText);
 
             // # Click edit button
             cy.get('#editButton').click();


### PR DESCRIPTION
#### Summary
- Fix some failing prod messaging e2e

Test report - https://automation-dashboard.vercel.app/cycles/bd3f7721-690f-4385-9966-58753174c377

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-10-04 at 9 49 04 AM](https://user-images.githubusercontent.com/487991/135892178-3081416c-d6ae-4d1a-9588-b7f9451c21f7.png)
![Screen Shot 2021-10-04 at 9 51 17 AM](https://user-images.githubusercontent.com/487991/135892182-e6c3fafc-9ab7-430b-9f6f-24ca6c79fd3c.png)

#### Release Note
```release-note
NONE
```