### PR TITLE
MM-39046 Don't modify all drafts on page load

### DIFF
--- a/actions/storage.js
+++ b/actions/storage.js
@@ -62,24 +62,9 @@ export function clear(options = {exclude: []}) {
 }
 
 export function actionOnGlobalItemsWithPrefix(prefix, action) {
-    return (dispatch) => {
-        dispatch({
-            type: StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX,
-            data: {prefix, action},
-        });
-        return {data: true};
-    };
-}
-
-export function actionOnItemsWithPrefix(prefix, action) {
-    return (dispatch, getState) => {
-        const state = getState();
-        const globalPrefix = getPrefix(state);
-        dispatch({
-            type: StorageTypes.ACTION_ON_ITEMS_WITH_PREFIX,
-            data: {globalPrefix, prefix, action},
-        });
-        return {data: true};
+    return {
+        type: StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX,
+        data: {prefix, action},
     };
 }
 

--- a/actions/storage.test.js
+++ b/actions/storage.test.js
@@ -70,23 +70,6 @@ describe('Actions.Storage', () => {
         );
     });
 
-    it('actionOnItemsWithPrefix', async () => {
-        store.dispatch(Actions.setItem('prefix_test1', 1));
-        store.dispatch(Actions.setItem('prefix_test2', 2));
-        store.dispatch(Actions.setItem('not_prefix_test', 3));
-
-        const touchedPairs = [];
-        store.dispatch(Actions.actionOnItemsWithPrefix(
-            'prefix',
-            (key, value) => touchedPairs.push([key, value]),
-        ));
-
-        assert.deepEqual(
-            touchedPairs,
-            [['prefix_test1', 1], ['prefix_test2', 2]],
-        );
-    });
-
     it('clear', async () => {
         store.dispatch(Actions.setGlobalItem('key', 'value'));
         store.dispatch(Actions.setGlobalItem('excluded', 'not-cleared'));

--- a/actions/views/create_comment.tsx
+++ b/actions/views/create_comment.tsx
@@ -34,11 +34,12 @@ import {GlobalState} from 'types/store';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 export function clearCommentDraftUploads() {
-    return actionOnGlobalItemsWithPrefix(StoragePrefixes.COMMENT_DRAFT, (_key: string, value: PostDraft) => {
-        if (value) {
-            return {...value, uploadsInProgress: []};
+    return actionOnGlobalItemsWithPrefix(StoragePrefixes.COMMENT_DRAFT, (_key: string, draft: PostDraft) => {
+        if (!draft || draft.uploadsInProgress.length === 0) {
+            return draft;
         }
-        return value;
+
+        return {...draft, uploadsInProgress: []};
     });
 }
 

--- a/components/create_post/create_post.tsx
+++ b/components/create_post/create_post.tsx
@@ -255,7 +255,7 @@ type Props = {
         /**
       *  func called on load of component to clear drafts
       */
-        clearDraftUploads: (prefix: string, action: (key: string, value?: PostDraft) => PostDraft | undefined) => void;
+        clearDraftUploads: () => void;
 
         /**
       * hooks called before a message is sent to the server
@@ -391,12 +391,7 @@ class CreatePost extends React.PureComponent<Props, State> {
         const {useGroupMentions, currentChannel, isTimezoneEnabled, actions} = this.props;
         this.onOrientationChange();
         actions.setShowPreview(false);
-        actions.clearDraftUploads(StoragePrefixes.DRAFT, (key, value) => {
-            if (value) {
-                return {...value, uploadsInProgress: []};
-            }
-            return value;
-        });
+        actions.clearDraftUploads();
         this.focusTextbox();
         document.addEventListener('paste', this.pasteHandler);
         document.addEventListener('keydown', this.documentKeyHandler);

--- a/components/create_post/index.ts
+++ b/components/create_post/index.ts
@@ -146,7 +146,7 @@ type Actions = {
     addReaction: (postId: string, emojiName: string) => void;
     onSubmitPost: (post: Post, fileInfos: FileInfo[]) => void;
     removeReaction: (postId: string, emojiName: string) => void;
-    clearDraftUploads: (prefix: string, action: (key: string, value?: PostDraft) => PostDraft | undefined) => void;
+    clearDraftUploads: () => void;
     runMessageWillBePostedHooks: (originalPost: Post) => ActionResult;
     runSlashCommandWillBePostedHooks: (originalMessage: string, originalArgs: CommandArgs) => ActionResult;
     setDraft: (name: string, value: PostDraft | null) => void;
@@ -172,6 +172,16 @@ function setDraft(key: string, value: PostDraft) {
     return setGlobalItem(key, value);
 }
 
+function clearDraftUploads() {
+    return actionOnGlobalItemsWithPrefix(StoragePrefixes.DRAFT, (_key: string, draft: PostDraft) => {
+        if (!draft || draft.uploadsInProgress.length === 0) {
+            return draft;
+        }
+
+        return {...draft, uploadsInProgress: []};
+    });
+}
+
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<any>, Actions>({
@@ -182,7 +192,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
             addReaction,
             removeReaction,
             setDraft,
-            clearDraftUploads: actionOnGlobalItemsWithPrefix,
+            clearDraftUploads,
             selectPostFromRightHandSideSearchByPostId,
             setEditingPost,
             emitShortcutReactToLastPostFrom,

--- a/reducers/storage.test.js
+++ b/reducers/storage.test.js
@@ -9,7 +9,7 @@ import {StorageTypes} from 'utils/constants';
 describe('Reducers.Storage', () => {
     const now = new Date();
 
-    it('Storage.SET_ITEM', async () => {
+    it('Storage.SET_ITEM', () => {
         const nextState = storageReducer(
             {
                 storage: {},
@@ -32,7 +32,7 @@ describe('Reducers.Storage', () => {
         );
     });
 
-    it('Storage.SET_GLOBAL_ITEM', async () => {
+    it('Storage.SET_GLOBAL_ITEM', () => {
         const nextState = storageReducer(
             {
                 storage: {},
@@ -54,7 +54,7 @@ describe('Reducers.Storage', () => {
         );
     });
 
-    it('Storage.REMOVE_ITEM', async () => {
+    it('Storage.REMOVE_ITEM', () => {
         var nextState = storageReducer(
             {
                 storage: {
@@ -91,7 +91,7 @@ describe('Reducers.Storage', () => {
         );
     });
 
-    it('Storage.REMOVE_GLOBAL_ITEM', async () => {
+    it('Storage.REMOVE_GLOBAL_ITEM', () => {
         var nextState = storageReducer(
             {
                 storage: {
@@ -126,7 +126,7 @@ describe('Reducers.Storage', () => {
         );
     });
 
-    it('Storage.CLEAR', async () => {
+    it('Storage.CLEAR', () => {
         const nextState = storageReducer(
             {
                 storage: {
@@ -149,56 +149,54 @@ describe('Reducers.Storage', () => {
         );
     });
 
-    it('Storage.ACTION_ON_ITEMS_WITH_PREFIX', async () => {
-        var touchedPairs = [];
-        storageReducer(
-            {
-                storage: {
-                    user_id_prefix_key1: {value: 1, timestamp: now},
-                    user_id_prefix_key2: {value: 2, timestamp: now},
-                    user_id_not_prefix_key: {value: 3, timestamp: now},
-                },
-            },
-            {
-                type: StorageTypes.ACTION_ON_ITEMS_WITH_PREFIX,
-                data: {
-                    globalPrefix: 'user_id_',
-                    prefix: 'prefix',
-                    action: (key, value) => touchedPairs.push([key, value]),
-                },
-            },
-        );
-        assert.deepEqual(
-            touchedPairs,
-            [['prefix_key1', 1], ['prefix_key2', 2]],
-        );
-    });
-
-    it('Storage.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX', async () => {
-        var touchedPairs = [];
-        storageReducer(
-            {
+    describe('Storage.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX', () => {
+        it('should call the provided action on the given objects', () => {
+            const state = storageReducer({
                 storage: {
                     prefix_key1: {value: 1, timestamp: now},
                     prefix_key2: {value: 2, timestamp: now},
                     not_prefix_key: {value: 3, timestamp: now},
                 },
-            },
-            {
+            }, {});
+
+            const nextState = storageReducer(state, {
                 type: StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX,
                 data: {
                     prefix: 'prefix',
-                    action: (key, value) => touchedPairs.push([key, value]),
+                    action: (key, value) => value + 5,
                 },
-            },
-        );
-        assert.deepEqual(
-            touchedPairs,
-            [['prefix_key1', 1], ['prefix_key2', 2]],
-        );
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.storage.prefix_key1.value).toBe(6);
+            expect(nextState.storage.prefix_key1.timestamp).not.toBe(now);
+            expect(nextState.storage.prefix_key2.value).toBe(7);
+            expect(nextState.storage.prefix_key2.timestamp).not.toBe(now);
+            expect(nextState.storage.prefix_key3).toBe(state.storage.prefix_key3);
+        });
+
+        it('should return the original state if no results change', () => {
+            const state = storageReducer({
+                storage: {
+                    prefix_key1: {value: 1, timestamp: now},
+                    prefix_key2: {value: 2, timestamp: now},
+                    not_prefix_key: {value: 3, timestamp: now},
+                },
+            }, {});
+
+            const nextState = storageReducer(state, {
+                type: StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX,
+                data: {
+                    prefix: 'prefix',
+                    action: (key, value) => value,
+                },
+            });
+
+            expect(nextState).toBe(state);
+        });
     });
 
-    it('Storage.STORAGE_REHYDRATE', async () => {
+    it('Storage.STORAGE_REHYDRATE', () => {
         var nextState = storageReducer(
             {
                 storage: {},

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -593,7 +593,6 @@ export const StorageTypes = keyMirror({
     REMOVE_GLOBAL_ITEM: null,
     CLEAR: null,
     ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX: null,
-    ACTION_ON_ITEMS_WITH_PREFIX: null,
     STORAGE_REHYDRATE: null,
 });
 


### PR DESCRIPTION
I think this logic is also related to the performance issues we've been fighting. Every time a `CreatePost` or `CreateComment` is mounted, we go through and clear up all in-progress file uploads (which is another bug for the RHS since it means you have to leave the RHS open while a file uploads or else it'll be cleared), and when we do that, we mutate all the drafts. That, in turn, caused all the other tabs to rehydrate which caused other performance-affecting stuff to happen.

Now, we'll only mutate them if there were actually changes to be made.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39046

#### Release Note
```release-note
Reduce storage-related slow downs on page load
```
