### PR TITLE
Cypress/E2E: Fix some unstable messaging tests

### DIFF
--- a/e2e/cypress/integration/messaging/permalink_click_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_click_spec.js
@@ -63,9 +63,6 @@ describe('Permalink message edit', () => {
                         // # Go to channel 1 from url
                         cy.visit(`/${testTeam.name}/channels/${channel1.name}`);
 
-                        // * Verify that we've switched to the team related to channel
-                        cy.uiGetLHSHeader().findByText(testTeam.display_name);
-
                         // * Prompt should be shown upon going to the screen
                         verifyPrivateChannelJoinPromptIsVisible(channel1);
 

--- a/e2e/cypress/integration/messaging/single_image_thumbnail_spec.js
+++ b/e2e/cypress/integration/messaging/single_image_thumbnail_spec.js
@@ -40,7 +40,7 @@ function verifySingleImageThumbnail({mode = null} = {}) {
 
     // # Make a post with some text and a single image
     cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(filename);
-    cy.get('post-image__thumbnail').should('be.visible');
+    cy.get('.post-image__thumbnail').should('be.visible');
 
     cy.postMessage(MESSAGES.MEDIUM);
 


### PR DESCRIPTION
#### Summary
- Fix some failing unstable messaging e2e

Test report - N/A (currently broken)

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-10-04 at 12 38 28 PM](https://user-images.githubusercontent.com/487991/135914144-00016715-d349-4496-a580-e5cfdbb4d75b.png)
![Screen Shot 2021-10-04 at 12 39 58 PM](https://user-images.githubusercontent.com/487991/135914146-f1ec1b0c-f505-45e3-aecd-1896d44a93dd.png)

#### Release Note
```release-note
NONE
```