### PR TITLE
Automated cherry pick of #8971

### DIFF
--- a/components/file_preview_modal/file_preview_modal.jsx
+++ b/components/file_preview_modal/file_preview_modal.jsx
@@ -277,7 +277,7 @@ export default class FilePreviewModal extends React.PureComponent {
 
         const fileInfo = this.props.fileInfos[this.state.imageIndex];
         const showPublicLink = !fileInfo.link;
-        const fileName = fileInfo.link || fileInfo.name;
+        const fileName = fileInfo.name || fileInfo.link;
         const fileType = Utils.getFileType(fileInfo.extension);
         const fileUrl = fileInfo.link || getFileUrl(fileInfo.id);
         const fileDownloadUrl = fileInfo.link || getFileDownloadUrl(fileInfo.id);

--- a/components/post_view/post_image/post_image.jsx
+++ b/components/post_view/post_image/post_image.jsx
@@ -58,6 +58,7 @@ export default class PostImage extends React.PureComponent {
                                     has_preview_image: false,
                                     link: safeLink,
                                     extension: this.props.imageMetadata.format,
+                                    name: this.props.link,
                                 }]}
                             />
                         </React.Fragment>


### PR DESCRIPTION
Cherry pick of #8971 on release-6.0.

/cc  @BenCookie95

```release-note
NONE
```