### PR TITLE
[MM-38428] Fix apps modal multi-select theme issue

### DIFF
--- a/components/apps_form/apps_form_field/apps_form_select_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_select_field.tsx
@@ -36,6 +36,13 @@ const commonProps = {
     classNamePrefix: 'react-select-auto react-select',
     menuPortalTarget: document.body,
     styles: reactStyles,
+    components: {
+        MultiValueLabel: (props: {data: {label: string}}) => (
+            <div className='react-select__padded-component'>
+                {props.data.label}
+            </div>
+        ),
+    }
 };
 
 export default class AppsFormSelectField extends React.PureComponent<Props, State> {


### PR DESCRIPTION
#### Summary

This is broken on master but fixed in the open PR https://github.com/mattermost/mattermost-webapp/pull/8126. I've brought the fix over to a new PR here.

I tested on the original commit of the apps modal and it has the issue, so this bug has likely existed since then. I don't think I've seen it occur consistently since the form had been introduced, but it has consistently reproduced since the ticket for this had been created. @DHaussermann Do you recall this happening in your testing?

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-38428

#### Screenshots

Before

<img width="500px" src="https://user-images.githubusercontent.com/6913320/135949365-9296af25-c8e2-4f85-84e4-e8e080e9afb6.png"/>

After

<img width="500px" src="https://user-images.githubusercontent.com/6913320/135950694-223a01f6-80ea-4273-ba46-0a602c0b8887.png"/>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
