### PR TITLE
MM-39073: fixes threads unread tab

### DIFF
--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -91,7 +91,7 @@ const GlobalThreads = () => {
     }, [currentUserId, currentTeamId, filter]);
 
     useEffect(() => {
-        if ((!selectedThread || !selectedPost) && !isLoading) {
+        if (!selectedThread && !selectedPost && !isLoading) {
             clear();
         }
     }, [currentTeamId, selectedThread, selectedPost, isLoading, counts, filter]);


### PR DESCRIPTION
#### Summary

Clicking on an unread thread sometimes made the thread disappear.
This happened because the `getThread` selector was looking in both all
threads and in unread threads to verify the thread exists in this team,
but if you landed at unread threads tab after a refresh you don't have
more than 5 threads in all threads reducer, and if you click a thread it
was getting removed from the unread reducer.

This commit fixes that by refactoring the `getThread` selector to use
user's current team channels to check if threads belong in a current
team's channel.

There is still a way to have that buggy behavior even after this fix.
The scenario is if you have left a channel you don't get the threads
removed as of yet, so you could replicate the above buggy behavior in
that case.
Since we are going to fix this in a later task (threads will be removed
from "left" channels) I didn't bother to fix it as well.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39073

#### Release Note

```release-note
NONE
```
