### PR TITLE
[MM-38636] - edited indicator overlay now shows the clock format according to user settings

### DIFF
--- a/components/post_view/post_edited_indicator/index.ts
+++ b/components/post_view/post_edited_indicator/index.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {Preferences} from 'utils/constants';
+import {GlobalState} from '../../../types/store';
+
+import PostEditedIndicator from './post_edited_indicator';
+
+type OwnProps = {
+    postId?: string;
+    editedAt?: number;
+}
+
+type StateProps = {
+    isMilitaryTime: boolean;
+}
+
+export type Props = OwnProps & StateProps;
+
+function mapStateToProps(state: GlobalState): StateProps {
+    const isMilitaryTime = getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false);
+    return {isMilitaryTime};
+}
+
+export default connect<StateProps, null, OwnProps, GlobalState>(mapStateToProps)(PostEditedIndicator);

--- a/components/post_view/post_edited_indicator/post_edited_indicator.tsx
+++ b/components/post_view/post_edited_indicator/post_edited_indicator.tsx
@@ -4,17 +4,14 @@
 import React from 'react';
 import {Tooltip} from 'react-bootstrap';
 import {useIntl} from 'react-intl';
-import Icon from '@mattermost/compass-components/foundations/icon/Icon';
+import Icon from '@mattermost/compass-components/foundations/icon';
 
-import {isSameDay, isWithinLastWeek, isYesterday} from '../../../utils/datetime';
+import {isSameDay, isWithinLastWeek, isYesterday} from 'utils/datetime';
 import OverlayTrigger from '../../overlay_trigger';
 
-interface Props {
-    postId?: string;
-    editedAt?: number;
-}
+import {Props} from './index';
 
-const PostEditedIndicator = ({postId, editedAt = 0}: Props): JSX.Element | null => {
+const PostEditedIndicator = ({postId, isMilitaryTime, editedAt = 0}: Props): JSX.Element | null => {
     if (!postId || editedAt === 0) {
         return null;
     }
@@ -38,7 +35,7 @@ const PostEditedIndicator = ({postId, editedAt = 0}: Props): JSX.Element | null 
         date = formatDate(editedDate, {month: 'long', day: 'numeric'});
     }
 
-    const time = formatTime(editedDate, {hour: 'numeric', minute: '2-digit'});
+    const time = formatTime(editedDate, {hour: 'numeric', minute: '2-digit', hour12: isMilitaryTime});
 
     const editedText = formatMessage({
         id: 'post_message_view.edited',


### PR DESCRIPTION
#### Summary
If the user has set his clock preferences set to 24 hour format (aka "military time") it is now being respected in the edited indicator hover overlay.

#### Ticket Link
[MM-38636](https://mattermost.atlassian.net/browse/MM-38636)

#### Release Note
```release-note
edited indicator overlay now uses time format preferences
```
