### PR TITLE
[MM-38289] - Add product branding tests

### DIFF
--- a/components/global/product_branding/__snapshots__/product_branding.test.tsx.snap
+++ b/components/global/product_branding/__snapshots__/product_branding.test.tsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/ProductBranding should show correct icon glyph when we are on Boards 1`] = `
+<ProductBrandingContainer>
+  <Icon
+    glyph="product-boards"
+    size={20}
+  />
+  <Heading
+    element="h1"
+    margin="none"
+    size={200}
+  >
+    Boards
+  </Heading>
+</ProductBrandingContainer>
+`;
+
+exports[`components/ProductBranding should show correct icon glyph when we are on Channels 1`] = `
+<ProductBrandingContainer>
+  <Icon
+    glyph="product-channels"
+    size={20}
+  />
+  <Heading
+    element="h1"
+    margin="none"
+    size={200}
+  >
+    Channels
+  </Heading>
+</ProductBrandingContainer>
+`;
+
+exports[`components/ProductBranding should show correct icon glyph when we are on Playbooks 1`] = `
+<ProductBrandingContainer>
+  <Icon
+    glyph="product-playbooks"
+    size={20}
+  />
+  <Heading
+    element="h1"
+    margin="none"
+    size={200}
+  >
+    Playbooks
+  </Heading>
+</ProductBrandingContainer>
+`;

--- a/components/global/product_branding/product_branding.test.tsx
+++ b/components/global/product_branding/product_branding.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React from 'react';
+import {shallow} from 'enzyme';
+import Icon from '@mattermost/compass-components/foundations/icon';
+
+import {ProductComponent} from 'types/store/plugins';
+import {TopLevelProducts} from 'utils/constants';
+
+import ProductBranding from './product_branding';
+import * as hooks from '../hooks';
+import {makeProduct} from '../test_helpers'
+
+describe('components/ProductBranding', () => {
+    test('should show correct icon glyph when we are on Channels', () => {
+        const spyProduct = jest.spyOn(hooks, 'useCurrentProductId');
+        spyProduct.mockReturnValue('Channels');
+        const products = jest.spyOn(hooks, 'useProducts');
+        products.mockReturnValue([]);
+
+        const wrapper = shallow(
+            <ProductBranding/>,
+        );
+
+        expect(wrapper.find(Icon).prop('glyph')).toEqual('product-channels');
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should show correct icon glyph when we are on Playbooks', () => {
+        const products = jest.spyOn(hooks, 'useProducts');
+        products.mockReturnValue([makeProduct(TopLevelProducts.BOARDS) as ProductComponent,
+                                    makeProduct(TopLevelProducts.PLAYBOOKS) as ProductComponent
+                                ]);
+
+        const spyProduct = jest.spyOn(hooks, 'useCurrentProductId');
+        spyProduct.mockReturnValue('Playbooks');
+        const wrapper = shallow(
+            <ProductBranding/>,
+        );
+
+        expect(wrapper.find(Icon).prop('glyph')).toEqual('product-playbooks');
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should show correct icon glyph when we are on Boards', () => {
+        const products = jest.spyOn(hooks, 'useProducts');
+        products.mockReturnValue([makeProduct(TopLevelProducts.BOARDS) as ProductComponent,
+                                    makeProduct(TopLevelProducts.PLAYBOOKS) as ProductComponent
+                                ]);
+
+        const spyProduct = jest.spyOn(hooks, 'useCurrentProductId');
+        spyProduct.mockReturnValue('Boards');
+        const wrapper = shallow(
+            <ProductBranding/>,
+        );
+
+        expect(wrapper.find(Icon).prop('glyph')).toEqual('product-boards');
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/global/product_switcher_tip/product_switcher_tip.test.tsx
+++ b/components/global/product_switcher_tip/product_switcher_tip.test.tsx
@@ -5,26 +5,11 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import TutorialTip from 'components/tutorial/tutorial_tip';
-
 import {ProductComponent} from 'types/store/plugins';
-
 import {TutorialSteps, TopLevelProducts} from 'utils/constants';
 
 import {Props, ProductSwitcherTip} from './product_switcher_tip';
-
-function makeProduct(name: string): ProductComponent {
-    return {
-        id: '',
-        pluginId: '',
-        switcherIcon: 'none',
-        switcherText: name,
-        baseURL: '',
-        switcherLinkURL: '',
-        mainComponent: null,
-        headerCentreComponent: null,
-        headerRightComponent: null,
-    };
-}
+import {makeProduct} from '../test_helpers'
 
 let props: Props = {
     currentUserId: '',
@@ -39,8 +24,8 @@ describe('components/product_switcher/product_switcher_tip', () => {
         props = {
             currentUserId: '',
             products: [
-                makeProduct(TopLevelProducts.BOARDS),
-                makeProduct(TopLevelProducts.PLAYBOOKS),
+                makeProduct(TopLevelProducts.BOARDS) as ProductComponent,
+                makeProduct(TopLevelProducts.PLAYBOOKS) as ProductComponent,
             ],
             step: TutorialSteps.PRODUCT_SWITCHER,
             actions: {
@@ -66,7 +51,7 @@ describe('components/product_switcher/product_switcher_tip', () => {
     it('does not skip tutorial tip when tutorial step does not match and a product is missing', () => {
         props.step = TutorialSteps.PRODUCT_SWITCHER - 1;
         props.products = [
-            makeProduct(TopLevelProducts.BOARDS),
+            makeProduct(TopLevelProducts.BOARDS) as ProductComponent,
         ];
         shallow(<ProductSwitcherTip {...props}/>);
         expect(props.actions.savePreferences).not.toHaveBeenCalled();
@@ -74,7 +59,7 @@ describe('components/product_switcher/product_switcher_tip', () => {
 
     it('does not show tutorial tip when playbooks is missing', () => {
         props.products = [
-            makeProduct(TopLevelProducts.BOARDS),
+            makeProduct(TopLevelProducts.BOARDS) as ProductComponent,
         ];
 
         expect(props.actions.savePreferences).not.toHaveBeenCalled();
@@ -86,7 +71,7 @@ describe('components/product_switcher/product_switcher_tip', () => {
 
     it('does not show tutorial tip when boards is missing', () => {
         props.products = [
-            makeProduct(TopLevelProducts.PLAYBOOKS),
+            makeProduct(TopLevelProducts.PLAYBOOKS) as ProductComponent,
         ];
         expect(props.actions.savePreferences).not.toHaveBeenCalled();
         const wrapper = shallow(<ProductSwitcherTip {...props}/>);

--- a/components/global/test_helpers.tsx
+++ b/components/global/test_helpers.tsx
@@ -1,0 +1,19 @@
+import {ProductComponent} from 'types/store/plugins';
+
+type TestProductComponent = Omit<ProductComponent, 'switcherIcon'> & {
+    switcherIcon: string;
+}
+
+export function makeProduct(name: string): TestProductComponent {
+    return {
+        id: name,
+        pluginId: '',
+        switcherIcon: `product-${name.toLowerCase()}`,
+        switcherText: name,
+        baseURL: '',
+        switcherLinkURL: '',
+        mainComponent: null,
+        headerCentreComponent: null,
+        headerRightComponent: null,
+    };
+}


### PR DESCRIPTION

#### Summary
Adds a simple unit and snapshot test for product branding

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38289

#### Release Note

```release-note
NONE
```
