### PR TITLE
[MM-38290] - Add test for global header buttons

### DIFF
--- a/components/global/at_mentions_button/__snapshots__/at_mentions_button.test.tsx.snap
+++ b/components/global/at_mentions_button/__snapshots__/at_mentions_button.test.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/global/AtMentionsButton should match snapshot 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  delayShow={400}
+  overlay={<React.Fragment />}
+  placement="bottom"
+  trigger={
+    Array [
+      "hover",
+    ]
+  }
+>
+  <ForwardRef
+    aria-label="Select to toggle a list of recent mentions."
+    compact={true}
+    icon="at"
+    inverted={true}
+    onClick={[Function]}
+    size="sm"
+    toggled={false}
+  />
+</OverlayTrigger>
+`;
+
+exports[`components/global/settings_button should match snapshot 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Subscription {
+        "handleChangeWrapper": [Function],
+        "listeners": Object {
+          "notify": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": null,
+      },
+    }
+  }
+>
+  <AtMentionsButton />
+</ContextProvider>
+`;

--- a/components/global/at_mentions_button/at_mentions_button.test.tsx
+++ b/components/global/at_mentions_button/at_mentions_button.test.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import IconButton from '@mattermost/compass-components/components/icon-button';
+
+import {GlobalState} from 'types/store';
+
+import AtMentionsButton from './at_mentions_button';
+
+const mockDispatch = jest.fn();
+let mockState: GlobalState;
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux') as typeof import('react-redux'),
+    useSelector: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+    useDispatch: () => mockDispatch,
+}));
+
+describe('components/global/AtMentionsButton', () => {
+    beforeEach(() => {
+        mockState = {views: {rhs: {isSidebarOpen: true}}} as GlobalState;
+    });
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <AtMentionsButton/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should show active mentions', () => {
+        const wrapper = shallow(
+            <AtMentionsButton/>,
+        );
+
+        wrapper.find(IconButton).simulate('click', {
+            preventDefault: jest.fn(),
+        });
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/components/global/saved_posts_button/__snapshots__/saved_posts_button.test.tsx.snap
+++ b/components/global/saved_posts_button/__snapshots__/saved_posts_button.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/global/AtMentionsButton should match snapshot 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  delayShow={400}
+  overlay={<React.Fragment />}
+  placement="bottom"
+  trigger={
+    Array [
+      "hover",
+    ]
+  }
+>
+  <ForwardRef
+    aria-label="Select to toggle a list of saved posts."
+    compact={true}
+    icon="bookmark-outline"
+    inverted={true}
+    onClick={[Function]}
+    size="sm"
+    toggled={false}
+  />
+</OverlayTrigger>
+`;

--- a/components/global/saved_posts_button/saved_posts_button.test.tsx
+++ b/components/global/saved_posts_button/saved_posts_button.test.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import IconButton from '@mattermost/compass-components/components/icon-button';
+
+import {GlobalState} from 'types/store';
+
+import SavedPostsButton from './saved_posts_button';
+
+const mockDispatch = jest.fn();
+let mockState: GlobalState;
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux') as typeof import('react-redux'),
+    useSelector: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+    useDispatch: () => mockDispatch,
+}));
+
+describe('components/global/AtMentionsButton', () => {
+    beforeEach(() => {
+        mockState = {views: {rhs: {isSidebarOpen: true}}} as GlobalState;
+    });
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <SavedPostsButton/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should show active mentions', () => {
+        const wrapper = shallow(
+            <SavedPostsButton/>,
+        );
+
+        wrapper.find(IconButton).simulate('click', {
+            preventDefault: jest.fn(),
+        });
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/components/global/settings_button/__snapshots__/settings_button.test.tsx.snap
+++ b/components/global/settings_button/__snapshots__/settings_button.test.tsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/global/settings_button should match snapshot 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  delayShow={400}
+  overlay={
+    <Tooltip
+      bsClass="tooltip"
+      id="productSettings"
+      placement="right"
+    >
+      <Memo(MemoizedFormattedMessage)
+        defaultMessage="Settings"
+        id="global_header.productSettings"
+      />
+    </Tooltip>
+  }
+  placement="bottom"
+  trigger={
+    Array [
+      "hover",
+    ]
+  }
+>
+  <ForwardRef
+    aria-label="Select to open the settings modal."
+    compact={true}
+    icon="settings-outline"
+    inverted={true}
+    onClick={[Function]}
+    size="sm"
+  />
+</OverlayTrigger>
+`;
+
+exports[`components/global/settings_button should trigger the open modal action 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  delayShow={400}
+  overlay={
+    <Tooltip
+      bsClass="tooltip"
+      id="productSettings"
+      placement="right"
+    >
+      <Memo(MemoizedFormattedMessage)
+        defaultMessage="Settings"
+        id="global_header.productSettings"
+      />
+    </Tooltip>
+  }
+  placement="bottom"
+  trigger={
+    Array [
+      "hover",
+    ]
+  }
+>
+  <ForwardRef
+    aria-label="Select to open the settings modal."
+    compact={true}
+    icon="settings-outline"
+    inverted={true}
+    onClick={[Function]}
+    size="sm"
+  />
+</OverlayTrigger>
+`;

--- a/components/global/settings_button/settings_button.test.tsx
+++ b/components/global/settings_button/settings_button.test.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import IconButton from '@mattermost/compass-components/components/icon-button';
+
+import SettingsButton from './settings_button';
+
+const baseProps = {
+    actions: {
+        openModal: jest.fn(),
+    },
+};
+
+describe('components/global/settings_button', () => {
+    it('should match snapshot', () => {
+        const wrapper = shallow(<SettingsButton {...baseProps}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should trigger the open modal action', () => {
+        const wrapper = shallow(<SettingsButton {...baseProps}/>);
+
+        wrapper.find(IconButton).simulate('click');
+        expect(baseProps.actions.openModal).toHaveBeenCalled();
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION

#### Summary
Adds simple unit tests and snapshots for the global header buttons

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38290

#### Release Note
```release-note
NONE
```
