### PR TITLE
Stopped changing page URL when toggling unread filter

### DIFF
--- a/components/sidebar/channel_filter/channel_filter.tsx
+++ b/components/sidebar/channel_filter/channel_filter.tsx
@@ -22,8 +22,8 @@ type State = {
 };
 
 export default class ChannelFilter extends React.PureComponent<Props, State> {
-    toggleUnreadFilter = (e: React.MouseEvent) => {
-        e.preventDefault();
+    toggleUnreadFilter = (e?: React.MouseEvent) => {
+        e?.preventDefault();
 
         const {unreadFilterEnabled} = this.props;
 


### PR DESCRIPTION
Related to MM-38947, navigation is being hijacked in the desktop app by certain actions including toggling the unread filter. Unlike other cases which involve browser back and forth, this one is easy enough to fix with a code change since we usually add `preventDefault` on other anchor tags with `href='#'`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38947

#### Release Note
```release-note
NONE
```
