### PR TITLE
MM-38951 Change Custom Emoji link to use react-router

### DIFF
--- a/components/emoji_picker/components/emoji_picker_preview.jsx
+++ b/components/emoji_picker/components/emoji_picker_preview.jsx
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
+import {Link} from 'react-router-dom';
 
 import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 import AnyTeamPermissionGate from 'components/permissions_gates/any_team_permission_gate';
@@ -28,15 +29,15 @@ export default class EmojiPickerPreview extends React.PureComponent {
         return (
             <AnyTeamPermissionGate permissions={[Permissions.CREATE_EMOJIS]}>
                 <div className='emoji-picker__custom'>
-                    <a
+                    <Link
                         className='btn btn-link'
-                        href={`/${this.props.currentTeamName}/emoji`}
+                        to={`/${this.props.currentTeamName}/emoji`}
                     >
                         <FormattedMessage
                             id='emoji_picker.custom_emoji'
                             defaultMessage='Custom Emoji'
                         />
-                    </a>
+                    </Link>
                 </div>
             </AnyTeamPermissionGate>
         );


### PR DESCRIPTION
I can't actually figure out how we tell react-router about the subpath, but it seems to be aware of it at least. I haven't been able to test this locally, but it matches other links to the System Console, and those work as expected on servers with a subpath configured.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38951

#### Release Note
```release-note
Fixed broken Custom Emoji link on servers with a subpath configured
```
