### PR TITLE
Cypress/E2E: Require email test only when sysadmin has permission to do so

### DIFF
--- a/e2e/cypress/integration/auth_sso/authentication_1_spec.js
+++ b/e2e/cypress/integration/auth_sso/authentication_1_spec.js
@@ -21,7 +21,7 @@ describe('Authentication', () => {
 
     before(() => {
         // # Do email test if setup properly
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         cy.apiInitSetup().then(({user, team}) => {
             testUserAlreadyInTeam = user;

--- a/e2e/cypress/integration/auth_sso/authentication_4_spec.js
+++ b/e2e/cypress/integration/auth_sso/authentication_4_spec.js
@@ -18,7 +18,7 @@ describe('Authentication', () => {
 
     before(() => {
         // # Do email test if setup properly
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         cy.apiCreateUser().then(({user: newUser}) => {
             testUser = newUser;

--- a/e2e/cypress/integration/enterprise/auth_sso/mfa_authentication_spec.js
+++ b/e2e/cypress/integration/enterprise/auth_sso/mfa_authentication_spec.js
@@ -22,7 +22,7 @@ describe('Authentication', () => {
         cy.apiRequireLicenseForFeature('MFA');
 
         // # Do email test if setup properly
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         cy.apiInitSetup().then(({user}) => {
             testUser = user;

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/login_page_link_account_creation_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/login_page_link_account_creation_spec.js
@@ -33,7 +33,7 @@ describe('Onboarding', () => {
             siteName = config.TeamSettings.SiteName;
             siteUrl = config.ServiceSettings.SiteURL;
         });
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         cy.apiInitSetup().then(({team}) => {
             testTeam = team;

--- a/e2e/cypress/integration/notifications/channel_links_show_as_links_spec.js
+++ b/e2e/cypress/integration/notifications/channel_links_show_as_links_spec.js
@@ -26,7 +26,7 @@ describe('Notifications', () => {
     let receiver;
 
     before(() => {
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         // # Get config
         cy.apiGetConfig().then((data) => {

--- a/e2e/cypress/integration/notifications/mention_email_notification_spec.js
+++ b/e2e/cypress/integration/notifications/mention_email_notification_spec.js
@@ -25,7 +25,7 @@ describe('Email notification', () => {
 
     before(() => {
         // # Do email test if setup properly
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         // # Get config
         cy.apiGetConfig().then((data) => {

--- a/e2e/cypress/integration/onboarding/invalidate_pending_email_invitations_spec.js
+++ b/e2e/cypress/integration/onboarding/invalidate_pending_email_invitations_spec.js
@@ -39,7 +39,7 @@ describe('Onboarding', () => {
         }).then(({config}) => {
             siteName = config.TeamSettings.SiteName;
         });
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         cy.apiInitSetup().then(({team}) => {
             testTeam = team;

--- a/e2e/cypress/integration/onboarding/use_team_invite_link_to_sign_up_spec.js
+++ b/e2e/cypress/integration/onboarding/use_team_invite_link_to_sign_up_spec.js
@@ -28,7 +28,7 @@ describe('Onboarding', () => {
         });
 
         // # Do email test if setup properly
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         // # Update config to require email verification and onboarding flow
         cy.apiUpdateConfig({

--- a/e2e/cypress/integration/signin_authentication/forgot_password_spec.js
+++ b/e2e/cypress/integration/signin_authentication/forgot_password_spec.js
@@ -22,7 +22,7 @@ describe('Signin/Authentication', () => {
 
     before(() => {
         // # Do email test if setup properly
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         // # Create new team and users
         cy.apiInitSetup().then(({team, user}) => {

--- a/e2e/cypress/integration/team_settings/closed_team_invite_by_email_spec.js
+++ b/e2e/cypress/integration/team_settings/closed_team_invite_by_email_spec.js
@@ -41,7 +41,7 @@ describe('Team Settings', () => {
         }).then(({config}) => {
             siteName = config.TeamSettings.SiteName;
         });
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         cy.apiInitSetup().then(({team}) => {
             testTeam = team;

--- a/e2e/cypress/integration/team_settings/closed_team_invite_with_non_mattermost_domain_spec.js
+++ b/e2e/cypress/integration/team_settings/closed_team_invite_with_non_mattermost_domain_spec.js
@@ -34,7 +34,7 @@ describe('Team Settings', () => {
         });
 
         // # Do email test if setup properly
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         cy.apiInitSetup().then(({team}) => {
             testTeam = team;

--- a/e2e/cypress/integration/team_settings/closed_team_invite_with_specific_domain_spec.js
+++ b/e2e/cypress/integration/team_settings/closed_team_invite_with_specific_domain_spec.js
@@ -33,7 +33,7 @@ describe('Team Settings', () => {
         });
 
         // # Do email test if setup properly
-        cy.apiEmailTest();
+        cy.shouldHaveEmailEnabled();
 
         cy.apiInitSetup().then(({team}) => {
             testTeam = team;

--- a/e2e/cypress/support/api/system.d.ts
+++ b/e2e/cypress/support/api/system.d.ts
@@ -189,5 +189,15 @@ declare namespace Cypress {
          *   cy.shouldHaveFeatureFlag('feature', 'expected-value');
          */
         shouldHaveFeatureFlag(feature: string, expectedValue: any): Chainable;
+
+        /**
+         * Require email service to be reachable by the server
+         * thru "/api/v4/email/test" if sysadmin account has
+         * permission to do so. Otherwise, skip email test.
+         *
+         * @example
+         *   cy.shouldHaveEmailEnabled();
+         */
+        shouldHaveEmailEnabled(): Chainable;
     }
 }

--- a/e2e/cypress/support/api/system.js
+++ b/e2e/cypress/support/api/system.js
@@ -283,6 +283,14 @@ Cypress.Commands.add('shouldHaveFeatureFlag', (key, expectedValue) => {
     });
 });
 
+Cypress.Commands.add('shouldHaveEmailEnabled', () => {
+    return cy.apiGetConfig().then(({config}) => {
+        if (!config.ExperimentalSettings.RestrictSystemAdmin) {
+            cy.apiEmailTest();
+        }
+    });
+});
+
 /**
  * Upload a license if it does not exist.
  */


### PR DESCRIPTION
#### Summary
Require email test only when sysadmin has permission to do so

#### Release Note
```release-note
NONE
```
