### PR TITLE
MM-38077 Don't return to login screen when navigating to /

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -61,6 +61,8 @@ import {enableDevModeFeatures, isDevMode} from 'utils/utils';
 
 import A11yController from 'utils/a11y_controller';
 
+import RootRedirect from './root_redirect';
+
 const CreateTeam = makeAsyncComponent(LazyCreateTeam);
 const ErrorPage = makeAsyncComponent(LazyErrorPage);
 const TermsOfService = makeAsyncComponent(LazyTermsOfService);
@@ -416,12 +418,7 @@ export default class Root extends React.PureComponent {
                                 path={'/:team'}
                                 component={NeedsTeam}
                             />
-                            <Redirect
-                                to={{
-                                    ...this.props.location,
-                                    pathname: '/login',
-                                }}
-                            />
+                            <RootRedirect/>
                         </Switch>
                     </CompassThemeProvider>
                 </Switch>

--- a/components/root/root_redirect/index.ts
+++ b/components/root/root_redirect/index.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import {GlobalState} from 'types/store';
+
+import RootRedirect from './root_redirect';
+
+function mapStateToProps(state: GlobalState) {
+    return {
+        currentUserId: getCurrentUserId(state),
+    };
+}
+
+export default connect(mapStateToProps)(RootRedirect);

--- a/components/root/root_redirect/root_redirect.tsx
+++ b/components/root/root_redirect/root_redirect.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useEffect} from 'react';
+import {Redirect} from 'react-router-dom';
+
+import * as GlobalActions from 'actions/global_actions';
+
+type Props = {
+    currentUserId: string;
+    location: Location;
+}
+
+export default function RootRedirect(props: Props) {
+    useEffect(() => {
+        if (props.currentUserId) {
+            GlobalActions.redirectUserToDefaultTeam();
+        }
+    }, [props.currentUserId]);
+
+    if (props.currentUserId) {
+        // Ideally, this would be a Redirect like below, but since we need to call an action, this redirect is done above
+        return null;
+    }
+
+    return (
+        <Redirect
+            to={{
+                ...props.location,
+                pathname: '/login',
+            }}
+        />
+    );
+}


### PR DESCRIPTION
When navigating to Channels from the global header, we just send the user back to `/` instead of sending them anywhere specific, and we let the routing logic figure out where to send you from there. This caused the Login screen to appear briefly because that's where the routing logic sent you.

I added a RootRedirect component to encapsulate that since I'd hope we can move more of the "I don't know where to go" logic in the app to it such as sending the first user to the signup page or sending someone to the Terms of Service there when this gets cleaned up more.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38077

#### Release Note
```release-note
Fixed login page appearing when switching from Boards/Playbooks to Channels
```
