### PR TITLE
MM-T566 New message bar - Displays in permalink view

### DIFF
--- a/e2e/cypress/integration/notifications/message_bar_spec.js
+++ b/e2e/cypress/integration/notifications/message_bar_spec.js
@@ -16,18 +16,12 @@ describe('Notifications', () => {
     let testTeam;
     let testChannel;
     let otherUser;
-    let townChannelId;
 
     beforeEach(() => {
         cy.apiInitSetup().then(({team, channel, user}) => {
             testTeam = team;
             testChannel = channel;
             otherUser = user;
-
-            cy.makeClient().then(async (client) => {
-                const townChannel = await client.getChannelByName(testTeam.id, 'town-square');
-                townChannelId = townChannel.id;
-            });
 
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
         });
@@ -62,33 +56,38 @@ describe('Notifications', () => {
     });
 
     it('MM-T566 New message bar - Displays in permalink view', () => {
-        // # Post messages in town-square channel
-        Cypress._.times(15, (postNumber) => {
-            cy.postMessageAs({sender: otherUser, message: `P${postNumber}`, channelId: townChannelId});
+        cy.makeClient().then(async (client) => {
+            const townChannel = await client.getChannelByName(testTeam.id, 'town-square');
+            const townChannelId = townChannel.id;
+
+            // # Post messages in town-square channel
+            Cypress._.times(15, (postNumber) => {
+                cy.postMessageAs({sender: otherUser, message: `P${postNumber}`, channelId: townChannelId});
+            });
+
+            // # Enter "in:town-square" in the search bar and hit ENTER
+            cy.get('#searchBox').type('in:town-square').type('{enter}', {force: true}).type('{enter}', {force: true});
+
+            // # Click "Jump" to one of the search results
+            cy.get('a.search-item__jump').last().click();
+
+            // * Verify permalink in main channel view (post highlighted, fades in 6sec.)
+            cy.getNthPostId(1).then((postIdTest) => {
+                cy.get(`#post_${postIdTest}`, {timeout: TIMEOUTS.HALF_MIN}).should('have.class', 'post--highlight');
+                cy.clock();
+                cy.tick(6000);
+                cy.get(`#post_${postIdTest}`).should('not.have.class', 'post--highlight');
+            });
+
+            // # Other user post a message in town-square channel
+            cy.postMessageAs({
+                sender: otherUser,
+                message: 'message from user B',
+                channelId: townChannelId,
+            });
+
+            // * Verify New message bar appears
+            cy.get('.NotificationSeparator').should('exist');
         });
-
-        // # Enter "in:town-square" in the search bar and hit ENTER
-        cy.get('#searchBox').type('in:town-square').type('{enter}', {force: true}).type('{enter}', {force: true});
-
-        // # Click "Jump" to one of the search results
-        cy.get('a.search-item__jump').last().click();
-
-        // * Verify permalink in main channel view (post highlighted, fades in 6sec.)
-        cy.getNthPostId(1).then((postIdTest) => {
-            cy.get(`#post_${postIdTest}`, {timeout: TIMEOUTS.HALF_MIN}).should('have.class', 'post--highlight');
-            cy.clock();
-            cy.tick(6000);
-            cy.get(`#post_${postIdTest}`).should('not.have.class', 'post--highlight');
-        });
-
-        // # Other user post a message in town-square channel
-        cy.postMessageAs({
-            sender: otherUser,
-            message: 'message from user B',
-            channelId: townChannelId,
-        });
-
-        // * Verify New message bar appears
-        cy.get('.NotificationSeparator').should('exist');
     });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add Webapp E2E tests for MM-T566

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/18520


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
