### PR TITLE
[MM-36369]: Fix caret placed before emoji bug

### DIFF
--- a/components/create_comment/create_comment.tsx
+++ b/components/create_comment/create_comment.tsx
@@ -491,6 +491,7 @@ class CreateComment extends React.PureComponent<Props, State> {
         let newMessage = '';
         if (draft.message === '') {
             newMessage = `:${emojiAlias}: `;
+            this.setCaretPosition(newMessage.length);
         } else {
             const {message} = draft;
             const {firstPiece, lastPiece} = splitMessageBasedOnCaretPosition(this.state.caretPosition || 0, message);

--- a/components/create_post/create_post.tsx
+++ b/components/create_post/create_post.tsx
@@ -1288,7 +1288,8 @@ class CreatePost extends React.PureComponent<Props, State> {
         }
 
         if (this.state.message === '') {
-            this.setState({message: ':' + emojiAlias + ': '});
+            const newMessage = ':' + emojiAlias + ': ';
+            this.setMessageAndCaretPostion(newMessage, newMessage.length);
         } else {
             const {message} = this.state;
             const {firstPiece, lastPiece} = splitMessageBasedOnCaretPosition(this.state.caretPosition, message);

--- a/components/edit_post_modal/edit_post_modal.tsx
+++ b/components/edit_post_modal/edit_post_modal.tsx
@@ -164,7 +164,18 @@ export class EditPostModal extends React.PureComponent<Props, State> {
         }
 
         if (this.state.editText === '') {
-            this.setState({editText: ':' + emojiAlias + ': '});
+            const newMessage = ':' + emojiAlias + ': ';
+            const textbox = this.editbox && this.editbox.getInputBox();
+
+            this.setState(
+                {
+                    editText: newMessage,
+                    caretPosition: newMessage.length,
+                },
+                () => {
+                    Utils.setCaretPosition(textbox, newMessage.length);
+                },
+            );
         } else {
             const {editText} = this.state;
             const {firstPiece, lastPiece} = splitMessageBasedOnCaretPosition(


### PR DESCRIPTION
#### Summary
Fixes a bug where when picking two emojis in an empty message the order is reversed and the caret is placed between them :
```emojiB (caret) emojiA```
instead of:
```emojiA emojiB (caret)```

Fix is achieved by specifying the new caret location when the message is empty.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-36369
Fixes https://github.com/mattermost/mattermost-server/issues/18482

#### Release Note

```release-note
NONE
```
