### PR TITLE
Plugin registry additions for Calls plugin

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -20,6 +20,8 @@ import PostListRow from 'components/post_view/post_list_row';
 import ScrollToBottomArrows from 'components/post_view/scroll_to_bottom_arrows';
 import ToastWrapper from 'components/toast_wrapper';
 
+import Pluggable from 'plugins/pluggable';
+
 import LatestPostReader from './latest_post_reader';
 
 const OVERSCAN_COUNT_BACKWARD = 80;
@@ -590,7 +592,13 @@ export default class PostList extends React.PureComponent {
                             <AutoSizer>
                                 {({height, width}) => (
                                     <React.Fragment>
-                                        <div>{this.renderToasts(width)}</div>
+                                        <div>
+                                            <Pluggable
+                                                pluggableName='ChannelToast'
+                                            />
+
+                                            {this.renderToasts(width)}
+                                        </div>
 
                                         <DynamicSizeList
                                             ref={this.listRef}

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -421,6 +421,7 @@ export default class Root extends React.PureComponent {
                             />
                             <RootRedirect/>
                         </Switch>
+                        <Pluggable pluggableName='Global'/>
                     </CompassThemeProvider>
                 </Switch>
             </IntlProvider>

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
@@ -38,6 +38,27 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     >
       channel_label
     </span>
+    <Connect(Pluggable)
+      channel={
+        Object {
+          "create_at": 0,
+          "creator_id": "",
+          "delete_at": 0,
+          "display_name": "channel_display_name",
+          "group_constrained": false,
+          "header": "",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "name": "",
+          "purpose": "",
+          "scheme_id": "",
+          "team_id": "",
+          "type": "O",
+          "update_at": 0,
+        }
+      }
+      pluggableName="SidebarChannelLinkLabel"
+    />
   </div>
   <ChannelMentionBadge
     unreadMentions={0}
@@ -108,6 +129,27 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     >
       channel_label
     </span>
+    <Connect(Pluggable)
+      channel={
+        Object {
+          "create_at": 0,
+          "creator_id": "",
+          "delete_at": 0,
+          "display_name": "channel_display_name",
+          "group_constrained": false,
+          "header": "",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "name": "",
+          "purpose": "",
+          "scheme_id": "",
+          "team_id": "",
+          "type": "O",
+          "update_at": 0,
+        }
+      }
+      pluggableName="SidebarChannelLinkLabel"
+    />
   </div>
   <ChannelMentionBadge
     unreadMentions={0}
@@ -202,6 +244,27 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
         </span>
       </div>
     </OverlayTrigger>
+    <Connect(Pluggable)
+      channel={
+        Object {
+          "create_at": 0,
+          "creator_id": "",
+          "delete_at": 0,
+          "display_name": "channel_display_name",
+          "group_constrained": false,
+          "header": "",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "name": "",
+          "purpose": "",
+          "scheme_id": "",
+          "team_id": "",
+          "type": "O",
+          "update_at": 0,
+        }
+      }
+      pluggableName="SidebarChannelLinkLabel"
+    />
   </div>
   <ChannelMentionBadge
     unreadMentions={0}
@@ -272,6 +335,27 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     >
       channel_label
     </span>
+    <Connect(Pluggable)
+      channel={
+        Object {
+          "create_at": 0,
+          "creator_id": "",
+          "delete_at": 0,
+          "display_name": "channel_display_name",
+          "group_constrained": false,
+          "header": "",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "name": "",
+          "purpose": "",
+          "scheme_id": "",
+          "team_id": "",
+          "type": "O",
+          "update_at": 0,
+        }
+      }
+      pluggableName="SidebarChannelLinkLabel"
+    />
   </div>
   <ChannelMentionBadge
     unreadMentions={2}

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -6,6 +6,8 @@ import {Tooltip} from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 import classNames from 'classnames';
 
+import Pluggable from 'plugins/pluggable';
+
 import {Channel} from 'mattermost-redux/types/channels';
 
 import {mark, trackEvent} from 'actions/telemetry_actions';
@@ -242,6 +244,10 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                 >
                     {labelElement}
                     {customStatus}
+                    <Pluggable
+                        pluggableName='SidebarChannelLinkLabel'
+                        channel={this.props.channel}
+                    />
                 </div>
                 <ChannelMentionBadge
                     unreadMentions={unreadMentions}

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -766,4 +766,28 @@ export default class PluginRegistry {
 
         return id;
     }
+
+    // INTERNAL: Subject to change without notice.
+    // Register a component to render in the LHS next to a channel's link label.
+    // All parameters are required.
+    // Returns a unique identifier.
+    registerSidebarChannelLinkLabelComponent(component) {
+        return dispatchPluginComponentAction('SidebarChannelLinkLabel', this.id, component);
+    }
+
+    // INTERNAL: Subject to change without notice.
+    // Register a component to render in channel's center view, in place of a channel toast.
+    // All parameters are required.
+    // Returns a unique identifier.
+    registerChannelToastComponent(component) {
+        return dispatchPluginComponentAction('ChannelToast', this.id, component);
+    }
+
+    // INTERNAL: Subject to change without notice.
+    // Register a global component at the root of the app that survives across product switches.
+    // All parameters are required.
+    // Returns a unique identifier.
+    registerGlobalComponent(component) {
+        return dispatchPluginComponentAction('Global', this.id, component);
+    }
 }


### PR DESCRIPTION
#### Summary

These are the changes that were made to webapp code during initial development of the Calls plugin.
While all of these are subject to change (as noted in the doc comments) they are currently needed in order to install (and hopefully demo) the plugin on community.

#### Screenshots

- `SidebarChannelLinkLabel`:

![image](https://user-images.githubusercontent.com/1832946/136749576-89b7d6cd-ec3f-4092-833b-530a904338f0.png)

- `ChannelToast`:

![image](https://user-images.githubusercontent.com/1832946/136749541-f6a55422-f1a3-45b4-b6c7-0722e0e8054d.png)

- `Global`:

https://user-images.githubusercontent.com/1832946/136750601-276e899b-bee4-4cd0-b4c8-93ea20a541cf.mp4

#### Release Note

```release-note
NONE
```
