### PR TITLE
Disable explicit-module-boundary-types ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -114,6 +114,7 @@
         "@typescript-eslint/no-empty-function": 0,
         "@typescript-eslint/prefer-interface": 0,
         "@typescript-eslint/explicit-function-return-type": 0,
+        "@typescript-eslint/explicit-module-boundary-types": 0,
         "@typescript-eslint/indent": [
           2,
           4,


### PR DESCRIPTION
Turning this off since it just generates noise most of the time. When we start actually exporting modules for use elsewhere, we can consider selectively turning this on for that code since type changes may not be caught there, but as long as we're the only ones using the code in the web app, any incorrect type changes will be caught by CI via `npm run check-types`

#### Release Note
```release-note
NONE
```
