### PR TITLE
MM-39284 - show user count -without limit reference for paying customers

### DIFF
--- a/components/admin_console/billing/plan_details/plan_details.tsx
+++ b/components/admin_console/billing/plan_details/plan_details.tsx
@@ -165,20 +165,6 @@ export const planDetailsTopElements = (
                     defaultMessage='Mattermost Cloud'
                 />
             );
-            userCountDisplay = (
-                <div
-                    className={classNames('PlanDetails__userCount', {
-                        withinLimit: (userLimit - userCount) <= 5,
-                        overLimit: userCount > userLimit,
-                    })}
-                >
-                    <FormattedMarkdownMessage
-                        id='admin.billing.subscription.planDetails.userCountWithLimit'
-                        defaultMessage='{userCount} / {userLimit} users'
-                        values={{userCount, userLimit}}
-                    />
-                </div>
-            );
             break;
         }
     } else {


### PR DESCRIPTION
#### Summary
This PR adds the logic to do not show above limit css styles (red) neither user limit count for legacy paying cloud customers in the page billing > subscription > plan details section > user count.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39284

#### Screenshots
<img width="833" alt="Captura de pantalla 2021-10-13 a las 14 25 40" src="https://user-images.githubusercontent.com/10082627/137136370-020510b3-e525-408a-b09e-2dc3c97b6b5c.png">

#### Release Note
```release-note
NONE
```
