### PR TITLE
MM-T1244 CTRL/CMD+K - Esc closes modal

### DIFF
--- a/e2e/cypress/integration/keyboard_shortcuts/esc_close_modal_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/esc_close_modal_spec.js
@@ -14,7 +14,7 @@ describe('Keyboard Shortcuts', () => {
 
     before(() => {
         cy.apiInitSetup({loginAfter: true}).then(({offTopicUrl}) => {
-            channelUrl = offTopicUrl
+            channelUrl = offTopicUrl;
             cy.visit(channelUrl);
         });
     });
@@ -38,6 +38,6 @@ describe('Keyboard Shortcuts', () => {
         cy.get('.modal-content').should('not.exist');
 
         // * Verify that the user does not leave the off-topic channel
-        cy.url().should('contain', channelUrl)
+        cy.url().should('contain', channelUrl);
     });
 });


### PR DESCRIPTION

#### Summary
MM-T1244 CTRL/CMD+K - Esc closes modal

#### Ticket Link
Implements the test detailed in the issue https://github.com/mattermost/mattermost-server/issues/18654

#### Related Pull Requests
NA

#### Screenshots
NA

#### Release Note
```release-note
NONE
```
