### PR TITLE
MM-T1249: Added cypress test of cmd/ctrl-shift-L

### DIFF
--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_l_set_message_focus_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_l_set_message_focus_spec.js
@@ -31,6 +31,7 @@ describe('Keyboard Shortcuts', () => {
             // * Confirm the RHS is shown
             cy.get('#rhsCloseButton').should('exist');
 
+            // # Press CTRL/CMD+SHIFT+L
             cy.get('body').cmdOrCtrlShortcut('{shift}L');
 
             // * Confirm the message box has focus


### PR DESCRIPTION
#### Summary
Adds e2e test of cmd/ctrl-shift-L, with RHS container open.

#### Ticket Link
fixes https://github.com/mattermost/mattermost-server/issues/18649

#### Release Note

```release-note
NONE
```
