### PR TITLE
Cypress/E2E: Revert to cypress@7.7.0

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@testing-library/cypress": "8.0.1",
+        "@testing-library/cypress": "7.0.6",
         "@types/lodash": "4.14.175",
         "async": "3.2.1",
         "authenticator": "1.1.5",
@@ -2142,7 +2142,6 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
       "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -2889,26 +2888,26 @@
       "peer": true
     },
     "node_modules/@testing-library/cypress": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.1.tgz",
-      "integrity": "sha512-JCGy8u4ia+OQQJxVqKqjqpb0i4kmHQhu5jKFVBp+v/YSICnf52fil2MWIJqO+tH9ZQXtp3aF7uKHsVipWaI0BQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-7.0.6.tgz",
+      "integrity": "sha512-atnjqlkEt6spU4Mv7evvpA8fMXeRw7AN2uTKOR1dP6WBvBixVwAYMZY+1fMOaZULWAj9vGLCXXvmw++u3TxuCQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.14.6",
-        "@testing-library/dom": "^8.1.0"
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
       },
       "engines": {
-        "node": ">=12",
+        "node": ">=10",
         "npm": ">=6"
       },
       "peerDependencies": {
-        "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+        "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.7.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.7.2.tgz",
-      "integrity": "sha512-2zN0Zv9dMnaMAd4c/1E1ZChu4QrICyvWtkUvHFQBPhS1oG3VYGcM7SLGLYdda7187ILRXzIUOvOsbXQm4EASjA==",
+      "version": "7.31.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
+      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -2918,62 +2917,10 @@
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.6",
         "lz-string": "^1.4.4",
-        "pretty-format": "^27.0.2"
+        "pretty-format": "^26.6.2"
       },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/@jest/types": {
-      "version": "27.2.4",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
-      "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/@types/yargs": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/pretty-format": {
-      "version": "27.2.4",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
-      "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.2.4",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@types/aria-query": {
@@ -3051,7 +2998,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
       "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -4871,9 +4817,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.2.tgz",
-      "integrity": "sha512-4hMMLUlZhKJKOWbbGD1/VDUxGPEhEoN/T01k7bx271WiBKCvCfkgPzy0IeRS4PB50p6/N1q/SZL4B/TRsTE5bA==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.3.tgz",
+      "integrity": "sha512-qfskyO/KjtbYn09bn1IPkuhHl5PlJ6IzJ9s9sraJ1EqcuGyLGKzhSM1cY0zgyL9hx42eulQLZ6WaeK5ycJCkqw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -5286,9 +5232,9 @@
       }
     },
     "node_modules/dom-accessibility-api": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz",
-      "integrity": "sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.8.tgz",
+      "integrity": "sha512-rAfghuBPeJldxqsmZQtBbna4TqMgFe4xhYs24vPULNslbmXUdcga+CXiKWzZxyWw0FCkGKPgmizIysIvsAEN8w==",
       "dev": true
     },
     "node_modules/dotenv": {
@@ -11178,7 +11124,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
       "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/types": "^26.6.2",
         "ansi-regex": "^5.0.0",
@@ -15577,7 +15522,6 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
       "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -16213,19 +16157,19 @@
       "peer": true
     },
     "@testing-library/cypress": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.1.tgz",
-      "integrity": "sha512-JCGy8u4ia+OQQJxVqKqjqpb0i4kmHQhu5jKFVBp+v/YSICnf52fil2MWIJqO+tH9ZQXtp3aF7uKHsVipWaI0BQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-7.0.6.tgz",
+      "integrity": "sha512-atnjqlkEt6spU4Mv7evvpA8fMXeRw7AN2uTKOR1dP6WBvBixVwAYMZY+1fMOaZULWAj9vGLCXXvmw++u3TxuCQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.14.6",
-        "@testing-library/dom": "^8.1.0"
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
       }
     },
     "@testing-library/dom": {
-      "version": "8.7.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.7.2.tgz",
-      "integrity": "sha512-2zN0Zv9dMnaMAd4c/1E1ZChu4QrICyvWtkUvHFQBPhS1oG3VYGcM7SLGLYdda7187ILRXzIUOvOsbXQm4EASjA==",
+      "version": "7.31.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
+      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -16235,49 +16179,7 @@
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.6",
         "lz-string": "^1.4.4",
-        "pretty-format": "^27.0.2"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.2.4",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
-          "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.2.4",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
-          "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.2.4",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
-        }
+        "pretty-format": "^26.6.2"
       }
     },
     "@types/aria-query": {
@@ -16355,7 +16257,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
       "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -17822,9 +17723,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.2.tgz",
-      "integrity": "sha512-4hMMLUlZhKJKOWbbGD1/VDUxGPEhEoN/T01k7bx271WiBKCvCfkgPzy0IeRS4PB50p6/N1q/SZL4B/TRsTE5bA==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.3.tgz",
+      "integrity": "sha512-qfskyO/KjtbYn09bn1IPkuhHl5PlJ6IzJ9s9sraJ1EqcuGyLGKzhSM1cY0zgyL9hx42eulQLZ6WaeK5ycJCkqw==",
       "dev": true
     },
     "core-util-is": {
@@ -18143,9 +18044,9 @@
       "dev": true
     },
     "dom-accessibility-api": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz",
-      "integrity": "sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.8.tgz",
+      "integrity": "sha512-rAfghuBPeJldxqsmZQtBbna4TqMgFe4xhYs24vPULNslbmXUdcga+CXiKWzZxyWw0FCkGKPgmizIysIvsAEN8w==",
       "dev": true
     },
     "dotenv": {
@@ -22853,7 +22754,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
       "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jest/types": "^26.6.2",
         "ansi-regex": "^5.0.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@testing-library/cypress": "8.0.1",
+    "@testing-library/cypress": "7.0.6",
     "@types/lodash": "4.14.175",
     "async": "3.2.1",
     "authenticator": "1.1.5",


### PR DESCRIPTION
#### Summary
Main issue: encountering failed tests with error log below.
```
TypeError: Cannot set property name of [object Object] which has only a getter
```
Tried cypress@8.6.0, but same issue - https://github.com/mattermost/mattermost-webapp/pull/9130

Looks like its due to the `@testing-library/cypress` version 8 and since it requires peer dependency to v7 of Cypress, then Cypress is downgraded as well.

Revert to cypress@7.7.0.

Test report - https://automation-dashboard.vercel.app/cycles/2601cded-27ca-47e3-a744-29ee9e4c597e

#### Release Note
```release-note
NONE
```
