### PR TITLE
MM-T1242 CTRL/CMD+K: Typed characters are not lost after switching channels

### DIFF
--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_channel_switch_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_channel_switch_spec.js
@@ -10,14 +10,8 @@
 // Group: @keyboard_shortcuts¨
 
 describe('Keyboard Shortcuts', () => {
-    let testChannel;
-    let testUser;
-
     before(() => {
-        cy.apiInitSetup().then(({channel, user, channelUrl}) => {
-            testUser = user;
-            testChannel = channel;
-            cy.apiAddUserToChannel(testChannel.id, testUser.id);
+        cy.apiInitSetup().then(({channelUrl}) => {
             cy.visit(channelUrl);
         });
     });


### PR DESCRIPTION
#### Summary
Added e2e according to ticket.

I was a bit unsure where to add the test... it seems like shortcuts test are generally scattered over multiple files... also, I added in `keyboard_shortcuts_1_spec.js` for now, and remove the `@prod` label from the file.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/18647

#### Release Note
```release-note
NONE
```
