### PR TITLE
MM-T1245 CTRL/CMD+K - Open GM using mouse

### DIFF
--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_gm_with_mouse_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_gm_with_mouse_spec.js
@@ -39,7 +39,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1245 CTRL/CMD+K - Open GM using mouse', () => {
         // # Create a GM channel
-        cy.apiCreateGroupChannel([firstUser.id, secondUser.id, thirdUser.id]).then(({channel}) => {
+        cy.apiCreateGroupChannel([firstUser.id, secondUser.id, thirdUser.id]).then(() => {
             // # Press Cmd/Ctrl-K to open "Switch Channels" modal
             cy.get('#post_textbox').cmdOrCtrlShortcut('K');
 


### PR DESCRIPTION
#### Summary
This PR adds Cypress test spec for checking opening a GM channel via Cmd/Ctrl-K hotkey and mouse

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-server/issues/18651

#### Related Pull Requests

None

#### Screenshots

N/A

#### Release Note
```
NONE
```