### PR TITLE
MM-T1265 UP - System message does not open for edit; opens previous regular message

### DIFF
--- a/e2e/cypress/integration/keyboard_shortcuts/system_message_not_open_for_edit_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/system_message_not_open_for_edit_spec.js
@@ -27,15 +27,12 @@ describe('Keyboard Shortcuts', () => {
         // # Open the edit the channel header modal
         cy.findByRole('button', {name: 'Set a Header dialog'}).click();
 
-        // #
-        cy.get('.modal').
-            should('be.visible').within(() => {
-                cy.findByRole('textbox', {name: 'edit the channel header...'}).
-                    type(newHeader);
-            });
-
-        // * Click save button to change header
-        cy.uiSave();
+        // * Verify modal is open
+        cy.findByRole('dialog', {name: 'Edit Header for Off-Topic'}).within(() => {
+            // # Enter new header and save
+            cy.findByRole('textbox', {name: 'edit the channel header...'}).type(newHeader);
+            cy.uiSave();
+        });
 
         // * Wait for the system message to be posted
         cy.uiWaitUntilMessagePostedIncludes(newHeader);


### PR DESCRIPTION
#### Summary
Write Webapp E2E with Cypress: "MM-T1265 UP - System message does not open for edit; opens previous regular message"

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-server/issues/18715
#### Related Pull Requests
 #### Screenshots
#### Release Note 
```release-note
  NONE
 ```