### PR TITLE
MM-T1251 CTRL/CMD+SHIFT+L - When not to set focus to center channel message box

### DIFF
--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_shift_l_does_not_change_focus_to_msgbox_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_shift_l_does_not_change_focus_to_msgbox_spec.js
@@ -18,22 +18,28 @@ describe('Keyboard Shortcuts', () => {
     });
 
     it('MM-T1251 CTRL/CMD+SHIFT+L - When not to set focus to center channel message box', () => {
-
         // # Open settings modal
         cy.uiOpenSettingsModal();
+
         // # Press ctrl/cmd+shift+l
         cy.get('body').cmdOrCtrlShortcut('{shift+l}');
-        // * check if channel message box is focused
+
+        // * Verify channel message box is not focused
         cy.get('#post_textbox').should('not.be.focused');
-        // # close account settings modal
-       cy.uiClose();
-        // # open invite members full-page screen
+
+        // # Close settings modal
+        cy.uiClose();
+
+        // # Open invite members full-page screen
         cy.get('#introTextInvite').click();
+
         // # Press ctrl/cmd+shift+l
         cy.get('body').cmdOrCtrlShortcut('{shift+l}');
-        // * check if channel message box is focused
+
+        // * Verify channel message box is not focused
         cy.get('#post_textbox').should('not.be.focused');
-        // # close invite memebers full-page screen
+
+        // # Close invite members full-page screen
         cy.get('#closeIcon > svg').click();
     });
 });


### PR DESCRIPTION
#### Summary
MM-T1251 CTRL/CMD+SHIFT+L - When not to set focus to center channel message box

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/18707

#### Release Note

```release note
NONE
```