### PR TITLE
[MM-38584]: fixing offline indicator color

### DIFF
--- a/components/compass_theme_provider/compass_theme_provider.tsx
+++ b/components/compass_theme_provider/compass_theme_provider.tsx
@@ -45,7 +45,6 @@ const CompassThemeProvider = ({theme, children}: Props): JSX.Element | null => {
                 online: theme.onlineIndicator,
                 away: theme.awayIndicator,
                 dnd: theme.dndIndicator,
-                offline: theme.centerChannelColor,
             },
             text: {
                 ...compassTheme.text,

--- a/components/widgets/icons/status_offline_avatar_icon.tsx
+++ b/components/widgets/icons/status_offline_avatar_icon.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {useIntl} from 'react-intl';
 
-export default function StatusDndAvatarIcon(props: React.HTMLAttributes<HTMLSpanElement>) {
+export default function StatusOfflineAvatarIcon(props: React.HTMLAttributes<HTMLSpanElement>) {
     const {formatMessage} = useIntl();
     return (
         <span {...props}>

--- a/sass/base/_css_variables.scss
+++ b/sass/base/_css_variables.scss
@@ -52,6 +52,10 @@
     --error-box-background: 197, 67, 72;
     --sidebar-team-background-rgb: 11, 66, 140;
 
+    // offline indicator color stays the same in all themes, that's why it is separated from the other variables
+    // the color specified here is the new hard-coded color from the compass design system
+    --offline-indicator: rgba(175, 179, 192, 0.64);
+
     // Elevation values used for box shadows.
     // Defined as CSS variables so that both sass and JS can use them.
     --elevation-1: 0 2px 3px 0 rgba(0, 0, 0, 0.08);

--- a/sass/components/_status-icon.scss
+++ b/sass/components/_status-icon.scss
@@ -50,7 +50,7 @@
 
                 &.offline--icon,
                 .offline--icon {
-                    fill: var(--sidebar-text);
+                    fill: var(--offline-indicator);
                 }
             }
         }
@@ -105,7 +105,7 @@
         }
 
         .offline--icon {
-            fill: var(--center-channel-color);
+            fill: var(--offline-indicator);
         }
     }
 }
@@ -199,7 +199,7 @@
     }
 
     .offline--icon {
-        fill: rgba(var(--center-channel-color-rgb), 0.56);
+        fill: var(--offline-indicator);
     }
 }
 
@@ -226,14 +226,14 @@
         }
 
         .offline--icon {
-            fill: var(--center-channel-color);
+            fill: var(--offline-indicator);
         }
     }
 
     .sidebar--left {
         .status {
             .offline--icon {
-                fill: var(--sidebar-text);
+                fill: var(--offline-indicator);
             }
         }
     }

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -128,7 +128,7 @@
                 color: var(--sidebar-header-text-color);
 
                 .offline--icon {
-                    fill: var(--sidebar-text);
+                    fill: var(--offline-indicator);
                 }
 
                 svg {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -425,7 +425,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .post .card-icon__container', 'color:' + changeOpacity(theme.centerChannelColor, 0.3));
         changeCss('.app__body .post-image__details .post-image__download svg', 'stroke:' + changeOpacity(theme.centerChannelColor, 0.4));
         changeCss('.app__body .post-image__details .post-image__download svg', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.35));
-        changeCss('.app__body .modal .status .offline--icon, .app__body .channel-header__links .icon, .app__body .sidebar--right .sidebar--right__subheader .usage__icon, .app__body .more-modal__header svg, .app__body .icon--body', 'fill:' + theme.centerChannelColor);
+        changeCss('.app__body .channel-header__links .icon, .app__body .sidebar--right .sidebar--right__subheader .usage__icon, .app__body .more-modal__header svg, .app__body .icon--body', 'fill:' + theme.centerChannelColor);
         changeCss('@media(min-width: 768px){.app__body .post:hover .post__header .post-menu, .app__body .post.post--hovered .post__header .post-menu, .app__body .post.a11y--active .post__header .post-menu', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .help-text, .app__body .post .post-waiting, .app__body .post.post--system .post__body', 'color:' + changeOpacity(theme.centerChannelColor, 0.6));
         changeCss('.app__body .nav-tabs, .app__body .nav-tabs > li.active > a, pp__body .input-group-addon, .app__body .app__content, .app__body .post-create__container .post-create-body .btn-file, .app__body .post-create__container .post-create-footer .msg-typing, .app__body .dropdown-menu, .app__body .popover, .app__body .suggestion-list__item .suggestion-list__ellipsis .suggestion-list__main, .app__body .tip-overlay, .app__body .form-control[disabled], .app__body .form-control[readonly], .app__body fieldset[disabled] .form-control', 'color:' + theme.centerChannelColor);
@@ -489,8 +489,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .post.post--comment .post__body', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('@media(min-width: 768px){.app__body .post.post--compact.same--root.post--comment .post__content', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .post.post--comment.current--user .post__body', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
-        changeCss('.app__body .channel-header__info .status .offline--icon', 'fill:' + theme.centerChannelColor);
-        changeCss('.app__body .navbar .status .offline--icon', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .emoji-picker', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .emoji-picker', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .emoji-picker__search-icon', 'color:' + changeOpacity(theme.centerChannelColor, 0.4));


### PR DESCRIPTION
#### Summary
fix for a wrong indicator color in the global header avatar and account menu.
It was using an inherited color for that, but since the other avatar implementations (e.g. in the channels view) still use the "old" avatar it was out of line with them.

I added the `badges.offline` property to the interim theme-adjustments introduced by @deanwhillier so that it now consumes the correct color value. 

We do have a certain inconsistency introduced now as well, that might need some input from UX/UI: In themes where the channel view has a light theme and the surrounding elements (global header and sidebar) are dark the center channel color does not work on the dark background. this can be observed in the [screenshots section](#screenshots)

#### Ticket Link
[MM-38584](https://mattermost.atlassian.net/browse/MM-38584)

#### Screenshots
|  theme  |  in channel view  |  in global header  |
|----|----|----|
|  light  |<img width="294" alt="Screenshot 2021-10-19 at 15 18 04" src="https://user-images.githubusercontent.com/32863416/137919142-71357f6e-8de9-44c9-9d0f-5330c416d8c7.png">|<img width="160" alt="Screenshot 2021-10-19 at 15 18 23" src="https://user-images.githubusercontent.com/32863416/137919279-00a369dd-ef67-4243-be47-42cb31467e80.png">|
|  dark  |<img width="294" alt="Screenshot 2021-10-19 at 15 17 49" src="https://user-images.githubusercontent.com/32863416/137919322-b1acef5f-5137-4de8-9d30-0887a54ad266.png">|<img width="160" alt="Screenshot 2021-10-19 at 15 18 34" src="https://user-images.githubusercontent.com/32863416/137919368-1e1c53bb-86fe-421e-b0b7-1883b3f0b197.png">|

#### Release Note
```release-note
changed offline indicator color to use correct theme color
```
