### PR TITLE
[MM-39426]: removing div with sidebar--right__bg class since it has no effect

### DIFF
--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -216,10 +216,6 @@ export default class SidebarRight extends React.PureComponent {
                 role='complementary'
                 ref={this.sidebarRight}
             >
-                <div
-                    onClick={this.onShrink}
-                    className='sidebar--right__bg'
-                />
                 <div className='sidebar-right-container'>
                     <Search
                         isFocus={searchVisible && !isFlaggedPosts && !isPinnedPosts && !isChannelFiles && !isSuppressed}

--- a/sass/layout/_sidebar-right.scss
+++ b/sass/layout/_sidebar-right.scss
@@ -30,22 +30,6 @@
         &.move--left {
             transition: width 0.25s 0s ease-in, z-index 0.15s 0.1s step-start;
         }
-
-        .sidebar--right__bg {
-            visibility: visible;
-        }
-    }
-
-    .sidebar--right__bg {
-        position: absolute;
-        z-index: 5;
-        top: -70px;
-        left: -500%;
-        // Since the element (sidebar--right__bg) is tied to the sidebar, we need to expand beyond it, we're given an arbitrary large width and left positioning so that it may take the width completely
-        width: 1000%;
-        height: 110%;
-        background-color: transparent;
-        visibility: hidden;
     }
 
     .sidebar-right__table {

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -1733,10 +1733,6 @@
             transform: none !important;
         }
 
-        .sidebar--right__bg {
-            display: none;
-        }
-
         .sidebar--right__expand {
             display: none;
         }


### PR DESCRIPTION
#### Summary
fixes a bug where the sidebar could be scrolled sideways, since the `div` with the class `sidebar--right__bg` had a width of `1000%` set to it.

I searched for ocurences and possible use-cases, but could not find any. It seems that this part was used before, but is now a obsolete.

Strangely enough the `div` was set to `visibility: hidden` in web view and to `display: none` in mobile view, so it could not have any effect anyways, since it was never really rendered. :D

#### Ticket Link
[MM-39426](https://mattermost.atlassian.net/browse/MM-39426)

#### Release Note
```release-note
NONE
```
