### PR TITLE
MM-38972: Luxon: locale and timezone defaults

### DIFF
--- a/components/root/effects.ts
+++ b/components/root/effects.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Settings} from 'luxon';
+
+import {getCurrentLocale} from 'selectors/i18n';
+import {areTimezonesEnabledAndSupported} from 'selectors/general';
+import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
+import {GlobalState} from 'types/store';
+
+let prevTimezone: string | undefined;
+let prevLocale: string | undefined;
+export function applyLuxonDefaults(state: GlobalState) {
+    const locale = getCurrentLocale(state);
+    if (locale !== prevLocale) {
+        prevLocale = locale;
+        Settings.defaultLocale = locale;
+    }
+
+    if (areTimezonesEnabledAndSupported(state)) {
+        const tz = getUserCurrentTimezone(getUserTimezone(state, getCurrentUserId(state))) ?? undefined;
+        if (tz !== prevTimezone) {
+            prevTimezone = tz;
+            Settings.defaultZone = tz ?? 'system';
+        }
+    }
+}

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -62,6 +62,8 @@ import {enableDevModeFeatures, isDevMode} from 'utils/utils';
 
 import A11yController from 'utils/a11y_controller';
 
+import {applyLuxonDefaults} from './effects';
+
 import RootRedirect from './root_redirect';
 
 const CreateTeam = makeAsyncComponent(LazyCreateTeam);
@@ -151,6 +153,8 @@ export default class Root extends React.PureComponent {
 
         // set initial window size state
         this.props.actions.emitBrowserWindowResized();
+
+        store.subscribe(() => applyLuxonDefaults(store.getState()));
     }
 
     onConfigLoaded = () => {

--- a/utils/datetime.ts
+++ b/utils/datetime.ts
@@ -3,14 +3,6 @@
 
 import moment from 'moment-timezone';
 import {Unit} from '@formatjs/intl-relativetimeformat';
-import {Settings} from 'luxon';
-
-import store from 'stores/redux_store';
-import {getCurrentLocale} from 'selectors/i18n';
-import {areTimezonesEnabledAndSupported} from 'selectors/general';
-import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 
 const shouldTruncate = new Map<Unit, boolean>([
     ['year', true],
@@ -97,22 +89,3 @@ export function toUTCUnix(date: Date): number {
     return Math.round(new Date(date.toISOString()).getTime() / 1000);
 }
 
-let prevTimezone: string | undefined;
-let prevLocale: string | undefined;
-store.subscribe(() => {
-    const state = store.getState();
-
-    const locale = getCurrentLocale(state);
-    if (locale !== prevLocale) {
-        prevLocale = locale;
-        Settings.defaultLocale = locale;
-    }
-
-    if (areTimezonesEnabledAndSupported(state)) {
-        const tz = getUserCurrentTimezone(getUserTimezone(state, getCurrentUserId(state))) ?? undefined;
-        if (tz !== prevTimezone) {
-            prevTimezone = tz;
-            Settings.defaultZone = tz ?? 'system';
-        }
-    }
-});


### PR DESCRIPTION
#### Summary

Luxon was introduced in https://github.com/mattermost/mattermost-webapp/pull/9107. This PR adds default values for lang/tz.

- Set Luxon defaults
  - Listen for language change
  - Listen for timezone change

These defaults will propagate downstream to plugins that use webpack externals to import `luxon`.

There is no default 12/24hr concept with Luxon, in usage: please manually specify user preference if applicable (time included when formatting).

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38972

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added lang/tz defaults to Luxon
```
