### PR TITLE
MM-39389 Add null check for draft.uploadsInProgress

### DIFF
--- a/actions/views/create_comment.tsx
+++ b/actions/views/create_comment.tsx
@@ -35,7 +35,7 @@ import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 export function clearCommentDraftUploads() {
     return actionOnGlobalItemsWithPrefix(StoragePrefixes.COMMENT_DRAFT, (_key: string, draft: PostDraft) => {
-        if (!draft || draft.uploadsInProgress.length === 0) {
+        if (!draft || !draft.uploadsInProgress || draft.uploadsInProgress.length === 0) {
             return draft;
         }
 

--- a/components/create_post/index.ts
+++ b/components/create_post/index.ts
@@ -175,7 +175,7 @@ function setDraft(key: string, value: PostDraft) {
 
 function clearDraftUploads() {
     return actionOnGlobalItemsWithPrefix(StoragePrefixes.DRAFT, (_key: string, draft: PostDraft) => {
-        if (!draft || draft.uploadsInProgress.length === 0) {
+        if (!draft || !draft.uploadsInProgress || draft.uploadsInProgress.length === 0) {
             return draft;
         }
 


### PR DESCRIPTION
I'm not sure exactly what causes a draft to become null, but I'm not surprised if that happened because of us messing around with drafts trying to fix the performance issues they caused. When we update the storage system or move drafts to the server, the root cause of this will likely be fixed by itself.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39389

#### Release Note
```release-note
NONE
```
