### PR TITLE
MM-38910 - Allow plugins to import mattermost-redux directly

### DIFF
--- a/packages/mattermost-redux/src/constants/general.ts
+++ b/packages/mattermost-redux/src/constants/general.ts
@@ -51,6 +51,7 @@ export default {
     OPEN_CHANNEL: 'O',
     PRIVATE_CHANNEL: 'P',
     GM_CHANNEL: 'G',
+    ARCHIVED_CHANNEL: 'archive',
     PUSH_NOTIFY_APPLE_REACT_NATIVE: 'apple_rn',
     PUSH_NOTIFY_ANDROID_REACT_NATIVE: 'android_rn',
     STORE_REHYDRATION_COMPLETE: 'store_hydation_complete',

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -69,7 +69,6 @@ import {
     calculateUnreadCount,
 } from 'mattermost-redux/utils/channel_utils';
 import {createIdsSelector} from 'mattermost-redux/utils/helpers';
-import {Constants} from 'utils/constants';
 import {getDataRetentionCustomPolicy} from 'mattermost-redux/selectors/entities/admin';
 
 import {getThreadCounts} from './threads';
@@ -213,13 +212,13 @@ export const getCurrentChannelNameForSearchShortcut: (state: GlobalState) => str
         const channel = allChannels[currentChannelId];
 
         // Only get the extra info from users if we need it
-        if (channel?.type === Constants.DM_CHANNEL) {
+        if (channel?.type === General.DM_CHANNEL) {
             const dmChannelWithInfo = completeDirectChannelInfo(users, Preferences.DISPLAY_PREFER_USERNAME, channel);
             return `@${dmChannelWithInfo.display_name}`;
         }
 
         // Replace spaces in GM channel names
-        if (channel?.type === Constants.GM_CHANNEL) {
+        if (channel?.type === General.GM_CHANNEL) {
             const gmChannelWithInfo = completeDirectGroupInfo(users, Preferences.DISPLAY_PREFER_USERNAME, channel, false);
             return `@${gmChannelWithInfo.display_name.replace(/\s/g, '')}`;
         }
@@ -979,13 +978,13 @@ export function filterChannelList(channelList: Channel[], filters: ChannelSearch
     const channelType: string[] = [];
     const channels = channelList;
     if (filters.public) {
-        channelType.push(Constants.OPEN_CHANNEL);
+        channelType.push(General.OPEN_CHANNEL);
     }
     if (filters.private) {
-        channelType.push(Constants.PRIVATE_CHANNEL);
+        channelType.push(General.PRIVATE_CHANNEL);
     }
     if (filters.deleted) {
-        channelType.push(Constants.ARCHIVED_CHANNEL);
+        channelType.push(General.ARCHIVED_CHANNEL);
     }
     channelType.forEach((type) => {
         result = result.concat(channels.filter((channel) => channel.type === type));


### PR DESCRIPTION
#### Summary
- Plugins need to import the real `mattermost-redux` package directly because the mattermost-redux on npm is horribly out of date. This is causing troubles when we need to use the `getTheme` selector (see the attached ticket for more context)
- To allow this, eliminate a dependency on webapp. If this is fixed, we can import it without trouble.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38910

#### Related Pull Requests
- https://github.com/mattermost/mattermost-plugin-playbooks/pull/821 depends on this one.


```release-note
NONE
```
