### PR TITLE
[MM-39440] fixes Custom Emoji name validation to accept plus signs

### DIFF
--- a/components/emoji/add_emoji/add_emoji.tsx
+++ b/components/emoji/add_emoji/add_emoji.tsx
@@ -110,13 +110,13 @@ export default class AddEmoji extends React.PureComponent<AddEmojiProps, AddEmoj
             return;
         }
 
-        if ((/[^a-z0-9_-]/).test(emoji.name)) {
+        if ((/[^a-z0-9+_-]/).test(emoji.name)) {
             this.setState({
                 saving: false,
                 error: (
                     <FormattedMessage
                         id='add_emoji.nameInvalid'
-                        defaultMessage="An emoji's name can only contain lowercase letters, numbers, and the symbols '-' and '_'."
+                        defaultMessage="An emoji's name can only contain lowercase letters, numbers, and the symbols '-', '+' and '_'."
                     />
                 ),
             });


### PR DESCRIPTION
#### Summary

Fixes the client-side Custom Emoji name validation to accept plus signs, like the server already does.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/18764

See also: https://mattermost.atlassian.net/browse/MM-39440

#### Related Pull Requests
(None.)

#### Screenshots
(None.)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed Custom Emoji name validation to accept plus signs.
```
