### PR TITLE
MM-35366 Improve messaging in the add members to channel modal

### DIFF
--- a/components/multiselect/__snapshots__/multiselect.test.tsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.tsx.snap
@@ -116,6 +116,45 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
           }
         />
       </div>
+      <MultiSelectList
+        ariaLabelRenderer={[Function]}
+        onAction={[Function]}
+        onAdd={[Function]}
+        onSelect={[Function]}
+        optionRenderer={[Function]}
+        options={
+          Array [
+            Object {
+              "id": "0",
+              "label": "0",
+              "value": "0",
+            },
+            Object {
+              "id": "1",
+              "label": "1",
+              "value": "1",
+            },
+            Object {
+              "id": "2",
+              "label": "2",
+              "value": "2",
+            },
+            Object {
+              "id": "3",
+              "label": "3",
+              "value": "3",
+            },
+            Object {
+              "id": "4",
+              "label": "4",
+              "value": "4",
+            },
+          ]
+        }
+        page={0}
+        perPage={5}
+        query=""
+      />
       <div
         className="multi-select__help"
         id="multiSelectHelpMemberInfo"
@@ -132,45 +171,6 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
         />
       </div>
     </div>
-    <MultiSelectList
-      ariaLabelRenderer={[Function]}
-      onAction={[Function]}
-      onAdd={[Function]}
-      onSelect={[Function]}
-      optionRenderer={[Function]}
-      options={
-        Array [
-          Object {
-            "id": "0",
-            "label": "0",
-            "value": "0",
-          },
-          Object {
-            "id": "1",
-            "label": "1",
-            "value": "1",
-          },
-          Object {
-            "id": "2",
-            "label": "2",
-            "value": "2",
-          },
-          Object {
-            "id": "3",
-            "label": "3",
-            "value": "3",
-          },
-          Object {
-            "id": "4",
-            "label": "4",
-            "value": "4",
-          },
-        ]
-      }
-      page={0}
-      perPage={5}
-      query=""
-    />
     <div
       className="multi-select__help"
       id="multiSelectMessageNote"
@@ -308,6 +308,35 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
           }
         />
       </div>
+      <MultiSelectList
+        ariaLabelRenderer={[Function]}
+        onAction={[Function]}
+        onAdd={[Function]}
+        onSelect={[Function]}
+        optionRenderer={[Function]}
+        options={
+          Array [
+            Object {
+              "id": "5",
+              "label": "5",
+              "value": "5",
+            },
+            Object {
+              "id": "6",
+              "label": "6",
+              "value": "6",
+            },
+            Object {
+              "id": "7",
+              "label": "7",
+              "value": "7",
+            },
+          ]
+        }
+        page={1}
+        perPage={5}
+        query=""
+      />
       <div
         className="multi-select__help"
         id="multiSelectHelpMemberInfo"
@@ -324,35 +353,6 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
         />
       </div>
     </div>
-    <MultiSelectList
-      ariaLabelRenderer={[Function]}
-      onAction={[Function]}
-      onAdd={[Function]}
-      onSelect={[Function]}
-      optionRenderer={[Function]}
-      options={
-        Array [
-          Object {
-            "id": "5",
-            "label": "5",
-            "value": "5",
-          },
-          Object {
-            "id": "6",
-            "label": "6",
-            "value": "6",
-          },
-          Object {
-            "id": "7",
-            "label": "7",
-            "value": "7",
-          },
-        ]
-      }
-      page={1}
-      perPage={5}
-      query=""
-    />
     <div
       className="multi-select__help"
       id="multiSelectMessageNote"

--- a/components/multiselect/__snapshots__/multiselect.test.tsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
         className="multi-select__container react-select"
       >
         <StateManager
-          className=""
+          className="MultiSelect"
           classNamePrefix="react-select-auto react-select"
           components={
             Object {
@@ -204,7 +204,7 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
         className="multi-select__container react-select"
       >
         <StateManager
-          className=""
+          className="MultiSelect"
           classNamePrefix="react-select-auto react-select"
           components={
             Object {

--- a/components/multiselect/multiselect.tsx
+++ b/components/multiselect/multiselect.tsx
@@ -286,18 +286,18 @@ export default class MultiSelect<T extends Value> extends React.PureComponent<Pr
                 exceedsMaxValues = true;
                 numRemainingText = (
                     <div className='InputErrorBox'>
-                    <FormattedMessage
-                        id='multiselect.numRemaining'
-                        defaultMessage='Up to {max, number} can be added at a time.'
-                        values={{
-                            max: this.props.maxValues,
-                            num: this.props.maxValues - this.props.values.length,
-                        }}
-                    />
+                        <FormattedMessage
+                            id='multiselect.numRemaining'
+                            defaultMessage='Up to {max, number} can be added at a time.'
+                            values={{
+                                max: this.props.maxValues,
+                                num: this.props.maxValues - this.props.values.length,
+                            }}
+                        />
                     </div>
                 );
             } else {
-                numRemainingText = "";
+                numRemainingText = '';
                 exceedsMaxValues = false;
             }
         }
@@ -468,7 +468,7 @@ export default class MultiSelect<T extends Value> extends React.PureComponent<Pr
                                 className={classNames(
                                     'MultiSelect',
                                     exceedsMaxValues ? 'error' : '',
-                                    this.state.a11yActive ? 'multi-select__focused' : ""
+                                    this.state.a11yActive ? 'multi-select__focused' : '',
                                 )}
                                 classNamePrefix='react-select-auto react-select'
                             />
@@ -491,7 +491,8 @@ export default class MultiSelect<T extends Value> extends React.PureComponent<Pr
                         </div>
                     </div>
                     {multiSelectList}
-                    {exceedsMaxValues && <div
+                    {exceedsMaxValues &&
+                    <div
                         id='multselectErrorMessage'
                         className='multi-select__error'
                     >

--- a/components/save_button.tsx
+++ b/components/save_button.tsx
@@ -51,7 +51,7 @@ export default class SaveButton extends React.PureComponent<Props> {
         if (!disabled || saving) {
             className += ' ' + btnClass;
         } else {
-            className += ' ' + 'btn-inactive';
+            className += ' btn-inactive';
         }
 
         if (extraClasses) {

--- a/components/save_button.tsx
+++ b/components/save_button.tsx
@@ -50,6 +50,8 @@ export default class SaveButton extends React.PureComponent<Props> {
         let className = 'save-button btn';
         if (!disabled || saving) {
             className += ' ' + btnClass;
+        } else {
+            className += ' ' + 'btn-inactive';
         }
 
         if (extraClasses) {

--- a/components/widgets/inputs/users_emails_input.scss
+++ b/components/widgets/inputs/users_emails_input.scss
@@ -293,6 +293,7 @@
     margin-top: 2px;
     background: rgba(var(--error-box-background), 0.1);
     border-radius: 4px;
+    box-shadow: 0 0 3px 1px lightgrey;
 
     span {
         position: relative;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3699,7 +3699,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "Up to {max, number} can be added at a time.",
+  "multiselect.numRemaining": "You can only add **{max} people** at one time.",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3699,7 +3699,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "Up to {max, number} can be added at a time. You have {num, number} remaining.",
+  "multiselect.numRemaining": "Up to {max, number} can be added at a time.",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -3699,7 +3699,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "Up to {max, number} can be added at a time.",
+  "multiselect.numRemaining": "You can only add **{max} people** at one time.",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -3699,7 +3699,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "Up to {max, number} can be added at a time. You have {num, number} remaining.",
+  "multiselect.numRemaining": "Up to {max, number} can be added at a time.",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",

--- a/sass/components/_channel-invite-modal.scss
+++ b/sass/components/_channel-invite-modal.scss
@@ -43,7 +43,7 @@
         height: auto;
         max-height: 272px;
         padding: 12px 0;
-        margin: -28px 0 0 24px;
+        margin: 0 0 0 24px;
         border-radius: 4px;
         box-shadow: $elevation-4;
     }

--- a/sass/components/_multi-select.scss
+++ b/sass/components/_multi-select.scss
@@ -90,3 +90,7 @@
         }
     }
 }
+
+.multi-select__padding {
+    height: 14px;
+}

--- a/sass/components/_multi-select.scss
+++ b/sass/components/_multi-select.scss
@@ -1,5 +1,30 @@
 @charset 'UTF-8';
 
+.MultiSelect {
+    &.error {
+        .react-select__control {
+            border: none;
+            box-shadow: 0 0 0 2px rgba(var(--error-text-color-rgb)), 0 0 0 1px var(--error-text) !important;
+
+            &--is-focused,
+            &--menu-is-open {
+                &:hover {
+                    border: none;
+                    box-shadow: 0 0 0 2px rgba(var(--error-text-color-rgb)), 0 0 0 1px var(--error-text) !important;
+                }
+
+                border: none;
+                box-shadow: 0 0 0 2px rgba(var(--error-text-color-rgb)), 0 0 0 1px var(--error-text) !important;
+            }
+
+            .a11y--focused {
+                border: none;
+                box-shadow: 0 0 0 2px rgba(var(--error-text-color-rgb)), 0 0 0 1px var(--error-text) !important;
+            }
+        }
+    }
+}
+
 .multi-select__container {
     display: table;
     width: 100%;
@@ -37,6 +62,16 @@
     > div:not(.multi-select__note),
     > span {
         @include opacity(0.6);
+    }
+}
+
+.multi-select__error {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 23px 0;
+
+    &:empty {
+        display: none;
     }
 }
 


### PR DESCRIPTION
#### Summary

Update add members to channel modal so message about user limit is only displayed when limit is reached. Message no longer mentions 'You can add X more'. Aim is to be consistent with current behaviour of invite users modal. The approach taken stemmed from discussion here https://community.mattermost.com/core/pl/tr1epqd9big7zr3xh3dsmqdwxw

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/17707
https://mattermost.atlassian.net/browse/MM-35366

#### Screenshots

Before:
![before](https://user-images.githubusercontent.com/14108146/138276100-ebbc5861-fcc5-4671-a65e-9f581fdabb9d.PNG)

After:
![s1](https://user-images.githubusercontent.com/14108146/138276306-5693fbb3-897f-453c-8fc2-550c2d6fd0bb.PNG)
![s2](https://user-images.githubusercontent.com/14108146/138276537-2db27f82-0435-4fb3-ae53-8a74eb98d650.PNG)
![s3](https://user-images.githubusercontent.com/14108146/138276549-c8610360-e9f7-4a45-9948-fd6a549294ca.PNG)
![s4](https://user-images.githubusercontent.com/14108146/138276559-76e81d17-fc02-4a7e-a78b-87c6603f694d.PNG)

Note: the numbers seen in the images were temporarily modified in the example for ease of testing. The actual limit remains the same (20).

#### Release Note

```release-note
Added behavioural and UI changes for Multiselect component.
```
