### PR TITLE
ci: remove image push to the official image repository and use the test instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,8 +251,7 @@ jobs:
             export DOCKER_CLI_EXPERIMENTAL=enabled
             echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
             export MM_PACKAGE=https://pr-builds.mattermost.com/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}/mattermost-enterprise-linux-amd64.tar.gz
-            # Pushing the images to two places to not break anything, but the `mattermost/mattermost-enterprise-edition` will be removed soon.
-            docker buildx build --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mattermost-enterprise-edition:${TAG} -t mattermost/mm-ee-test:${TAG} .
+            docker buildx build --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mm-ee-test:${TAG} .
 
 workflows:
   version: 2


### PR DESCRIPTION
#### Summary
cherry pick of #9074 #9170 #8987 in the release 5.38 branch

#### Ticket Link


#### Release Note

```release-note
NONE
```
