### PR TITLE
Fix type definition for state.entities.users.profilesInChannel

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -50,6 +50,7 @@ import {
     IDMappedObjects,
     NameMappedObjects,
     RelationOneToMany,
+    RelationOneToManyUnique,
     RelationOneToOne,
     UserIDMappedObjects,
 } from 'mattermost-redux/types/utilities';
@@ -858,7 +859,7 @@ export const getDirectAndGroupChannels: (a: GlobalState) => Channel[] = createSe
     },
 );
 
-const getProfiles = (currentUserId: string, usersIdsInChannel: string[], users: IDMappedObjects<UserProfile>): UserProfile[] => {
+const getProfiles = (currentUserId: string, usersIdsInChannel: Set<string>, users: IDMappedObjects<UserProfile>): UserProfile[] => {
     const profiles: UserProfile[] = [];
     usersIdsInChannel.forEach((userId) => {
         if (userId !== currentUserId) {
@@ -876,11 +877,11 @@ export const getChannelsWithUserProfiles: (state: GlobalState) => Array<{
     getUsers,
     getGroupChannels,
     getCurrentUserId,
-    (channelUserMap: RelationOneToMany<Channel, UserProfile>, users: IDMappedObjects<UserProfile>, channels: Channel[], currentUserId: string) => {
+    (channelUserMap: RelationOneToManyUnique<Channel, UserProfile>, users: IDMappedObjects<UserProfile>, channels: Channel[], currentUserId: string) => {
         return channels.map((channel: Channel): {
             profiles: UserProfile[];
         } & Channel => {
-            const profiles = getProfiles(currentUserId, channelUserMap[channel.id] || [], users);
+            const profiles = getProfiles(currentUserId, channelUserMap[channel.id], users);
             return {
                 ...channel,
                 profiles,

--- a/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -42,6 +42,7 @@ import {
     EmailMappedObjects,
     IDMappedObjects,
     RelationOneToMany,
+    RelationOneToManyUnique,
     RelationOneToOne,
     UsernameMappedObjects,
 } from 'mattermost-redux/types/utilities';
@@ -58,11 +59,11 @@ type Filters = {
     team_roles?: string[];
 };
 
-export function getUserIdsInChannels(state: GlobalState): RelationOneToMany<Channel, UserProfile> {
+export function getUserIdsInChannels(state: GlobalState): RelationOneToManyUnique<Channel, UserProfile> {
     return state.entities.users.profilesInChannel;
 }
 
-export function getUserIdsNotInChannels(state: GlobalState): RelationOneToMany<Channel, UserProfile> {
+export function getUserIdsNotInChannels(state: GlobalState): RelationOneToManyUnique<Channel, UserProfile> {
     return state.entities.users.profilesNotInChannel;
 }
 
@@ -217,7 +218,7 @@ export const getCurrentUserMentionKeys: (state: GlobalState) => UserMentionKey[]
     },
 );
 
-export const getProfileSetInCurrentChannel: (state: GlobalState) => Array<$ID<UserProfile>> = createSelector(
+export const getProfileSetInCurrentChannel: (state: GlobalState) => Set<$ID<UserProfile>> = createSelector(
     'getProfileSetInCurrentChannel',
     getCurrentChannelId,
     getUserIdsInChannels,
@@ -226,7 +227,7 @@ export const getProfileSetInCurrentChannel: (state: GlobalState) => Array<$ID<Us
     },
 );
 
-export const getProfileSetNotInCurrentChannel: (state: GlobalState) => Array<$ID<UserProfile>> = createSelector(
+export const getProfileSetNotInCurrentChannel: (state: GlobalState) => Set<$ID<UserProfile>> = createSelector(
     'getProfileSetNotInCurrentChannel',
     getCurrentChannelId,
     getUserIdsNotInChannels,

--- a/packages/mattermost-redux/src/types/users.ts
+++ b/packages/mattermost-redux/src/types/users.ts
@@ -7,7 +7,7 @@ import {Group} from './groups';
 import {PostType} from './posts';
 import {Session} from './sessions';
 import {Team} from './teams';
-import {$ID, Dictionary, IDMappedObjects, RelationOneToMany, RelationOneToOne} from './utilities';
+import {$ID, Dictionary, IDMappedObjects, RelationOneToMany, RelationOneToManyUnique, RelationOneToOne} from './utilities';
 
 export type UserNotifyProps = {
     desktop: 'default' | 'all' | 'mention' | 'none';
@@ -70,8 +70,8 @@ export type UsersState = {
     profilesInTeam: RelationOneToMany<Team, UserProfile>;
     profilesNotInTeam: RelationOneToMany<Team, UserProfile>;
     profilesWithoutTeam: Set<string>;
-    profilesInChannel: RelationOneToMany<Channel, UserProfile>;
-    profilesNotInChannel: RelationOneToMany<Channel, UserProfile>;
+    profilesInChannel: RelationOneToManyUnique<Channel, UserProfile>;
+    profilesNotInChannel: RelationOneToManyUnique<Channel, UserProfile>;
     profilesInGroup: RelationOneToMany<Group, UserProfile>;
     statuses: RelationOneToOne<UserProfile, string>;
     stats: RelationOneToOne<UserProfile, UsersStats>;

--- a/packages/mattermost-redux/src/types/utilities.ts
+++ b/packages/mattermost-redux/src/types/utilities.ts
@@ -11,6 +11,9 @@ export type RelationOneToOne<E extends {id: string}, T> = {
 export type RelationOneToMany<E1 extends {id: string}, E2 extends {id: string}> = {
     [x in $ID<E1>]: Array<$ID<E2>>;
 };
+export type RelationOneToManyUnique<E1 extends {id: string}, E2 extends {id: string}> = {
+    [x in $ID<E1>]: Set<$ID<E2>>;
+};
 export type IDMappedObjects<E extends {id: string}> = RelationOneToOne<E, E>;
 export type UserIDMappedObjects<E extends {user_id: string}> = {
     [x in $UserID<E>]: E;


### PR DESCRIPTION
#### Summary
Modify UserState profilesInChannel and profilesNotInChannel attributes to both be typed Record<string, Set>
Introduce a RelationOneToManyUnique type that mimics RelationOneToMany but use a Set instead of an Array

#### Ticket Link
Fixes mattermost/mattermost-server#18112
JIRA: https://mattermost.atlassian.net/browse/MM-37631

#### Release Note
NONE