### PR TITLE
[MM-39429]: show edited indicator on empty/deleted messages with attachment

### DIFF
--- a/components/markdown/markdown.tsx
+++ b/components/markdown/markdown.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isString} from 'lodash';
 import React from 'react';
 
 import {Team} from 'mattermost-redux/types/teams';
@@ -128,7 +127,7 @@ export default class Markdown extends React.PureComponent<Props> {
 
     render() {
         const {postId, editedAt, message, enableFormatting} = this.props;
-        if ((isString(message) && message.length === 0) || !enableFormatting) {
+        if (message === '' || !enableFormatting) {
             return (
                 <span>
                     {message}

--- a/components/markdown/markdown.tsx
+++ b/components/markdown/markdown.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {isString} from 'lodash';
 import React from 'react';
 
 import {Team} from 'mattermost-redux/types/teams';
@@ -126,11 +127,11 @@ export default class Markdown extends React.PureComponent<Props> {
     }
 
     render() {
-        const {postId, editedAt, message} = this.props;
-        if (!this.props.enableFormatting) {
+        const {postId, editedAt, message, enableFormatting} = this.props;
+        if ((isString(message) && message.length === 0) || !enableFormatting) {
             return (
                 <span>
-                    {this.props.message}
+                    {message}
                     <PostEditedIndicator
                         postId={postId}
                         editedAt={editedAt}


### PR DESCRIPTION
#### Summary
added a new condition in `Markdown` component to check for the message to be a string and have a length of 0 (empty string)

#### Ticket Link
[MM-39429](https://mattermost.atlassian.net/browse/MM-39429)

#### Release Note
```release-note
edited indicator now shows on edited messages with attachments, where message is empty or deleted
```
