### PR TITLE
Remove string-refs usage in ThemeSetting component as it isn't needed anymore

### DIFF
--- a/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
+++ b/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
@@ -1,22 +1,21 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable react/no-string-refs */
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
+
 import React from 'react';
-import ReactDOM from 'react-dom';
+
 import {FormattedMessage} from 'react-intl';
+
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min';
+import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 
 import {ActionTypes, Constants} from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
-import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
-import SettingItemMax from 'components/setting_item_max.jsx';
-import SettingItemMin from 'components/setting_item_min';
 
 import CustomThemeChooser from './custom_theme_chooser.jsx';
 import PremadeThemeChooser from './premade_theme_chooser';
-
 export default class ThemeSetting extends React.PureComponent {
     static propTypes = {
         actions: PropTypes.shape({

--- a/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
+++ b/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
@@ -43,20 +43,9 @@ export default class ThemeSetting extends React.PureComponent {
         this.originalTheme = Object.assign({}, this.state.theme);
     }
 
-    componentDidMount() {
-        if (this.props.selected) {
-            $(ReactDOM.findDOMNode(this.refs[this.state.theme])).addClass('active-border'); // eslint-disable-line jquery/no-class
-        }
-    }
-
     componentDidUpdate(prevProps) {
         if (prevProps.selected && !this.props.selected) {
             this.resetFields();
-        }
-
-        if (this.props.selected) {
-            $('.color-btn').removeClass('active-border'); // eslint-disable-line jquery/no-class
-            $(ReactDOM.findDOMNode(this.refs[this.state.theme])).addClass('active-border'); // eslint-disable-line jquery/no-class
         }
     }
 

--- a/sass/routes/_settings.scss
+++ b/sass/routes/_settings.scss
@@ -646,14 +646,6 @@
     padding-top: 50px;
 }
 
-.active-border {
-    border: 1px solid red;
-}
-
-.color-btn {
-    margin: 4px;
-}
-
 .no-resize {
     resize: none;
 }


### PR DESCRIPTION
#### Summary

I've removed string-refs usage for that one as it doesn't correspond to anything in the app.
The code dates back from 2016 and I wasn't able to blame before that to understand why it was added (and with which corresponding code)

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/15843
JIRA ticket: https://mattermost.atlassian.net/browse/MM-29404

#### Release Note
NONE