### PR TITLE
MM-39580 Switch EditChannelHeaderModal to onExited

### DIFF
--- a/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.tsx.snap
+++ b/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.tsx.snap
@@ -24,13 +24,13 @@ exports[`components/EditChannelHeaderModal edit direct message channel 1`] = `
     }
   }
   onEntering={[Function]}
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
-  show={false}
+  show={true}
 >
   <ModalHeader
     bsClass="modal-header"
@@ -145,13 +145,13 @@ exports[`components/EditChannelHeaderModal error with intl message 1`] = `
     }
   }
   onEntering={[Function]}
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
-  show={false}
+  show={true}
 >
   <ModalHeader
     bsClass="modal-header"
@@ -289,13 +289,13 @@ exports[`components/EditChannelHeaderModal error without intl message 1`] = `
     }
   }
   onEntering={[Function]}
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
-  show={false}
+  show={true}
 >
   <ModalHeader
     bsClass="modal-header"
@@ -425,13 +425,13 @@ exports[`components/EditChannelHeaderModal should match snapshot, init 1`] = `
     }
   }
   onEntering={[Function]}
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
-  show={false}
+  show={true}
 >
   <ModalHeader
     bsClass="modal-header"
@@ -551,13 +551,13 @@ exports[`components/EditChannelHeaderModal submitted 1`] = `
     }
   }
   onEntering={[Function]}
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
-  show={false}
+  show={true}
 >
   <ModalHeader
     bsClass="modal-header"

--- a/components/edit_channel_header_modal/edit_channel_header_modal.tsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.tsx
@@ -12,7 +12,7 @@ import {ServerError} from 'mattermost-redux/types/errors';
 import Textbox from 'components/textbox';
 import TextboxClass from 'components/textbox/textbox';
 import TextboxLinks from 'components/textbox/textbox_links';
-import Constants, {ModalIdentifiers} from 'utils/constants';
+import Constants from 'utils/constants';
 import {isMobile} from 'utils/user_agent';
 import {insertLineBreakFromKeyEvent, isKeyPressed, isUnhandledLineBreakKeyCombo, localizeMessage} from 'utils/utils.jsx';
 
@@ -28,11 +28,6 @@ type Props = {
     channel: Channel;
 
     /*
-     * Set whether to show the modal or not
-     */
-    show: boolean;
-
-    /*
      * boolean should be `ctrl` button pressed to send
      */
     ctrlSend: boolean;
@@ -42,15 +37,15 @@ type Props = {
      */
     shouldShowPreview: boolean;
 
+    /**
+     * Called when the modal has been hidden and should be removed.
+     */
+    onExited: () => void;
+
     /*
      * Collection of redux actions
      */
     actions: {
-
-        /*
-         * Close the modal
-         */
-        closeModal: (modalId: string) => {data: boolean};
 
         /*
          * patch channel redux-action
@@ -67,6 +62,7 @@ type Props = {
 type State = {
     header?: string;
     saving: boolean;
+    show: boolean;
     serverError?: ServerError;
     postError?: React.ReactNode;
 }
@@ -80,6 +76,7 @@ export default class EditChannelHeaderModal extends React.PureComponent<Props, S
         this.state = {
             header: props.channel.header,
             saving: false,
+            show: true,
         };
         this.editChannelHeaderTextboxRef = React.createRef<TextboxClass>();
     }
@@ -119,7 +116,9 @@ export default class EditChannelHeaderModal extends React.PureComponent<Props, S
     }
 
     private hideModal = (): void => {
-        this.props.actions.closeModal(ModalIdentifiers.EDIT_CHANNEL_HEADER);
+        this.setState({
+            show: false,
+        });
     }
 
     private focusTextbox = (): void => {
@@ -219,12 +218,12 @@ export default class EditChannelHeaderModal extends React.PureComponent<Props, S
         return (
             <Modal
                 dialogClassName='a11y__modal'
-                show={this.props.show}
+                show={this.state.show}
                 keyboard={false}
                 onKeyDown={this.handleModalKeyDown}
                 onHide={this.hideModal}
                 onEntering={this.handleEntering}
-                onExited={this.hideModal}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='editChannelHeaderModalLabel'
             >

--- a/components/edit_channel_header_modal/index.ts
+++ b/components/edit_channel_header_modal/index.ts
@@ -11,25 +11,19 @@ import {Preferences} from 'mattermost-redux/constants';
 
 import {GlobalState} from 'types/store';
 
-import {closeModal} from 'actions/views/modals';
 import {setShowPreviewOnEditChannelHeaderModal} from 'actions/views/textbox';
 import {showPreviewOnEditChannelHeaderModal} from 'selectors/views/textbox';
-
-import {isModalOpen} from '../../selectors/views/modals';
-import {ModalIdentifiers} from '../../utils/constants';
 
 import EditChannelHeaderModal from './edit_channel_header_modal';
 
 function mapStateToProps(state: GlobalState) {
     return {
         shouldShowPreview: showPreviewOnEditChannelHeaderModal(state),
-        show: isModalOpen(state, ModalIdentifiers.EDIT_CHANNEL_HEADER),
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
     };
 }
 
 type Actions = {
-    closeModal: (modalId: string) => {data: boolean};
     patchChannel: (channelId: string, patch: Partial<Channel>) => Promise<ActionResult>;
     setShowPreview: (showPreview: boolean) => void;
 }
@@ -37,7 +31,6 @@ type Actions = {
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc | GenericAction>, Actions>({
-            closeModal,
             patchChannel,
             setShowPreview: setShowPreviewOnEditChannelHeaderModal,
         }, dispatch),


### PR DESCRIPTION
I'm renaming onHide to onExited so that it mirrors how it's supposed to be used with React-Bootstrap. GenericModal is one of those modals.

The only functional change here is that this modal will now fade out nicely before unmounting instead of just disappearing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39580

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9280
https://github.com/mattermost/mattermost-webapp/pull/9281
https://github.com/mattermost/mattermost-webapp/pull/9282

#### Release Note
```release-note
NONE
```
