### PR TITLE
MM-37746 Fix premature truncation of names in emoji picker

### DIFF
--- a/build/emoji/emoji_gen.mjs
+++ b/build/emoji/emoji_gen.mjs
@@ -337,37 +337,40 @@ for (const key of emojiFilePositions.keys()) {
 
 const cssRules = `
 @charset "UTF-8";
+
 .emojisprite-preview {
+    width: ${EMOJI_SIZE_PADDED}px;
+    max-width: none;
+    height: ${EMOJI_SIZE_PADDED}px;
+    background-repeat: no-repeat;
+    cursor: pointer;
+    -moz-transform: scale(0.5);
+    transform-origin: 0 0;
     // Using zoom for now as it results in less blurry emojis on Chrome - MM-34178
     zoom: 0.5;
-    -moz-transform: scale(0.5);
-    background-repeat: no-repeat;
-    cursor: pointer;
-    height: ${EMOJI_SIZE_PADDED}px;
-    max-width: none;
-    width: ${EMOJI_SIZE_PADDED}px;
-    transform-origin: 0 0;
 }
+
 .emojisprite {
-    zoom: 0.35;
-    -moz-transform: scale(0.35);
+    width: ${EMOJI_SIZE_PADDED}px;
+    max-width: none;
+    height: ${EMOJI_SIZE_PADDED}px;
     background-repeat: no-repeat;
     border-radius: 18px;
     cursor: pointer;
-    height: ${EMOJI_SIZE_PADDED}px;
-    max-width: none;
-    width: ${EMOJI_SIZE_PADDED}px;
+    -moz-transform: scale(0.35);
+    zoom: 0.35;
 }
+
 .emojisprite-loading {
+    width: ${EMOJI_SIZE_PADDED}px;
+    max-width: none;
+    height: ${EMOJI_SIZE_PADDED}px;
     background-image: none !important;
-    zoom: 0.35;
-    -moz-transform: scale(0.35);
     background-repeat: no-repeat;
     border-radius: 18px;
     cursor: pointer;
-    height: ${EMOJI_SIZE_PADDED}px;
-    max-width: none;
-    width: ${EMOJI_SIZE_PADDED}px;
+    -moz-transform: scale(0.35);
+    zoom: 0.35;
 }
 
 ${cssCats.join('\n')};

--- a/build/emoji/emoji_gen.mjs
+++ b/build/emoji/emoji_gen.mjs
@@ -339,14 +339,13 @@ const cssRules = `
 @charset "UTF-8";
 .emojisprite-preview {
     // Using zoom for now as it results in less blurry emojis on Chrome - MM-34178
-    zoom: 0.55;
-    -moz-transform: scale(0.55);
+    zoom: 0.5;
+    -moz-transform: scale(0.5);
     background-repeat: no-repeat;
     cursor: pointer;
     height: ${EMOJI_SIZE_PADDED}px;
     max-width: none;
     width: ${EMOJI_SIZE_PADDED}px;
-    padding: 0 10px 0 0;
     transform-origin: 0 0;
 }
 .emojisprite {

--- a/sass/components/_emojisprite.scss
+++ b/sass/components/_emojisprite.scss
@@ -5,13 +5,12 @@
     width: 66px;
     max-width: none;
     height: 66px;
-    padding: 0 10px 0 0;
     background-repeat: no-repeat;
     cursor: pointer;
-    -moz-transform: scale(0.55);
+    -moz-transform: scale(0.5);
     transform-origin: 0 0;
     // Using zoom for now as it results in less blurry emojis on Chrome - MM-34178
-    zoom: 0.55;
+    zoom: 0.5;
 }
 
 .emojisprite {

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -548,15 +548,24 @@
     z-index: 99999;
 }
 
+$emoji-picker-footer-margin: 12px;
+$emoji-half-height: 33px;
+
 .emoji-picker__footer {
+    $border-width: 1px;
+
     display: flex;
     justify-content: space-between;
-    border-top: solid 1px rgba(61, 60, 64, 0.2);
+    align-items: center;
+    min-height: $border-width + $emoji-half-height + $emoji-picker-footer-margin * 2; // prevents tiny layout shift when emoji replaces placeholder
+    border-top: solid $border-width rgba(61, 60, 64, 0.2);
 }
 
 .emoji-picker__custom {
-    position: relative;
-    margin: 12px;
+    flex-shrink: 0;
+    margin: $emoji-picker-footer-margin {
+        left: 0;
+    }
     text-decoration: none;
 
     a,
@@ -576,85 +585,40 @@
 }
 
 .emoji-picker__preview {
-    position: relative;
-    display: flex;
     overflow: hidden;
-    max-width: 210px;
-    height: 56px;
-    flex-direction: row;
-    flex-grow: 0;
-    flex-shrink: 0;
-    align-items: stretch;
-    justify-content: flex-start;
-    padding: 18px 0 18px 16px;
+    margin: $emoji-picker-footer-margin;
     background: var(--center-channel-bg);
-    vertical-align: middle;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &.emoji-picker__preview-placeholder {
-        padding: 12px;
-
         span {
-            display: flex;
-            align-items: center;
             font-weight: bold;
         }
-    }
-
-    > div {
-        display: table-cell;
-        vertical-align: middle;
     }
 
     .emoji-picker__preview-image-label-box {
+        display: inline;
+
         .emoji-picker__preview-name {
             @include user-select(text);
 
-            display: inline-block;
-            overflow: hidden;
-            max-width: 120px;
-            font-size: 14px;
             font-weight: bold;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-
-        .emoji-picker__preview-aliases {
-            display: block;
-            overflow: hidden;
-            font-size: 12px;
-            font-weight: bold;
-            text-overflow: ellipsis;
-            white-space: nowrap;
         }
     }
 
     .emoji-picker__preview-image-box {
-        position: relative;
-        display: flex;
-        width: 32px;
-        height: 32px;
-        max-height: 36px;
-        align-items: center;
-        justify-content: center;
+        vertical-align: middle;
         margin-right: 12px;
-        text-align: center;
 
+        &,
         .sprite-preview {
             display: inline-block;
-            width: 32px;
-            height: 32px;
-            padding: 0;
-            border: none;
-            margin-top: -20px;
-            vertical-align: middle;
         }
     }
 
     .emoji-picker__preview-image {
-        position: relative;
-        top: -8px;
-        left: 2px;
-        max-width: 36px;
-        max-height: 36px;
+        max-width: $emoji-half-height;
+        max-height: $emoji-half-height;
     }
 }

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -555,9 +555,9 @@ $emoji-half-height: 33px;
     $border-width: 1px;
 
     display: flex;
-    justify-content: space-between;
-    align-items: center;
     min-height: $border-width + $emoji-half-height + $emoji-picker-footer-margin * 2; // prevents tiny layout shift when emoji replaces placeholder
+    align-items: center;
+    justify-content: space-between;
     border-top: solid $border-width rgba(61, 60, 64, 0.2);
 }
 
@@ -608,8 +608,8 @@ $emoji-half-height: 33px;
     }
 
     .emoji-picker__preview-image-box {
-        vertical-align: middle;
         margin-right: 12px;
+        vertical-align: middle;
 
         &,
         .sprite-preview {

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -614,6 +614,8 @@ $emoji-half-height: 33px;
         &,
         .sprite-preview {
             display: inline-block;
+            width: $emoji-half-height;
+            height: $emoji-half-height;
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix premature truncation of names in emoji picker. Generally simplify style now that aliases are shown on the same line as the primary name.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/18430  
https://mattermost.atlassian.net/browse/MM-37746

#### Screenshots
|  before  |  after  |
|----|----|
| ![Screenshot_20211029_110846](https://user-images.githubusercontent.com/28617290/139354663-407d08a9-fcbc-4b29-a12f-fbb0717cb490.png) | ![Screenshot_20211028_115539](https://user-images.githubusercontent.com/28617290/139354543-98fb2a7b-2257-44c2-b9bd-439cfec6ed7f.png) |

#### Release Note
```release-note
NONE
```