### PR TITLE
Cypress/E2E: Fix custom status expiry

### DIFF
--- a/e2e/cypress/integration/custom_status/custom_status_expiry/custom_status_expiry_3_spec.js
+++ b/e2e/cypress/integration/custom_status/custom_status_expiry/custom_status_expiry_3_spec.js
@@ -32,6 +32,7 @@ describe('MM-T4065 Setting manual status clear time less than 7 days away', () =
     const today = Cypress.dayjs();
     const dateToBeSelected = today.add(3, 'd');
     const months = dateToBeSelected.get('month') - today.get('month');
+
     it('MM-T4065_1 should open status dropdown', () => {
         // # Click on the sidebar header to open status dropdown
         cy.get('.MenuWrapper .status-wrapper').click();


### PR DESCRIPTION
#### Summary
- Fixed `custom_status_expiry_3_spec` similar to `custom_status_expiry_4_spec` - the issue only showed itself because of timing in the calendar.

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-10-28 at 8 18 37 PM](https://user-images.githubusercontent.com/487991/139371013-e7d4bcca-9713-4dac-b023-fc5315b59bd6.png)


#### Release Note
```release-note
NONE
```