### PR TITLE
[MM-37990] Update recent emojis based on default selected skin tone

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -553,8 +553,26 @@ export default class EmojiPicker extends React.PureComponent {
 
             return this.sortEmojis(emojis);
         }
-        return this.state.categories[category.name].emojiIds.map((emojiId) =>
-            this.state.allEmojis[emojiId]);
+
+        return this.state.categories[category.name].emojiIds.map((emojiId) => {
+            const emoji = this.state.allEmojis[emojiId];
+            if(category.name === 'recent' && emoji.skins && emoji.skins.length > 0) {
+                const skinCode = emoji.skins[0].toLowerCase();
+                const userSkinTone = this.props.userSkinTone.toLowerCase();
+                // const defaultEmoji = emojiId.replace(`-${skinCode.toLowerCase()}`, '');
+                const skinnedEmojiCode = userSkinTone === 'default'
+                    ? emojiId.replace(`-${skinCode}`, '')
+                    : emojiId.replace(skinCode, userSkinTone);
+                if(emojiId !== skinnedEmojiCode) {
+                    //retrieve it from the emoji map
+                    const emojiIndex = Emoji.EmojiIndicesByUnicode.get(skinnedEmojiCode);
+                    return Emoji.Emojis[emojiIndex];
+                }
+            }
+            return emoji;
+        });
+        // return this.state.categories[category.name].emojiIds.map((emojiId) =>
+        //     this.state.allEmojis[emojiId]);
     }
 
     getCurrentEmojiName() {

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -554,25 +554,36 @@ export default class EmojiPicker extends React.PureComponent {
             return this.sortEmojis(emojis);
         }
 
-        return this.state.categories[category.name].emojiIds.map((emojiId) => {
+        const emojis = this.state.categories[category.name].emojiIds.map((emojiId) => {
             const emoji = this.state.allEmojis[emojiId];
-            if(category.name === 'recent' && emoji.skins && emoji.skins.length > 0) {
+
+            if (category.name === 'recent' && emoji.skin_variations && emoji.skin_variations.hasOwnProperty(this.props.userSkinTone)) {
+                const skinVariation = emoji.skin_variations[this.props.userSkinTone];
+
+                //retrieve it from the emoji map
+                const emojiIndex = Emoji.EmojiIndicesByUnicode.get(skinVariation.unified.toLowerCase());
+                return Emoji.Emojis[emojiIndex];
+            }
+
+            if (category.name === 'recent' && emoji.skins && emoji.skins.length > 0) {
                 const skinCode = emoji.skins[0].toLowerCase();
                 const userSkinTone = this.props.userSkinTone.toLowerCase();
-                // const defaultEmoji = emojiId.replace(`-${skinCode.toLowerCase()}`, '');
-                const skinnedEmojiCode = userSkinTone === 'default'
-                    ? emojiId.replace(`-${skinCode}`, '')
-                    : emojiId.replace(skinCode, userSkinTone);
-                if(emojiId !== skinnedEmojiCode) {
+
+                const skinnedEmojiCode = userSkinTone === 'default' ?
+                    emojiId.replace(`-${skinCode}`, '') :
+                    emojiId.replace(skinCode, userSkinTone);
+
+                if (emojiId !== skinnedEmojiCode) {
                     //retrieve it from the emoji map
                     const emojiIndex = Emoji.EmojiIndicesByUnicode.get(skinnedEmojiCode);
                     return Emoji.Emojis[emojiIndex];
                 }
             }
+
             return emoji;
         });
-        // return this.state.categories[category.name].emojiIds.map((emojiId) =>
-        //     this.state.allEmojis[emojiId]);
+
+        return [...new Map(emojis.map((e) => [e.unified, e])).values()];
     }
 
     getCurrentEmojiName() {

--- a/components/emoji_picker/emoji_picker.test.jsx
+++ b/components/emoji_picker/emoji_picker.test.jsx
@@ -143,24 +143,4 @@ describe('components/emoji_picker/EmojiPicker', () => {
             expect(wrapper.find('.emoji-picker__items').prop('style')).toStrictEqual({overflowY: 'auto'});
         }, 1000);
     });
-
-    test('Changing default skin tone should update recent emojis skin tone', () => {
-        const props = {
-            ...baseProps,
-            recentEmojis: [
-                'thumbsup',
-            ],
-        };
-
-        const wrapper = shallow(
-            <EmojiPicker {...props}/>,
-        );
-
-        wrapper.instance().emojiPickerContainer = {
-            offsetHeight: 200,
-        };
-
-        console.log(wrapper.state);
-        expect(wrapper.state.categories.recent.emojiIds).toHaveLength(1);
-    });
 });

--- a/components/emoji_picker/emoji_picker.test.jsx
+++ b/components/emoji_picker/emoji_picker.test.jsx
@@ -143,4 +143,24 @@ describe('components/emoji_picker/EmojiPicker', () => {
             expect(wrapper.find('.emoji-picker__items').prop('style')).toStrictEqual({overflowY: 'auto'});
         }, 1000);
     });
+
+    test('Changing default skin tone should update recent emojis skin tone', () => {
+        const props = {
+            ...baseProps,
+            recentEmojis: [
+                'thumbsup',
+            ],
+        };
+
+        const wrapper = shallow(
+            <EmojiPicker {...props}/>,
+        );
+
+        wrapper.instance().emojiPickerContainer = {
+            offsetHeight: 200,
+        };
+
+        console.log(wrapper.state);
+        expect(wrapper.state.categories.recent.emojiIds).toHaveLength(1);
+    });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Recent emojis now change (when applicable) based on the default selected
skin tone.

If more than one skin tone was available in the recent section, this
feature will trim all duplicates, displaying only the emoji matching
the default selected skin tone.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Jira ticket: https://mattermost.atlassian.net/browse/MM-37990
Fixes https://github.com/mattermost/mattermost-server/issues/18847
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/14358537/139396327-66ab69e1-5cf7-48d6-8ae9-90353246e3b5.png) | ![perf-after](https://user-images.githubusercontent.com/14358537/139396331-687b6f87-32ca-4410-a08d-06bd83c3d8a0.PNG) |

-->
|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/14358537/139396327-66ab69e1-5cf7-48d6-8ae9-90353246e3b5.png) | ![perf-after](https://user-images.githubusercontent.com/14358537/139396331-687b6f87-32ca-4410-a08d-06bd83c3d8a0.PNG) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Recent emojis get updated based on default selected skin tone.
```