### PR TITLE
MM-39680 Switch Channel modals to onExited

### DIFF
--- a/components/channel_info_modal/channel_info_modal.test.tsx
+++ b/components/channel_info_modal/channel_info_modal.test.tsx
@@ -16,14 +16,18 @@ describe('components/ChannelInfoModal', () => {
         header: '',
         purpose: '',
     });
-    const mockTeam = TestHelper.getTeamMock();
+
+    const baseProps = {
+        channel: mockChannel,
+        currentChannel: mockChannel,
+        currentTeam: TestHelper.getTeamMock(),
+        onExited: jest.fn(),
+    };
+
     it('should match snapshot', () => {
         const wrapper = shallow(
             <ChannelInfoModal
-                channel={mockChannel}
-                currentChannel={mockChannel}
-                currentTeam={mockTeam}
-                onHide={jest.fn()}
+                {...baseProps}
             />,
         );
 
@@ -46,38 +50,29 @@ describe('components/ChannelInfoModal', () => {
 
         const wrapper = shallow(
             <ChannelInfoModal
+                {...baseProps}
                 channel={channel}
                 currentChannel={channel}
-                currentTeam={mockTeam}
-                onHide={jest.fn()}
             />,
         );
 
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('should call onHide callback when modal is hidden', () => {
-        const onHide = jest.fn();
-
+    it('should call onExited callback when modal is hidden', () => {
         const wrapper = mountWithIntl(
             <ChannelInfoModal
-                channel={mockChannel}
-                currentChannel={mockChannel}
-                currentTeam={mockTeam}
-                onHide={onHide}
+                {...baseProps}
             />,
         );
         wrapper.find(Modal).first().props().onExited!(document.createElement('div'));
-        expect(onHide).toHaveBeenCalled();
+        expect(baseProps.onExited).toHaveBeenCalled();
     });
 
     it('should call onHide when current channel changes', () => {
         const wrapper = mountWithIntl(
             <ChannelInfoModal
-                channel={mockChannel}
-                currentChannel={mockChannel}
-                currentTeam={mockTeam}
-                onHide={jest.fn()}
+                {...baseProps}
             />,
         );
 
@@ -89,10 +84,7 @@ describe('components/ChannelInfoModal', () => {
     it('should call hide when RHS opens', () => {
         const wrapper = mountWithIntl(
             <ChannelInfoModal
-                channel={mockChannel}
-                currentChannel={mockChannel}
-                currentTeam={mockTeam}
-                onHide={jest.fn()}
+                {...baseProps}
             />,
         );
 

--- a/components/channel_info_modal/channel_info_modal.tsx
+++ b/components/channel_info_modal/channel_info_modal.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
@@ -24,11 +23,35 @@ import * as Utils from 'utils/utils.jsx';
 const headerMarkdownOptions = {singleline: false, mentionHighlight: false};
 
 type Props = {
-    onHide: () => void;
+
+    /**
+     * Function that is called when modal is hidden
+     */
+    onExited: () => void;
+
+    /**
+     * Channel object
+     */
     channel: Channel;
+
+    /**
+     * Current channel object, used to determine if the current channel is different from the one this modal was instantiated with
+     */
     currentChannel: Channel;
+
+    /**
+     * Current team object
+     */
     currentTeam: Team;
+
+    /**
+     * Boolean whether the RHS is open, used to check if we need to hide the channel info modal
+     */
     isRHSOpen?: boolean;
+
+    /**
+     * Relative url for the team, used to redirect to another channel within the team from the modal
+     */
     currentRelativeTeamUrl?: string;
 };
 
@@ -37,39 +60,6 @@ type State = {
 };
 
 export default class ChannelInfoModal extends React.PureComponent<Props, State> {
-    static propTypes = {
-
-        /**
-         * Function that is called when modal is hidden
-         */
-        onHide: PropTypes.func.isRequired,
-
-        /**
-         * Channel object
-         */
-        channel: PropTypes.object.isRequired,
-
-        /**
-         * Current channel object, used to determine if the current channel is different from the one this modal was instantiated with
-         */
-        currentChannel: PropTypes.object.isRequired,
-
-        /**
-         * Current team object
-         */
-        currentTeam: PropTypes.object.isRequired,
-
-        /**
-         * Boolean whether the RHS is open, used to check if we need to hide the channel info modal
-         */
-        isRHSOpen: PropTypes.bool,
-
-        /**
-         * Relative url for the team, used to redirect to another channel within the team from the modal
-         */
-        currentRelativeTeamUrl: PropTypes.string,
-    };
-
     constructor(props: Props) {
         super(props);
 
@@ -200,7 +190,7 @@ export default class ChannelInfoModal extends React.PureComponent<Props, State> 
                 dialogClassName='a11y__modal about-modal'
                 show={this.state.show}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='channelInfoModalLabel'
             >

--- a/components/channel_invite_modal/channel_invite_modal.test.tsx
+++ b/components/channel_invite_modal/channel_invite_modal.test.tsx
@@ -67,7 +67,7 @@ describe('components/channel_invite_modal', () => {
             loadStatusesForProfilesList: jest.fn(),
             searchProfiles: jest.fn(),
         },
-        onHide: jest.fn(),
+        onExited: jest.fn(),
     };
 
     test('should match snapshot for channel_invite_modal with profiles', () => {
@@ -141,7 +141,7 @@ describe('components/channel_invite_modal', () => {
         );
 
         wrapper.find(Modal).props().onExited!(document.createElement('div'));
-        expect(props.onHide).toHaveBeenCalledTimes(1);
+        expect(props.onExited).toHaveBeenCalledTimes(1);
     });
 
     test('should fail to add users on handleSubmit', (done) => {

--- a/components/channel_invite_modal/channel_invite_modal.tsx
+++ b/components/channel_invite_modal/channel_invite_modal.tsx
@@ -30,7 +30,7 @@ export type Props = {
     profilesNotInCurrentChannel: UserProfileValue[];
     profilesNotInCurrentTeam: UserProfileValue[];
     userStatuses: RelationOneToOne<UserProfile, string>;
-    onHide: () => void;
+    onExited: () => void;
     channel: Channel;
 
     // skipCommit = true used with onAddCallback will result in users not being committed immediately
@@ -323,7 +323,7 @@ export default class ChannelInviteModal extends React.PureComponent<Props, State
                 dialogClassName='a11y__modal channel-invite'
                 show={this.state.show}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='channelInviteModalLabel'
             >

--- a/components/channel_members_modal/__snapshots__/channel_members_modal.test.tsx.snap
+++ b/components/channel_members_modal/__snapshots__/channel_members_modal.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`components/ChannelMembersModal should match snapshot 1`] = `
         "remove": [Function],
       }
     }
-    onExited={[Function]}
+    onExited={[MockFunction]}
     onHide={[Function]}
     renderBackdrop={[Function]}
     restoreFocus={true}
@@ -119,7 +119,7 @@ exports[`components/ChannelMembersModal should match snapshot with archived chan
         "remove": [Function],
       }
     }
-    onExited={[Function]}
+    onExited={[MockFunction]}
     onHide={[Function]}
     renderBackdrop={[Function]}
     restoreFocus={true}

--- a/components/channel_members_modal/channel_members_modal.test.tsx
+++ b/components/channel_members_modal/channel_members_modal.test.tsx
@@ -32,7 +32,7 @@ describe('components/ChannelMembersModal', () => {
             group_constrained: false,
         },
         canManageChannelMembers: true,
-        onHide: jest.fn(),
+        onExited: jest.fn(),
         actions: {
             openModal: jest.fn(),
         },
@@ -47,32 +47,24 @@ describe('components/ChannelMembersModal', () => {
     });
 
     test('should match state when onHide is called', () => {
-        const wrapper = shallow(
+        const wrapper = shallow<ChannelMembersModal>(
             <ChannelMembersModal {...baseProps}/>,
         );
 
         wrapper.setState({show: true});
-        (wrapper.instance() as ChannelMembersModal).handleHide();
+        wrapper.instance().handleHide();
         expect(wrapper.state('show')).toEqual(false);
     });
 
-    test('should have called props.actions.openModal and props.onHide when onAddNewMembersButton is called', () => {
-        const onHide = jest.fn();
-        const openModal = jest.fn();
-        const props = {
-            ...baseProps,
-            onHide,
-            actions: {
-                openModal,
-            },
-        };
-        const wrapper = shallow(
-            <ChannelMembersModal {...props}/>,
+    test('should have called props.actions.openModal and hide modal when onAddNewMembersButton is called', () => {
+        const wrapper = shallow<ChannelMembersModal>(
+            <ChannelMembersModal {...baseProps}/>,
         );
 
-        (wrapper.instance() as ChannelMembersModal).onAddNewMembersButton();
-        expect(openModal).toHaveBeenCalledTimes(1);
-        expect(onHide).toHaveBeenCalledTimes(1);
+        wrapper.instance().onAddNewMembersButton();
+        expect(baseProps.actions.openModal).toHaveBeenCalledTimes(1);
+
+        expect(wrapper.state('show')).toBe(false);
     });
 
     test('should have state when Modal.onHide', () => {

--- a/components/channel_members_modal/channel_members_modal.tsx
+++ b/components/channel_members_modal/channel_members_modal.tsx
@@ -27,9 +27,9 @@ type Props = {
     channel: Channel;
 
     /**
-     * Function that is called when modal is hidden
+     * Function that is called after the modal is hidden
      */
-    onHide: () => void;
+    onExited: () => void;
 
     actions: {
         openModal: <P>(modalData: ModalData<P>) => void;
@@ -53,10 +53,6 @@ export default class ChannelMembersModal extends React.PureComponent<Props, Stat
         this.setState({show: false});
     }
 
-    handleExit = () => {
-        this.props.onHide();
-    }
-
     onAddNewMembersButton = () => {
         const {channel, actions} = this.props;
 
@@ -66,7 +62,7 @@ export default class ChannelMembersModal extends React.PureComponent<Props, Stat
             dialogProps: {channel},
         });
 
-        this.handleExit();
+        this.handleHide();
     }
 
     render() {
@@ -77,7 +73,7 @@ export default class ChannelMembersModal extends React.PureComponent<Props, Stat
                     dialogClassName='a11y__modal more-modal more-modal--action'
                     show={this.state.show}
                     onHide={this.handleHide}
-                    onExited={this.handleExit}
+                    onExited={this.props.onExited}
                     role='dialog'
                     aria-labelledby='channelMembersModalLabel'
                     id='channelMembersModal'

--- a/components/channel_notifications_modal/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal/channel_notifications_modal.jsx
@@ -18,9 +18,9 @@ export default class ChannelNotificationsModal extends React.PureComponent {
     static propTypes = {
 
         /**
-         * Function that is called when modal is hidden
+         * Function that is called when the modal has been hidden and should be removed
          */
-        onHide: PropTypes.func.isRequired,
+        onExited: PropTypes.func.isRequired,
 
         /**
          * Object with info about current channel
@@ -110,7 +110,7 @@ export default class ChannelNotificationsModal extends React.PureComponent {
 
     handleExit = () => {
         this.updateSection(NotificationSections.NONE);
-        this.props.onHide();
+        this.props.onExited();
     }
 
     updateSection = (section = NotificationSections.NONE) => {

--- a/components/channel_notifications_modal/channel_notifications_modal.test.jsx
+++ b/components/channel_notifications_modal/channel_notifications_modal.test.jsx
@@ -10,7 +10,7 @@ import ChannelNotificationsModal from 'components/channel_notifications_modal/ch
 describe('components/channel_notifications_modal/ChannelNotificationsModal', () => {
     const baseProps = {
         show: true,
-        onHide: () => {}, //eslint-disable-line no-empty-function
+        onExited: jest.fn(),
         channel: {id: 'channel_id', display_name: 'channel_display_name'},
         channelMember: {
             notify_props: {
@@ -156,28 +156,26 @@ describe('components/channel_notifications_modal/ChannelNotificationsModal', () 
         expect(wrapper.state('ignoreChannelMentions')).toEqual(IgnoreChannelMentions.ON);
     });
 
-    test('should call onHide and match state on handleOnHide', () => {
-        const onHide = jest.fn();
-        const props = {...baseProps, onHide};
+    test('should call onExited and match state on handleOnHide', () => {
         const wrapper = shallow(
-            <ChannelNotificationsModal {...props}/>,
+            <ChannelNotificationsModal {...baseProps}/>,
         );
 
         wrapper.setState({activeSection: NotificationSections.DESKTOP, desktopNotifyLevel: NotificationLevels.NONE});
         wrapper.instance().handleExit();
-        expect(onHide).toHaveBeenCalledTimes(1);
+        expect(baseProps.onExited).toHaveBeenCalledTimes(1);
         expect(wrapper.state('activeSection')).toEqual(NotificationSections.NONE);
         expect(wrapper.state('desktopNotifyLevel')).toEqual(NotificationLevels.ALL);
 
         wrapper.setState({activeSection: NotificationSections.MARK_UNREAD, markUnreadNotifyLevel: NotificationLevels.NONE});
         wrapper.instance().handleExit();
-        expect(onHide).toHaveBeenCalledTimes(2);
+        expect(baseProps.onExited).toHaveBeenCalledTimes(2);
         expect(wrapper.state('activeSection')).toEqual(NotificationSections.NONE);
         expect(wrapper.state('markUnreadNotifyLevel')).toEqual(NotificationLevels.ALL);
 
         wrapper.setState({activeSection: NotificationSections.PUSH, pushNotifyLevel: NotificationLevels.NONE});
         wrapper.instance().handleExit();
-        expect(onHide).toHaveBeenCalledTimes(3);
+        expect(baseProps.onExited).toHaveBeenCalledTimes(3);
         expect(wrapper.state('activeSection')).toEqual(NotificationSections.NONE);
         expect(wrapper.state('pushNotifyLevel')).toEqual(NotificationLevels.DEFAULT);
     });

--- a/components/delete_channel_modal/delete_channel_modal.test.tsx
+++ b/components/delete_channel_modal/delete_channel_modal.test.tsx
@@ -42,7 +42,7 @@ describe('components/delete_channel_modal', () => {
                 return {data: true};
             }),
         },
-        onHide: jest.fn(),
+        onExited: jest.fn(),
         penultimateViewedChannelName: 'my-prev-channel',
     };
 
@@ -80,13 +80,12 @@ describe('components/delete_channel_modal', () => {
         expect(wrapper.state('show')).toEqual(false);
     });
 
-    test('should have called props.onHide when Modal.onExited is called', () => {
-        const props = {...baseProps};
+    test('should have called props.onExited when Modal.onExited is called', () => {
         const wrapper = shallow(
-            <DeleteChannelModal {...props}/>,
+            <DeleteChannelModal {...baseProps}/>,
         );
 
         wrapper.find(Modal).props().onExited!(document.createElement('div'));
-        expect(props.onHide).toHaveBeenCalledTimes(1);
+        expect(baseProps.onExited).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/delete_channel_modal/delete_channel_modal.tsx
+++ b/components/delete_channel_modal/delete_channel_modal.tsx
@@ -12,7 +12,7 @@ import Constants from 'utils/constants';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 export type Props = {
-    onHide: () => void;
+    onExited: () => void;
     channel: Channel;
     currentTeamDetails: {name: string};
     canViewArchivedChannels?: boolean;
@@ -55,7 +55,7 @@ export default class DeleteChannelModal extends React.PureComponent<Props, State
                 dialogClassName='a11y__modal'
                 show={this.state.show}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='deleteChannelModalLabel'
                 id='deleteChannelModal'

--- a/components/edit_channel_purpose_modal/edit_channel_purpose_modal.test.tsx
+++ b/components/edit_channel_purpose_modal/edit_channel_purpose_modal.test.tsx
@@ -20,7 +20,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn()}}
             />,
             {disableLifecycleMethods: true},
@@ -39,7 +39,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channelWithDisplayName}
                 ctrlSend={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn()}}
             />,
             {disableLifecycleMethods: true},
@@ -58,7 +58,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={privateChannel}
                 ctrlSend={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn()}}
             />,
             {disableLifecycleMethods: true},
@@ -72,7 +72,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn()}}
             />,
             {disableLifecycleMethods: true},
@@ -91,7 +91,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={false}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn().mockResolvedValue({error: serverError})}}
             />,
             {disableLifecycleMethods: true},
@@ -113,7 +113,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={false}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn().mockResolvedValue({error: serverError})}}
             />,
             {disableLifecycleMethods: true},
@@ -130,7 +130,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={false}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn().mockResolvedValue({data: true})}}
             />,
             {disableLifecycleMethods: true},
@@ -151,7 +151,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn()}}
             />,
             {disableLifecycleMethods: true},
@@ -173,7 +173,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel: jest.fn().mockResolvedValue({data: true})}}
             />,
             {disableLifecycleMethods: true},
@@ -191,7 +191,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel}}
             />,
             {disableLifecycleMethods: true},
@@ -209,7 +209,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel}}
             />,
             {disableLifecycleMethods: true},
@@ -232,7 +232,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
             <EditChannelPurposeModal
                 channel={channel}
                 ctrlSend={false}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 actions={{patchChannel}}
             />,
             {disableLifecycleMethods: true},
@@ -255,7 +255,7 @@ describe('comoponents/EditChannelPurposeModal', () => {
                 purpose: value,
             }}
             ctrlSend={true}
-            onHide={jest.fn()}
+            onExited={jest.fn()}
             actions={{patchChannel: jest.fn()}}
         />
     ), (instance: EditChannelPurposeModalClass) => instance.state.purpose);

--- a/components/edit_channel_purpose_modal/edit_channel_purpose_modal.tsx
+++ b/components/edit_channel_purpose_modal/edit_channel_purpose_modal.tsx
@@ -20,7 +20,7 @@ type ServerError = {
 const purposeMaxLength = 250;
 
 type Props = {
-    onHide: () => void;
+    onExited: () => void;
     channel?: Channel;
     ctrlSend: boolean;
     actions: Actions;
@@ -158,7 +158,7 @@ export class EditChannelPurposeModal extends React.PureComponent<Props, State> {
                 show={this.state.show}
                 onHide={this.onHide}
                 onEntering={this.handleEntering}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='editChannelPurposeModalLabel'
             >

--- a/components/rename_channel_modal/rename_channel_modal.test.tsx
+++ b/components/rename_channel_modal/rename_channel_modal.test.tsx
@@ -27,7 +27,7 @@ describe('components/RenameChannelModal', () => {
 
     const baseProps = {
         show: true,
-        onHide: jest.fn(),
+        onExited: jest.fn(),
         channel: {...channel},
         requestStatus: RequestStatus.NOT_STARTED,
         team: {...team},

--- a/components/rename_channel_modal/rename_channel_modal.tsx
+++ b/components/rename_channel_modal/rename_channel_modal.tsx
@@ -46,7 +46,7 @@ type Props = {
     /**
      * Function that is called when modal is hidden
      */
-    onHide: () => void;
+    onExited: () => void;
 
     /**
      * Object with info about current channel
@@ -264,7 +264,7 @@ export class RenameChannelModal extends React.PureComponent<Props, State> {
                 show={this.state.show}
                 onHide={this.handleCancel}
                 onEntering={this.handleEntering}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='renameChannelModalLabel'
             >

--- a/components/unarchive_channel_modal/unarchive_channel_modal.test.tsx
+++ b/components/unarchive_channel_modal/unarchive_channel_modal.test.tsx
@@ -37,7 +37,7 @@ describe('components/unarchive_channel_modal', () => {
         actions: {
             unarchiveChannel: jest.fn(),
         },
-        onHide: jest.fn(),
+        onExited: jest.fn(),
         penultimateViewedChannelName: 'my-prev-channel',
     };
 
@@ -74,13 +74,11 @@ describe('components/unarchive_channel_modal', () => {
     });
 
     test('should have called props.onHide when Modal.onExited is called', () => {
-        const onHide = jest.fn();
-        const props = {...baseProps, onHide};
         const wrapper = shallow(
-            <UnarchiveChannelModal {...props}/>,
+            <UnarchiveChannelModal {...baseProps}/>,
         );
 
         wrapper.find(Modal).props().onExited!(document.createElement('div'));
-        expect(onHide).toHaveBeenCalledTimes(1);
+        expect(baseProps.onExited).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/unarchive_channel_modal/unarchive_channel_modal.tsx
+++ b/components/unarchive_channel_modal/unarchive_channel_modal.tsx
@@ -12,7 +12,7 @@ import Constants from 'utils/constants';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 type Props = {
-    onHide: () => void;
+    onExited: () => void;
     channel: Channel;
     actions: ChannelDetailsActions;
 }
@@ -50,7 +50,7 @@ export default class UnarchiveChannelModal extends React.PureComponent<Props, St
                 dialogClassName='a11y__modal'
                 show={this.state.show}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='unarchiveChannelModalLabel'
                 id='unarchiveChannelModal'


### PR DESCRIPTION
I'm renaming onHide to onExited so that it mirrors how it's supposed to be used with React-Bootstrap. GenericModal is one of those modals.

The only functional change here is that the Channel Info and Channel Members modals will now fade out nicely before unmounting instead of just disappearing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39580

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9280
https://github.com/mattermost/mattermost-webapp/pull/9281
https://github.com/mattermost/mattermost-webapp/pull/9282
https://github.com/mattermost/mattermost-webapp/pull/9283

#### Release Note
```release-note
NONE
```
