### PR TITLE
MM-39580 Switch admin-related modals to onExited

### DIFF
--- a/components/add_groups_to_channel_modal/__snapshots__/add_groups_to_channel_modal.test.tsx.snap
+++ b/components/add_groups_to_channel_modal/__snapshots__/add_groups_to_channel_modal.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`components/AddGroupsToChannelModal should match snapshot 1`] = `
       "remove": [Function],
     }
   }
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}

--- a/components/add_groups_to_channel_modal/add_groups_to_channel_modal.test.tsx
+++ b/components/add_groups_to_channel_modal/add_groups_to_channel_modal.test.tsx
@@ -15,7 +15,7 @@ describe('components/AddGroupsToChannelModal', () => {
         teamID: '456',
         searchTerm: '',
         groups: [],
-        onHide: () => { },
+        onExited: jest.fn(),
         actions: {
             getGroupsNotAssociatedToChannel: jest.fn().mockResolvedValue({data: true}),
             setModalSearchTerm: jest.fn().mockResolvedValue({data: true}),
@@ -31,17 +31,6 @@ describe('components/AddGroupsToChannelModal', () => {
             <AddGroupsToChannelModal {...baseProps}/>,
         );
         expect(wrapper).toMatchSnapshot();
-    });
-
-    test('should have called onHide when handleExit is called', () => {
-        const onHide = jest.fn();
-        const props = {...baseProps, onHide};
-        const wrapper = shallow(
-            <AddGroupsToChannelModal {...props}/>,
-        );
-
-        (wrapper.instance() as AddGroupsToChannelModal).handleExit();
-        expect(onHide).toHaveBeenCalledTimes(1);
     });
 
     test('should match state when handleResponse is called', () => {

--- a/components/add_groups_to_channel_modal/add_groups_to_channel_modal.tsx
+++ b/components/add_groups_to_channel_modal/add_groups_to_channel_modal.tsx
@@ -34,7 +34,7 @@ export type Props = {
 
     excludeGroups?: Group[];
     includeGroups?: Group[];
-    onHide?: () => void;
+    onExited: () => void;
     skipCommit?: boolean;
     onAddCallback?: (groupIDs: string[]) => void;
 
@@ -112,12 +112,6 @@ export default class AddGroupsToChannelModal extends React.PureComponent<Props, 
     handleHide = () => {
         this.props.actions.setModalSearchTerm('');
         this.setState({show: false});
-    }
-
-    handleExit = () => {
-        if (this.props.onHide) {
-            this.props.onHide();
-        }
     }
 
     handleResponse = (err?: ServerError) => {
@@ -275,7 +269,7 @@ export default class AddGroupsToChannelModal extends React.PureComponent<Props, 
                 dialogClassName={'a11y__modal more-modal more-direct-channels'}
                 show={this.state.show}
                 onHide={this.handleHide}
-                onExited={this.handleExit}
+                onExited={this.props.onExited}
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>

--- a/components/admin_console/system_roles/system_role/add_users_to_role_modal/add_users_to_role_modal.test.tsx
+++ b/components/admin_console/system_roles/system_role/add_users_to_role_modal/add_users_to_role_modal.test.tsx
@@ -19,7 +19,7 @@ describe('admin_console/add_users_to_role_modal', () => {
             asdf123: TestHelper.getUserMock(),
         },
         onAddCallback: jest.fn(),
-        onHide: jest.fn(),
+        onExited: jest.fn(),
         actions: {
             getProfiles: jest.fn(),
             searchProfiles: jest.fn(),

--- a/components/admin_console/system_roles/system_role/add_users_to_role_modal/add_users_to_role_modal.tsx
+++ b/components/admin_console/system_roles/system_role/add_users_to_role_modal/add_users_to_role_modal.tsx
@@ -32,7 +32,7 @@ export type Props = {
     excludeUsers: { [userId: string]: UserProfile };
     includeUsers: { [userId: string]: UserProfile };
     onAddCallback: (users: UserProfile[]) => void;
-    onHide?: () => void;
+    onExited: () => void;
 
     actions: {
         getProfiles: (page: number, perPage?: number, options?: Record<string, any>) => Promise<{ data: UserProfile[] }>;
@@ -98,8 +98,8 @@ export default class AddUsersToRoleModal extends React.PureComponent<Props, Stat
     }
 
     handleExit = () => {
-        if (this.props.onHide) {
-            this.props.onHide();
+        if (this.props.onExited) {
+            this.props.onExited();
         }
     }
 

--- a/components/admin_console/team_channel_settings/group/group_members_modal.test.tsx
+++ b/components/admin_console/team_channel_settings/group/group_members_modal.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {TestHelper} from '../../../../utils/test_helper';
+import {TestHelper} from 'utils/test_helper';
 
 import GroupMembersModal from './group_members_modal';
 
@@ -15,8 +15,9 @@ describe('admin_console/team_channel_settings/group/GroupList', () => {
         const wrapper = shallow(
             <GroupMembersModal
                 group={group}
-                onHide={jest.fn()}
-            />);
+                onExited={jest.fn()}
+            />,
+        );
         wrapper.setState({show: true});
         expect(wrapper).toMatchSnapshot();
     });

--- a/components/admin_console/team_channel_settings/group/group_members_modal.tsx
+++ b/components/admin_console/team_channel_settings/group/group_members_modal.tsx
@@ -11,7 +11,7 @@ import MemberListGroup from 'components/admin_console/member_list_group';
 
 type Props = {
     group: Group;
-    onHide: () => void;
+    onExited: () => void;
     onLoad?: () => void;
 }
 
@@ -39,7 +39,7 @@ export default class GroupMembersModal extends React.PureComponent<Props, State>
     }
 
     handleExit = () => {
-        this.props.onHide();
+        this.props.onExited();
     }
 
     render() {

--- a/components/admin_console/team_channel_settings/users_to_be_removed_modal.jsx
+++ b/components/admin_console/team_channel_settings/users_to_be_removed_modal.jsx
@@ -37,7 +37,7 @@ export default class UsersToBeRemovedModal extends React.PureComponent {
          */
         users: PropTypes.arrayOf(PropTypes.object).isRequired,
 
-        onHide: PropTypes.func,
+        onExited: PropTypes.func,
     }
 
     constructor(props) {
@@ -54,8 +54,8 @@ export default class UsersToBeRemovedModal extends React.PureComponent {
     }
 
     handleExit = () => {
-        if (this.props.onHide) {
-            this.props.onHide();
+        if (this.props.onExited) {
+            this.props.onExited();
         }
     }
 

--- a/components/commercial_support_modal/__snapshots__/commercial_support_modal.test.tsx.snap
+++ b/components/commercial_support_modal/__snapshots__/commercial_support_modal.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`components/CommercialSupportModal should match snapshot 1`] = `
       "remove": [Function],
     }
   }
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}

--- a/components/commercial_support_modal/commercial_support_modal.test.tsx
+++ b/components/commercial_support_modal/commercial_support_modal.test.tsx
@@ -12,8 +12,7 @@ describe('components/CommercialSupportModal', () => {
         const mockUser = TestHelper.getUserMock();
         const wrapper = shallow(
             <CommercialSupportModal
-                show={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 showBannerWarning={true}
                 isCloud={false}
                 currentUser={mockUser}

--- a/components/commercial_support_modal/commercial_support_modal.tsx
+++ b/components/commercial_support_modal/commercial_support_modal.tsx
@@ -16,11 +16,9 @@ import './commercial_support_modal.scss';
 type Props = {
 
     /**
-     * Function that is called when the modal is dismissed
+     * Function called after the modal has been hidden
      */
-    onHide: () => void;
-
-    show?: boolean;
+    onExited: () => void;
 
     showBannerWarning: boolean;
 
@@ -35,10 +33,6 @@ type State = {
 };
 
 export default class CommercialSupportModal extends React.PureComponent<Props, State> {
-    static defaultProps = {
-        show: false,
-    };
-
     constructor(props: Props) {
         super(props);
 
@@ -56,10 +50,6 @@ export default class CommercialSupportModal extends React.PureComponent<Props, S
 
     doHide = () => {
         this.setState({show: false});
-    }
-
-    handleExit = () => {
-        this.props.onHide();
     }
 
     updateBannerWarning = (showBannerWarning: boolean) => {
@@ -82,7 +72,7 @@ export default class CommercialSupportModal extends React.PureComponent<Props, S
                 dialogClassName='a11y__modal more-modal more-direct-channels'
                 show={this.state.show}
                 onHide={this.doHide}
-                onExited={this.handleExit}
+                onExited={this.props.onExited}
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>

--- a/components/commercial_support_modal/index.ts
+++ b/components/commercial_support_modal/index.ts
@@ -6,15 +6,11 @@ import {connect} from 'react-redux';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
-import {ModalIdentifiers} from 'utils/constants';
-import {isModalOpen} from 'selectors/views/modals';
-
 import {GlobalState} from 'types/store';
 
 import CommercialSupportModal from './commercial_support_modal';
 
 function mapStateToProps(state: GlobalState) {
-    const modalId = ModalIdentifiers.COMMERCIAL_SUPPORT;
     const config = getConfig(state);
     const license = getLicense(state);
     const isCloud = license.Cloud === 'true';
@@ -22,7 +18,6 @@ function mapStateToProps(state: GlobalState) {
     const showBannerWarning = (config.EnableFile !== 'true' || config.FileLevel !== 'DEBUG') && !(isCloud);
 
     return {
-        show: isModalOpen(state, modalId),
         isCloud,
         currentUser,
         showBannerWarning,

--- a/components/delete_post_modal/delete_post_modal.test.tsx
+++ b/components/delete_post_modal/delete_post_modal.test.tsx
@@ -45,7 +45,7 @@ describe('components/delete_post_modal', () => {
         actions: {
             deleteAndRemovePost: jest.fn(),
         },
-        onHide: jest.fn(),
+        onExited: jest.fn(),
         channelName: 'channel_name',
         teamName: 'team_name',
         location: {
@@ -193,17 +193,15 @@ describe('components/delete_post_modal', () => {
         expect(browserHistory.replace).toHaveBeenCalledWith('/teamname/channels/channelName');
     });
 
-    test('should have called props.onHide when Modal.onExited is called', () => {
-        const onHide = jest.fn();
-        const props = {...baseProps, onHide};
+    test('should have called props.onExiteed when Modal.onExited is called', () => {
         const wrapper = shallow(
-            <DeletePostModal {...props}/>,
+            <DeletePostModal {...baseProps}/>,
         );
 
         const modalProps = wrapper.find(Modal).first().props();
         if (modalProps.onExited) {
             modalProps.onExited(document.createElement('div'));
         }
-        expect(onHide).toHaveBeenCalledTimes(1);
+        expect(baseProps.onExited).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/delete_post_modal/delete_post_modal.tsx
+++ b/components/delete_post_modal/delete_post_modal.tsx
@@ -20,7 +20,7 @@ type Props = {
     post: Post;
     commentCount: number;
     isRHS: boolean;
-    onHide: () => void;
+    onExited: () => void;
     actions: {
         deleteAndRemovePost: (post: Post) => Promise<{data: boolean}>;
     };
@@ -132,7 +132,7 @@ export default class DeletePostModal extends React.PureComponent<Props, State> {
                 show={this.state.show}
                 onEntered={this.handleEntered}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 enforceFocus={false}
                 id='deletePostModal'
                 role='dialog'

--- a/components/join_private_channel_modal.tsx
+++ b/components/join_private_channel_modal.tsx
@@ -9,11 +9,11 @@ import ConfirmModal from 'components/confirm_modal';
 type Props = {
     channelName: string;
     onCancel: () => void;
-    onHide: () => void;
+    onExited: () => void;
     onJoin: () => void;
 }
 
-function JoinPrivateChannelModal({channelName, onCancel, onHide, onJoin}: Props) {
+function JoinPrivateChannelModal({channelName, onCancel, onExited, onJoin}: Props) {
     const join = React.useRef<boolean>(false);
     const [show, setShow] = React.useState<boolean>(true);
 
@@ -34,9 +34,8 @@ function JoinPrivateChannelModal({channelName, onCancel, onHide, onJoin}: Props)
         } else if (typeof onCancel === 'function') {
             onCancel();
         }
-        if (typeof onHide === 'function') {
-            onHide();
-        }
+
+        onExited();
     };
 
     return (


### PR DESCRIPTION
I'm renaming onHide to onExited so that it mirrors how it's supposed to be used with React-Bootstrap. GenericModal is one of those modals.

There shouldn't be any functional changes from this PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39580

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9280
https://github.com/mattermost/mattermost-webapp/pull/9281
https://github.com/mattermost/mattermost-webapp/pull/9282
https://github.com/mattermost/mattermost-webapp/pull/9283
https://github.com/mattermost/mattermost-webapp/pull/9291
https://github.com/mattermost/mattermost-webapp/pull/9292

#### Release Note
```release-note
NONE
```
