### PR TITLE
MM-39580 Switch misc modals to onExited

### DIFF
--- a/components/about_build_modal/__snapshots__/about_build_modal.test.tsx.snap
+++ b/components/about_build_modal/__snapshots__/about_build_modal.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`components/AboutBuildModal should match snapshot for cloud edition 1`] 
       "remove": [Function],
     }
   }
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[MockFunction]}
   renderBackdrop={[Function]}
   restoreFocus={true}
@@ -188,7 +188,7 @@ exports[`components/AboutBuildModal should match snapshot for enterprise edition
       "remove": [Function],
     }
   }
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
@@ -426,7 +426,7 @@ exports[`components/AboutBuildModal should match snapshot for team edition 1`] =
       "remove": [Function],
     }
   }
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
@@ -653,7 +653,7 @@ exports[`components/AboutBuildModal should show ci if a ci build 1`] = `
       "remove": [Function],
     }
   }
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
@@ -891,7 +891,7 @@ exports[`components/AboutBuildModal should show dev if this is a dev build 1`] =
       "remove": [Function],
     }
   }
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}

--- a/components/about_build_modal/about_build_modal.test.tsx
+++ b/components/about_build_modal/about_build_modal.test.tsx
@@ -84,7 +84,7 @@ describe('components/AboutBuildModal', () => {
                 config={config}
                 license={license}
                 show={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
                 doHide={jest.fn()}
             />,
         );
@@ -122,21 +122,20 @@ describe('components/AboutBuildModal', () => {
         expect(wrapper.find('#buildnumberString').text()).toBe('\u00a0123');
     });
 
-    test('should call onHide callback when the modal is hidden', () => {
-        const onHide = jest.fn();
+    test('should call onExited callback when the modal is hidden', () => {
+        const onExited = jest.fn();
 
         const wrapper = mountWithIntl(
             <AboutBuildModal
                 config={config}
                 license={license}
                 webappBuildHash='0a1b2c3d4f'
-                show={true}
-                onHide={onHide}
+                onExited={onExited}
             />,
         );
 
         wrapper.find(Modal).first().props().onExited?.(document.createElement('div'));
-        expect(onHide).toHaveBeenCalledTimes(1);
+        expect(onExited).toHaveBeenCalledTimes(1);
     });
 
     test('should show default tos and privacy policy links and not the config links', () => {
@@ -144,8 +143,7 @@ describe('components/AboutBuildModal', () => {
             <AboutBuildModal
                 config={config}
                 license={license}
-                show={true}
-                onHide={jest.fn()}
+                onExited={jest.fn()}
             />,
         );
 
@@ -157,12 +155,12 @@ describe('components/AboutBuildModal', () => {
     });
 
     function shallowAboutBuildModal(props = {}) {
-        const onHide = jest.fn();
+        const onExited = jest.fn();
         const show = true;
 
         const allProps = {
             show,
-            onHide,
+            onExited,
             webappBuildHash: '0a1b2c3d4f',
             config,
             license,

--- a/components/about_build_modal/about_build_modal.tsx
+++ b/components/about_build_modal/about_build_modal.tsx
@@ -18,9 +18,9 @@ import AboutBuildModalCloud from './about_build_modal_cloud/about_build_modal_cl
 type Props = {
 
     /**
-     * Function that is called when the modal is dismissed
+     * Function called after the modal has been hidden
      */
-    onHide: () => void;
+    onExited: () => void;
 
     /**
      * Global config object
@@ -36,8 +36,6 @@ type Props = {
      * Webapp build hash override. By default, webpack sets this (so it must be overridden in tests).
      */
     webappBuildHash?: string;
-
-    show?: boolean;
 };
 
 type State = {
@@ -45,10 +43,6 @@ type State = {
 };
 
 export default class AboutBuildModal extends React.PureComponent<Props, State> {
-    // static defaultProps = {
-    //     show: false,
-    // };
-
     constructor(props: Props) {
         super(props);
 
@@ -59,10 +53,6 @@ export default class AboutBuildModal extends React.PureComponent<Props, State> {
 
     doHide = () => {
         this.setState({show: false});
-    }
-
-    handleExit = () => {
-        this.props.onHide();
     }
 
     render() {
@@ -212,7 +202,7 @@ export default class AboutBuildModal extends React.PureComponent<Props, State> {
                 dialogClassName='a11y__modal about-modal'
                 show={this.state.show}
                 onHide={this.doHide}
-                onExited={this.handleExit}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='aboutModalLabel'
             >

--- a/components/about_build_modal/about_build_modal_cloud/about_build_modal_cloud.tsx
+++ b/components/about_build_modal/about_build_modal_cloud/about_build_modal_cloud.tsx
@@ -12,7 +12,7 @@ import MattermostLogo from 'components/widgets/icons/mattermost_logo';
 import './about_build_modal_cloud.scss';
 
 type Props = {
-    onHide: () => void;
+    onExited: () => void;
     config: any;
     license: any;
     show: boolean;
@@ -23,10 +23,6 @@ type Props = {
 declare const COMMIT_HASH: string;
 
 export default function AboutBuildModalCloud(props: Props) {
-    const handleExit = () => {
-        props.onHide();
-    };
-
     const config = props.config;
     const license = props.license;
 
@@ -64,7 +60,7 @@ export default function AboutBuildModalCloud(props: Props) {
             dialogClassName={classNames('a11y__modal', 'about-modal', 'cloud')}
             show={props.show}
             onHide={props.doHide}
-            onExited={handleExit}
+            onExited={props.onExited}
             role='dialog'
             aria-labelledby='aboutModalLabel'
         >

--- a/components/about_build_modal/index.ts
+++ b/components/about_build_modal/index.ts
@@ -5,19 +5,14 @@ import {connect} from 'react-redux';
 
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
-import {ModalIdentifiers} from 'utils/constants';
-import {isModalOpen} from 'selectors/views/modals';
-
 import {GlobalState} from 'types/store';
 
 import AboutBuildModal from './about_build_modal';
 
 function mapStateToProps(state: GlobalState) {
-    const modalId = ModalIdentifiers.ABOUT;
     return {
         config: getConfig(state),
         license: getLicense(state),
-        show: isModalOpen(state, modalId),
     };
 }
 

--- a/components/apps_form/__snapshots__/apps_form_container.test.jsx.snap
+++ b/components/apps_form/__snapshots__/apps_form_container.test.jsx.snap
@@ -28,6 +28,6 @@ exports[`components/apps_form/AppsFormContainer should match snapshot 1`] = `
       "title": "Form Title",
     }
   }
-  onHide={[Function]}
+  onExited={[MockFunction]}
 />
 `;

--- a/components/apps_form/apps_form_component.test.tsx
+++ b/components/apps_form/apps_form_component.test.tsx
@@ -19,7 +19,7 @@ import {AppsForm, Props} from './apps_form_component';
 describe('AppsFormComponent', () => {
     const baseProps: Props = {
         intl: {} as any,
-        onHide: jest.fn(),
+        onExited: jest.fn(),
         isEmbedded: false,
         actions: {
             performLookupCall: jest.fn(),

--- a/components/apps_form/apps_form_component.tsx
+++ b/components/apps_form/apps_form_component.tsx
@@ -29,7 +29,7 @@ import AppsFormHeader from './apps_form_header';
 export type AppsFormProps = {
     form: AppForm;
     isEmbedded?: boolean;
-    onHide: () => void;
+    onExited: () => void;
     actions: {
         submit: (submission: {
             values: AppFormValues;
@@ -353,7 +353,7 @@ export class AppsForm extends React.PureComponent<Props, State> {
                 dialogClassName='a11y__modal about-modal'
                 show={this.state.show}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 backdrop='static'
                 role='dialog'
                 aria-labelledby='appsModalLabel'

--- a/components/apps_form/apps_form_container.test.jsx
+++ b/components/apps_form/apps_form_container.test.jsx
@@ -47,7 +47,7 @@ describe('components/apps_form/AppsFormContainer', () => {
         actions: {
             doAppCall: jest.fn().mockResolvedValue({}),
         },
-        onHide: jest.fn(),
+        onExited: jest.fn(),
     };
 
     test('should match snapshot', () => {

--- a/components/apps_form/apps_form_container.tsx
+++ b/components/apps_form/apps_form_container.tsx
@@ -17,7 +17,7 @@ type Props = {
     intl: IntlShape;
     form?: AppForm;
     call?: AppCallRequest;
-    onHide: () => void;
+    onExited: () => void;
     actions: {
         doAppCall: DoAppCall<any>;
         postEphemeralCallResponseForContext: PostEphemeralCallResponseForContext;
@@ -205,10 +205,6 @@ class AppsFormContainer extends React.PureComponent<Props, State> {
         };
     }
 
-    onHide = () => {
-        this.props.onHide();
-    };
-
     render() {
         const call = this.getCall();
         if (!call) {
@@ -223,7 +219,7 @@ class AppsFormContainer extends React.PureComponent<Props, State> {
         return (
             <AppsForm
                 form={form}
-                onHide={this.onHide}
+                onExited={this.props.onExited}
                 actions={{
                     submit: this.submitForm,
                     performLookupCall: this.performLookupCall,

--- a/components/confirm_modal_redux/confirm_modal_redux.test.tsx
+++ b/components/confirm_modal_redux/confirm_modal_redux.test.tsx
@@ -10,13 +10,13 @@ import ConfirmModalRedux from './confirm_modal_redux';
 
 describe('ConfirmModalRedux', () => {
     const baseProps = {
-        onHide: jest.fn(),
+        onExited: jest.fn(),
     };
 
     // These tests will time out when failing, so we override the timeout period to make them fail faster.
 
     test('should call closeModal after confirming', (done) => {
-        baseProps.onHide.mockImplementation(() => done());
+        baseProps.onExited.mockImplementation(() => done());
 
         const wrapper = mountWithIntl(
             <ConfirmModalRedux
@@ -25,15 +25,15 @@ describe('ConfirmModalRedux', () => {
         );
 
         expect(wrapper.find(Modal).prop('show')).toBe(true);
-        expect(baseProps.onHide).not.toHaveBeenCalled();
+        expect(baseProps.onExited).not.toHaveBeenCalled();
 
         wrapper.find('#confirmModalButton').simulate('click');
 
         expect(wrapper.find(Modal).prop('show')).toBe(false);
     }, 1000);
 
-    test('should call onHide after cancelling', (done) => {
-        baseProps.onHide.mockImplementation(() => done());
+    test('should call onExited after cancelling', (done) => {
+        baseProps.onExited.mockImplementation(() => done());
 
         const wrapper = mountWithIntl(
             <ConfirmModalRedux
@@ -42,7 +42,7 @@ describe('ConfirmModalRedux', () => {
         );
 
         expect(wrapper.find(Modal).prop('show')).toBe(true);
-        expect(baseProps.onHide).not.toHaveBeenCalled();
+        expect(baseProps.onExited).not.toHaveBeenCalled();
 
         wrapper.find('#cancelModalButton').simulate('click');
 

--- a/components/confirm_modal_redux/confirm_modal_redux.tsx
+++ b/components/confirm_modal_redux/confirm_modal_redux.tsx
@@ -6,14 +6,14 @@ import React, {useCallback, useState} from 'react';
 import ConfirmModal from 'components/confirm_modal';
 
 type Props = Omit<React.ComponentProps<typeof ConfirmModal>, 'show'> & {
-    onHide: () => void;
+    onExited: () => void;
 };
 
 export default function ConfirmModalRedux(props: Props) {
     const {
         onCancel,
         onConfirm,
-        onHide, // TODO MM-39580 this should be renamed
+        onExited,
         ...otherProps
     } = props;
 
@@ -35,7 +35,7 @@ export default function ConfirmModalRedux(props: Props) {
             {...otherProps}
             onCancel={wrappedOnCancel}
             onConfirm={wrappedOnConfirm}
-            onExited={onHide}
+            onExited={onExited}
             show={show}
         />
     );

--- a/components/create_comment/create_comment.tsx
+++ b/components/create_comment/create_comment.tsx
@@ -245,11 +245,6 @@ type Props = {
       * Function to open a modal
       */
     openModal: <P>(modalData: ModalData<P>) => void;
-
-    /**
-      * Function to close a modal
-      */
-    closeModal: (modalId: string) => void;
 }
 
 type State = {
@@ -462,7 +457,6 @@ class CreateComment extends React.PureComponent<Props, State> {
     }
 
     handleNotifyAllConfirmation = () => {
-        this.props.closeModal(ModalIdentifiers.NOTIFY_CONFIRM_MODAL);
         this.doSubmit();
     }
 
@@ -475,7 +469,6 @@ class CreateComment extends React.PureComponent<Props, State> {
                 channelTimezoneCount,
                 memberNotifyCount,
                 onConfirm: () => this.handleNotifyAllConfirmation(),
-                onCancel: () => this.props.closeModal(ModalIdentifiers.NOTIFY_CONFIRM_MODAL),
             },
         });
     }

--- a/components/create_comment/index.ts
+++ b/components/create_comment/index.ts
@@ -38,7 +38,7 @@ import {emitShortcutReactToLastPostFrom} from 'actions/post_actions';
 import {getPostDraft, getIsRhsExpanded, getSelectedPostFocussedAt} from 'selectors/rhs';
 import {showPreviewOnCreateComment} from 'selectors/views/textbox';
 import {setShowPreviewOnCreateComment} from 'actions/views/textbox';
-import {openModal, closeModal} from 'actions/views/modals';
+import {openModal} from 'actions/views/modals';
 
 import CreateComment from './create_comment';
 
@@ -120,7 +120,6 @@ type Actions = {
     setShowPreview: (showPreview: boolean) => void;
     getChannelMemberCountsByGroup: (channelID: string) => void;
     openModal: <P>(modalData: ModalData<P>) => void;
-    closeModal: (modalId: string) => void;
 }
 
 function makeMapDispatchToProps() {
@@ -172,7 +171,6 @@ function makeMapDispatchToProps() {
             setShowPreview: setShowPreviewOnCreateComment,
             getChannelMemberCountsByGroup,
             openModal,
-            closeModal,
         }, dispatch);
     };
 }

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -69,7 +69,6 @@ const actionsProp = {
     setDraft: jest.fn(),
     setEditingPost: jest.fn(),
     openModal: jest.fn(),
-    closeModal: jest.fn(),
     setShowPreview: jest.fn(),
     executeCommand: async () => {
         return {data: true};

--- a/components/create_post/create_post.tsx
+++ b/components/create_post/create_post.tsx
@@ -288,11 +288,6 @@ type Props = {
       */
         openModal: <P>(modalData: ModalData<P>) => void;
 
-        /**
-      * Function to close a modal
-      */
-        closeModal: (modalId: string) => void;
-
         executeCommand: (message: string, args: CommandArgs) => ActionResult;
 
         /**
@@ -614,7 +609,6 @@ class CreatePost extends React.PureComponent<Props, State> {
     }
 
     handleNotifyAllConfirmation = () => {
-        this.props.actions.closeModal(ModalIdentifiers.NOTIFY_CONFIRM_MODAL);
         this.doSubmit();
     }
 
@@ -627,7 +621,6 @@ class CreatePost extends React.PureComponent<Props, State> {
                 channelTimezoneCount,
                 memberNotifyCount,
                 onConfirm: () => this.handleNotifyAllConfirmation(),
-                onCancel: () => this.props.actions.closeModal(ModalIdentifiers.NOTIFY_CONFIRM_MODAL),
             },
         });
     }

--- a/components/create_post/index.ts
+++ b/components/create_post/index.ts
@@ -55,7 +55,7 @@ import {showPreviewOnCreatePost} from 'selectors/views/textbox';
 import {getCurrentLocale} from 'selectors/i18n';
 import {getEmojiMap, getShortcutReactToLastPostEmittedFrom} from 'selectors/emojis';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
-import {openModal, closeModal} from 'actions/views/modals';
+import {openModal} from 'actions/views/modals';
 import {Constants, Preferences, StoragePrefixes, TutorialSteps, UserStatuses} from 'utils/constants';
 import {canUploadFiles} from 'utils/file_utils';
 import {PrewrittenMessagesTreatments} from 'mattermost-redux/constants/config';
@@ -198,7 +198,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
             setEditingPost,
             emitShortcutReactToLastPostFrom,
             openModal,
-            closeModal,
             executeCommand,
             getChannelTimezones,
             runMessageWillBePostedHooks,

--- a/components/integrations/delete_integration_link/delete_integration_link.tsx
+++ b/components/integrations/delete_integration_link/delete_integration_link.tsx
@@ -4,7 +4,7 @@
 import React, {useCallback} from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {closeModal as closeModalAction, openModal as openModalAction} from 'actions/views/modals';
+import {openModal as openModalAction} from 'actions/views/modals';
 
 import ConfirmModalRedux from 'components/confirm_modal_redux';
 import WarningIcon from 'components/widgets/icons/fa_warning_icon';
@@ -12,7 +12,6 @@ import WarningIcon from 'components/widgets/icons/fa_warning_icon';
 const ModalId = 'delete_integration_confirm';
 
 type Props = {
-    closeModal: typeof closeModalAction;
     confirmButtonText?: React.ReactNode;
     linkText?: React.ReactNode;
     modalMessage?: React.ReactNode;
@@ -23,7 +22,6 @@ type Props = {
 
 export default function DeleteIntegrationLink(props: Props) {
     const {
-        closeModal,
         confirmButtonText = (
             <FormattedMessage
                 id='integrations.delete.confirm.button'
@@ -63,7 +61,7 @@ export default function DeleteIntegrationLink(props: Props) {
             },
             dialogType: ConfirmModalRedux,
         });
-    }, [closeModal, confirmButtonText, modalMessage, modalTitle, onDelete, openModal]);
+    }, [confirmButtonText, modalMessage, modalTitle, onDelete, openModal]);
 
     return (
         <button

--- a/components/integrations/delete_integration_link/index.ts
+++ b/components/integrations/delete_integration_link/index.ts
@@ -3,12 +3,11 @@
 
 import {connect} from 'react-redux';
 
-import {closeModal, openModal} from 'actions/views/modals';
+import {openModal} from 'actions/views/modals';
 
 import DeleteIntegrationLink from './delete_integration_link';
 
 const mapDispatchToProps = {
-    closeModal,
     openModal,
 };
 

--- a/components/interactive_dialog/interactive_dialog.jsx
+++ b/components/interactive_dialog/interactive_dialog.jsx
@@ -29,7 +29,7 @@ export default class InteractiveDialog extends React.PureComponent {
         submitLabel: PropTypes.string,
         notifyOnCancel: PropTypes.bool,
         state: PropTypes.string,
-        onHide: PropTypes.func,
+        onExited: PropTypes.func,
         actions: PropTypes.shape({
             submitInteractiveDialog: PropTypes.func.isRequired,
         }).isRequired,
@@ -196,7 +196,7 @@ export default class InteractiveDialog extends React.PureComponent {
                 dialogClassName='a11y__modal about-modal'
                 show={this.state.show}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 backdrop='static'
                 role='dialog'
                 aria-labelledby='interactiveDialogModalLabel'

--- a/components/interactive_dialog/interactive_dialog.test.jsx
+++ b/components/interactive_dialog/interactive_dialog.test.jsx
@@ -23,7 +23,7 @@ describe('components/interactive_dialog/InteractiveDialog', () => {
         submitLabel: 'Yes',
         notifyOnCancel: true,
         state: 'some state',
-        onHide: () => {},
+        onExited: () => {},
         actions: {
             submitInteractiveDialog: () => ({}),
         },

--- a/components/more_direct_channels/more_direct_channels.test.jsx
+++ b/components/more_direct_channels/more_direct_channels.test.jsx
@@ -52,7 +52,7 @@ describe('components/MoreDirectChannels', () => {
         isExistingChannel: false,
         restrictDirectMessage: 'any',
         onModalDismissed: emptyFunction,
-        onHide: emptyFunction,
+        onExited: emptyFunction,
         actions: {
             getProfiles: jest.fn(() => {
                 return new Promise((resolve) => {

--- a/components/more_direct_channels/more_direct_channels.tsx
+++ b/components/more_direct_channels/more_direct_channels.tsx
@@ -44,7 +44,7 @@ export type Props = {
     */
     restrictDirectMessage?: string;
     onModalDismissed: () => void;
-    onHide?: () => void;
+    onExited?: () => void;
     actions: {
         getProfiles: (page?: number | undefined, perPage?: number | undefined, options?: any) => Promise<any>;
         getProfilesInTeam: (teamId: string, page: number, perPage?: number | undefined, sort?: string | undefined, options?: any) => Promise<any>;
@@ -170,7 +170,7 @@ export default class MoreDirectChannels extends React.PureComponent<Props, State
         }
 
         this.props.onModalDismissed?.();
-        this.props.onHide?.();
+        this.props.onExited?.();
     }
 
     handleSubmit = (values = this.state.values) => {

--- a/components/next_steps_view/steps/setup_preferences_step/setup_preferences_step.tsx
+++ b/components/next_steps_view/steps/setup_preferences_step/setup_preferences_step.tsx
@@ -34,7 +34,7 @@ export default function SetupPreferencesStep(props: StepComponentProps) {
             dialogType: UserSettingsModal,
             dialogProps: {
                 isContentProductSettings: true,
-                onExit: onFinish,
+                onExited: onFinish,
             },
         }));
     };

--- a/components/notify_confirm_modal.tsx
+++ b/components/notify_confirm_modal.tsx
@@ -4,8 +4,9 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import ConfirmModal from 'components/confirm_modal';
-import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
+import ConfirmModalRedux from 'components/confirm_modal_redux';
+import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+
 import {t} from 'utils/i18n';
 
 type Props = {
@@ -13,10 +14,10 @@ type Props = {
     memberNotifyCount: number;
     channelTimezoneCount: number;
     onConfirm: (checked: boolean) => void;
-    onCancel: (checked: boolean) => void;
+    onExited: () => void;
 };
 
-export default class NotifyConfirmModal extends React.Component<Props> {
+export default class NotifyConfirmModal extends React.PureComponent<Props> {
     render() {
         const {mentions, channelTimezoneCount, memberNotifyCount} = this.props;
 
@@ -128,13 +129,12 @@ export default class NotifyConfirmModal extends React.Component<Props> {
         );
 
         return (
-            <ConfirmModal
+            <ConfirmModalRedux
                 title={notifyAllTitle}
                 message={notifyAllMessage}
                 confirmButtonText={notifyAllConfirm}
-                show={true}
                 onConfirm={this.props.onConfirm}
-                onCancel={this.props.onCancel}
+                onExited={this.props.onExited}
             />
         );
     }

--- a/components/quick_switch_modal/quick_switch_modal.test.tsx
+++ b/components/quick_switch_modal/quick_switch_modal.test.tsx
@@ -10,7 +10,7 @@ import QuickSwitchModal from 'components/quick_switch_modal/quick_switch_modal';
 
 describe('components/QuickSwitchModal', () => {
     const baseProps = {
-        onHide: jest.fn(),
+        onExited: jest.fn(),
         showTeamSwitcher: false,
         actions: {
             joinChannelById: jest.fn().mockResolvedValue({data: true}),
@@ -40,7 +40,7 @@ describe('components/QuickSwitchModal', () => {
             );
 
             wrapper.instance().handleSubmit();
-            expect(baseProps.onHide).not.toBeCalled();
+            expect(baseProps.onExited).not.toBeCalled();
             expect(props.actions.switchToChannel).not.toBeCalled();
         });
 
@@ -53,7 +53,7 @@ describe('components/QuickSwitchModal', () => {
             wrapper.instance().handleSubmit({channel});
             expect(baseProps.actions.switchToChannel).toBeCalledWith(channel);
             process.nextTick(() => {
-                expect(baseProps.onHide).not.toBeCalled();
+                expect(baseProps.onExited).not.toBeCalled();
                 done();
             });
         });
@@ -78,7 +78,7 @@ describe('components/QuickSwitchModal', () => {
             wrapper.instance().handleSubmit({channel});
             expect(props.actions.switchToChannel).toBeCalledWith(channel);
             process.nextTick(() => {
-                expect(baseProps.onHide).toBeCalled();
+                expect(baseProps.onExited).toBeCalled();
                 done();
             });
         });
@@ -137,7 +137,7 @@ describe('components/QuickSwitchModal', () => {
             expect(props.actions.joinChannelById).not.toHaveBeenCalled();
             expect(props.actions.switchToChannel).toBeCalledWith(channel);
             process.nextTick(() => {
-                expect(baseProps.onHide).toBeCalled();
+                expect(baseProps.onExited).toBeCalled();
                 done();
             });
         });

--- a/components/quick_switch_modal/quick_switch_modal.tsx
+++ b/components/quick_switch_modal/quick_switch_modal.tsx
@@ -34,9 +34,9 @@ type ProviderSuggestions = {
 export type Props = {
 
     /**
-     * The function called to hide the modal
+     * The function called to immediately hide the modal
      */
-    onHide: () => void;
+    onExited: () => void;
 
     actions: {
         joinChannelById: (channelId: string) => Promise<ActionResult>;
@@ -94,7 +94,7 @@ export default class QuickSwitchModal extends React.PureComponent<Props, State> 
         this.setState({
             text: '',
         });
-        this.props.onHide();
+        this.props.onExited();
     };
 
     private focusPostTextbox = (): void => {

--- a/components/removed_from_channel_modal/removed_from_channel_modal.test.tsx
+++ b/components/removed_from_channel_modal/removed_from_channel_modal.test.tsx
@@ -14,7 +14,7 @@ describe('components/RemoveFromChannelModal', () => {
         currentUserId: 'current_user_id',
         channelName: 'test-channel',
         remover: 'Administrator',
-        onHide: jest.fn(),
+        onExited: jest.fn(),
     };
 
     test('should match snapshot', () => {

--- a/components/removed_from_channel_modal/removed_from_channel_modal.tsx
+++ b/components/removed_from_channel_modal/removed_from_channel_modal.tsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 type Props = {
     currentUserId: string;
-    onHide: () => void;
+    onExited: () => void;
     channelName?: string;
     remover?: string;
 }
@@ -60,7 +60,7 @@ export default class RemovedFromChannelModal extends React.PureComponent<Props, 
                 dialogClassName='a11y__modal'
                 show={this.state.show}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 role='dialog'
                 aria-labelledby='removeFromChannelModalLabel'
             >

--- a/components/reset_status_modal/reset_status_modal.jsx
+++ b/components/reset_status_modal/reset_status_modal.jsx
@@ -31,9 +31,9 @@ export default class ResetStatusModal extends React.PureComponent {
         newStatus: PropTypes.string,
 
         /**
-         * Function called when modal is dismissed
+         * Function called after the modal has been hidden
          */
-        onHide: PropTypes.func,
+        onExited: PropTypes.func,
         actions: PropTypes.shape({
 
             /*
@@ -181,7 +181,7 @@ export default class ResetStatusModal extends React.PureComponent {
                 onConfirm={this.onConfirm}
                 cancelButtonText={manualStatusCancel}
                 onCancel={this.onCancel}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 showCheckbox={showCheckbox}
                 checkboxText={manualStatusCheckbox}
             />

--- a/components/user_settings/modal/user_settings_modal.tsx
+++ b/components/user_settings/modal/user_settings_modal.tsx
@@ -75,8 +75,7 @@ const holders = defineMessages({
 
 export type Props = {
     currentUser: UserProfile;
-    onHide: () => void;
-    onExit?: () => void;
+    onExited: () => void;
     intl: IntlShape;
     collapsedThreads: boolean;
     isContentProductSettings: boolean;
@@ -106,10 +105,6 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
     private customConfirmAction: ((handleConfirm: () => void) => void) | null;
     private modalBodyRef: React.RefObject<Modal>;
     private afterConfirm: (() => void) | null;
-
-    static defaultProps = {
-        onExit: () => {},
-    };
 
     constructor(props: Props) {
         super(props);
@@ -195,8 +190,7 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
             active_tab: this.props.isContentProductSettings ? 'notifications' : 'profile',
             active_section: '',
         });
-        this.props.onHide();
-        this.props.onExit?.();
+        this.props.onExited();
 
         if (this.showCRTBetaModal) {
             this.props.actions.openModal({

--- a/components/widgets/menu/menu_modals/submenu_modal/submenu_modal.test.tsx
+++ b/components/widgets/menu/menu_modals/submenu_modal/submenu_modal.test.tsx
@@ -41,7 +41,7 @@ describe('components/submenu_modal', () => {
                 ],
             },
         ],
-        onHide: jest.fn(),
+        onExited: jest.fn(),
     };
 
     test('should match snapshot', () => {
@@ -86,14 +86,12 @@ describe('components/submenu_modal', () => {
         expect(wrapper.state('show')).toEqual(false);
     });
 
-    test('should have called props.onHide when Modal.onExited is called', () => {
-        const onHide = jest.fn();
-        const props = {...baseProps, onHide};
+    test('should have called props.onExited when Modal.onExited is called', () => {
         const wrapper = shallow(
-            <SubMenuModal {...props}/>,
+            <SubMenuModal {...baseProps}/>,
         );
 
         wrapper.find(Modal).props().onExited!(document.createElement('div'));
-        expect(onHide).toHaveBeenCalledTimes(1);
+        expect(baseProps.onExited).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/widgets/menu/menu_modals/submenu_modal/submenu_modal.tsx
+++ b/components/widgets/menu/menu_modals/submenu_modal/submenu_modal.tsx
@@ -14,7 +14,7 @@ import './submenu_modal.scss';
 
 type Props = {
     elements?: Array<React.ComponentProps<typeof SubMenuItem>>;
-    onHide: () => void;
+    onExited: () => void;
 }
 
 type State = {
@@ -55,7 +55,7 @@ export default class SubMenuModal extends React.PureComponent<Props, State> {
                 dialogClassName={'SubMenuModal a11y__modal mobile-sub-menu'}
                 show={this.state.show}
                 onHide={this.onHide}
-                onExited={this.props.onHide}
+                onExited={this.props.onExited}
                 enforceFocus={false}
                 id='submenuModal'
                 role='dialog'


### PR DESCRIPTION
I'm renaming onHide to onExited so that it mirrors how it's supposed to be used with React-Bootstrap. GenericModal is one of those modals.

There shouldn't be any functional changes here, but there is some extra cleanup since is the last of these PRs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39580

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9280
https://github.com/mattermost/mattermost-webapp/pull/9281
https://github.com/mattermost/mattermost-webapp/pull/9282
https://github.com/mattermost/mattermost-webapp/pull/9283
https://github.com/mattermost/mattermost-webapp/pull/9291
https://github.com/mattermost/mattermost-webapp/pull/9292

#### Release Note
```release-note
NONE
```
