### PR TITLE
Automated cherry pick of #9174

### DIFF
--- a/components/post_view/post_message_preview/__snapshots__/post_message_preview.test.tsx.snap
+++ b/components/post_view/post_message_preview/__snapshots__/post_message_preview.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`PostMessagePreview should not render bot icon 1`] = `
     >
       <p>
         <MemoizedFormattedMessage
-          defaultMessage="Originally posted in ~{channel}"
+          defaultMessage="Only visible to users in ~{channel}"
           id="post_message_preview.channel"
           values={
             Object {
@@ -168,7 +168,7 @@ exports[`PostMessagePreview should render bot icon 1`] = `
     >
       <p>
         <MemoizedFormattedMessage
-          defaultMessage="Originally posted in ~{channel}"
+          defaultMessage="Only visible to users in ~{channel}"
           id="post_message_preview.channel"
           values={
             Object {
@@ -254,7 +254,7 @@ exports[`PostMessagePreview should render correctly 1`] = `
     >
       <p>
         <MemoizedFormattedMessage
-          defaultMessage="Originally posted in ~{channel}"
+          defaultMessage="Only visible to users in ~{channel}"
           id="post_message_preview.channel"
           values={
             Object {

--- a/components/post_view/post_message_preview/post_message_preview.tsx
+++ b/components/post_view/post_message_preview/post_message_preview.tsx
@@ -126,7 +126,7 @@ const PostMessagePreview = (props: Props) => {
                     <p>
                         <FormattedMessage
                             id='post_message_preview.channel'
-                            defaultMessage='Originally posted in ~{channel}'
+                            defaultMessage='Only visible to users in ~{channel}'
                             values={{
                                 channel: metadata.channel_display_name,
                             }}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3920,7 +3920,7 @@
   "post_info.tooltip.add_reactions": "Add Reaction",
   "post_info.unpin": "Unpin from Channel",
   "post_info.unread": "Mark as Unread",
-  "post_message_preview.channel": "Originally posted in ~{channel}",
+  "post_message_preview.channel": "Only visible to users in ~{channel}",
   "post_message_view.edited": "Edited",
   "post_pre_header.flagged": "Saved",
   "post_pre_header.pinned": "Pinned",


### PR DESCRIPTION
Cherry pick of #9174 on release-6.1.

/cc  @esethna

```release-note
NONE
```