### PR TITLE
MM-39773 Re-add default value in getChannelsWithUserProfiles

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -869,6 +869,9 @@ const getProfiles = (currentUserId: string, usersIdsInChannel: Set<string>, user
     return profiles;
 };
 
+/**
+ * Returns an array of unsorted group channels, each with an array of the user profiles in the channel attached to them.
+ */
 export const getChannelsWithUserProfiles: (state: GlobalState) => Array<{
     profiles: UserProfile[];
 } & Channel> = createSelector(
@@ -881,7 +884,7 @@ export const getChannelsWithUserProfiles: (state: GlobalState) => Array<{
         return channels.map((channel: Channel): {
             profiles: UserProfile[];
         } & Channel => {
-            const profiles = getProfiles(currentUserId, channelUserMap[channel.id], users);
+            const profiles = getProfiles(currentUserId, channelUserMap[channel.id] || new Set(), users);
             return {
                 ...channel,
                 profiles,


### PR DESCRIPTION
Fixes a regression in #9261 that causes the web app to crash when opening the DMs modal because it's displaying a GM channel which has no members loaded for it yet.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39773

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9261

#### Release Note
```release-note
NONE
```
