### PR TITLE
Automated cherry pick of #9264

### DIFF
--- a/components/markdown/markdown.tsx
+++ b/components/markdown/markdown.tsx
@@ -126,11 +126,11 @@ export default class Markdown extends React.PureComponent<Props> {
     }
 
     render() {
-        const {postId, editedAt, message} = this.props;
-        if (!this.props.enableFormatting) {
+        const {postId, editedAt, message, enableFormatting} = this.props;
+        if (message === '' || !enableFormatting) {
             return (
                 <span>
-                    {this.props.message}
+                    {message}
                     <PostEditedIndicator
                         postId={postId}
                         editedAt={editedAt}


### PR DESCRIPTION
Cherry pick of #9264 on release-6.1.

/cc  @michelengelen

```release-note
NONE
```