### PR TITLE
MM-39850: fixes follow in thread footer

### DIFF
--- a/components/threading/common/follow_button/follow_button.tsx
+++ b/components/threading/common/follow_button/follow_button.tsx
@@ -22,7 +22,7 @@ function FollowButton({
         <Button
             {...props}
             className={classNames(props.className, 'FollowButton')}
-            disabled={props.disabled}
+            disabled={Boolean(props.disabled)}
             isActive={isFollowing ?? false}
         >
             {formatMessage(isFollowing ? {

--- a/components/threading/common/follow_button/follow_button.tsx
+++ b/components/threading/common/follow_button/follow_button.tsx
@@ -22,7 +22,7 @@ function FollowButton({
         <Button
             {...props}
             className={classNames(props.className, 'FollowButton')}
-            disabled={props.disabled ?? isFollowing == null}
+            disabled={props.disabled}
             isActive={isFollowing ?? false}
         >
             {formatMessage(isFollowing ? {


### PR DESCRIPTION
#### Summary

Since https://github.com/mattermost/mattermost-server/pull/18740 the API can return `null` for `isFollowing` property,
this caused the thread footer's follow button to appear disabled.
This commit fixes that issue.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39850

#### Release Note

```release-note
NONE
```
