### PR TITLE
[MM-39770] Make thread mention badge visible in all themes

### DIFF
--- a/components/threading/global_threads/thread_item/thread_item.scss
+++ b/components/threading/global_threads/thread_item/thread_item.scss
@@ -67,9 +67,9 @@
         display: inline-block;
         width: 16px;
         height: 16px;
-        background: rgba(var(--mention-color-rgb), 1);
+        background: rgba(var(--button-bg-rgb), 1);
         border-radius: 50%;
-        color: rgba(var(--center-channel-bg-rgb), 1);
+        color: rgba(var(--button-color-rgb), 1);
         font-size: 10px;
         font-weight: 700;
         line-height: 16px;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Mention badge in thread wasn't visible in some themes.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[MM-39770](https://mattermost.atlassian.net/browse/MM-39770)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
 Made thread mention badge visible in all themes
```
