### PR TITLE
Cypress E2E: Moved from unstable to prod

### DIFF
--- a/e2e/cypress/integration/account_settings/security/password_spec.js
+++ b/e2e/cypress/integration/account_settings/security/password_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 describe('Account Settings', () => {

--- a/e2e/cypress/integration/enterprise/system_console/compliance/data_retention_policies_2_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/data_retention_policies_2_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 import {

--- a/e2e/cypress/integration/enterprise/system_console/compliance/data_retention_policies_3_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/data_retention_policies_3_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 import {

--- a/e2e/cypress/integration/enterprise/system_console/compliance/data_retention_policies_4_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/compliance/data_retention_policies_4_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console
 
 import {

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_up_down_in_rhs_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_up_down_in_rhs_spec.js
@@ -6,6 +6,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @keyboard_shortcuts
 
 describe('Keyboard Shortcuts', () => {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Moved following `spec` to Prod
`cypress/integration/account_settings/security/password_spec.js`
`cypress/integration/enterprise/system_console/compliance/data_retention_policies_2_spec.js`
`cypress/integration/enterprise/system_console/compliance/data_retention_policies_3_spec.js`
`cypress/integration/enterprise/system_console/compliance/data_retention_policies_4_spec.js`
`cypress/integration/keyboard_shortcuts/ctrl_cmd_up_down_in_rhs_spec.js`

Using following Cycles results,

1. https://automation-dashboard.vercel.app/cycles/c06a2697-866d-41b4-94c0-9c030b113dae
2. https://automation-dashboard.vercel.app/cycles/ea217de2-8cc7-449c-9cd0-a5d94174b667
3. https://automation-dashboard.vercel.app/cycles/0b80019b-4e4f-4692-b375-7a66da757ce9
4. https://automation-dashboard.vercel.app/cycles/a9568747-8e96-4a38-82eb-b67f4afa1d09
5. https://automation-dashboard.vercel.app/cycles/d860ac04-f5cf-453f-b202-9880eceff8ff

<!--

-->


#### Release Note
`release-note-none`
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->

