### PR TITLE
fix: set token if not already set

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -121,6 +121,9 @@ export default class Root extends React.PureComponent {
         // Redux
         setUrl(getSiteURL());
 
+        // Disable auth header to enable CSRF check
+        Client4.setAuthHeader = false;
+
         setSystemEmojis(EmojiIndicesByAlias);
 
         // Force logout of all tabs if one tab is logged out

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -679,7 +679,7 @@ export default class Client4 {
         );
     }
 
-    login = (loginId: string, password: string, token = '', deviceId = '', ldapOnly = false) => {
+    login = async (loginId: string, password: string, token = '', deviceId = '', ldapOnly = false) => {
         this.trackEvent('api', 'api_users_login');
 
         if (ldapOnly) {
@@ -697,10 +697,19 @@ export default class Client4 {
             body.ldap_only = 'true';
         }
 
-        return this.doFetch<UserProfile>(
+        const {
+            data: profile,
+            headers,
+        } = await this.doFetchWithResponse<UserProfile>(
             `${this.getUsersRoute()}/login`,
             {method: 'post', body: JSON.stringify(body)},
         );
+
+        if (headers.has('Token')) {
+            this.setToken(headers.get('Token')!);
+        }
+
+        return profile;
     };
 
     loginById = (id: string, password: string, token = '', deviceId = '') => {

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -146,6 +146,7 @@ export default class Client4 {
     userId = '';
     diagnosticId = '';
     includeCookies = true;
+    setAuthHeader = true;
     translations = {
         connectionError: 'There appears to be a problem with your internet connection.',
         unknownError: 'We received an unexpected status code from the server.',
@@ -449,7 +450,7 @@ export default class Client4 {
             ...this.defaultHeaders,
         };
 
-        if (this.token) {
+        if (this.setAuthHeader && this.token) {
             headers[HEADER_AUTH] = `${HEADER_BEARER} ${this.token}`;
         }
 


### PR DESCRIPTION
Fixes: https://github.com/mattermost/mattermost-redux/issues/1359

Currently the token isn't set on login, so using login actually does nothing and any following request that requires permission fails with 401 `'api.context.session_expired.app_error'`