### PR TITLE
Promote Polish to Official Availability

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -326,7 +326,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 8,
-                  "text": "Polski (Alpha)",
+                  "text": "Polski",
                   "value": "pl",
                 },
                 Object {


### PR DESCRIPTION
#### Summary
Polish promoted to official availability

```release-note
Polish has been promoted as an officially available language.
```
