### PR TITLE
[MM-39374] Remove references to DesktopMinVersion and DesktopLatestVersion

### DIFF
--- a/e2e/cypress/support/api/on_prem_default_config.json
+++ b/e2e/cypress/support/api/on_prem_default_config.json
@@ -106,8 +106,6 @@
     "ClientRequirements": {
         "AndroidLatestVersion": "",
         "AndroidMinVersion": "",
-        "DesktopLatestVersion": "",
-        "DesktopMinVersion": "",
         "IosLatestVersion": "",
         "IosMinVersion": ""
     },

--- a/packages/mattermost-redux/src/types/config.ts
+++ b/packages/mattermost-redux/src/types/config.ts
@@ -41,8 +41,6 @@ export type ClientConfig = {
     DataRetentionMessageRetentionDays: string;
     DefaultClientLocale: string;
     DefaultTheme: ThemeKey;
-    DesktopLatestVersion: string;
-    DesktopMinVersion: string;
     DiagnosticId: string;
     DiagnosticsEnabled: string;
     EmailLoginButtonBorderColor: string;
@@ -359,8 +357,6 @@ export type TeamSettings = {
 export type ClientRequirements = {
     AndroidLatestVersion: string;
     AndroidMinVersion: string;
-    DesktopLatestVersion: string;
-    DesktopMinVersion: string;
     IosLatestVersion: string;
     IosMinVersion: string;
 };


### PR DESCRIPTION
#### Summary
Removing references to `DesktopMinVersion` and `DesktopLatestVersion` since we aren't using them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39374

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/18979)

#### Release Note
```release-note
NONE
```