### PR TITLE
[MM-36009] fixes keyboard shortcut with global threads

### DIFF
--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -873,23 +873,6 @@ describe('components/create_post', () => {
         expect(instance.handleFileUploadChange).toHaveBeenCalledTimes(1);
     });
 
-    it('Should call Shortcut modal on FORWARD_SLASH+cntrl/meta', () => {
-        const wrapper = shallowWithIntl(createPost());
-        const instance = wrapper.instance();
-
-        instance.documentKeyHandler({ctrlKey: true, key: Constants.KeyCodes.BACK_SLASH[0], keyCode: Constants.KeyCodes.BACK_SLASH[1], preventDefault: jest.fn()});
-        expect(wrapper.instance().props.actions.openModal).not.toHaveBeenCalled();
-
-        instance.documentKeyHandler({ctrlKey: true, key: 'ù', keyCode: Constants.KeyCodes.FORWARD_SLASH[1], preventDefault: jest.fn()});
-        expect(wrapper.instance().props.actions.openModal).toHaveBeenCalledWith(expect.objectContaining({modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL}));
-
-        instance.documentKeyHandler({ctrlKey: true, key: '/', keyCode: Constants.KeyCodes.SEVEN[1], preventDefault: jest.fn()});
-        expect(wrapper.instance().props.actions.openModal).toHaveBeenCalledWith(expect.objectContaining({modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL}));
-
-        instance.documentKeyHandler({ctrlKey: true, key: Constants.KeyCodes.FORWARD_SLASH[0], keyCode: Constants.KeyCodes.FORWARD_SLASH[1], preventDefault: jest.fn()});
-        expect(wrapper.instance().props.actions.openModal).toHaveBeenCalledWith(expect.objectContaining({modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL}));
-    });
-
     it('Should just return as ctrlSend is enabled and its ctrl+enter', () => {
         const wrapper = shallowWithIntl(createPost({
             ctrlSend: true,

--- a/components/create_post/create_post.tsx
+++ b/components/create_post/create_post.tsx
@@ -60,7 +60,6 @@ import {ModalData} from 'types/actions';
 import {FileInfo} from 'mattermost-redux/types/files';
 import {Emoji} from 'mattermost-redux/types/emojis';
 import {FilePreviewInfo} from 'components/file_preview/file_preview';
-import KeyboardShortcutsModal from 'components/keyboard_shortcuts/keyboard_shortcuts_modal/keyboard_shortcuts_modal';
 
 import CreatePostTip from './create_post_tip';
 import PrewrittenChips from './prewritten_chips';
@@ -1066,19 +1065,8 @@ class CreatePost extends React.PureComponent<Props, State> {
 
     documentKeyHandler = (e: KeyboardEvent) => {
         const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
-        const shortcutModalKeyCombo = ctrlOrMetaKeyPressed && Utils.isKeyPressed(e, KeyCodes.FORWARD_SLASH);
         const lastMessageReactionKeyCombo = ctrlOrMetaKeyPressed && e.shiftKey && Utils.isKeyPressed(e, KeyCodes.BACK_SLASH);
-
-        if (shortcutModalKeyCombo) {
-            e.preventDefault();
-
-            this.props.actions.openModal({
-                modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL,
-                dialogType: KeyboardShortcutsModal,
-            });
-
-            return;
-        } else if (lastMessageReactionKeyCombo) {
+        if (lastMessageReactionKeyCombo) {
             this.reactToLastMessage(e);
             return;
         }

--- a/components/sidebar/sidebar.test.tsx
+++ b/components/sidebar/sidebar.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import Sidebar from 'components/sidebar/sidebar';
+import Constants, {ModalIdentifiers} from '../../utils/constants';
 
 describe('components/sidebar', () => {
     const baseProps = {
@@ -49,6 +50,33 @@ describe('components/sidebar', () => {
 
         wrapper.instance().setState({showMoreChannelsModal: true});
         expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Should call Shortcut modal on FORWARD_SLASH+ctrl/meta', () => {
+        const wrapper = shallow<Sidebar>(
+            <Sidebar {...baseProps}/>,
+        );
+        const instance = wrapper.instance();
+
+        let key = Constants.KeyCodes.BACK_SLASH[0] as string;
+        let keyCode = Constants.KeyCodes.BACK_SLASH[1] as number;
+        instance.handleKeyDownEvent({ctrlKey: true, preventDefault: jest.fn(), key, keyCode} as any);
+        expect(wrapper.instance().props.actions.openModal).not.toHaveBeenCalled();
+
+        key = 'ù';
+        keyCode = Constants.KeyCodes.FORWARD_SLASH[1] as number;
+        instance.handleKeyDownEvent({ctrlKey: true, preventDefault: jest.fn(), key, keyCode} as any);
+        expect(wrapper.instance().props.actions.openModal).toHaveBeenCalledWith(expect.objectContaining({modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL}));
+
+        key = '/';
+        keyCode = Constants.KeyCodes.SEVEN[1] as number;
+        instance.handleKeyDownEvent({ctrlKey: true, preventDefault: jest.fn(), key, keyCode} as any);
+        expect(wrapper.instance().props.actions.openModal).toHaveBeenCalledWith(expect.objectContaining({modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL}));
+
+        key = Constants.KeyCodes.FORWARD_SLASH[0] as string;
+        keyCode = Constants.KeyCodes.FORWARD_SLASH[1] as number;
+        instance.handleKeyDownEvent({ctrlKey: true, preventDefault: jest.fn(), key, keyCode} as any);
+        expect(wrapper.instance().props.actions.openModal).toHaveBeenCalledWith(expect.objectContaining({modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL}));
     });
 
     test('should toggle direct messages modal correctly', () => {

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -19,6 +19,8 @@ import {ModalData} from 'types/actions';
 import Constants, {ModalIdentifiers} from 'utils/constants';
 import * as Utils from 'utils/utils';
 
+import KeyboardShortcutsModal from '../keyboard_shortcuts/keyboard_shortcuts_modal/keyboard_shortcuts_modal';
+
 import ChannelNavigator from './channel_navigator';
 import SidebarChannelList from './sidebar_channel_list';
 import SidebarHeader from './sidebar_header';
@@ -63,7 +65,7 @@ export default class Sidebar extends React.PureComponent<Props, State> {
         }
 
         window.addEventListener('click', this.handleClickClearChannelSelection);
-        window.addEventListener('keydown', this.handleKeyDownClearChannelSelection);
+        window.addEventListener('keydown', this.handleKeyDownEvent);
     }
 
     componentDidUpdate(prevProps: Props) {
@@ -74,7 +76,7 @@ export default class Sidebar extends React.PureComponent<Props, State> {
 
     componentWillUnmount() {
         window.removeEventListener('click', this.handleClickClearChannelSelection);
-        window.removeEventListener('keydown', this.handleKeyDownClearChannelSelection);
+        window.removeEventListener('keydown', this.handleKeyDownEvent);
     }
 
     handleClickClearChannelSelection = (event: MouseEvent) => {
@@ -85,9 +87,19 @@ export default class Sidebar extends React.PureComponent<Props, State> {
         this.props.actions.clearChannelSelection();
     }
 
-    handleKeyDownClearChannelSelection = (event: KeyboardEvent) => {
+    handleKeyDownEvent = (event: KeyboardEvent) => {
         if (Utils.isKeyPressed(event, Constants.KeyCodes.ESCAPE)) {
             this.props.actions.clearChannelSelection();
+            return;
+        }
+        const ctrlOrMetaKeyPressed = event.ctrlKey || event.metaKey;
+        const shortcutModalKeyCombo = ctrlOrMetaKeyPressed && Utils.isKeyPressed(event, Constants.KeyCodes.FORWARD_SLASH);
+        if (shortcutModalKeyCombo) {
+            event.preventDefault();
+            this.props.actions.openModal({
+                modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL,
+                dialogType: KeyboardShortcutsModal,
+            });
         }
     }
 


### PR DESCRIPTION


#### Summary
CRT: Shortcut (Command-/) for the keyboard shortcuts Modal doesn't work in global threads

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-36009

#### Related Pull Requests
``None``

#### Screenshots

<img width="1792" alt="Screenshot 2021-11-15 at 3 54 11 PM" src="https://user-images.githubusercontent.com/16203333/141765392-7f309a8d-6301-4d62-a092-18cfb4f6d7e9.png">


#### Release Note
-->
```release-note
* fixes keyboard shortcut not working with global threads
```
