### PR TITLE
Cypress/E2E: Fix cloud test related to max file size

### DIFF
--- a/e2e/cypress/integration/onboarding/set_profile_and_team_spec.js
+++ b/e2e/cypress/integration/onboarding/set_profile_and_team_spec.js
@@ -9,13 +9,20 @@
 
 // Group: @enterprise @onboarding
 
+import {fileSizeToString} from '../../utils';
+
 describe('Onboarding - Sysadmin', () => {
     let townSquarePage;
     let sysadmin;
+    let maxFileSize;
 
     before(() => {
         cy.apiUpdateConfig({
             ServiceSettings: {EnableOnboardingFlow: true},
+        });
+
+        cy.apiGetConfig(true).then(({config}) => {
+            maxFileSize = config.MaxFileSize;
         });
 
         cy.apiInitSetup().then(({team}) => {
@@ -108,7 +115,7 @@ describe('Onboarding - Sysadmin', () => {
         cy.findByTestId('PictureSelector__input-CompleteProfileStep__profilePicture').attachFile('saml_users.json');
 
         // * Verify error message is displayed
-        cy.get('.CompleteProfileStep__pictureError').should('contain', 'Photos must be in BMP, JPG or PNG format. Maximum file size is 50MB.');
+        cy.get('.CompleteProfileStep__pictureError').should('contain', `Photos must be in BMP, JPG or PNG format. Maximum file size is ${fileSizeToString(maxFileSize)}.`);
     });
 
     it('MM-T3331_1 Sysadmin - Set team name and team icon', () => {
@@ -171,6 +178,6 @@ describe('Onboarding - Sysadmin', () => {
         cy.findByTestId('PictureSelector__input-TeamProfileStep__teamIcon').attachFile('saml_users.json');
 
         // * Verify error message is displayed
-        cy.get('.TeamProfileStep__pictureError').should('contain', 'Photos must be in BMP, JPG or PNG format. Maximum file size is 50MB.');
+        cy.get('.TeamProfileStep__pictureError').should('contain', `Photos must be in BMP, JPG or PNG format. Maximum file size is ${fileSizeToString(maxFileSize)}.`);
     });
 });

--- a/e2e/cypress/support/api/on_prem_default_config.json
+++ b/e2e/cypress/support/api/on_prem_default_config.json
@@ -168,7 +168,7 @@
         "EnableFileAttachments": true,
         "EnableMobileUpload": true,
         "EnableMobileDownload": true,
-        "MaxFileSize": 52428800,
+        "MaxFileSize": 104857600,
         "DriverName": "local",
         "Directory": "./data/",
         "EnablePublicLink": false,

--- a/e2e/cypress/utils/file.js
+++ b/e2e/cypress/utils/file.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Converts a file size in bytes into a human-readable string of the form '123MB'.
+export function fileSizeToString(bytes) {
+    // it's unlikely that we'll have files bigger than this
+    if (bytes > 1024 ** 4) {
+        // check if file is smaller than 10 to display fractions
+        if (bytes < (1024 ** 4) * 10) {
+            return (Math.round((bytes / (1024 ** 4)) * 10) / 10) + 'TB';
+        }
+        return Math.round(bytes / (1024 ** 4)) + 'TB';
+    } else if (bytes > 1024 ** 3) {
+        if (bytes < (1024 ** 3) * 10) {
+            return (Math.round((bytes / (1024 ** 3)) * 10) / 10) + 'GB';
+        }
+        return Math.round(bytes / (1024 ** 3)) + 'GB';
+    } else if (bytes > 1024 ** 2) {
+        if (bytes < (1024 ** 2) * 10) {
+            return (Math.round((bytes / (1024 ** 2)) * 10) / 10) + 'MB';
+        }
+        return Math.round(bytes / (1024 ** 2)) + 'MB';
+    } else if (bytes > 1024) {
+        return Math.round(bytes / 1024) + 'KB';
+    }
+    return bytes + 'B';
+}

--- a/e2e/cypress/utils/index.js
+++ b/e2e/cypress/utils/index.js
@@ -10,6 +10,7 @@ import messageMenusWithDatasourceData from '../fixtures/hooks/message_menus_with
 
 export * from './constants';
 export * from './email';
+export * from './file';
 export * from './plugins';
 
 /**


### PR DESCRIPTION
#### Summary
- changed default max file size to 100MB
- make the text verification depends on what's with the current config instead of hard-coded value

#### Screenshots
<img width="629" alt="Screen Shot 2021-11-16 at 9 08 35 AM" src="https://user-images.githubusercontent.com/5334504/141877481-22c09ee1-2a4e-45fc-84b9-377e8db8404d.png">

#### Release Note
```release-note
NONE
```
