### PR TITLE
Cypress/E2E: Fix reply e2e

### DIFF
--- a/e2e/cypress/integration/enterprise/accessibility/accessibility_input_fields_spec.js
+++ b/e2e/cypress/integration/enterprise/accessibility/accessibility_input_fields_spec.js
@@ -194,7 +194,7 @@ describe('Verify Accessibility Support in different input fields', () => {
 
         cy.get('#rhsContainer').within(() => {
             // * Verify Accessibility Support in RHS input
-            cy.get('#reply_textbox').should('have.attr', 'aria-label', 'add a comment...').and('have.attr', 'role', 'textbox').focus().type('test').tab({shift: true}).tab().tab();
+            cy.get('#reply_textbox').should('have.attr', 'aria-label', 'reply to this thread...').and('have.attr', 'role', 'textbox').focus().type('test').tab({shift: true}).tab().tab();
 
             // * Verify if the focus is on the attachment icon
             cy.get('#fileUploadButton').should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'attachment').tab();
@@ -205,8 +205,8 @@ describe('Verify Accessibility Support in different input fields', () => {
             // * Verify if the focus is on the help link
             cy.get('.textbox-help-link').should('have.class', 'a11y--active a11y--focused').tab();
 
-            // * Verify if the focus is on the Add Comment button
-            cy.get('#addCommentButton').should('have.class', 'a11y--active a11y--focused');
+            // * Verify if the focus is on the Reply button
+            cy.uiGetReply().should('have.class', 'a11y--active a11y--focused');
         });
     });
 });

--- a/e2e/cypress/integration/integrations/poll_spec.js
+++ b/e2e/cypress/integration/integrations/poll_spec.js
@@ -81,7 +81,7 @@ describe('/poll', () => {
         cy.uiGetRHS().within(() => {
             // # In RHS, post `/poll reply`
             cy.get('#reply_textbox').type('/poll reply');
-            cy.uiAddComment();
+            cy.uiReply();
 
             // * Poll displays as expected in RHS.
             cy.findByLabelText('matterpoll').should('be.visible');

--- a/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -81,8 +81,8 @@ describe('Messaging', () => {
             cy.get('@replyTextBox').type(`post ${i}`).type('{enter}');
         }
 
-        // * Check if "Add Comment" button is visible
-        cy.get('#addCommentButton').scrollIntoView().should('be.visible').and('have.value', 'Add Comment');
+        // * Check if "Reply" button is visible
+        cy.uiGetReply().should('be.visible');
 
         // # Reset the viewport
         cy.viewport(1280, 900);

--- a/e2e/cypress/integration/messaging/message_reply_part2_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_part2_spec.js
@@ -47,21 +47,21 @@ describe('Message Reply', () => {
         });
     });
 
-    it('MM-T2133 - Reply arrow opens RHS with Add Comment button disabled until text entered', () => {
+    it('MM-T2133 - Reply arrow opens RHS with Reply button disabled until text entered', () => {
         // # Click on the `...` menu icon and click on `Reply`
         cy.uiClickPostDropdownMenu(rootId, 'Reply', 'CENTER');
 
         // * RHS is open
         cy.get('#rhsContainer').should('be.visible');
 
-        // * `Add Comment` button is disabled
-        cy.get('#addCommentButton').should('be.disabled');
+        // * Reply button is disabled
+        cy.uiGetReply().should('be.disabled');
 
         // # Type a character in the comment box
         cy.get('#reply_textbox').type('A');
 
-        // * `Add Comment` button is not disabled
-        cy.get('#addCommentButton').should('not.be.disabled');
+        // * Reply button is not disabled
+        cy.uiGetReply().should('not.be.disabled');
 
         // # Clear comment box
         cy.get('#reply_textbox').clear();

--- a/e2e/cypress/integration/messaging/message_spec.js
+++ b/e2e/cypress/integration/messaging/message_spec.js
@@ -154,8 +154,8 @@ describe('Message', () => {
         // # Click on Preview
         cy.get('#previewLink').click();
 
-        // # Click on Add Comment
-        cy.get('#addCommentButton').click();
+        // # Click on Reply
+        cy.uiReply();
 
         // * Focus to remain in the RHS text box
         cy.get('#reply_textbox').should('be.focused');

--- a/e2e/cypress/support/ui/sidebar_right.d.ts
+++ b/e2e/cypress/support/ui/sidebar_right.d.ts
@@ -52,6 +52,14 @@ declare namespace Cypress {
         isExpanded(): Chainable;
 
         /**
+         * Get "Reply" button
+         *
+         * @example
+         *   cy.uiGetReply();
+         */
+        uiGetReply(): Chainable;
+
+        /**
          * Reply by clicking "Reply" button
          *
          * @example

--- a/e2e/cypress/support/ui/sidebar_right.d.ts
+++ b/e2e/cypress/support/ui/sidebar_right.d.ts
@@ -52,12 +52,12 @@ declare namespace Cypress {
         isExpanded(): Chainable;
 
         /**
-         * Add comment by clicking "Add Comment" button
+         * Reply by clicking "Reply" button
          *
          * @example
-         *   cy.uiAddComment();
+         *   cy.uiReply();
          */
-        uiAddComment(): Chainable;
+        uiReply(): Chainable;
 
         /**
          * Get RHS container

--- a/e2e/cypress/support/ui/sidebar_right.js
+++ b/e2e/cypress/support/ui/sidebar_right.js
@@ -21,8 +21,12 @@ Cypress.Commands.add('isExpanded', {prevSubject: true}, (subject) => {
     return cy.get(subject).should('have.class', 'sidebar--right--expanded');
 });
 
-Cypress.Commands.add('uiAddComment', () => {
-    cy.findByRole('button', {name: 'Add Comment'}).click();
+Cypress.Commands.add('uiGetReply', () => {
+    return cy.findByRole('button', {name: 'Reply'});
+});
+
+Cypress.Commands.add('uiReply', () => {
+    cy.uiGetReply().click();
 });
 
 // Sidebar search container


### PR DESCRIPTION
#### Summary
- Changed `Add Comment` to `Reply`, `uiAddComment` to `uiReply` and `add a comment...` to `reply to this thread...`
- Also updated corresponding terms on zephyr tickets

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-11-15 at 7 37 38 PM](https://user-images.githubusercontent.com/487991/141896074-228dcf93-6a04-4b1d-a918-d013a449d922.png)
![Screen Shot 2021-11-15 at 7 44 47 PM](https://user-images.githubusercontent.com/487991/141896092-aa614939-2cdf-45a6-8930-a1aa5e6abaa2.png)
![Screen Shot 2021-11-15 at 7 45 53 PM](https://user-images.githubusercontent.com/487991/141896098-2b8188c9-c022-4022-85c6-a3c47c4a5c85.png)
![Screen Shot 2021-11-15 at 7 47 39 PM](https://user-images.githubusercontent.com/487991/141896103-34508c47-ff37-43e6-a2da-d6bb6e94d8ed.png)
![Screen Shot 2021-11-15 at 7 48 35 PM](https://user-images.githubusercontent.com/487991/141896112-792e6d9f-1173-4d1c-bbb1-3cfddfb6d801.png)


#### Release Note
```release-note
NONE
```