### PR TITLE
Cypress/E2E: Cleanup find channels

### DIFF
--- a/e2e/cypress/integration/custom_status/custom_status_5_spec.js
+++ b/e2e/cypress/integration/custom_status/custom_status_5_spec.js
@@ -156,8 +156,8 @@ describe('Custom Status - Verifying Where Custom Status Appears', () => {
     });
 
     it('MM-T3850_12 should show custom status emoji at channel switcher', () => {
-        // # Click channel switcher button
-        cy.uiGetChannelSwitcher().click();
+        // # Open Find Channels
+        cy.uiOpenFindChannels();
 
         // # Type username on the input
         cy.findByRole('textbox', {name: 'quick switch input'}).type(currentUser.username);

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
@@ -151,8 +151,8 @@ describe('Verify Guest User Identification in different screens', () => {
     });
 
     it('Verify Guest Badge in Switch Channel Dialog', () => {
-        // # Click the sidebar switcher button
-        cy.uiGetChannelSwitcher().click();
+        // # Open Find Channels
+        cy.uiOpenFindChannels();
 
         // # Type the guest user name on Channel switcher input
         cy.findByRole('textbox', {name: 'quick switch input'}).type(guest.username).wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/integration/enterprise/ldap/ldap_group_sync_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_group_sync_spec.js
@@ -398,8 +398,8 @@ context('ldap', () => {
 
                 cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
-                // # Click the sidebar switcher button
-                cy.uiGetChannelSwitcher().click();
+                // # Open Find Channels
+                cy.uiOpenFindChannels();
 
                 // * Channel switcher hint should be visible
                 cy.get('#quickSwitchHint', {timeout: TIMEOUTS.TWO_SEC}).should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');
@@ -423,8 +423,8 @@ context('ldap', () => {
                 cy.apiLogin(testUser);
                 cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
-                // # Click the sidebar switcher button
-                cy.uiGetChannelSwitcher().click();
+                // # Open Find Channels
+                cy.uiOpenFindChannels();
 
                 // * Channel switcher hint should be visible
                 cy.get('#quickSwitchHint', {timeout: TIMEOUTS.TWO_SEC}).should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');

--- a/e2e/cypress/integration/system_console/user_management/users_deactivation_spec.js
+++ b/e2e/cypress/integration/system_console/user_management/users_deactivation_spec.js
@@ -77,8 +77,8 @@ describe('System Console > User Management > Deactivation', () => {
             // # Deactivate the user
             cy.apiDeactivateUser(other.id);
 
-            // # Open Channel Switcher
-            cy.uiGetChannelSwitcher().click();
+            // # Open Find Channels
+            cy.uiOpenFindChannels();
 
             // # Type the user name on Channel switcher input
             cy.get('#quickSwitchInput').type(other.username).wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/support/ui/sidebar_left.d.ts
+++ b/e2e/cypress/support/ui/sidebar_left.d.ts
@@ -85,11 +85,18 @@ declare namespace Cypress {
         uiAddDirectMessage(): Chainable;
 
         /**
-         * Get a button for channel switcher
+         * Get find channels button
          * @example
-         *   cy.uiGetChannelSwitcher();
+         *   cy.uiGetFindChannels();
          */
-        uiGetChannelSwitcher(): Chainable;
+        uiGetFindChannels(): Chainable;
+
+        /**
+         * Open find channels
+         * @example
+         *   cy.uiOpenFindChannels();
+         */
+        uiOpenFindChannels(): Chainable;
 
         /**
          * Open menu of a channel in the sidebar

--- a/e2e/cypress/support/ui/sidebar_left.js
+++ b/e2e/cypress/support/ui/sidebar_left.js
@@ -95,8 +95,12 @@ Cypress.Commands.add('uiAddDirectMessage', () => {
     return cy.findByRole('button', {name: 'Write a direct message'});
 });
 
-Cypress.Commands.add('uiGetChannelSwitcher', () => {
+Cypress.Commands.add('uiGetFindChannels', () => {
     return cy.get('#lhsNavigator').findByRole('button', {name: 'Find Channels'});
+});
+
+Cypress.Commands.add('uiOpenFindChannels', () => {
+    return cy.uiGetFindChannels().click();
 });
 
 Cypress.Commands.add('uiGetChannelSidebarMenu', (channelName) => {

--- a/e2e/cypress/support/ui/sidebar_left.js
+++ b/e2e/cypress/support/ui/sidebar_left.js
@@ -100,7 +100,7 @@ Cypress.Commands.add('uiGetFindChannels', () => {
 });
 
 Cypress.Commands.add('uiOpenFindChannels', () => {
-   cy.uiGetFindChannels().click();
+    cy.uiGetFindChannels().click();
 });
 
 Cypress.Commands.add('uiGetChannelSidebarMenu', (channelName) => {

--- a/e2e/cypress/support/ui/sidebar_left.js
+++ b/e2e/cypress/support/ui/sidebar_left.js
@@ -100,7 +100,7 @@ Cypress.Commands.add('uiGetFindChannels', () => {
 });
 
 Cypress.Commands.add('uiOpenFindChannels', () => {
-    return cy.uiGetFindChannels().click();
+   cy.uiGetFindChannels().click();
 });
 
 Cypress.Commands.add('uiGetChannelSidebarMenu', (channelName) => {


### PR DESCRIPTION
#### Summary
- Based on @furqanmlk's original changes in PR https://github.com/mattermost/mattermost-webapp/pull/9275, applied additional changes so that it's consistent, i.e. change `uiGetChannelSwitcher` to `uiGetFindChannels` and use `uiOpenFindChannels`

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-11-15 at 8 16 09 PM](https://user-images.githubusercontent.com/487991/141920428-9732ecdf-f7c6-4a58-92f7-af5684adb5a0.png)
![Screen Shot 2021-11-15 at 8 17 29 PM](https://user-images.githubusercontent.com/487991/141920445-3448f498-c1ec-4a77-baf2-c8a6a59740de.png)
![Screen Shot 2021-11-15 at 8 19 08 PM](https://user-images.githubusercontent.com/487991/141920455-eb2749fe-c080-4a26-a87b-58676da43693.png)
![Screen Shot 2021-11-15 at 8 24 46 PM](https://user-images.githubusercontent.com/487991/141920462-ac5dcb22-9b49-4581-81a4-26a8438f430f.png)

#### Release Note
```release-note
NONE
```