### PR TITLE
[MM-38376]fix-app-crash-on-root-post-delete-from-global-threads

### DIFF
--- a/components/delete_post_modal/delete_post_modal.tsx
+++ b/components/delete_post_modal/delete_post_modal.tsx
@@ -15,8 +15,8 @@ const urlFormatForDMGMPermalink = '/:teamName/messages/:username/:postid';
 const urlFormatForChannelPermalink = '/:teamName/channels/:channelname/:postid';
 
 type Props = {
-    channelName: string;
-    teamName: string;
+    channelName?: string;
+    teamName?: string;
     post: Post;
     commentCount: number;
     isRHS: boolean;

--- a/components/delete_post_modal/index.ts
+++ b/components/delete_post_modal/index.ts
@@ -19,8 +19,8 @@ type Actions = {
 };
 
 type Props = {
-    channelName: string;
-    teamName: string;
+    channelName?: string;
+    teamName?: string;
     post: Post;
     commentCount: number;
     isRHS: boolean;

--- a/components/threading/global_threads/thread_item/index.ts
+++ b/components/threading/global_threads/thread_item/index.ts
@@ -26,11 +26,11 @@ function makeMapStateToProps() {
         const post = getPost(state, threadId);
 
         return {
-            channel: getChannel(state, {id: post.channel_id}),
-            currentRelativeTeamUrl: getCurrentRelativeTeamUrl(state),
-            displayName: getDisplayName(state, post.user_id, true),
             post,
-            postsInThread: getPostsForThread(state, post.id),
+            channel: post && getChannel(state, {id: post.channel_id}),
+            currentRelativeTeamUrl: getCurrentRelativeTeamUrl(state),
+            displayName: post && getDisplayName(state, post.user_id, true),
+            postsInThread: post && getPostsForThread(state, post.id),
             thread: getThread(state, threadId),
         };
     };

--- a/components/threading/global_threads/thread_item/index.ts
+++ b/components/threading/global_threads/thread_item/index.ts
@@ -27,10 +27,10 @@ function makeMapStateToProps() {
 
         return {
             post,
-            channel: post && getChannel(state, {id: post.channel_id}),
+            channel: getChannel(state, {id: post.channel_id}),
             currentRelativeTeamUrl: getCurrentRelativeTeamUrl(state),
-            displayName: post && getDisplayName(state, post.user_id, true),
-            postsInThread: post && getPostsForThread(state, post.id),
+            displayName: getDisplayName(state, post.user_id, true),
+            postsInThread: getPostsForThread(state, post.id),
             thread: getThread(state, threadId),
         };
     };

--- a/reducers/views/rhs.js
+++ b/reducers/views/rhs.js
@@ -17,7 +17,7 @@ function selectedPostId(state = '', action) {
         return action.postId;
     case ActionTypes.SELECT_POST_CARD:
         return '';
-    case PostTypes.REMOVE_POST:
+    case PostTypes.POST_REMOVED:
         if (action.data && action.data.id === state) {
             return '';
         }

--- a/reducers/views/threads.ts
+++ b/reducers/views/threads.ts
@@ -3,14 +3,27 @@
 
 import {combineReducers} from 'redux';
 
+import {findKey} from 'lodash';
+
 import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ViewsState} from 'types/store/views';
 
 import {Threads} from 'utils/constants';
+import {PostTypes} from 'mattermost-redux/action_types';
 
 export const selectedThreadIdInTeam = (state: ViewsState['threads']['selectedThreadIdInTeam'] | null = null, action: GenericAction) => {
     switch (action.type) {
+    case PostTypes.POST_REMOVED: {
+        const key = findKey(state, (id) => id === action.data.id);
+        if (key) {
+            return {
+                ...state,
+                [key]: '',
+            };
+        }
+        return state;
+    }
     case Threads.CHANGED_SELECTED_THREAD:
         return {
             ...state,


### PR DESCRIPTION
#### Summary
Webapp crashes when the root post is deleted from Threads RHS
Note: All other scenarios of post delete, as well as global threads RHS, require testing.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-38376

#### Related Pull Requests
``None``

#### Screenshots
|  before  |  after  |
|----|----|
| [https://www.loom.com/share/2c626dd0418444999390b2ed932cd719](https://www.loom.com/share/2c626dd0418444999390b2ed932cd719) | [https://www.loom.com/share/ff354c7621cd46a1a1fcc58c02c7fa32](https://www.loom.com/share/ff354c7621cd46a1a1fcc58c02c7fa32) |

#### Release Note

```release-note
* Bug fixes app crash on root post delete from global threads
```
