### PR TITLE
fix/MM-39870 : ADA Accessibility: NVDA does not read out all elements in a channel header, nor does it TAB to all elements in the channel header

### DIFF
--- a/components/channel_header/components/__snapshots__/header_icon_wrapper.test.tsx.snap
+++ b/components/channel_header/components/__snapshots__/header_icon_wrapper.test.tsx.snap
@@ -196,6 +196,7 @@ exports[`components/channel_header/components/HeaderIconWrapper should match sna
     }
   >
     <button
+      aria-label="plugin_tooltip_text"
       className="button_class"
       id="button_id"
       onClick={[Function]}

--- a/components/channel_header/components/header_icon_wrapper.tsx
+++ b/components/channel_header/components/header_icon_wrapper.tsx
@@ -22,7 +22,7 @@ type Props = {
     iconComponent: React.ReactNode;
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
     tooltipKey: string;
-    tooltipText?: string;
+    tooltipText?: React.ReactNode;
     isRhsOpen?: boolean;
 }
 
@@ -105,6 +105,11 @@ const HeaderIconWrapper: React.FC<Props> = (props: Props) => {
         );
     }
 
+    let ariaLabelText;
+    if (ariaLabel) {
+        ariaLabelText = `${localizeMessage(toolTips[tooltipKey].messageID, toolTips[tooltipKey].message)}`;
+    }
+
     let tooltip;
     if (tooltipKey === 'plugin' && tooltipText) {
         tooltip = (
@@ -115,13 +120,12 @@ const HeaderIconWrapper: React.FC<Props> = (props: Props) => {
                 <span>{tooltipText}</span>
             </Tooltip>
         );
+
+        if (typeof tooltipText === 'string') {
+            ariaLabelText = tooltipText;
+        }
     } else {
         tooltip = getTooltip(tooltipKey);
-    }
-
-    let ariaLabelText;
-    if (ariaLabel) {
-        ariaLabelText = `${localizeMessage(toolTips[tooltipKey].messageID, toolTips[tooltipKey].message)}`;
     }
 
     if (tooltip) {
@@ -135,7 +139,7 @@ const HeaderIconWrapper: React.FC<Props> = (props: Props) => {
                 >
                     <button
                         id={buttonId}
-                        aria-label={ariaLabelText || tooltipText}
+                        aria-label={ariaLabelText}
                         className={buttonClass || 'channel-header__icon'}
                         onClick={onClick}
                     >

--- a/components/channel_header/components/header_icon_wrapper.tsx
+++ b/components/channel_header/components/header_icon_wrapper.tsx
@@ -22,7 +22,7 @@ type Props = {
     iconComponent: React.ReactNode;
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
     tooltipKey: string;
-    tooltipText?: React.ReactNode;
+    tooltipText?: string;
     isRhsOpen?: boolean;
 }
 
@@ -135,7 +135,7 @@ const HeaderIconWrapper: React.FC<Props> = (props: Props) => {
                 >
                     <button
                         id={buttonId}
-                        aria-label={ariaLabelText}
+                        aria-label={ariaLabelText || tooltipText}
                         className={buttonClass || 'channel-header__icon'}
                         onClick={onClick}
                     >

--- a/plugins/channel_header_plug/__snapshots__/channel_header_plug.test.tsx.snap
+++ b/plugins/channel_header_plug/__snapshots__/channel_header_plug.test.tsx.snap
@@ -212,6 +212,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with one extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid"
             onClick={[Function]}
@@ -528,6 +529,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid"
             onClick={[Function]}
@@ -637,6 +639,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid2"
             onClick={[Function]}
@@ -746,6 +749,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid3"
             onClick={[Function]}
@@ -855,6 +859,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid4"
             onClick={[Function]}
@@ -964,6 +969,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid5"
             onClick={[Function]}
@@ -1073,6 +1079,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid6"
             onClick={[Function]}
@@ -1182,6 +1189,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid7"
             onClick={[Function]}
@@ -1291,6 +1299,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid8"
             onClick={[Function]}
@@ -1400,6 +1409,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid9"
             onClick={[Function]}
@@ -1509,6 +1519,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid10"
             onClick={[Function]}
@@ -1618,6 +1629,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid11"
             onClick={[Function]}
@@ -1727,6 +1739,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid12"
             onClick={[Function]}
@@ -1836,6 +1849,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid13"
             onClick={[Function]}
@@ -1945,6 +1959,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid14"
             onClick={[Function]}
@@ -2054,6 +2069,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
           }
         >
           <button
+            aria-label="some tooltip text"
             className="channel-header__icon"
             id="someid15"
             onClick={[Function]}


### PR DESCRIPTION
#### Summary
Adds `aria-label` to plugin channel buttons.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39870

#### Related Pull Requests
~Has server changes (please link here)~
~Has mobile changes (please link here)~

#### Screenshots

https://user-images.githubusercontent.com/17708702/141994903-807711db-4513-444c-8bee-a3d7b700046b.mov

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
