### PR TITLE
Cypress/E2E: Fix unstable autocomplete

### DIFF
--- a/e2e/cypress/integration/autocomplete/common_test.js
+++ b/e2e/cypress/integration/autocomplete/common_test.js
@@ -51,10 +51,10 @@ export function doTestUserChannelSection(prefix, testTeam, testUsers) {
         type(`@${prefix}odinson`);
 
     // * Thor should be a channel member
-    cy.uiVerifyAtMentionInSuggestionList('Channel Members', thor, true);
+    cy.uiVerifyAtMentionInSuggestionList(thor, true);
 
     // * Loki should NOT be a channel member
-    cy.uiVerifyAtMentionInSuggestionList('Not in Channel', loki, false);
+    cy.uiVerifyAtMentionInSuggestionList(loki, false);
 }
 
 export function doTestDMChannelSidebar(testUsers) {

--- a/e2e/cypress/integration/channel/channel_mention_autocomplete_spec.js
+++ b/e2e/cypress/integration/channel/channel_mention_autocomplete_spec.js
@@ -41,14 +41,12 @@ describe('Channel', () => {
         cy.get('#loadingSpinner').should('not.exist');
 
         // * Should open up suggestion list for channels
-        // * Should match each channel item and group label
+        // * Should match each channel item
         cy.get('#suggestionList').should('be.visible').children().within((el) => {
-            cy.wrap(el).eq(0).should('contain', 'My Channels');
-            cy.wrap(el).eq(1).should('contain', ownChannel.display_name);
-            cy.wrap(el).eq(2).should('contain', 'Off-Topic');
-            cy.wrap(el).eq(3).should('contain', 'Town Square');
-            cy.wrap(el).eq(4).should('contain', 'Other Channels');
-            cy.wrap(el).eq(5).should('contain', otherChannel.display_name);
+            cy.wrap(el).eq(0).should('contain', ownChannel.display_name);
+            cy.wrap(el).eq(1).should('contain', 'Off-Topic');
+            cy.wrap(el).eq(2).should('contain', 'Town Square');
+            cy.wrap(el).eq(3).should('contain', otherChannel.display_name);
         });
     });
 
@@ -64,13 +62,12 @@ describe('Channel', () => {
         cy.get('#loadingSpinner').should('not.exist');
 
         // * Should open up suggestion list for channels
-        // * Should match each channel item and group label
+        // * Should match each channel
         cy.get('#suggestionList').should('be.visible').children().within((el) => {
-            cy.wrap(el).eq(0).should('contain', 'My Channels');
-            cy.wrap(el).eq(1).should('contain', ownChannel.display_name);
-            cy.wrap(el).eq(2).should('contain', otherChannel.display_name);
-            cy.wrap(el).eq(3).should('contain', 'Off-Topic');
-            cy.wrap(el).eq(4).should('contain', 'Town Square');
+            cy.wrap(el).eq(0).should('contain', ownChannel.display_name);
+            cy.wrap(el).eq(1).should('contain', otherChannel.display_name);
+            cy.wrap(el).eq(2).should('contain', 'Off-Topic');
+            cy.wrap(el).eq(3).should('contain', 'Town Square');
         });
     });
 
@@ -89,14 +86,12 @@ describe('Channel', () => {
             cy.get('#loadingSpinner').should('not.exist');
 
             // * Should open up suggestion list for channels
-            // * Should match each channel item and group label
+            // * Should match each channel item
             cy.get('#suggestionList').should('be.visible').children().within((el) => {
-                cy.wrap(el).eq(0).should('contain', 'My Channels');
-                cy.wrap(el).eq(1).should('contain', ownChannel.display_name);
-                cy.wrap(el).eq(2).should('contain', 'Off-Topic');
-                cy.wrap(el).eq(3).should('contain', 'Town Square');
-                cy.wrap(el).eq(4).should('contain', 'Other Channels');
-                cy.wrap(el).eq(5).should('contain', otherChannel.display_name);
+                cy.wrap(el).eq(0).should('contain', ownChannel.display_name);
+                cy.wrap(el).eq(1).should('contain', 'Off-Topic');
+                cy.wrap(el).eq(2).should('contain', 'Town Square');
+                cy.wrap(el).eq(3).should('contain', otherChannel.display_name);
             });
         });
     });

--- a/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
@@ -112,9 +112,7 @@ function uploadFileAndAddAutocompleteThenVerifyNoOverlap() {
             cy.wait(TIMEOUTS.HALF_SEC).then(() => {
                 // * Suggestion list should visibly render just within the channel header
                 cy.wrap(header[0].getBoundingClientRect().top).should('be.lt', list[0].getBoundingClientRect().top);
-                cy.wrap(list[0]).findByText('Channel Members').then((channelMembers) => {
-                    cy.wrap(header[0].getBoundingClientRect().bottom).should('be.lt', channelMembers[0].getBoundingClientRect().top);
-                });
+                cy.wrap(header[0].getBoundingClientRect().bottom).should('be.lt', list[0].getBoundingClientRect().top);
             });
         });
     });

--- a/e2e/cypress/integration/settings/sidebar/fullname_spec.js
+++ b/e2e/cypress/integration/settings/sidebar/fullname_spec.js
@@ -55,7 +55,7 @@ describe('Settings > Sidebar > General', () => {
         cy.get('#post_textbox').clear().type(`@${newFirstName.substring(0, 11)}`);
 
         // * Verify that the testUser is selected from mention autocomplete
-        cy.uiVerifyAtMentionInSuggestionList('Channel Members', {...testUser, first_name: newFirstName}, true);
+        cy.uiVerifyAtMentionInSuggestionList({...testUser, first_name: newFirstName}, true);
 
         // # Press tab on text input
         cy.get('#post_textbox').tab();

--- a/e2e/cypress/support/ui/suggestion_list.d.ts
+++ b/e2e/cypress/support/ui/suggestion_list.d.ts
@@ -19,14 +19,14 @@ declare namespace Cypress {
 
         /**
          * Verify user's at-mention in the suggestion list
-         * @param {UserProfile} sectionDividerName - name of the section in suggestion list, ex. "Channel Members"
          * @param {UserProfile} user - user object
          * @param {boolean} isSelected - check if user is selected with false as default
+         * @param {string} sectionDividerName - name of the section in suggestion list, ex. "Channel Members"
          *
          * @example
-         *   cy.uiVerifyAtMentionInSuggestionList('Channel Members', user, true);
+         *   cy.uiVerifyAtMentionInSuggestionList(user, true, 'Channel Members');
          */
-        uiVerifyAtMentionInSuggestionList(sectionDividerName: string, user: UserProfile, isSelected: boolean): Chainable;
+        uiVerifyAtMentionInSuggestionList(user: UserProfile, isSelected: boolean, sectionDividerName: string): Chainable;
 
         /**
          * Verify user's at-mention suggestion

--- a/e2e/cypress/support/ui/suggestion_list.js
+++ b/e2e/cypress/support/ui/suggestion_list.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-Cypress.Commands.add('uiVerifyAtMentionInSuggestionList', (sectionDividerName, user, isSelected = false) => {
+Cypress.Commands.add('uiVerifyAtMentionInSuggestionList', (user, isSelected = false, sectionDividerName = null) => {
     // * Verify that the suggestion list is open and visible
     return cy.get('#suggestionList').should('be.visible').within(() => {
         if (sectionDividerName) {


### PR DESCRIPTION
#### Summary
- Since suggestion list section divider name has been recently removed from autocomplete, I'm disabling the check for that one for now. I'm going to keep the logic in the function in case we decide to put it back in.

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-11-16 at 11 38 23 AM](https://user-images.githubusercontent.com/487991/142055118-cc60a94d-73fb-40ea-80ba-964a07c34318.png)
![Screen Shot 2021-11-16 at 11 40 43 AM](https://user-images.githubusercontent.com/487991/142055123-c1dfa9f6-8e4a-4930-8c53-bcf0489550ad.png)
![Screen Shot 2021-11-16 at 11 42 06 AM](https://user-images.githubusercontent.com/487991/142055125-89c409ee-2114-4c72-b49e-778cf2ce9f61.png)
![Screen Shot 2021-11-16 at 12 17 10 PM](https://user-images.githubusercontent.com/487991/142059737-3f5cc988-9b82-4f76-a9f0-754835a34ef9.png)
![Screen Shot 2021-11-16 at 12 35 37 PM](https://user-images.githubusercontent.com/487991/142061910-591e066b-1fa7-42af-ad11-2a52b82cde65.png)

#### Release Note
```release-note
NONE
```