### PR TITLE
add missing i18 variable for unread threads

### DIFF
--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -210,18 +210,7 @@ const GlobalThreads = () => {
                             }, {numUnread})}
                             subtitle={formatMessage({
                                 id: 'globalThreads.threadPane.unreadMessageLink',
-                                defaultMessage: `
-                                    You have
-                                    {numUnread, plural,
-                                        =0 {no unread threads}
-                                        =1 {<link>{numUnread} thread</link>}
-                                        other {<link>{numUnread} threads</link>}
-                                    }
-                                    {numUnread, plural,
-                                        =0 {}
-                                        other {with unread messages}
-                                    }
-                                `,
+                                defaultMessage: 'You have {numUnread, plural, =0 {no unread threads} =1 {<link>{numUnread} thread</link>} other {<link>{numUnread} threads</link>}} {numUnread, plural, =0 {} other {with unread messages}}',
                             }, {
                                 numUnread,
                                 link: (chunks) => (

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3207,6 +3207,7 @@
   "globalThreads.sidebarLink": "Threads",
   "globalThreads.subtitle": "Threads you’re participating in will automatically show here",
   "globalThreads.threadList.noUnreadThreads": "No unread threads",
+  "globalThreads.threadPane.unreadMessageLink": "You have {numUnread, plural, =0 {no unread threads} =1 {<link>{numUnread} thread</link>} other {<link>{numUnread} threads</link>}} {numUnread, plural, =0 {} other {with unread messages}}",
   "globalThreads.threadPane.unselectedTitle": "{numUnread, plural, =0 {Looks like you’re all caught up} other {Catch up on your threads}}",
   "globalThreads.title": "{prefix}Threads - {displayName} {siteName}",
   "group_list_modal.addGroupButton": "Add Groups",


### PR DESCRIPTION
#### Summary
Missing i18 variable for unread threads.
Note: we need to add translations for the new key added for missing text.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-38673

#### Related Pull Requests
``None``

#### Screenshots
<img width="526" alt="Screenshot 2021-11-17 at 1 44 30 PM" src="https://user-images.githubusercontent.com/16203333/142161397-4543d1ea-c986-4b10-98ad-05fae1e4e5fb.png">

#### Release Note
```release-note
* Added missing i18 variable for unread threads
```
