### PR TITLE
Command Shift F search in global threads without prefilled term

### DIFF
--- a/components/search/search.tsx
+++ b/components/search/search.tsx
@@ -5,6 +5,9 @@ import React, {ChangeEvent, MouseEvent, FormEvent, useEffect, useState, useRef} 
 import {useIntl} from 'react-intl';
 import classNames from 'classnames';
 
+import {useSelector} from 'react-redux';
+
+import {getCurrentChannelNameForSearchShortcut} from 'mattermost-redux/selectors/entities/channels';
 import {isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
 import {isDesktopApp, getDesktopVersion, isMacApp} from 'utils/user_agent';
 import Constants, {searchHintOptions, RHSStates, searchFilesHintOptions} from 'utils/constants';
@@ -71,6 +74,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
     const {actions, searchTerms, searchType, currentChannel, hideSearchBar, enableFindShortcut} = props;
 
     const intl = useIntl();
+    const currentChannelName = useSelector(getCurrentChannelNameForSearchShortcut);
 
     // generate intial component state and setters
     const [focused, setFocused] = useState<boolean>(false);
@@ -110,7 +114,9 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
                     actions.openRHSSearch();
                     setKeepInputFocused(true);
                 }
-                actions.updateSearchTermsForShortcut();
+                if (currentChannelName) {
+                    actions.updateSearchTermsForShortcut();
+                }
                 handleFocus();
             }
         };
@@ -119,7 +125,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
         return () => {
             document.removeEventListener('keydown', handleKeyDown);
         };
-    }, [hideSearchBar]);
+    }, [hideSearchBar, currentChannelName]);
 
     useEffect((): void => {
         if (!Utils.isMobile()) {


### PR DESCRIPTION
#### Summary
Command Shift F search in global threads without prefilled term

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-36641

#### Related Pull Requests
``None``

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="815" alt="Screenshot 2021-11-22 at 3 17 53 PM" src="https://user-images.githubusercontent.com/16203333/142839304-9727d0fe-2d5a-4384-b508-f33e591ffa91.png"> | <img width="816" alt="Screenshot 2021-11-22 at 3 19 03 PM" src="https://user-images.githubusercontent.com/16203333/142839491-0ba5a8ff-f7eb-40cc-9d42-ebe3f4752e72.png"> |

#### Release Note

```release-note
* On Cmd/Ctrl + Shift + F in global threads will not add a search term automatically
```
