### PR TITLE
Removing remaining jquery imports

### DIFF
--- a/components/activity_log_modal/activity_log_modal.tsx
+++ b/components/activity_log_modal/activity_log_modal.tsx
@@ -65,7 +65,7 @@ export default class ActivityLogModal extends React.PureComponent<Props, State> 
 
     submitRevoke = (altId: string, e: React.MouseEvent) => {
         e.preventDefault();
-        const modalContent = (e.target as Element).closest('.modal-content');
+        const modalContent = (e.target as Element)?.closest('.modal-content');
         modalContent?.classList.add('animation--highlight');
         setTimeout(() => {
             modalContent?.classList.remove('animation--highlight');

--- a/components/activity_log_modal/activity_log_modal.tsx
+++ b/components/activity_log_modal/activity_log_modal.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
@@ -66,10 +65,10 @@ export default class ActivityLogModal extends React.PureComponent<Props, State> 
 
     submitRevoke = (altId: string, e: React.MouseEvent) => {
         e.preventDefault();
-        const modalContent = $(e.target).closest('.modal-content'); // eslint-disable-line jquery/no-closest
-        modalContent.addClass('animation--highlight');
+        const modalContent = (e.target as Element).closest('.modal-content'); // eslint-disable-line jquery/no-closest
+        modalContent?.classList.add('animation--highlight');
         setTimeout(() => {
-            modalContent.removeClass('animation--highlight');
+            modalContent?.classList.remove('animation--highlight');
         }, 1500);
         this.props.actions.revokeSession(this.props.currentUserId, altId).then(() => {
             this.props.actions.getSessions(this.props.currentUserId);

--- a/components/activity_log_modal/activity_log_modal.tsx
+++ b/components/activity_log_modal/activity_log_modal.tsx
@@ -65,7 +65,7 @@ export default class ActivityLogModal extends React.PureComponent<Props, State> 
 
     submitRevoke = (altId: string, e: React.MouseEvent) => {
         e.preventDefault();
-        const modalContent = (e.target as Element).closest('.modal-content'); // eslint-disable-line jquery/no-closest
+        const modalContent = (e.target as Element).closest('.modal-content');
         modalContent?.classList.add('animation--highlight');
         setTimeout(() => {
             modalContent?.classList.remove('animation--highlight');

--- a/components/admin_console/brand_image_setting/brand_image_setting.tsx
+++ b/components/admin_console/brand_image_setting/brand_image_setting.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Tooltip} from 'react-bootstrap';
@@ -102,7 +101,7 @@ export default class BrandImageSetting extends React.PureComponent<Props, State>
               e.target?.result;
 
                 if (src) {
-                    $(img).attr('src', src); // eslint-disable-line jquery/no-attr
+                    img.setAttribute('src', src);
                 }
             };
 
@@ -116,11 +115,11 @@ export default class BrandImageSetting extends React.PureComponent<Props, State>
         if (!this.fileInputRef.current) {
             return;
         }
-        const element = $(this.fileInputRef.current) as any;
-        if (element.prop('files').length > 0) {
+        const element = this.fileInputRef.current;
+        if (element.files && element.files.length > 0) {
             this.props.setSaveNeeded();
             this.setState({
-                brandImage: element.prop('files')[0],
+                brandImage: element.files[0],
                 deleteBrandImage: false,
             });
         }

--- a/components/admin_console/file_upload_setting.jsx
+++ b/components/admin_console/file_upload_setting.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
@@ -30,9 +29,9 @@ export default class FileUploadSetting extends Setting {
         this.state = {
             fileName: null,
             serverError: props.error,
+            uploading: false,
         };
         this.fileInputRef = React.createRef();
-        this.uploadButtonRef = React.createRef();
     }
 
     handleChange = () => {
@@ -45,9 +44,9 @@ export default class FileUploadSetting extends Setting {
     handleSubmit = (e) => {
         e.preventDefault();
 
-        $(this.uploadButtonRef.current).button('loading');
+        this.setState({uploading: true});
         this.props.onSubmit(this.props.id, this.fileInputRef.current.files[0], (error) => {
-            $(this.uploadButtonRef.current).button('reset');
+            this.setState({uploading: false});
             if (error) {
                 Utils.clearFileInput(this.fileInputRef.current);
             }
@@ -108,13 +107,17 @@ export default class FileUploadSetting extends Setting {
                         className={btnClass}
                         disabled={!this.state.fileSelected}
                         onClick={this.handleSubmit}
-                        ref={this.uploadButtonRef}
-                        data-loading-text={`<span class='glyphicon glyphicon-refresh glyphicon-refresh-animate'></span> ${this.props.uploadingText}`}
                     >
-                        <FormattedMessage
-                            id='admin.file_upload.uploadFile'
-                            defaultMessage='Upload'
-                        />
+                        {this.state.uploading && (
+                            <>
+                                <span className='glyphicon glyphicon-refresh glyphicon-refresh-animate'/>
+                                {this.props.uploadingText}
+                            </>)}
+                        {!this.state.uploading &&
+                            <FormattedMessage
+                                id='admin.file_upload.uploadFile'
+                                defaultMessage='Upload'
+                            />}
                     </button>
                     <div className='help-text m-0'>
                         {fileName}

--- a/components/admin_console/remove_file_setting.jsx
+++ b/components/admin_console/remove_file_setting.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -24,15 +23,17 @@ export default class RemoveFileSetting extends Setting {
     constructor(props) {
         super(props);
 
-        this.removeButtonRef = React.createRef();
+        this.state = {
+            removing: false,
+        };
     }
 
     handleRemove = (e) => {
         e.preventDefault();
 
-        $(this.removeButtonRef.current).button('loading');
+        this.setState({removing: true});
         this.props.onSubmit(this.props.id, () => {
-            $(this.removeButtonRef.current).button('reset');
+            this.setState({removing: false});
         });
     }
 
@@ -53,9 +54,13 @@ export default class RemoveFileSetting extends Setting {
                         onClick={this.handleRemove}
                         ref={this.removeButtonRef}
                         disabled={this.props.disabled}
-                        data-loading-text={`<span class='glyphicon glyphicon-refresh glyphicon-refresh-animate'></span> ${this.props.removingText}`}
                     >
-                        {this.props.removeButtonText}
+                        {this.state.removing && (
+                            <>
+                                <span className='glyphicon glyphicon-refresh glyphicon-refresh-animate'/>
+                                {this.props.removingText}
+                            </>)}
+                        {!this.state.removing && this.props.removeButtonText}
                     </button>
                 </div>
             </Setting>

--- a/components/audio_video_preview.jsx
+++ b/components/audio_video_preview.jsx
@@ -1,10 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import Constants from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
@@ -39,7 +37,7 @@ export default class AudioVideoPreview extends React.PureComponent {
         this.handleFileInfoChanged(this.props.fileInfo);
 
         if (this.sourceRef.current) {
-            $(ReactDOM.findDOMNode(this.sourceRef.current)).one('error', this.handleLoadError);
+            this.sourceRef.current.addEventListener('error', this.handleLoadeError, {once: true});
         }
     }
 
@@ -49,12 +47,12 @@ export default class AudioVideoPreview extends React.PureComponent {
         }
 
         if (this.sourceRef.current) {
-            $(ReactDOM.findDOMNode(this.sourceRef.current)).one('error', this.handleLoadError);
+            this.sourceRef.current.addEventListener('error', this.handleLoadeError, {once: true});
         }
     }
 
     handleFileInfoChanged = (fileInfo) => {
-        let video = ReactDOM.findDOMNode(this.videoRef.current);
+        let video = this.videoRef.current;
         if (!video) {
             video = document.createElement('video');
         }
@@ -74,7 +72,7 @@ export default class AudioVideoPreview extends React.PureComponent {
 
     stop = () => {
         if (this.videoRef.current) {
-            const video = ReactDOM.findDOMNode(this.videoRef.current);
+            const video = this.videoRef.current;
             video.pause();
             video.currentTime = 0;
         }

--- a/components/audio_video_preview.jsx
+++ b/components/audio_video_preview.jsx
@@ -37,7 +37,7 @@ export default class AudioVideoPreview extends React.PureComponent {
         this.handleFileInfoChanged(this.props.fileInfo);
 
         if (this.sourceRef.current) {
-            this.sourceRef.current.addEventListener('error', this.handleLoadeError, {once: true});
+            this.sourceRef.current.addEventListener('error', this.handleLoadError, {once: true});
         }
     }
 
@@ -47,7 +47,7 @@ export default class AudioVideoPreview extends React.PureComponent {
         }
 
         if (this.sourceRef.current) {
-            this.sourceRef.current.addEventListener('error', this.handleLoadeError, {once: true});
+            this.sourceRef.current.addEventListener('error', this.handleLoadError, {once: true});
         }
     }
 

--- a/components/code_preview.jsx
+++ b/components/code_preview.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -57,18 +56,16 @@ export default class CodePreview extends React.PureComponent {
         }
     }
 
-    getCode = () => {
+    getCode = async () => {
         if (!this.state.lang || this.props.fileInfo.size > Constants.CODE_PREVIEW_MAX_FILE_SIZE) {
             return;
         }
-        $.ajax({ // eslint-disable-line jquery/no-ajax
-            async: true,
-            url: this.props.fileUrl,
-            type: 'GET',
-            dataType: 'text',
-            error: this.handleReceivedError,
-            success: this.handleReceivedCode,
-        });
+        try {
+            const data = await fetch(this.props.fileUrl, {dataType: 'text'});
+            this.handleReceivedCode(data);
+        } catch (e) {
+            this.handleReceivedError();
+        }
     }
 
     handleReceivedCode = (data) => {

--- a/components/post_view/scroll_to_bottom_arrows.jsx
+++ b/components/post_view/scroll_to_bottom_arrows.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -16,7 +15,7 @@ export default class ScrollToBottomArrows extends React.PureComponent {
 
     render() {
         // only show on mobile
-        if ($(window).width() > 768) {
+        if (window.innerWidth > 768) {
             return null;
         }
 

--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -2,10 +2,8 @@
 // See LICENSE.txt for license information.
 /* eslint-disable react/no-string-refs */
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
 import LoadingScreen from 'components/loading_screen';
@@ -130,13 +128,13 @@ export default class SearchableChannelList extends React.PureComponent {
         this.setState({page: this.state.page + 1, nextDisabled: true});
         this.nextTimeoutId = setTimeout(() => this.setState({nextDisabled: false}), NEXT_BUTTON_TIMEOUT_MILLISECONDS);
         this.props.nextPage(this.state.page + 1);
-        $(ReactDOM.findDOMNode(this.channelListScroll.current)).scrollTop(0);
+        this.channelListScroll.current?.scrollTo(0);
     }
 
     previousPage = (e) => {
         e.preventDefault();
         this.setState({page: this.state.page - 1});
-        $(ReactDOM.findDOMNode(this.channelListScroll.current)).scrollTop(0);
+        this.channelListScroll.current?.scrollTo(0);
     }
 
     doSearch = () => {

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -2,10 +2,8 @@
 // See LICENSE.txt for license information.
 /* eslint-disable react/no-string-refs */
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {FormattedMessage, injectIntl} from 'react-intl';
 
 import QuickInput from 'components/quick_input';
@@ -84,14 +82,14 @@ class SearchableUserList extends React.PureComponent {
         this.nextTimeoutId = setTimeout(() => this.setState({nextDisabled: false}), NEXT_BUTTON_TIMEOUT);
 
         this.props.nextPage();
-        $(ReactDOM.findDOMNode(this.refs.channelListScroll)).scrollTop(0);
+        this.refs.userList.scrollToTop();
     }
 
     previousPage = (e) => {
         e.preventDefault();
 
         this.props.previousPage();
-        $(ReactDOM.findDOMNode(this.refs.channelListScroll)).scrollTop(0);
+        this.refs.userList.scrollToTop();
     }
 
     focusSearchBar = () => {

--- a/components/settings_sidebar.tsx
+++ b/components/settings_sidebar.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import React from 'react';
 
 import * as UserAgent from 'utils/user_agent';
@@ -23,12 +22,12 @@ export default class SettingsSidebar extends React.PureComponent<Props> {
     public handleClick = (tab: Tab, e: React.MouseEvent) => {
         e.preventDefault();
         this.props.updateTab(tab.name);
-        $(e.target).closest('.settings-modal').addClass('display--content'); // eslint-disable-line jquery/no-closest, jquery/no-class
+        (e.target as Element).closest('.settings-modal')?.classList.add('display--content');
     }
 
     public componentDidMount() {
         if (UserAgent.isFirefox()) {
-            $('.settings-modal .settings-table .nav').addClass('position--top'); // eslint-disable-line jquery/no-closest, jquery/no-class
+            document.querySelector('.settings-modal .settings-table .nav')?.classList.add('position--top');
         }
     }
 

--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 /* eslint-disable react/no-string-refs */
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage, FormattedDate} from 'react-intl';
@@ -289,11 +288,11 @@ export default class GeneralTab extends React.PureComponent {
     }
 
     componentDidMount() {
-        $('#team_settings').on('hidden.bs.modal', this.handleClose);
+        document.getElementById('team_settings').addEventListener('hidden.bs.modal', this.handleClose);
     }
 
     componentWillUnmount() {
-        $('#team_settings').off('hidden.bs.modal', this.handleClose);
+        document.getElementById('team_settings').addEventListener('hidden.bs.modal', this.handleClose);
     }
 
     handleUpdateSection = (section) => {

--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -288,11 +288,11 @@ export default class GeneralTab extends React.PureComponent {
     }
 
     componentDidMount() {
-        document.getElementById('team_settings').addEventListener('hidden.bs.modal', this.handleClose);
+        document.getElementById('team_settings')?.addEventListener('hidden.bs.modal', this.handleClose);
     }
 
     componentWillUnmount() {
-        document.getElementById('team_settings').addEventListener('hidden.bs.modal', this.handleClose);
+        document.getElementById('team_settings')?.removeEventListener('hidden.bs.modal', this.handleClose);
     }
 
     handleUpdateSection = (section) => {

--- a/components/team_settings_modal/team_settings_modal.tsx
+++ b/components/team_settings_modal/team_settings_modal.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Modal} from 'react-bootstrap';
@@ -51,7 +50,8 @@ export default class TeamSettingsModal extends React.PureComponent<Props, State>
 
     collapseModal = () => {
         const el = ReactDOM.findDOMNode(this.modalBodyRef.current) as HTMLDivElement;
-        $(el).closest('.modal-dialog').removeClass('display--content'); // eslint-disable-line jquery/no-closest, jquery/no-class
+        const modalDialog = el.closest('.modal-dialog');
+        modalDialog?.classList.remove('display--content');
 
         this.setState({
             activeTab: '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,7 +187,6 @@
         "jest-cli": "27.0.6",
         "jest-junit": "12.2.0",
         "jest-watch-typeahead": "0.6.4",
-        "jquery-deferred": "0.3.1",
         "mini-css-extract-plugin": "2.0.0",
         "mmjstool": "github:mattermost/mattermost-utilities#40d7640e85385248773504548ef962037ac842ea",
         "nock": "13.1.0",
@@ -27066,15 +27065,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
-    "node_modules/jquery-deferred": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/jquery-deferred/-/jquery-deferred-0.3.1.tgz",
-      "integrity": "sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -61678,12 +61668,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
-    "jquery-deferred": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/jquery-deferred/-/jquery-deferred-0.3.1.tgz",
-      "integrity": "sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=",
-      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "jest-cli": "27.0.6",
     "jest-junit": "12.2.0",
     "jest-watch-typeahead": "0.6.4",
-    "jquery-deferred": "0.3.1",
     "mini-css-extract-plugin": "2.0.0",
     "mmjstool": "github:mattermost/mattermost-utilities#40d7640e85385248773504548ef962037ac842ea",
     "nock": "13.1.0",

--- a/tests/helpers/client-test-helper.jsx
+++ b/tests/helpers/client-test-helper.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import jqd from 'jquery-deferred';
-
 import {Client4} from 'mattermost-redux/client';
 
 import WebSocketClient from 'client/websocket_client';
@@ -136,7 +134,7 @@ class TestHelperClass {
             done.fail(new Error(err.message));
         }
 
-        var d1 = jqd.Deferred();
+        var d1 = new Promise();
         var email = this.fakeEmail();
         var user = this.fakeUser();
         var team = this.fakeTeam();
@@ -192,7 +190,7 @@ class TestHelperClass {
             throwerror,
         );
 
-        jqd.when(d1).done(() => {
+        d1.then(() => {
             callback();
         });
     }


### PR DESCRIPTION
This leave the jquery dependency in the package.json because it is required by
bootstrap. We need to eventually remove bootstrap to be able to definitively
get rid of jquery.

#### Summary
Removing remaining jquery imports

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27444
https://mattermost.atlassian.net/browse/MM-27445
https://mattermost.atlassian.net/browse/MM-29031
https://mattermost.atlassian.net/browse/MM-29032

#### Release Note
```release-note
NONE
```