### PR TITLE
[MM-39745] Disable channel header buttons temporarily when the RHS closes

### DIFF
--- a/plugins/channel_header_plug/__snapshots__/channel_header_plug.test.tsx.snap
+++ b/plugins/channel_header_plug/__snapshots__/channel_header_plug.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with no extended compon
       "timeZone": "Etc/UTC",
     }
   }
+  sidebarOpen={false}
   theme={Object {}}
 />
 `;
@@ -115,6 +116,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with one extended compo
       "timeZone": "Etc/UTC",
     }
   }
+  sidebarOpen={false}
   theme={Object {}}
 >
   <HeaderIconWrapper
@@ -431,6 +433,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with six extended compo
       "timeZone": "Etc/UTC",
     }
   }
+  sidebarOpen={false}
   theme={Object {}}
 >
   <HeaderIconWrapper

--- a/plugins/channel_header_plug/channel_header_plug.test.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.test.tsx
@@ -27,6 +27,7 @@ describe('plugins/ChannelHeaderPlug', () => {
                 channel={{} as Channel}
                 channelMember={{} as ChannelMembership}
                 theme={{} as Theme}
+                sidebarOpen={false}
                 actions={{
                     doAppCall: jest.fn(),
                     postEphemeralCallResponseForChannel: jest.fn(),
@@ -46,6 +47,7 @@ describe('plugins/ChannelHeaderPlug', () => {
                 channel={{} as Channel}
                 channelMember={{} as ChannelMembership}
                 theme={{} as Theme}
+                sidebarOpen={false}
                 actions={{
                     doAppCall: jest.fn(),
                     postEphemeralCallResponseForChannel: jest.fn(),
@@ -81,6 +83,7 @@ describe('plugins/ChannelHeaderPlug', () => {
                 channel={{} as Channel}
                 channelMember={{} as ChannelMembership}
                 theme={{} as Theme}
+                sidebarOpen={false}
                 actions={{
                     doAppCall: jest.fn(),
                     postEphemeralCallResponseForChannel: jest.fn(),

--- a/plugins/channel_header_plug/channel_header_plug.test.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.test.tsx
@@ -27,7 +27,6 @@ describe('plugins/ChannelHeaderPlug', () => {
                 channel={{} as Channel}
                 channelMember={{} as ChannelMembership}
                 theme={{} as Theme}
-                sidebarOpen={false}
                 actions={{
                     doAppCall: jest.fn(),
                     postEphemeralCallResponseForChannel: jest.fn(),
@@ -47,7 +46,6 @@ describe('plugins/ChannelHeaderPlug', () => {
                 channel={{} as Channel}
                 channelMember={{} as ChannelMembership}
                 theme={{} as Theme}
-                sidebarOpen={false}
                 actions={{
                     doAppCall: jest.fn(),
                     postEphemeralCallResponseForChannel: jest.fn(),
@@ -83,7 +81,6 @@ describe('plugins/ChannelHeaderPlug', () => {
                 channel={{} as Channel}
                 channelMember={{} as ChannelMembership}
                 theme={{} as Theme}
-                sidebarOpen={false}
                 actions={{
                     doAppCall: jest.fn(),
                     postEphemeralCallResponseForChannel: jest.fn(),

--- a/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.tsx
@@ -112,7 +112,6 @@ type ChannelHeaderPlugProps = {
 
 type ChannelHeaderPlugState = {
     dropdownOpen: boolean;
-    disableButtonsClosingRHS: boolean;
 }
 
 const CHANNEL_HEADER_PLUG_DISABLE_TIMEOUT = 500;
@@ -123,22 +122,21 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
         appBindings: [],
     }
 
+    private disableButtonsClosingRHS = false;
+
     constructor(props: ChannelHeaderPlugProps) {
         super(props);
         this.state = {
             dropdownOpen: false,
-            disableButtonsClosingRHS: false,
         };
     }
 
     componentDidUpdate(prevProps: ChannelHeaderPlugProps) {
         if (prevProps.sidebarOpen && !this.props.sidebarOpen) {
-            // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({disableButtonsClosingRHS: true});
+            this.disableButtonsClosingRHS = true;
 
             setTimeout(() => {
-                // eslint-disable-next-line react/no-did-update-set-state
-                this.setState({disableButtonsClosingRHS: false});
+                this.disableButtonsClosingRHS = false;
             }, CHANNEL_HEADER_PLUG_DISABLE_TIMEOUT);
         }
     }
@@ -152,7 +150,7 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
     }
 
     fireAction = (action: (channel: Channel, channelMember: ChannelMembership) => void) => {
-        if (this.state.disableButtonsClosingRHS) {
+        if (this.disableButtonsClosingRHS) {
             return;
         }
 
@@ -160,10 +158,6 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
     }
 
     fireActionAndClose = (action: (channel: Channel, channelMember: ChannelMembership) => void) => {
-        if (this.state.disableButtonsClosingRHS) {
-            return;
-        }
-
         action(this.props.channel, this.props.channelMember);
         this.onClose();
     }
@@ -183,7 +177,7 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
     }
 
     onBindingClick = async (binding: AppBinding) => {
-        if (this.state.disableButtonsClosingRHS) {
+        if (this.disableButtonsClosingRHS) {
             return;
         }
 

--- a/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.tsx
@@ -102,6 +102,7 @@ type ChannelHeaderPlugProps = {
     channel: Channel;
     channelMember: ChannelMembership;
     theme: Theme;
+    sidebarOpen: boolean;
     actions: {
         doAppCall: DoAppCall;
         postEphemeralCallResponseForChannel: PostEphemeralCallResponseForChannel;

--- a/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.tsx
@@ -102,7 +102,6 @@ type ChannelHeaderPlugProps = {
     channel: Channel;
     channelMember: ChannelMembership;
     theme: Theme;
-    sidebarOpen: boolean;
     actions: {
         doAppCall: DoAppCall;
         postEphemeralCallResponseForChannel: PostEphemeralCallResponseForChannel;

--- a/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.tsx
@@ -133,9 +133,11 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
 
     componentDidUpdate(prevProps: ChannelHeaderPlugProps) {
         if (prevProps.sidebarOpen && !this.props.sidebarOpen) {
+            // eslint-disable-next-line react/no-did-update-set-state
             this.setState({disableButtonsClosingRHS: true});
 
             setTimeout(() => {
+                // eslint-disable-next-line react/no-did-update-set-state
                 this.setState({disableButtonsClosingRHS: false});
             }, CHANNEL_HEADER_PLUG_DISABLE_TIMEOUT);
         }

--- a/plugins/channel_header_plug/index.ts
+++ b/plugins/channel_header_plug/index.ts
@@ -27,6 +27,7 @@ function mapStateToProps(state: GlobalState) {
         appBindings: getChannelHeaderBindings(state),
         appsEnabled: apps,
         theme: getTheme(state),
+        sidebarOpen: state.views.rhs.isSidebarOpen,
     };
 }
 


### PR DESCRIPTION
#### Summary

With the current channel header icon placement in relation to the RHS, users have been accidentally starting zoom meetings because the zoom icon is placed at the same spot as the close-x of the RHS thread view. If the user clicks to close the RHS twice, the zoom button gets clicked.

The channel header icons will be moved to the App Bar in the near future, which will make it so this is no longer a problem, but this PR is a solution to avoid this issue in the meantime. This PR makes it so when user closes the RHS, the channel header icons are disabled for a short period of time, to avoid the double-click issue.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39745