### PR TITLE
Cypress/E2E: Fix flaky tests on MFA

### DIFF
--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_spec.js
@@ -75,28 +75,11 @@ describe('Guest Accounts', () => {
         cy.findByTestId('ServiceSettings.EnforceMultifactorAuthenticationtrue').check();
 
         // # Click "Save".
-        cy.get('#saveSetting').scrollIntoView().click();
+        cy.findByText('Save').click().wait(TIMEOUTS.ONE_SEC);
 
-        cy.url().then((url) => {
-            if (url.includes('mfa/setup')) {
-                // # Complete MFA setup if we are on token setup page /mfa/setup
-                cy.get('#mfa').wait(TIMEOUTS.HALF_SEC).find('.col-sm-12').then((p) => {
-                    const secretp = p.text();
-                    adminMFASecret = secretp.split(' ')[1];
-
-                    const token = authenticator.generateToken(adminMFASecret);
-                    cy.get('#mfa').find('.form-control').type(token);
-                    cy.get('#mfa').find('.btn.btn-primary').click();
-
-                    cy.wait(TIMEOUTS.HALF_SEC);
-                    cy.get('#mfa').find('.btn.btn-primary').click();
-                });
-            } else {
-                // # If the sysadmin already has MFA enabled, reset the secret.
-                cy.apiGenerateMfaSecret(sysadmin.id).then((res) => {
-                    adminMFASecret = res.code.secret;
-                });
-            }
+        // # Get MFA secret
+        cy.uiGetMFASecret(sysadmin.id).then((secret) => {
+            adminMFASecret = secret;
         });
 
         // # Navigate to Guest Access page.

--- a/e2e/cypress/integration/signin_authentication/mfa_authentication_spec.js
+++ b/e2e/cypress/integration/signin_authentication/mfa_authentication_spec.js
@@ -60,7 +60,8 @@ describe('Authentication', () => {
         cy.get('#mfaEdit').should('be.visible').click();
         cy.findByText('Add MFA to Account').should('be.visible').click();
 
-        getUserSecret(testUser).then(({secret}) => {
+        // # Get MFA secret
+        cy.uiGetMFASecret(testUser.id).then((secret) => {
             // # Logout
             cy.apiLogout();
 
@@ -120,31 +121,6 @@ describe('Authentication', () => {
         });
     });
 });
-
-function getUserSecret(user) {
-    return cy.url().then((url) => {
-        if (url.includes('mfa/setup')) {
-            return cy.get('#mfa').wait(timeouts.HALF_SEC).find('.col-sm-12').then((p) => {
-                const secretp = p.text();
-                const secret = secretp.split(' ')[1];
-
-                const token = authenticator.generateToken(secret);
-                cy.get('#mfa').find('.form-control').type(token);
-                cy.get('#mfa').find('.btn.btn-primary').click();
-
-                cy.wait(timeouts.HALF_SEC);
-                cy.get('#mfa').find('.btn.btn-primary').click();
-                return cy.wrap({secret});
-            });
-        }
-
-        // # If the user already has MFA enabled, reset the secret.
-        return cy.apiGenerateMfaSecret(user.id).then((res) => {
-            const secret = res.code.secret;
-            return cy.wrap({secret});
-        });
-    });
-}
 
 function fillMFACode(code) {
     cy.wait(timeouts.TWO_SEC);

--- a/e2e/cypress/support/ui/index.js
+++ b/e2e/cypress/support/ui/index.js
@@ -16,6 +16,7 @@ import './emoji';
 import './file_preview';
 import './login';
 import './menu';
+import './mfa';
 import './modal';
 import './post';
 import './post_dropdown_menu';

--- a/e2e/cypress/support/ui/mfa.d.ts
+++ b/e2e/cypress/support/ui/mfa.d.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `ui` prefix, e.g. `uiGetMFASecret`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable {
+
+        /**
+         * Get MFA secret of a given user
+         * @param {string} userId - ID of user
+         *
+         * @returns {string} `secret` - MFA secret
+         *
+         * @example
+         *   const headerLabel = 'What\'s New';
+         *   cy.uiGetMFASecret('user-id').then((secret) => {
+         *       // do something with the secret
+         *   });
+         */
+        uiGetMFASecret(userId: string): Chainable<string>;
+    }
+}

--- a/e2e/cypress/support/ui/mfa.js
+++ b/e2e/cypress/support/ui/mfa.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import authenticator from 'authenticator';
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+Cypress.Commands.add('uiGetMFASecret', (userId) => {
+    return cy.url().then((url) => {
+        if (url.includes('mfa/setup')) {
+            // # Complete MFA setup if we are on token setup page /mfa/setup
+            return cy.get('#mfa').wait(TIMEOUTS.HALF_SEC).find('.col-sm-12').then((p) => {
+                const secretp = p.text();
+                const secret = secretp.split(' ')[1];
+
+                const token = authenticator.generateToken(secret);
+                cy.findByPlaceholderText('MFA Code').type(token);
+                cy.findByText('Save').click();
+
+                cy.wait(TIMEOUTS.HALF_SEC);
+                cy.findByText('Okay').click();
+
+                return cy.wrap(secret);
+            });
+        }
+
+        // # If the user already has MFA enabled, reset the secret.
+        return cy.apiGenerateMfaSecret(userId).then((res) => {
+            return cy.wrap(res.code.secret);
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
- Fixed flaky tests on MFA
- Moved common UI command as `cy.uiGetMFASecret`

#### Ticket Link
none, failed on daily Cypress run

#### Screenshots
<img width="394" alt="Screen Shot 2021-11-24 at 12 22 57 PM" src="https://user-images.githubusercontent.com/5334504/143179715-01212cbf-0a39-4fa1-a3e4-5388e55d208f.png">
<img width="392" alt="Screen Shot 2021-11-24 at 1 19 56 PM" src="https://user-images.githubusercontent.com/5334504/143179742-42a173d0-664c-41df-b3c9-bbcf8fa776f2.png">
<img width="392" alt="Screen Shot 2021-11-24 at 1 21 26 PM" src="https://user-images.githubusercontent.com/5334504/143179745-caf4b5ad-4be4-459b-a70d-a63fba985ed9.png">

#### Release Note
```release-note
NONE
```
