### PR TITLE
Cypress/E2E: Fix user profile focus and menu option aria-label

### DIFF
--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
     </MenuGroup>
     <MenuGroup>
       <MenuItemToggleModalRedux
-        ariaLabel="Profile}"
+        ariaLabel="Profile"
         dialogProps={
           Object {
             "isContentProductSettings": false,
@@ -440,7 +440,7 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
     </MenuGroup>
     <MenuGroup>
       <MenuItemToggleModalRedux
-        ariaLabel="Profile}"
+        ariaLabel="Profile"
         dialogProps={
           Object {
             "isContentProductSettings": false,
@@ -687,7 +687,7 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
     </MenuGroup>
     <MenuGroup>
       <MenuItemToggleModalRedux
-        ariaLabel="Profile}"
+        ariaLabel="Profile"
         dialogProps={
           Object {
             "isContentProductSettings": false,
@@ -934,7 +934,7 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
     </MenuGroup>
     <MenuGroup>
       <MenuItemToggleModalRedux
-        ariaLabel="Profile}"
+        ariaLabel="Profile"
         dialogProps={
           Object {
             "isContentProductSettings": false,
@@ -1182,7 +1182,7 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
     </MenuGroup>
     <MenuGroup>
       <MenuItemToggleModalRedux
-        ariaLabel="Profile}"
+        ariaLabel="Profile"
         dialogProps={
           Object {
             "isContentProductSettings": false,
@@ -1406,7 +1406,7 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
     </MenuGroup>
     <MenuGroup>
       <MenuItemToggleModalRedux
-        ariaLabel="Profile}"
+        ariaLabel="Profile"
         dialogProps={
           Object {
             "isContentProductSettings": false,
@@ -1626,7 +1626,7 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
     </MenuGroup>
     <MenuGroup>
       <MenuItemToggleModalRedux
-        ariaLabel="Profile}"
+        ariaLabel="Profile"
         dialogProps={
           Object {
             "isContentProductSettings": false,

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -482,7 +482,7 @@ export default class StatusDropdown extends React.PureComponent<Props, State> {
                     <Menu.Group>
                         <Menu.ItemToggleModalRedux
                             id='accountSettings'
-                            ariaLabel='Profile}'
+                            ariaLabel='Profile'
                             modalId={ModalIdentifiers.USER_SETTINGS}
                             dialogType={UserSettingsModal}
                             dialogProps={{isContentProductSettings: false}}

--- a/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
@@ -98,7 +98,7 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
         // * Verify the first option is not selected by default
         cy.uiGetLHSTeamMenu().find('.MenuItem').
             children().eq(0).
-            should('not.have.class', 'a11y--active a11y--focused').
+            should('not.be.focused').
             focus();
 
         // * Verify the accessibility support in the Main Menu Dropdown items
@@ -138,7 +138,7 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
 
         // * Verify the aria-label in status menu button
         cy.uiGetSetStatusButton().
-            should('have.class', 'a11y--active a11y--focused').
+            should('be.focused').
             click();
 
         // * Verify the accessibility support in the Status Dropdown
@@ -148,7 +148,15 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
             and('have.attr', 'role', 'menu');
 
         // * Verify the first option is not selected by default
-        cy.uiGetStatusMenuContainer().find('.dropdown-menu').children().eq(0).should('not.have.class', 'a11y--active a11y--focused');
+        cy.uiGetStatusMenuContainer().find('.dropdown-menu').children().eq(0).should('not.be.focused');
+
+        // # Press tab
+        cy.focused().tab();
+
+        // * Verify first focus is on menu header which is the profile image
+        cy.uiGetStatusMenuContainer().within(() => {
+            cy.findByAltText('user profile image').should('be.focused');
+        });
 
         // # Press tab
         cy.focused().tab();
@@ -160,6 +168,8 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
             {id: 'status-menu-away', label: 'away'},
             {id: 'status-menu-dnd_menuitem', label: 'do not disturb. disables all notifications'},
             {id: 'status-menu-offline', label: 'offline'},
+            {id: 'accountSettings', label: 'Profile dialog'},
+            {id: 'logout', label: 'Log Out'},
         ];
 
         menuItems.forEach((item) => {
@@ -167,7 +177,7 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
             cy.uiGetStatusMenuContainer().find(`#${item.id}`).
                 should('be.visible').
                 findAllByLabelText(item.label).first().
-                should('have.class', 'a11y--active a11y--focused');
+                should('be.focused');
 
             // # Press tab for next item
             cy.focused().tab();

--- a/e2e/cypress/integration/accessibility/accessibility_post_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_post_spec.js
@@ -104,7 +104,7 @@ describe('Verify Accessibility Support in Post', () => {
         // * Verify if focus changes to different posts when we use up arrows
         for (let index = 1; index < 5; index++) {
             cy.getNthPostId(-index - 1).then((postId) => {
-                cy.get(`#post_${postId}`).should('have.class', 'a11y--active a11y--focused');
+                cy.get(`#post_${postId}`).should('be.focused');
                 cy.get('body').type('{uparrow}');
             });
         }
@@ -112,7 +112,7 @@ describe('Verify Accessibility Support in Post', () => {
         // * Verify if focus changes to different posts when we use down arrows
         for (let index = 5; index > 0; index--) {
             cy.getNthPostId(-index - 1).then((postId) => {
-                cy.get(`#post_${postId}`).should('have.class', 'a11y--active a11y--focused');
+                cy.get(`#post_${postId}`).should('be.focused');
                 cy.get('body').type('{downarrow}');
             });
         }
@@ -144,7 +144,7 @@ describe('Verify Accessibility Support in Post', () => {
         // * Verify if focus changes to different posts when we use up arrows
         for (let index = 1; index < 5; index++) {
             cy.getNthPostId(-index - 1).then((postId) => {
-                cy.get(`#rhsPost_${postId}`).should('have.class', 'a11y--active a11y--focused');
+                cy.get(`#rhsPost_${postId}`).should('be.focused');
                 cy.get('body').type('{uparrow}');
             });
         }
@@ -152,7 +152,7 @@ describe('Verify Accessibility Support in Post', () => {
         // * Verify if focus changes to different posts when we use down arrows
         for (let index = 5; index > 1; index--) {
             cy.getNthPostId(-index - 1).then((postId) => {
-                cy.get(`#rhsPost_${postId}`).should('have.class', 'a11y--active a11y--focused');
+                cy.get(`#rhsPost_${postId}`).should('be.focused');
                 cy.get('body').type('{downarrow}');
             });
         }
@@ -168,18 +168,22 @@ describe('Verify Accessibility Support in Post', () => {
 
         cy.getLastPostId().then((postId) => {
             cy.get(`#post_${postId}`).within(() => {
+                // * Verify focus is on profile image
+                cy.findByAltText(`${otherUser.username} profile image`).should('be.focused');
+                cy.focused().tab();
+
                 // * Verify focus is on the username
-                cy.get('button.user-popover').should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', otherUser.username);
+                cy.get('button.user-popover').should('be.focused').and('have.attr', 'aria-label', otherUser.username);
                 cy.focused().tab();
 
                 // * Verify focus is on the time
-                cy.get(`#CENTER_time_${postId}`).should('have.class', 'a11y--active a11y--focused');
+                cy.get(`#CENTER_time_${postId}`).should('be.focused');
                 cy.focused().tab();
 
                 // eslint-disable-next-line no-negated-condition
                 if (!emojiPickerEnabled) {
                     // * Verify focus is on the actions button
-                    cy.get(`#CENTER_button_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'more actions');
+                    cy.get(`#CENTER_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'more actions');
                     cy.focused().tab();
                 } else {
                     for (let i = 0; i < 3; i++) {
@@ -190,25 +194,25 @@ describe('Verify Accessibility Support in Post', () => {
                 }
 
                 // * Verify focus is on the reactions button
-                cy.get(`#CENTER_reaction_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'add reaction');
+                cy.get(`#CENTER_reaction_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'add reaction');
                 cy.focused().tab();
 
                 // * Verify focus is on the save post button
-                cy.get(`#CENTER_flagIcon_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'save');
+                cy.get(`#CENTER_flagIcon_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'save');
                 cy.focused().tab();
 
                 // * Verify focus is on the comment button
-                cy.get(`#CENTER_commentIcon_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'reply');
+                cy.get(`#CENTER_commentIcon_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'reply');
                 cy.focused().tab();
 
                 if (emojiPickerEnabled) {
                     // * Verify focus is on the actions button
-                    cy.get(`#CENTER_button_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'more actions');
+                    cy.get(`#CENTER_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'more actions');
                     cy.focused().tab();
                 }
 
                 // * Verify focus is on the post text
-                cy.get(`#postMessageText_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-readonly', 'true');
+                cy.get(`#postMessageText_${postId}`).should('be.focused').and('have.attr', 'aria-readonly', 'true');
             });
         });
     });
@@ -238,27 +242,27 @@ describe('Verify Accessibility Support in Post', () => {
         cy.getLastPostId().then((postId) => {
             cy.get(`#rhsPost_${postId}`).within(() => {
                 // * Verify focus is on the post text
-                cy.get(`#rhsPostMessageText_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-readonly', 'true');
+                cy.get(`#rhsPostMessageText_${postId}`).should('be.focused').and('have.attr', 'aria-readonly', 'true');
                 cy.focused().tab({shift: true});
 
                 if (emojiPickerEnabled) {
                     // * Verify focus is on the actions button
-                    cy.get(`#RHS_COMMENT_button_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'more actions');
+                    cy.get(`#RHS_COMMENT_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'more actions');
                     cy.focused().tab({shift: true});
                 }
 
                 // * Verify focus is on the save icon
-                cy.get(`#RHS_COMMENT_flagIcon_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'save');
+                cy.get(`#RHS_COMMENT_flagIcon_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'save');
                 cy.focused().tab({shift: true});
 
                 // * Verify focus is on the reactions button
-                cy.get(`#RHS_COMMENT_reaction_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'add reaction');
+                cy.get(`#RHS_COMMENT_reaction_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'add reaction');
                 cy.focused().tab({shift: true});
 
                 // eslint-disable-next-line no-negated-condition
                 if (!emojiPickerEnabled) {
                     // * Verify focus is on the actions button
-                    cy.get(`#RHS_COMMENT_button_${postId}`).should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'more actions');
+                    cy.get(`#RHS_COMMENT_button_${postId}`).should('be.focused').and('have.attr', 'aria-label', 'more actions');
                     cy.focused().tab({shift: true});
                 } else {
                     cy.get('#recent_reaction_0').should('have.class', 'emoticon--post-menu');
@@ -266,11 +270,11 @@ describe('Verify Accessibility Support in Post', () => {
                 }
 
                 // * Verify focus is on the time
-                cy.get(`#RHS_COMMENT_time_${postId}`).should('have.class', 'a11y--active a11y--focused');
+                cy.get(`#RHS_COMMENT_time_${postId}`).should('be.focused');
                 cy.focused().tab({shift: true});
 
                 // * Verify focus is on the username
-                cy.get('button.user-popover').should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', otherUser.username);
+                cy.get('button.user-popover').should('be.focused').and('have.attr', 'aria-label', otherUser.username);
                 cy.focused().tab({shift: true});
             });
         });
@@ -347,7 +351,7 @@ function performActionsToLastPost() {
 
 function verifyPostLabel(elementId, username, labelSuffix) {
     // # Shift focus to the last post
-    cy.get(elementId).as('lastPost').should('have.class', 'a11y--active a11y--focused');
+    cy.get(elementId).as('lastPost').should('be.focused');
 
     // * Verify reader reads out the post correctly
     cy.get('@lastPost').then((el) => {

--- a/e2e/cypress/integration/enterprise/accessibility/accessibility_modals_dialogs_spec.js
+++ b/e2e/cypress/integration/enterprise/accessibility/accessibility_modals_dialogs_spec.js
@@ -22,7 +22,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
         // * Check if server has license for Guest Accounts
         cy.apiRequireLicenseForFeature('GuestAccounts');
 
-        cy.apiInitSetup().then(({team, channel, user}) => {
+        cy.apiInitSetup({userPrefix: 'user000a'}).then(({team, channel, user}) => {
             testTeam = team;
             testChannel = channel;
             testUser = user;
@@ -67,8 +67,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
         // * Verify the aria-label in create direct message button
         cy.uiAddDirectMessage().click();
 
-        // * Verify the accessibility support in Direct Messages Dialog`
-        // cy.get('#moreDmModal').should('have.attr', 'role', 'dialog').and('have.attr', 'aria-labelledby', 'moreDmModalLabel').within(() => {
+        // * Verify the accessibility support in Direct Messages Dialog
         cy.findAllByRole('dialog', 'Direct Messages').eq(0).within(() => {
             cy.findByRole('heading', 'Direct Messages');
 
@@ -143,19 +142,19 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
                     // * Verify channel name is highlighted and reader reads the channel name and channel description
                     cy.get('#moreChannelsList').children().eq(0).within(() => {
                         const selectedChannel = getChannelAriaLabel(channel);
-                        cy.findByLabelText(selectedChannel).should('have.class', 'a11y--active a11y--focused');
+                        cy.findByLabelText(selectedChannel).should('be.focused');
 
                         // * Press Tab and verify if focus changes to Join button
                         cy.focused().tab();
-                        cy.findByText('Join').parent().should('have.class', 'a11y--active a11y--focused');
+                        cy.findByText('Join').parent().should('be.focused');
 
                         // * Verify previous button should no longer be focused
-                        cy.findByLabelText(selectedChannel).should('not.have.class', 'a11y--active a11y--focused');
+                        cy.findByLabelText(selectedChannel).should('not.be.focused');
                     });
 
                     // * Press Tab again and verify if focus changes to next row
                     cy.focused().tab();
-                    cy.findByLabelText(getChannelAriaLabel(otherChannel)).should('have.class', 'a11y--active a11y--focused');
+                    cy.findByLabelText(getChannelAriaLabel(otherChannel)).should('be.focused');
                 });
             });
         });
@@ -234,33 +233,33 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
         cy.findByRole('dialog', {name: 'Off-Topic Members'}).within(() => {
             cy.findByRole('heading', {name: 'Off-Topic Members'});
 
-            // * Verify the accessibility support in search input
+            // # Set focus on search input
             cy.findByPlaceholderText('Search users').
                 focus().
                 type(' {backspace}').
                 wait(TIMEOUTS.HALF_SEC).
-                tab({shift: true}).tab().tab().tab();
+                tab({shift: true}).tab();
             cy.wait(TIMEOUTS.HALF_SEC);
 
-            // * Verify channel name is highlighted and reader reads the channel name
-            cy.get('.more-modal__list>div').children().eq(1).as('selectedRow');
-            cy.get('@selectedRow').within(() => {
-                cy.get('button.user-popover').
-                    should('have.class', 'a11y--active a11y--focused');
-                cy.get('.more-modal__name').invoke('text').then((user) => {
-                    selectedRowText = user.split(' ')[0].replace('@', '');
-                    cy.get('.more-modal__actions button .sr-only').should('have.text', selectedRowText);
-
-                    // * Verify image alt is displayed
-                    cy.get('img.Avatar').should('have.attr', 'alt', `${selectedRowText} profile image`);
-                });
-            });
-
-            // * Press Tab again and verify if focus changes to next row
+            // # Press tab and verify focus on first user's profile image
             cy.focused().tab();
-            cy.get('.more-modal__list>div').children().eq(1).as('selectedRow').
-                get('button.dropdown-toggle').
-                should('have.class', 'a11y--active a11y--focused');
+            cy.findByAltText('sysadmin profile image').should('be.focused');
+
+            // # Press tab and verify focus on first user's username
+            cy.focused().tab();
+            cy.focused().should('have.text', '@sysadmin');
+
+            // # Press tab and verify focus on second user's profile image
+            cy.focused().tab();
+            cy.findByAltText(`${testUser.username} profile image`).should('be.focused');
+
+            // # Press tab and verify focus on second user's username
+            cy.focused().tab();
+            cy.focused().should('have.text', `@${testUser.username}`);
+
+            // # Press tab and verify focus on second user's dropdown option
+            cy.focused().tab();
+            cy.focused().should('have.class', 'dropdown-toggle').and('contain', 'Channel Member');
 
             // * Verify accessibility support in search total results
             cy.get('#searchableUserListTotal').should('have.attr', 'aria-live', 'polite');
@@ -280,7 +279,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
         cy.get('button.icon-close').focus().tab({shift: true}).tab();
 
         // * Verify tab focuses on close button
-        cy.get('button.icon-close').should('have.attr', 'aria-label', 'Close').and('have.class', 'a11y--active a11y--focused').tab();
+        cy.get('button.icon-close').should('have.attr', 'aria-label', 'Close').and('be.focused');
     });
 });
 


### PR DESCRIPTION
#### Summary
- Fixed failed tests on user profile focus introduced by https://github.com/mattermost/mattermost-webapp/pull/9383
- Fixed aria-label of "Profile" menu item and include test on it
- Removed the use of implementation specific detail (CSS class) in favor of accessible attribute (`be.focused`)

#### Ticket Link
none, failed on daily run

#### Screenshots
<img width="535" alt="Screen Shot 2021-11-24 at 2 45 43 PM" src="https://user-images.githubusercontent.com/5334504/143192004-9c2e5170-80cf-4db3-9223-d06ca9ea31ff.png">
<img width="530" alt="Screen Shot 2021-11-24 at 3 05 32 PM" src="https://user-images.githubusercontent.com/5334504/143192013-539a1e71-a07f-48c1-8581-82e8b021f56d.png">

#### Release Note
```release-note
NONE
```
