### PR TITLE
[MM-40340] Uninitialize webapp plugin when a new version gets deployed

### DIFF
--- a/plugins/index.js
+++ b/plugins/index.js
@@ -28,6 +28,11 @@ window.plugins = {};
 // During the beta, plugins manipulated the global window.plugins data structure directly. This
 // remains possible, but is officially deprecated and may be removed in a future release.
 function registerPlugin(id, plugin) {
+    const oldPlugin = window.plugins[id];
+    if (oldPlugin && oldPlugin.uninitialize) {
+        oldPlugin.uninitialize();
+    }
+
     window.plugins[id] = plugin;
 }
 window.registerPlugin = registerPlugin;


### PR DESCRIPTION
#### Summary

The `uninitialize` method is used to revert any changes a plugin may have made to the environment that the plugin framework doesn't keep track of. It is called when plugin is disabled or removed from the system, but not when the plugin is re-deployed while during the user's browser session.

This PR makes it so `uninitialize` is called in this case, so the plugin has a chance to clean up before the next version starts up.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-40340