### PR TITLE
Cypress/E2E: Set @cypress/request to 2.88.7 to avoid error when installing deprecated "har-validator"

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@cypress/request": "2.88.7",
         "@testing-library/cypress": "7.0.6",
         "@types/lodash": "4.14.175",
         "async": "3.2.1",
@@ -25,7 +26,7 @@
         "deepmerge": "4.2.2",
         "dotenv": "10.0.0",
         "express": "4.17.1",
-        "extract-zip": "^2.0.1",
+        "extract-zip": "2.0.1",
         "knex": "0.21.5",
         "localforage": "1.10.0",
         "lodash.intersection": "4.4.0",
@@ -2060,9 +2061,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
-      "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+      "version": "2.88.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.7.tgz",
+      "integrity": "sha512-FTULIP2rnDJvZDT9t6B4nSfYR40ue19tVmv3wUcY05R9/FPCoMl1nAPJkzWzBCo7ltVn5ThQTbxiMoGBN7k0ig==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -15444,9 +15445,9 @@
       }
     },
     "@cypress/request": {
-      "version": "2.88.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
-      "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+      "version": "2.88.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.7.tgz",
+      "integrity": "sha512-FTULIP2rnDJvZDT9t6B4nSfYR40ue19tVmv3wUcY05R9/FPCoMl1nAPJkzWzBCo7ltVn5ThQTbxiMoGBN7k0ig==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@cypress/request": "2.88.7",
     "@testing-library/cypress": "7.0.6",
     "@types/lodash": "4.14.175",
     "async": "3.2.1",


### PR DESCRIPTION
#### Summary
Cypress install recently encountered error when installing deprecated "har-validator". 
```
npm ERR! Error: Cannot find module 'har-validator'
```

Workaround is to set @cypress/request to 2.88.7 until "har-validator" is totally removed from the said package (PR to track `https://github.com/cypress-io/request/pull/15`).



#### Release Note
```release-note
NONE
```
