### PR TITLE
Forward ref through QuickInput

### DIFF
--- a/components/__snapshots__/autosize_textarea.test.jsx.snap
+++ b/components/__snapshots__/autosize_textarea.test.jsx.snap
@@ -21,7 +21,6 @@ exports[`components/AutosizeTextarea should match snapshot, init 1`] = `
     aria-label=""
     dir="auto"
     height={0}
-    onChange={[Function]}
     role="textbox"
     rows={1}
   />

--- a/components/__snapshots__/searchable_channel_list.test.jsx.snap
+++ b/components/__snapshots__/searchable_channel_list.test.jsx.snap
@@ -12,8 +12,6 @@ exports[`components/SearchableChannelList should match init snapshot 1`] = `
     >
       <QuickInput
         className="form-control filter-textbox"
-        clearable={false}
-        delayInputUpdate={false}
         id="searchChannelsTextbox"
         inputComponent={
           Object {
@@ -29,8 +27,6 @@ exports[`components/SearchableChannelList should match init snapshot 1`] = `
             "id": "filtered_channels_list.search",
           }
         }
-        tooltipPosition="bottom"
-        value=""
       />
     </div>
   </div>

--- a/components/__snapshots__/textbox.test.tsx.snap
+++ b/components/__snapshots__/textbox.test.tsx.snap
@@ -10,7 +10,13 @@ exports[`components/TextBox should match snapshot with additional, optional prop
     contextId="channelId"
     disabled={true}
     id="someid"
-    inputComponent={[Function]}
+    inputComponent={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "displayName": "AutosizeTextarea",
+        "render": [Function],
+      }
+    }
     isRHS={true}
     listComponent={[Function]}
     listPosition="top"
@@ -115,7 +121,13 @@ exports[`components/TextBox should match snapshot with required props 1`] = `
     className="form-control custom-textarea"
     contextId="channelId"
     id="someid"
-    inputComponent={[Function]}
+    inputComponent={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "displayName": "AutosizeTextarea",
+        "render": [Function],
+      }
+    }
     isRHS={false}
     listComponent={[Function]}
     listenForMentionKeyClick={false}
@@ -202,7 +214,13 @@ exports[`components/TextBox should throw error when new property is too long 1`]
     className="form-control custom-textarea"
     contextId="channelId"
     id="someid"
-    inputComponent={[Function]}
+    inputComponent={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "displayName": "AutosizeTextarea",
+        "render": [Function],
+      }
+    }
     isRHS={false}
     listComponent={[Function]}
     listenForMentionKeyClick={false}
@@ -289,7 +307,13 @@ exports[`components/TextBox should throw error when value is too long 1`] = `
     className="form-control custom-textarea"
     contextId="channelId"
     id="someid"
-    inputComponent={[Function]}
+    inputComponent={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "displayName": "AutosizeTextarea",
+        "render": [Function],
+      }
+    }
     isRHS={false}
     listComponent={[Function]}
     listenForMentionKeyClick={false}

--- a/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
+++ b/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
@@ -15,12 +15,10 @@ exports[`components/AdminSidebar Plugins should filter plugins 1`] = `
     <QuickInput
       className="filter active"
       clearable={true}
-      delayInputUpdate={false}
       id="adminSidebarFilter"
       onChange={[Function]}
       onClear={[Function]}
       placeholder="Find settings"
-      tooltipPosition="bottom"
       type="text"
       value="autolink"
     />
@@ -94,12 +92,10 @@ exports[`components/AdminSidebar Plugins should match snapshot 1`] = `
     <QuickInput
       className="filter "
       clearable={true}
-      delayInputUpdate={false}
       id="adminSidebarFilter"
       onChange={[Function]}
       onClear={[Function]}
       placeholder="Find settings"
-      tooltipPosition="bottom"
       type="text"
       value=""
     />
@@ -383,12 +379,10 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
     <QuickInput
       className="filter "
       clearable={true}
-      delayInputUpdate={false}
       id="adminSidebarFilter"
       onChange={[Function]}
       onClear={[Function]}
       placeholder="Find settings"
-      tooltipPosition="bottom"
       type="text"
       value=""
     />
@@ -1148,12 +1142,10 @@ exports[`components/AdminSidebar should match snapshot, no access 1`] = `
     <QuickInput
       className="filter "
       clearable={true}
-      delayInputUpdate={false}
       id="adminSidebarFilter"
       onChange={[Function]}
       onClear={[Function]}
       placeholder="Find settings"
-      tooltipPosition="bottom"
       type="text"
       value=""
     />
@@ -1205,12 +1197,10 @@ exports[`components/AdminSidebar should match snapshot, not prevent the console 
     <QuickInput
       className="filter "
       clearable={true}
-      delayInputUpdate={false}
       id="adminSidebarFilter"
       onChange={[Function]}
       onClear={[Function]}
       placeholder="Find settings"
-      tooltipPosition="bottom"
       type="text"
       value=""
     />
@@ -1262,12 +1252,10 @@ exports[`components/AdminSidebar should match snapshot, render plugins without a
     <QuickInput
       className="filter "
       clearable={true}
-      delayInputUpdate={false}
       id="adminSidebarFilter"
       onChange={[Function]}
       onClear={[Function]}
       placeholder="Find settings"
-      tooltipPosition="bottom"
       type="text"
       value=""
     />
@@ -1319,12 +1307,10 @@ exports[`components/AdminSidebar should match snapshot, with license (with all f
     <QuickInput
       className="filter "
       clearable={true}
-      delayInputUpdate={false}
       id="adminSidebarFilter"
       onChange={[Function]}
       onClear={[Function]}
       placeholder="Find settings"
-      tooltipPosition="bottom"
       type="text"
       value=""
     />
@@ -2285,12 +2271,10 @@ exports[`components/AdminSidebar should match snapshot, with license (without an
     <QuickInput
       className="filter "
       clearable={true}
-      delayInputUpdate={false}
       id="adminSidebarFilter"
       onChange={[Function]}
       onClear={[Function]}
       placeholder="Find settings"
-      tooltipPosition="bottom"
       type="text"
       value=""
     />

--- a/components/autosize_textarea.test.jsx
+++ b/components/autosize_textarea.test.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import AutosizeTextarea from 'components/autosize_textarea';
+import {AutosizeTextarea} from 'components/autosize_textarea';
 
 describe('components/AutosizeTextarea', () => {
     test('should match snapshot, init', () => {

--- a/components/edit_post_modal/edit_post_modal.test.tsx
+++ b/components/edit_post_modal/edit_post_modal.test.tsx
@@ -285,17 +285,15 @@ describe('components/EditPostModal', () => {
         expect((wrapper.state() as EditPostModalState).editText).toBe('test  :thumbsup: ');
     });
 
-    it('should set the focus and recalculate the size of the edit box after entering', () => {
+    it('should set the focus to the edit box after entering', () => {
         const wrapper = shallowWithIntl(createEditPost({...defaultProps}));
         const instance = wrapper.instance() as EditPostModalClass;
-        (instance as any).editbox = {focus: jest.fn(), recalculateSize: jest.fn()};
+        (instance as any).editbox = {focus: jest.fn()};
 
         const ref = (instance as any).editbox;
         expect(ref.focus).not.toBeCalled();
-        expect(ref.recalculateSize).not.toBeCalled();
         instance.handleEntered();
         expect(ref.focus).toBeCalled();
-        expect(ref.recalculateSize).toBeCalled();
     });
 
     it('should hide the preview when exiting', () => {

--- a/components/edit_post_modal/edit_post_modal.tsx
+++ b/components/edit_post_modal/edit_post_modal.tsx
@@ -448,7 +448,6 @@ export class EditPostModal extends React.PureComponent<Props, State> {
     handleEntered = () => {
         if (this.editbox) {
             this.editbox.focus();
-            this.editbox.recalculateSize();
         }
     };
 

--- a/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
+++ b/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
@@ -220,7 +220,6 @@ exports[`components/marketplace/ MarketplaceModal should render with error banne
           <QuickInput
             className="form-control filter-textbox search_input"
             clearable={true}
-            delayInputUpdate={false}
             id="searchMarketplaceTextbox"
             inputComponent={
               Object {
@@ -237,7 +236,6 @@ exports[`components/marketplace/ MarketplaceModal should render with error banne
                 "id": "marketplace_modal.search",
               }
             }
-            tooltipPosition="bottom"
             value=""
           />
         </div>
@@ -302,7 +300,6 @@ exports[`components/marketplace/ MarketplaceModal should render with no plugins 
           <QuickInput
             className="form-control filter-textbox search_input"
             clearable={true}
-            delayInputUpdate={false}
             id="searchMarketplaceTextbox"
             inputComponent={
               Object {
@@ -319,7 +316,6 @@ exports[`components/marketplace/ MarketplaceModal should render with no plugins 
                 "id": "marketplace_modal.search",
               }
             }
-            tooltipPosition="bottom"
             value=""
           />
         </div>
@@ -384,7 +380,6 @@ exports[`components/marketplace/ MarketplaceModal should render with plugins ins
           <QuickInput
             className="form-control filter-textbox search_input"
             clearable={true}
-            delayInputUpdate={false}
             id="searchMarketplaceTextbox"
             inputComponent={
               Object {
@@ -401,7 +396,6 @@ exports[`components/marketplace/ MarketplaceModal should render with plugins ins
                 "id": "marketplace_modal.search",
               }
             }
-            tooltipPosition="bottom"
             value=""
           />
         </div>

--- a/components/plugin_marketplace/marketplace_modal.tsx
+++ b/components/plugin_marketplace/marketplace_modal.tsx
@@ -115,7 +115,7 @@ type MarketplaceModalState = {
 
 // MarketplaceModal is the marketplace modal.
 export class MarketplaceModal extends React.PureComponent<MarketplaceModalProps, MarketplaceModalState> {
-    private filterRef: React.RefObject<QuickInput>;
+    private filterRef: React.RefObject<HTMLInputElement>;
 
     constructor(props: MarketplaceModalProps) {
         super(props);

--- a/components/quick_input/quick_input.test.tsx
+++ b/components/quick_input/quick_input.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import QuickInput from 'components/quick_input/index';
+import {QuickInput} from './quick_input';
 
 describe('components/QuickInput', () => {
     test.each([

--- a/components/quick_input/quick_input.tsx
+++ b/components/quick_input/quick_input.tsx
@@ -80,7 +80,7 @@ export type Props = {
 // A component that can be used to make controlled inputs that function properly in certain
 // environments (ie. IE11) where typing quickly would sometimes miss inputs
 export default class QuickInput extends React.PureComponent<Props> {
-    private input?: HTMLInputElement | AutosizeTextarea;
+    private input?: HTMLInputElement | HTMLTextAreaElement;
 
     static defaultProps = {
         delayInputUpdate: false,

--- a/components/suggestion/modal_suggestion_list.jsx
+++ b/components/suggestion/modal_suggestion_list.jsx
@@ -33,7 +33,7 @@ export default class ModalSuggestionList extends React.PureComponent {
 
     calculateInputRect = () => {
         if (this.props.inputRef.current) {
-            const rect = this.props.inputRef.current.getInput().getBoundingClientRect();
+            const rect = this.props.inputRef.current.getBoundingClientRect();
             return {top: rect.top, bottom: rect.bottom, width: rect.width};
         }
         return {top: 0, bottom: 0, width: 0};

--- a/components/suggestion/rhs_suggestion_list.tsx
+++ b/components/suggestion/rhs_suggestion_list.tsx
@@ -3,7 +3,6 @@
 
 import React, {useEffect, useState} from 'react';
 
-import AutosizeTextarea from 'components/autosize_textarea';
 import QuickInput from 'components/quick_input';
 
 import Constants from 'utils/constants';
@@ -21,7 +20,7 @@ export default function RhsSuggestionList(props: Props): JSX.Element {
         const input = props.inputRef.current;
 
         if (props.open) {
-            const inputTop = (input?.getInput() as AutosizeTextarea).getDOMNode()?.getBoundingClientRect().top || 0;
+            const inputTop = (input?.getInput() as HTMLTextAreaElement).getBoundingClientRect().top || 0;
             const newPosition = (inputTop < Constants.SUGGESTION_LIST_SPACE_RHS) ? 'bottom' : 'top';
 
             if (newPosition !== position) {

--- a/components/suggestion/rhs_suggestion_list.tsx
+++ b/components/suggestion/rhs_suggestion_list.tsx
@@ -3,14 +3,12 @@
 
 import React, {useEffect, useState} from 'react';
 
-import QuickInput from 'components/quick_input';
-
 import Constants from 'utils/constants';
 
 import SuggestionList from './suggestion_list';
 
 type Props = React.ComponentProps<typeof SuggestionList> & {
-    inputRef: React.RefObject<QuickInput>;
+    inputRef: React.RefObject<HTMLTextAreaElement>;
 }
 
 export default function RhsSuggestionList(props: Props): JSX.Element {
@@ -19,8 +17,8 @@ export default function RhsSuggestionList(props: Props): JSX.Element {
     useEffect(() => {
         const input = props.inputRef.current;
 
-        if (props.open) {
-            const inputTop = (input?.getInput() as HTMLTextAreaElement).getBoundingClientRect().top || 0;
+        if (input && props.open) {
+            const inputTop = input.getBoundingClientRect().top ?? 0;
             const newPosition = (inputTop < Constants.SUGGESTION_LIST_SPACE_RHS) ? 'bottom' : 'top';
 
             if (newPosition !== position) {

--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -254,7 +254,7 @@ export default class SuggestionBox extends React.PureComponent {
             return null;
         }
 
-        return this.inputRef.current.getInput();
+        return this.inputRef.current;
     }
 
     handleEmitClearSuggestions = (delay = 0) => {

--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -796,7 +796,7 @@ export default class SuggestionBox extends React.PureComponent {
                     <div style={{width: this.state.width}}>
                         <SuggestionListComponent
                             ariaLiveRef={this.suggestionReadOut}
-                            open={true || this.state.focused || this.props.forceSuggestionsWhenBlur}
+                            open={this.state.focused || this.props.forceSuggestionsWhenBlur}
                             pretext={this.pretext}
                             position={listPosition}
                             renderDividers={renderDividers}

--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -254,23 +254,7 @@ export default class SuggestionBox extends React.PureComponent {
             return null;
         }
 
-        const input = this.inputRef.current.getInput();
-
-        if (input.getDOMNode) {
-            return input.getDOMNode();
-        }
-
-        return input;
-    }
-
-    recalculateSize = () => {
-        // Pretty hacky way to force an AutosizeTextarea to recalculate its height if that's what
-        // we're rendering as the input
-        const input = this.inputRef.current.getInput();
-
-        if (input.recalculateSize) {
-            input.recalculateSize();
-        }
+        return this.inputRef.current.getInput();
     }
 
     handleEmitClearSuggestions = (delay = 0) => {
@@ -812,7 +796,7 @@ export default class SuggestionBox extends React.PureComponent {
                     <div style={{width: this.state.width}}>
                         <SuggestionListComponent
                             ariaLiveRef={this.suggestionReadOut}
-                            open={this.state.focused || this.props.forceSuggestionsWhenBlur}
+                            open={true || this.state.focused || this.props.forceSuggestionsWhenBlur}
                             pretext={this.pretext}
                             position={listPosition}
                             renderDividers={renderDividers}

--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -140,11 +140,6 @@ export default class SuggestionBox extends React.PureComponent {
         listenForMentionKeyClick: PropTypes.bool,
 
         /**
-         * Passes the wrapper reference for height calculation
-         */
-        wrapperHeight: PropTypes.number,
-
-        /**
          * Allows parent to access received suggestions
          */
         onSuggestionsReceived: PropTypes.func,
@@ -783,7 +778,6 @@ export default class SuggestionBox extends React.PureComponent {
         Reflect.deleteProperty(props, 'renderDividers');
         Reflect.deleteProperty(props, 'contextId');
         Reflect.deleteProperty(props, 'listenForMentionKeyClick');
-        Reflect.deleteProperty(props, 'wrapperHeight');
         Reflect.deleteProperty(props, 'forceSuggestionsWhenBlur');
         Reflect.deleteProperty(props, 'onSuggestionsReceived');
         Reflect.deleteProperty(props, 'actions');
@@ -817,7 +811,6 @@ export default class SuggestionBox extends React.PureComponent {
                 {(this.props.openWhenEmpty || this.props.value.length >= this.props.requiredCharacters) && this.state.presentationType === 'text' &&
                     <div style={{width: this.state.width}}>
                         <SuggestionListComponent
-                            target={this.inputRef}
                             ariaLiveRef={this.suggestionReadOut}
                             open={this.state.focused || this.props.forceSuggestionsWhenBlur}
                             pretext={this.pretext}
@@ -834,7 +827,6 @@ export default class SuggestionBox extends React.PureComponent {
                             suggestionBoxAlgn={this.state.suggestionBoxAlgn}
                             selection={this.state.selection}
                             components={this.state.components}
-                            wrapperHeight={this.props.wrapperHeight}
                             inputRef={this.inputRef}
                             onLoseVisibility={this.blur}
                         />

--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -7,7 +7,7 @@ import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 import {cloneDeep} from 'lodash';
 
-import {isEmptyObject, windowHeight} from 'utils/utils.jsx';
+import {isEmptyObject} from 'utils/utils.jsx';
 import {Constants} from 'utils/constants.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
@@ -17,6 +17,7 @@ import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 export default class SuggestionList extends React.PureComponent {
     static propTypes = {
         ariaLiveRef: PropTypes.object,
+        inputRef: PropTypes.object,
         open: PropTypes.bool.isRequired,
         position: PropTypes.oneOf(['top', 'bottom']),
         renderDividers: PropTypes.bool,
@@ -31,7 +32,6 @@ export default class SuggestionList extends React.PureComponent {
         terms: PropTypes.array.isRequired,
         selection: PropTypes.string.isRequired,
         components: PropTypes.array.isRequired,
-        wrapperHeight: PropTypes.number,
         suggestionBoxAlgn: PropTypes.object,
     };
 
@@ -44,6 +44,7 @@ export default class SuggestionList extends React.PureComponent {
         super(props);
 
         this.contentRef = React.createRef();
+        this.wrapperRef = React.createRef();
         this.itemRefs = new Map();
         this.suggestionReadOut = React.createRef();
         this.currentLabel = '';
@@ -58,10 +59,27 @@ export default class SuggestionList extends React.PureComponent {
         if (!isEmptyObject(this.currentItem)) {
             this.generateLabel(this.currentItem);
         }
+
+        if (this.props.items.length > 0 && prevProps.items.length === 0) {
+            this.updateMaxHeight();
+        }
     }
 
     componentWillUnmount() {
         this.removeLabel();
+    }
+
+    updateMaxHeight = () => {
+        const inputHeight = this.props.inputRef.current?.input.getDOMNode().clientHeight ?? 0;
+
+        this.maxHeight = Math.min(
+            window.innerHeight - (inputHeight + Constants.POST_MODAL_PADDING),
+            Constants.SUGGESTION_LIST_MAXHEIGHT,
+        );
+
+        if (this.contentRef.current) {
+            this.contentRef.current.style['max-height'] = this.maxHeight;
+        }
     }
 
     announceLabel() {
@@ -244,22 +262,18 @@ export default class SuggestionList extends React.PureComponent {
         }
         const mainClass = 'suggestion-list suggestion-list--' + this.props.position;
         const contentClass = 'suggestion-list__content suggestion-list__content--' + this.props.position;
-        let maxHeight = Constants.SUGGESTION_LIST_MAXHEIGHT;
-        if (this.props.wrapperHeight) {
-            maxHeight = Math.min(
-                windowHeight() - (this.props.wrapperHeight + Constants.POST_MODAL_PADDING),
-                Constants.SUGGESTION_LIST_MAXHEIGHT,
-            );
-        }
 
         return (
-            <div className={mainClass}>
+            <div
+                ref={this.wrapperRef}
+                className={mainClass}
+            >
                 <div
                     id='suggestionList'
                     role='list'
                     ref={this.contentRef}
                     style={{
-                        maxHeight,
+                        maxHeight: this.maxHeight,
                         ...this.getTransform(),
                     }}
                     className={contentClass}

--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -70,7 +70,7 @@ export default class SuggestionList extends React.PureComponent {
     }
 
     updateMaxHeight = () => {
-        const inputHeight = this.props.inputRef.current?.input.getDOMNode().clientHeight ?? 0;
+        const inputHeight = this.props.inputRef.current?.input.clientHeight ?? 0;
 
         this.maxHeight = Math.min(
             window.innerHeight - (inputHeight + Constants.POST_MODAL_PADDING),

--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -70,7 +70,7 @@ export default class SuggestionList extends React.PureComponent {
     }
 
     updateMaxHeight = () => {
-        const inputHeight = this.props.inputRef.current?.input.clientHeight ?? 0;
+        const inputHeight = this.props.inputRef.current?.clientHeight ?? 0;
 
         this.maxHeight = Math.min(
             window.innerHeight - (inputHeight + Constants.POST_MODAL_PADDING),

--- a/components/textbox/textbox.tsx
+++ b/components/textbox/textbox.tsx
@@ -244,10 +244,6 @@ export default class Textbox extends React.PureComponent<Props> {
         this.getInputBox()?.blur();
     };
 
-    recalculateSize = () => {
-        this.message.current?.recalculateSize();
-    }
-
     render() {
         let preview = null;
 

--- a/components/textbox/textbox.tsx
+++ b/components/textbox/textbox.tsx
@@ -253,15 +253,11 @@ export default class Textbox extends React.PureComponent<Props> {
 
         let textboxClassName = 'form-control custom-textarea';
         let textWrapperClass = 'textarea-wrapper';
-        let wrapperHeight;
         if (this.props.emojiEnabled) {
             textboxClassName += ' custom-textarea--emoji-picker';
         }
         if (this.props.badConnection) {
             textboxClassName += ' bad-connection';
-        }
-        if (this.wrapper.current) {
-            wrapperHeight = this.getInputBox()?.clientHeight;
         }
         if (this.props.preview) {
             textboxClassName += ' custom-textarea--preview';
@@ -319,7 +315,6 @@ export default class Textbox extends React.PureComponent<Props> {
                     disabled={this.props.disabled}
                     contextId={this.props.channelId}
                     listenForMentionKeyClick={this.props.listenForMentionKeyClick}
-                    wrapperHeight={wrapperHeight}
                     openWhenEmpty={this.props.openWhenEmpty}
                 />
                 {preview}

--- a/components/user_settings/notifications/__snapshots__/manage_auto_responder.test.jsx.snap
+++ b/components/user_settings/notifications/__snapshots__/manage_auto_responder.test.jsx.snap
@@ -230,7 +230,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
           <div
             className="pt-2"
           >
-            <AutosizeTextarea
+            <textarea
               className="form-control"
               id="autoResponderMessageInput"
               maxLength={200}
@@ -324,7 +324,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
               <div
                 className="pt-2"
               >
-                <AutosizeTextarea
+                <textarea
                   className="form-control"
                   id="autoResponderMessageInput"
                   maxLength={200}
@@ -337,53 +337,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
                     }
                   }
                   value="Hello World!"
-                >
-                  <div>
-                    <textarea
-                      aria-label="message"
-                      className="form-control"
-                      data-testid="autoResponderMessageInput"
-                      dir="auto"
-                      height={0}
-                      id="autoResponderMessageInput"
-                      maxLength={200}
-                      onChange={[Function]}
-                      role="textbox"
-                      rows="5"
-                      style={
-                        Object {
-                          "resize": "none",
-                        }
-                      }
-                      value="Hello World!"
-                    />
-                    <div
-                      style={
-                        Object {
-                          "height": 0,
-                          "overflow": "hidden",
-                        }
-                      }
-                    >
-                      <textarea
-                        aria-hidden={true}
-                        className="form-control"
-                        dir="auto"
-                        disabled={true}
-                        id="autoResponderMessageInput-reference"
-                        maxLength={200}
-                        onChange={[Function]}
-                        rows="5"
-                        style={
-                          Object {
-                            "resize": "none",
-                          }
-                        }
-                        value="Hello World!"
-                      />
-                    </div>
-                  </div>
-                </AutosizeTextarea>
+                />
               </div>
             </div>
             <div

--- a/components/user_settings/notifications/manage_auto_responder.jsx
+++ b/components/user_settings/notifications/manage_auto_responder.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import AutosizeTextarea from 'components/autosize_textarea';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
 
@@ -70,7 +69,7 @@ export default class ManageAutoResponder extends React.PureComponent {
                 key='autoResponderMessage'
             >
                 <div className='pt-2'>
-                    <AutosizeTextarea
+                    <textarea
                         style={{resize: 'none'}}
                         id='autoResponderMessageInput'
                         className='form-control'

--- a/components/user_settings/notifications/manage_auto_responder.test.jsx
+++ b/components/user_settings/notifications/manage_auto_responder.test.jsx
@@ -53,7 +53,7 @@ describe('components/user_settings/notifications/ManageAutoResponder', () => {
         expect(wrapper.find('#autoResponderActive').exists()).toBe(true);
         expect(wrapper.find('#autoResponderMessageInput').exists()).toBe(true);
 
-        wrapper.find('#autoResponderMessageInput').at(1).simulate('change');
+        wrapper.find('#autoResponderMessageInput').simulate('change');
         expect(setParentState).toBeCalled();
         expect(setParentState).toBeCalledWith('autoResponderMessage', 'Hello World!');
 

--- a/utils/utils.d.ts
+++ b/utils/utils.d.ts
@@ -98,7 +98,6 @@ export function getUserIdFromChannelName(channel: Channel): string;
 export function getUserIdFromChannelId(channelId: string, currentUserId?: string): string;
 
 export function windowWidth(): number;
-export function windowHeight(): number;
 
 export function isFeatureEnabled(feature: {label: string}, state: GlobalState): boolean;
 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1311,10 +1311,6 @@ export function windowWidth() {
     return window.innerWidth;
 }
 
-export function windowHeight() {
-    return window.innerHeight;
-}
-
 // Should be refactored, seems to make most sense to wrap TextboxLinks in a connect(). To discuss
 export function isFeatureEnabled(feature, state) {
     return getBool(state, Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, Constants.FeatureTogglePrefix + feature.label);


### PR DESCRIPTION
This PR is based off https://github.com/mattermost/mattermost-webapp/pull/9451. Changes specific to it can be found here: https://github.com/mattermost/mattermost-webapp/compare/MM-40071_suggestion-list-height...MM-40071_style-recalc

This ended up not being needed for the previous PR, but I figured it was good to add anyway. Since we have to use refs to access the various textboxes, this'll make those easier to use by returning the DOM node for the input instead of returning the React component that wraps it.

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9451

#### Release Note
```release-note
NONE
```
