### PR TITLE
MM-40071 Attempt to improve performance by reducing direct DOM usage

### DIFF
--- a/components/dot_menu/__snapshots__/dot_menu.test.tsx.snap
+++ b/components/dot_menu/__snapshots__/dot_menu.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
 <MenuWrapper
   animationComponent={[Function]}
   className=""
-  onToggle={[MockFunction]}
+  onToggle={[Function]}
 >
   <OverlayTrigger
     className="hidden-xs"
@@ -141,7 +141,7 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
 <MenuWrapper
   animationComponent={[Function]}
   className=""
-  onToggle={[MockFunction]}
+  onToggle={[Function]}
 >
   <OverlayTrigger
     className="hidden-xs"

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -295,27 +295,6 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         </Tooltip>
     )
 
-    refCallback = (menuRef: Menu) => {
-        if (menuRef) {
-            const buttonRect = this.buttonRef.current?.getBoundingClientRect();
-            let y;
-            if (typeof buttonRect?.y === 'undefined') {
-                y = typeof buttonRect?.top == 'undefined' ? 0 : buttonRect?.top;
-            } else {
-                y = buttonRect?.y;
-            }
-            const windowHeight = window.innerHeight;
-
-            const totalSpace = windowHeight - MENU_BOTTOM_MARGIN;
-            const spaceOnTop = y - Constants.CHANNEL_HEADER_HEIGHT;
-            const spaceOnBottom = (totalSpace - (spaceOnTop + Constants.POST_AREA_HEIGHT));
-
-            this.setState({
-                openUp: (spaceOnTop > spaceOnBottom),
-            });
-        }
-    }
-
     renderDivider = (suffix: string) => {
         return (
             <li
@@ -395,6 +374,31 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         });
     }
 
+    handleDropdownOpened = (open: boolean) => {
+        this.props.handleDropdownOpened?.(open);
+
+        if (!open) {
+            return;
+        }
+
+        const buttonRect = this.buttonRef.current?.getBoundingClientRect();
+        let y;
+        if (typeof buttonRect?.y === 'undefined') {
+            y = typeof buttonRect?.top == 'undefined' ? 0 : buttonRect?.top;
+        } else {
+            y = buttonRect?.y;
+        }
+        const windowHeight = window.innerHeight;
+
+        const totalSpace = windowHeight - MENU_BOTTOM_MARGIN;
+        const spaceOnTop = y - Constants.CHANNEL_HEADER_HEIGHT;
+        const spaceOnBottom = (totalSpace - (spaceOnTop + Constants.POST_AREA_HEIGHT));
+
+        this.setState({
+            openUp: (spaceOnTop > spaceOnBottom),
+        });
+    }
+
     render() {
         const isSystemMessage = PostUtils.isSystemMessage(this.props.post);
         const isMobile = Utils.isMobile();
@@ -456,7 +460,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         const isFollowingThread = this.props.isFollowingThread ?? this.props.isMentionedInRootPost;
 
         return (
-            <MenuWrapper onToggle={this.props.handleDropdownOpened}>
+            <MenuWrapper onToggle={this.handleDropdownOpened}>
                 <OverlayTrigger
                     className='hidden-xs'
                     delayShow={500}
@@ -481,7 +485,6 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                     id={`${this.props.location}_dropdown_${this.props.post.id}`}
                     openLeft={true}
                     openUp={this.state.openUp}
-                    ref={this.refCallback}
                     ariaLabel={Utils.localizeMessage('post_info.menuAriaLabel', 'Post extra options')}
                 >
                     <Menu.ItemAction

--- a/components/file_attachment/file_attachment.tsx
+++ b/components/file_attachment/file_attachment.tsx
@@ -135,30 +135,36 @@ export default class FileAttachment extends React.PureComponent<Props, State> {
         }
     }
 
-    refCallback = (menuRef: Menu) => {
-        if (menuRef) {
-            const anchorRect = this.buttonRef.current?.getBoundingClientRect();
-            let y;
-            if (typeof anchorRect?.y === 'undefined') {
-                y = typeof anchorRect?.top === 'undefined' ? 0 : anchorRect?.top;
-            } else {
-                y = anchorRect?.y;
-            }
-            const windowHeight = window.innerHeight;
-
-            const totalSpace = windowHeight - 80;
-            const spaceOnTop = y - Constants.CHANNEL_HEADER_HEIGHT;
-            const spaceOnBottom = (totalSpace - (spaceOnTop + Constants.POST_AREA_HEIGHT));
-
-            this.setState({
-                openUp: (spaceOnTop > spaceOnBottom),
-            });
-        }
-    }
-
     private handleDropdownOpened = (open: boolean) => {
         this.props.handleFileDropdownOpened?.(open);
         this.setState({keepOpen: open});
+
+        if (open) {
+            this.setMenuPosition();
+        }
+    }
+
+    private setMenuPosition = () => {
+        if (!this.buttonRef.current) {
+            return;
+        }
+
+        const anchorRect = this.buttonRef.current?.getBoundingClientRect();
+        let y;
+        if (typeof anchorRect?.y === 'undefined') {
+            y = typeof anchorRect?.top === 'undefined' ? 0 : anchorRect?.top;
+        } else {
+            y = anchorRect?.y;
+        }
+        const windowHeight = window.innerHeight;
+
+        const totalSpace = windowHeight - 80;
+        const spaceOnTop = y - Constants.CHANNEL_HEADER_HEIGHT;
+        const spaceOnBottom = (totalSpace - (spaceOnTop + Constants.POST_AREA_HEIGHT));
+
+        this.setState({
+            openUp: (spaceOnTop > spaceOnBottom),
+        });
     }
 
     handleGetPublicLink = () => {
@@ -249,7 +255,6 @@ export default class FileAttachment extends React.PureComponent<Props, State> {
                     ariaLabel={'file menu'}
                     openLeft={true}
                     openUp={this.state.openUp}
-                    ref={this.refCallback}
                 >
                     {defaultItems}
                     {divider}

--- a/components/rhs_search_nav/rhs_search_nav.tsx
+++ b/components/rhs_search_nav/rhs_search_nav.tsx
@@ -32,7 +32,7 @@ type Props = {
 };
 
 type State = {
-    showSearchBar: boolean;
+    windowWidth: number;
 };
 
 const HEADER_ICON = 'channel-header__icon';
@@ -42,7 +42,7 @@ class RHSSearchNav extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
 
-        this.state = {showSearchBar: RHSSearchNav.getShowSearchBar(props)};
+        this.state = {windowWidth: window.innerWidth};
     }
 
     componentDidMount() {
@@ -55,17 +55,14 @@ class RHSSearchNav extends React.PureComponent<Props, State> {
         window.removeEventListener('resize', this.handleResize);
     }
 
-    static getDerivedStateFromProps(nextProps: Props) {
-        return {showSearchBar: RHSSearchNav.getShowSearchBar(nextProps)};
-    }
-
-    static getShowSearchBar(props: Props) {
-        return !Utils.isMobile() && (Utils.windowWidth() > SEARCH_BAR_MINIMUM_WINDOW_SIZE || props.rhsOpen);
-    }
-
     handleResize = () => {
-        this.setState({showSearchBar: RHSSearchNav.getShowSearchBar(this.props)});
+        this.setState({windowWidth: window.innerWidth});
     };
+
+    shouldShowSearchBar = () => {
+        const isMobile = this.state.windowWidth <= Constants.MOBILE_SCREEN_WIDTH;
+        return !isMobile && (this.state.windowWidth > SEARCH_BAR_MINIMUM_WINDOW_SIZE || this.props.rhsOpen);
+    }
 
     mentionButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
@@ -116,7 +113,7 @@ class RHSSearchNav extends React.PureComponent<Props, State> {
             <>
                 <Search
                     isFocus={Utils.isMobile() || (rhsOpen && Boolean(rhsState))}
-                    hideSearchBar={!this.state.showSearchBar}
+                    hideSearchBar={!this.shouldShowSearchBar()}
                     enableFindShortcut={true}
                 />
                 <HeaderIconWrapper

--- a/components/sidebar/sidebar_category/sidebar_category_menu/__snapshots__/sidebar_category_menu.test.tsx.snap
+++ b/components/sidebar/sidebar_category/sidebar_category_menu/__snapshots__/sidebar_category_menu.test.tsx.snap
@@ -7,8 +7,8 @@ exports[`components/sidebar/sidebar_category/sidebar_category_menu should match 
     buttonAriaLabel="Category Menu"
     id="SidebarCategoryMenu-category1"
     isMenuOpen={false}
+    onOpenDirectionChange={[Function]}
     onToggleMenu={[Function]}
-    refCallback={[Function]}
     tooltipText="Category options"
   >
     <MenuGroup>
@@ -111,8 +111,8 @@ exports[`components/sidebar/sidebar_category/sidebar_category_menu should match 
     buttonAriaLabel="Category Menu"
     id="SidebarCategoryMenu-category1"
     isMenuOpen={false}
+    onOpenDirectionChange={[Function]}
     onToggleMenu={[Function]}
-    refCallback={[Function]}
     tooltipText="Category options"
   >
     <MenuGroup>

--- a/components/sidebar/sidebar_category/sidebar_category_menu/sidebar_category_menu.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category_menu/sidebar_category_menu.tsx
@@ -11,7 +11,6 @@ import {trackEvent} from 'actions/telemetry_actions';
 import DeleteCategoryModal from 'components/delete_category_modal';
 import EditCategoryModal from 'components/edit_category_modal';
 import SidebarMenu from 'components/sidebar/sidebar_menu';
-import SidebarMenuType from 'components/sidebar/sidebar_menu/sidebar_menu';
 import Menu from 'components/widgets/menu/menu';
 import {ModalIdentifiers} from 'utils/constants';
 import {Props as SubmenuItemProps} from 'components/widgets/menu/menu_items/submenu_item';
@@ -214,12 +213,10 @@ class SidebarCategoryMenu extends React.PureComponent<Props, State> {
         );
     }
 
-    refCallback = (ref: SidebarMenuType) => {
-        if (ref) {
-            this.setState({
-                openUp: ref.state.openUp,
-            });
-        }
+    handleOpenDirectionChange = (openUp: boolean) => {
+        this.setState({
+            openUp,
+        });
     }
 
     render() {
@@ -228,11 +225,11 @@ class SidebarCategoryMenu extends React.PureComponent<Props, State> {
         return (
             <React.Fragment>
                 <SidebarMenu
-                    refCallback={this.refCallback}
                     id={`SidebarCategoryMenu-${category.id}`}
                     ariaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.dropdownAriaLabel', defaultMessage: 'Category Menu'})}
                     buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.dropdownAriaLabel', defaultMessage: 'Category Menu'})}
                     isMenuOpen={this.props.isMenuOpen}
+                    onOpenDirectionChange={this.handleOpenDirectionChange}
                     onToggleMenu={this.onToggleMenu}
                     tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.editCategory', defaultMessage: 'Category options'})}
                 >

--- a/components/sidebar/sidebar_category/sidebar_category_sorting_menu/sidebar_category_sorting_menu.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category_sorting_menu/sidebar_category_sorting_menu.tsx
@@ -13,7 +13,6 @@ import Constants from 'utils/constants';
 import {trackEvent} from 'actions/telemetry_actions';
 
 import SidebarMenu from 'components/sidebar/sidebar_menu';
-import SidebarMenuType from 'components/sidebar/sidebar_menu/sidebar_menu';
 import Menu from 'components/widgets/menu/menu';
 import {Props as SubmenuItemProps} from 'components/widgets/menu/menu_items/submenu_item';
 
@@ -144,12 +143,10 @@ export class SidebarCategorySortingMenu extends React.PureComponent<Props, State
         );
     }
 
-    refCallback = (ref: SidebarMenuType) => {
-        if (ref) {
-            this.setState({
-                openUp: ref.state.openUp,
-            });
-        }
+    handleOpenDirectionChange = (openUp: boolean) => {
+        this.setState({
+            openUp,
+        });
     }
 
     onToggleMenu = (open: boolean) => {
@@ -169,12 +166,12 @@ export class SidebarCategorySortingMenu extends React.PureComponent<Props, State
 
         return (
             <SidebarMenu
-                refCallback={this.refCallback}
                 id={'SidebarCategorySortingMenu'}
                 ariaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
                 buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
                 isMenuOpen={isMenuOpen}
                 onToggleMenu={this.onToggleMenu}
+                onOpenDirectionChange={this.handleOpenDirectionChange}
                 tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'})}
                 tabIndex={isCollapsed ? -1 : 0}
                 additionalClass='additionalClass'

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -6,8 +6,8 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   buttonAriaLabel="Channel Menu"
   id="SidebarChannelMenu-channel_id"
   isMenuOpen={true}
+  onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
-  refCallback={[Function]}
   tabIndex={0}
   tooltipText="Channel options"
 >
@@ -371,8 +371,8 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   buttonAriaLabel="Channel Menu"
   id="SidebarChannelMenu-channel_id"
   isMenuOpen={true}
+  onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
-  refCallback={[Function]}
   tabIndex={0}
   tooltipText="Channel options"
 >
@@ -446,8 +446,8 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   buttonAriaLabel="Channel Menu"
   id="SidebarChannelMenu-channel_id"
   isMenuOpen={true}
+  onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
-  refCallback={[Function]}
   tabIndex={0}
   tooltipText="Channel options"
 >
@@ -531,8 +531,8 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   buttonAriaLabel="Channel Menu"
   id="SidebarChannelMenu-channel_id"
   isMenuOpen={true}
+  onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
-  refCallback={[Function]}
   tabIndex={0}
   tooltipText="Channel options"
 >
@@ -629,8 +629,8 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   buttonAriaLabel="Channel Menu"
   id="SidebarChannelMenu-channel_id"
   isMenuOpen={true}
+  onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
-  refCallback={[Function]}
   tabIndex={0}
   tooltipText="Channel options"
 >
@@ -727,8 +727,8 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   buttonAriaLabel="Channel Menu"
   id="SidebarChannelMenu-channel_id"
   isMenuOpen={true}
+  onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
-  refCallback={[Function]}
   tabIndex={0}
   tooltipText="Channel options"
 >
@@ -825,8 +825,8 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   buttonAriaLabel="Channel Menu"
   id="SidebarChannelMenu-channel_id"
   isMenuOpen={true}
+  onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
-  refCallback={[Function]}
   tabIndex={0}
   tooltipText="Channel options"
 >

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -228,21 +228,6 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
         expect(wrapper.instance().renderDropdownItems()).toMatchSnapshot();
     });
 
-    test('should copy state from SidebarMenu when refCallback is called', () => {
-        const wrapper = shallowWithIntl(
-            <SidebarChannelMenu {...baseProps}/>,
-        ) as ShallowWrapper<typeof baseProps, any, SidebarChannelMenuType>;
-
-        const ref = {
-            state: {
-                openUp: false,
-            },
-        };
-
-        wrapper.instance().refCallback(ref as any);
-        expect(wrapper.instance().state.openUp).toEqual(ref.state.openUp);
-    });
-
     test('should call the close handler when leave channel is clicked', () => {
         const wrapper = shallowWithIntl(
             <SidebarChannelMenu {...baseProps}/>,

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -11,7 +11,6 @@ import {trackEvent} from 'actions/telemetry_actions';
 import CategoryMenuItems from 'components/category_menu_items';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import SidebarMenu from 'components/sidebar/sidebar_menu';
-import SidebarMenuType from 'components/sidebar/sidebar_menu/sidebar_menu';
 import Menu from 'components/widgets/menu/menu';
 
 import {ModalData} from 'types/actions';
@@ -243,12 +242,10 @@ export class SidebarChannelMenu extends React.PureComponent<Props, State> {
         );
     }
 
-    refCallback = (ref: SidebarMenuType) => {
-        if (ref) {
-            this.setState({
-                openUp: ref.state.openUp,
-            });
-        }
+    handleOpenDirectionChange = (openUp: boolean) => {
+        this.setState({
+            openUp,
+        });
     }
 
     onToggleMenu = (open: boolean) => {
@@ -269,11 +266,11 @@ export class SidebarChannelMenu extends React.PureComponent<Props, State> {
 
         return (
             <SidebarMenu
-                refCallback={this.refCallback}
                 id={`SidebarChannelMenu-${channel.id}`}
                 ariaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
                 buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
                 isMenuOpen={isMenuOpen}
+                onOpenDirectionChange={this.handleOpenDirectionChange}
                 onToggleMenu={this.onToggleMenu}
                 tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'})}
                 tabIndex={isCollapsed ? -1 : 0}

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1308,11 +1308,11 @@ export function getUserIdFromChannelId(channelId, currentUserId = getCurrentUser
     return otherUserId;
 }
 
-export function windowWidth() {
+export function windowWidth() { // TODO MM-40473 remove me
     return window.innerWidth;
 }
 
-export function windowHeight() {
+export function windowHeight() { // TODO MM-40473 remove me
     return window.innerHeight;
 }
 


### PR DESCRIPTION
Similar to the related PRs, we're trying to improve some performance issues that a customer was reporting where the JS thread would frequently get blocked on style recalculations. As part of an effort to combat that, I've been removing stuff that we think blocks on the UI based on [this list](https://gist.github.com/paulirish/5d52fb081b3570c81e3a).

There's technically two sets of changes, but I'm trying to save some work because of how much cherry-picking is required for these. For the two commits:
1. The first one is avoiding accessing dimensions of stuff during render. I have a theory this is the worst culprit for those issues.
2. The second one is avoiding accessing that when its doing ref callbacks since I assume that's similarly bad. All of the cases I saw where we were doing that was for positioning menus when they're opened. I *think* doing this in `componentDidUpdate` after the render is better, but I feel like the way we were doing it before was kind of abusing ref callbacks a bit

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40071

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9365
https://github.com/mattermost/mattermost-webapp/pull/9451

#### Release Note
```release-note
Improve performance by reducing DOM usage during render
```
