### PR TITLE
Switch to using `window.matchMedia` instead of the window `resize` event to determine current media query breakpoint.

### DIFF
--- a/actions/views/browser.ts
+++ b/actions/views/browser.ts
@@ -3,30 +3,9 @@
 
 import {GenericAction} from 'mattermost-redux/types/actions';
 
-import {Constants, ActionTypes, WindowSizes} from 'utils/constants';
+import {ActionTypes} from 'utils/constants';
 
-export function emitBrowserWindowResized(): GenericAction {
-    const width = window.innerWidth;
-
-    let windowSize;
-    switch (true) {
-    case width > Constants.TABLET_SCREEN_WIDTH && width <= Constants.DESKTOP_SCREEN_WIDTH: {
-        windowSize = WindowSizes.SMALL_DESKTOP_VIEW;
-        break;
-    }
-    case width > Constants.MOBILE_SCREEN_WIDTH && width <= Constants.TABLET_SCREEN_WIDTH: {
-        windowSize = WindowSizes.TABLET_VIEW;
-        break;
-    }
-    case width <= Constants.MOBILE_SCREEN_WIDTH: {
-        windowSize = WindowSizes.MOBILE_VIEW;
-        break;
-    }
-    default: {
-        windowSize = WindowSizes.DESKTOP_VIEW; // width > Constants.DESKTOP_SCREEN_WIDTH
-    }
-    }
-
+export function emitBrowserWindowResized(windowSize: string): GenericAction {
     return {
         type: ActionTypes.BROWSER_WINDOW_RESIZED,
         data: windowSize,


### PR DESCRIPTION
#### Summary
This PR switches the mechanism for determining the current window breakpoint size to use `window.matchMedia`.  `window.matchMedia` only fires its `change` event a single time when the window size crosses a defined media query boundary. With this change, the `emitBrowserWindowResized` action is only called once when the active window breakpoint changes instead of every 100ms whiles the window is resizing.

#### Release Note
```release-note
NONE
```
