### PR TITLE
MM-40176 - adjust hands svg size for trial benefits modal

### DIFF
--- a/components/trial_benefits_modal/trial_benefits_modal.scss
+++ b/components/trial_benefits_modal/trial_benefits_modal.scss
@@ -64,8 +64,8 @@
         }
 
         .handsSvg {
-            margin-left: 170px;
             margin-top: 50px;
+            margin-left: 170px;
         }
 
         .personMacSvg {

--- a/components/trial_benefits_modal/trial_benefits_modal.scss
+++ b/components/trial_benefits_modal/trial_benefits_modal.scss
@@ -64,7 +64,8 @@
         }
 
         .handsSvg {
-            margin-left: 190px;
+            margin-left: 170px;
+            margin-top: 50px;
         }
 
         .personMacSvg {

--- a/components/trial_benefits_modal/trial_benefits_modal.tsx
+++ b/components/trial_benefits_modal/trial_benefits_modal.tsx
@@ -109,10 +109,10 @@ const TrialBenefitsModal: React.FC<Props> = (props: Props): JSX.Element | null =
                     )}
                 </div>
             }
-            <div className='handSvg svg-wrapper'>
+            <div className='handsSvg svg-wrapper'>
                 <HandsSvg
-                    width={400}
-                    height={400}
+                    width={150}
+                    height={100}
                 />
             </div>
             <div className='bottom-text-left-message'>


### PR DESCRIPTION
#### Summary
During the initial implementation of the benefits trial modal, the hands svg image had an scaling problem related to the way figma was exporting the image. In order to make it fit in the space and be compliant with the design, we had to set a bigger size to the image. Now that the hands svg image was fixed and replaced as part of the changes for the license page https://github.com/mattermost/mattermost-webapp/pull/9372/files#diff-c9a0cfc007c0ec6684e230f4bf09f32c1a853fd174be5a6c1a226eb9d72b21e9R19 we can set the correct size to the image in the trial modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40176


#### Screenshots
Before:
<img width="1630" alt="Captura de pantalla 2021-12-01 a las 23 31 43" src="https://user-images.githubusercontent.com/10082627/144330047-4206868c-b73b-4580-8e18-da7f2eb04bb5.png">

After:
![hands_fixed](https://user-images.githubusercontent.com/10082627/144330079-e85d4567-c7a5-4a9a-9283-50f90f6368a9.gif)


#### Release Note
```release-note
NONE
```
