### PR TITLE
MM-40417 - fix the wording for the starter plan

### DIFF
--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
@@ -48,6 +48,9 @@ const EnterpriseEditionLeftPanel: React.FC<EnterpriseEditionProps> = ({
     case LicenseSkus.Professional:
         skuName = 'Professional';
         break;
+    case LicenseSkus.Starter:
+        skuName = 'Starter';
+        break;
     default:
         skuName = 'Enterprise';
         break;


### PR DESCRIPTION
#### Summary
There was a defect related to the licensing page not showing the accurate name for the starter license. This PR adds the starter option to the sku name generation so when a starter license is upload, the information shown in the license section is accurate.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40417

#### Related Pull Requests

#### Screenshots
Both images were taken from an env using a starter license.

Before:
<img width="988" alt="Screen Shot 2021-11-30 at 2 59 24 PM" src="https://user-images.githubusercontent.com/10082627/144476656-36899497-2a17-4dc5-93c4-02e2418c1e7d.png">


After:
<img width="1358" alt="Captura de pantalla 2021-12-02 a las 18 37 05" src="https://user-images.githubusercontent.com/10082627/144476080-44ee305a-4037-4347-a2e3-ea271cd3ffdc.png">


#### Release Note
```release-note
NONE
```
