### PR TITLE
Cypress/E2E: Fix group configuration spec

### DIFF
--- a/components/admin_console/group_settings/group_details/__snapshots__/group_teams_and_channels_row.test.tsx.snap
+++ b/components/admin_console/group_settings/group_details/__snapshots__/group_teams_and_channels_row.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`components/admin_console/group_settings/group_details/GroupTeamsAndChan
 
 exports[`components/admin_console/group_settings/group_details/GroupTeamsAndChannelsRow should match snapshot, when has children 1`] = `
 <tr
-  className="group-teams-and-channels-row has-clidren"
+  className="group-teams-and-channels-row has-children"
 >
   <ConfirmModal
     confirmButtonClass="btn btn-primary"
@@ -411,7 +411,7 @@ exports[`components/admin_console/group_settings/group_details/GroupTeamsAndChan
 
 exports[`components/admin_console/group_settings/group_details/GroupTeamsAndChannelsRow should match snapshot, when has children and is collapsed 1`] = `
 <tr
-  className="group-teams-and-channels-row has-clidren collapsed"
+  className="group-teams-and-channels-row has-children collapsed"
 >
   <ConfirmModal
     confirmButtonClass="btn btn-primary"

--- a/components/admin_console/group_settings/group_details/group_teams_and_channels_row.tsx
+++ b/components/admin_console/group_settings/group_details/group_teams_and_channels_row.tsx
@@ -141,7 +141,7 @@ State
                     onClick={this.toggleCollapse}
                 />
             );
-            extraClasses += ' has-clidren';
+            extraClasses += ' has-children';
         }
 
         if (this.props.collapsed) {

--- a/e2e/cypress/integration/enterprise/system_console/group_configuration_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/group_configuration_spec.js
@@ -243,7 +243,7 @@ describe('group configuration', () => {
 
             // * Check that the channel was added to the view
             teamOrChannelIsPresent(testChannel.display_name);
-            cy.get('.group-teams-and-channels-row', {timeout: TIMEOUTS.ONE_MIN}).should('have.length', 2);
+            cy.get('.group-teams-and-channels-row', {timeout: TIMEOUTS.ONE_MIN}).not('.has-children').should('have.length', 2);
 
             // # Click remove
             cy.findByTestId(`${testChannel.display_name}_groupsyncable_remove`).click();

--- a/sass/components/_groups.scss
+++ b/sass/components/_groups.scss
@@ -540,7 +540,7 @@
     .group-teams-and-channels--body {
         padding: 20px;
 
-        .group-teams-and-channels-row.has-clidren {
+        .group-teams-and-channels-row.has-children {
             .type {
                 margin-left: 20px;
             }


### PR DESCRIPTION
#### Summary
- Fix failing test on group configuration spec; only count rows that don't have children
- Also fixed css typo from `has-clidren` to `has-children`

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2021-12-02 at 9 45 57 AM](https://user-images.githubusercontent.com/487991/144478819-7b34a693-e312-496e-a62d-0cfb291a245e.png)

#### Release Note
```release-note
NONE
```