### PR TITLE
Updated About Mattermost TE modal's community URL

### DIFF
--- a/components/about_build_modal/__snapshots__/about_build_modal.test.tsx.snap
+++ b/components/about_build_modal/__snapshots__/about_build_modal.test.tsx.snap
@@ -531,11 +531,11 @@ exports[`components/AboutBuildModal should match snapshot for team edition 1`] =
           id="about.teamEditionLearn"
         />
         <a
-          href="http://www.mattermost.org/"
+          href="https://mattermost.com/community/"
           rel="noopener noreferrer"
           target="_blank"
         >
-          mattermost.org
+          mattermost.com/community/
         </a>
       </div>
       <div
@@ -769,11 +769,11 @@ exports[`components/AboutBuildModal should show ci if a ci build 1`] = `
           id="about.teamEditionLearn"
         />
         <a
-          href="http://www.mattermost.org/"
+          href="https://mattermost.com/community/"
           rel="noopener noreferrer"
           target="_blank"
         >
-          mattermost.org
+          mattermost.com/community/
         </a>
       </div>
       <div
@@ -996,11 +996,11 @@ exports[`components/AboutBuildModal should show dev if this is a dev build 1`] =
           id="about.teamEditionLearn"
         />
         <a
-          href="http://www.mattermost.org/"
+          href="https://mattermost.com/community/"
           rel="noopener noreferrer"
           target="_blank"
         >
-          mattermost.org
+          mattermost.com/community/
         </a>
       </div>
       <div

--- a/components/about_build_modal/about_build_modal.tsx
+++ b/components/about_build_modal/about_build_modal.tsx
@@ -92,9 +92,9 @@ export default class AboutBuildModal extends React.PureComponent<Props, State> {
                 <a
                     target='_blank'
                     rel='noopener noreferrer'
-                    href='http://www.mattermost.org/'
+                    href='https://mattermost.com/community/'
                 >
-                    {'mattermost.org'}
+                    {'mattermost.com/community/'}
                 </a>
             </div>
         );


### PR DESCRIPTION
Updated the About Mattermost Team Edition modal community URL to point to https://mattermost.com/community/ since the .org domain is being retired.

#### Summary
Updated the About Mattermost Team Edition modal to change the community link from `mattermost.org` to `mattermost.com/community/`.

#### Release Note

```release-note
Updated the About Mattermost Team Edition modal to change the community link from `mattermost.org` to `mattermost.com/community/`.
```
