### PR TITLE
MM-40493 Switch DND modal to rely more on GenericModal

### DIFF
--- a/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.scss
+++ b/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.scss
@@ -3,10 +3,6 @@
 .DndModal {
     width: 600px;
 
-    .modal-footer {
-        display: none;
-    }
-
     .btn-primary {
         height: 4rem;
         padding: 0 2rem;
@@ -50,7 +46,7 @@
 
 .DndModal__content {
     display: flex;
-    margin: 32px -10px 0;
+    margin: 32px -10px 10px;
 
     > div {
         flex: 1;
@@ -123,9 +119,4 @@
     background: rgba(var(--center-channel-bg-rgb), 1);
     color: rgba(var(--center-channel-color-rgb), 0.64);
     font-size: 10px;
-}
-
-.DndModal__footer {
-    padding: 20px 0;
-    text-align: right;
 }

--- a/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
+++ b/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
@@ -27,7 +27,6 @@ type Props = {
 };
 
 type State = {
-    show: boolean;
     selectedDate: Date;
     selectedTime: string;
     timeMenuList: string[];
@@ -47,7 +46,6 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
         }
 
         this.state = {
-            show: true,
             selectedDate,
             dayPickerStartDate: selectedDate,
             ...this.makeTimeMenuList(selectedDate),
@@ -81,8 +79,7 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
         };
     }
 
-    handleConfirm = (event: any) => {
-        event.preventDefault();
+    handleConfirm = () => {
         const hours = parseInt(this.state.selectedTime.split(':')[0], 10);
         const minutes = parseInt(this.state.selectedTime.split(':')[1], 10);
         const endTime = new Date(this.state.selectedDate);
@@ -96,9 +93,6 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
             dnd_end_time: toUTCUnix(endTime),
             manual: true,
             last_activity_at: toUTCUnix(this.props.currentDate),
-        });
-        this.setState({
-            show: false,
         });
     }
 
@@ -168,10 +162,10 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
 
         return (
             <GenericModal
-                show={this.state.show}
                 onExited={this.props.onExited}
                 modalHeaderText={modalHeaderText}
                 confirmButtonText={confirmButtonText}
+                handleConfirm={this.handleConfirm}
                 id='dndCustomTimePickerModal'
                 className={'DndModal modal-overflow'}
             >
@@ -221,15 +215,6 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
                             {timeMenuItems}
                         </Menu>
                     </MenuWrapper>
-                </div>
-                <div className='DndModal__footer'>
-                    <button
-                        type='button'
-                        className='btn btn-primary'
-                        onClick={this.handleConfirm}
-                    >
-                        {confirmButtonText}
-                    </button>
                 </div>
             </GenericModal>
         );


### PR DESCRIPTION
Previously, the DND modal had some internal state for tracking its show/hide, and it also implemented its own confirm button for whatever reason. Both of those didn't work together (the modal didn't close properly), so I removed the extra state and changed it so that the actual footer from the GenericModal is used. This results in some minor appearance changes, but I think consistency between modals is more important here.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40493

#### Screenshots
|  before  |  after  |
|----|----|
| ![Screen Shot 2021-12-07 at 2 55 25 PM](https://user-images.githubusercontent.com/3277310/145099176-93a5b51f-3ee8-4178-afe8-bb8b1b2f6fab.png) | ![Screen Shot 2021-12-07 at 2 55 29 PM](https://user-images.githubusercontent.com/3277310/145099208-66897430-9192-4865-9a8a-c5b44a86e97d.png) |

#### Release Note
```release-note
NONE
```
