### PR TITLE
MM-40528 Fix error caused by changes to QuickInput

### DIFF
--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -706,7 +706,7 @@ export default class SuggestionBox extends React.PureComponent {
     }
 
     focus = () => {
-        const input = this.inputRef.current.input;
+        const input = this.inputRef.current;
         if (input.value === '""' || input.value.endsWith('""')) {
             input.selectionStart = input.value.length - 1;
             input.selectionEnd = input.value.length - 1;


### PR DESCRIPTION
In my other PR to forward the ref through the QuickInput to the inner input, I missed a place that was still trying to access the ref as a field of the QuickInput

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40528

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9452

#### Release Note
```release-note
NONE
```
