### PR TITLE
MM-40114 Migrate post-related components to use getIsMobileView

### DIFF
--- a/components/dot_menu/dot_menu.test.tsx
+++ b/components/dot_menu/dot_menu.test.tsx
@@ -12,14 +12,6 @@ import {TestHelper} from 'utils/test_helper';
 
 import DotMenu, {PLUGGABLE_COMPONENT, DotMenuClass} from './dot_menu';
 
-jest.mock('utils/utils', () => {
-    const original = jest.requireActual('utils/utils');
-    return {
-        ...original,
-        isMobile: jest.fn(() => false),
-    };
-});
-
 describe('components/dot_menu/DotMenu', () => {
     const baseProps = {
         post: TestHelper.getPostMock({id: 'post_id_1', is_pinned: false, type: '' as PostType}),
@@ -54,6 +46,7 @@ describe('components/dot_menu/DotMenu', () => {
         teamId: 'team_id_1',
         isFollowingThread: false,
         isCollapsedThreadsEnabled: false,
+        isMobileView: false,
         threadId: 'post_id_1',
         threadReplyCount: 0,
         userId: 'user_id_1',

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -51,6 +51,7 @@ type Props = {
     teamUrl?: string; // TechDebt: Made non-mandatory while converting to typescript
     appBindings: AppBinding[] | null;
     appsEnabled: boolean;
+    isMobileView: boolean;
 
     /**
      * Components for overriding provided by plugins
@@ -400,8 +401,8 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
     }
 
     render() {
+        const isMobile = this.props.isMobileView;
         const isSystemMessage = PostUtils.isSystemMessage(this.props.post);
-        const isMobile = Utils.isMobile();
 
         const pluginItems = this.props.pluginMenuItems?.
             filter((item) => {

--- a/components/dot_menu/dot_menu_empty.test.tsx
+++ b/components/dot_menu/dot_menu_empty.test.tsx
@@ -9,7 +9,6 @@ import {TestHelper} from 'utils/test_helper';
 
 jest.mock('utils/utils', () => {
     return {
-        isMobile: jest.fn(() => false),
         localizeMessage: jest.fn().mockReturnValue(''),
     };
 });
@@ -51,6 +50,7 @@ describe('components/dot_menu/DotMenu returning empty ("")', () => {
             appBindings: [],
             pluginMenuItems: [],
             appsEnabled: false,
+            isMobileView: false,
             isReadOnly: false,
             isCollapsedThreadsEnabled: false,
             teamId: '',

--- a/components/dot_menu/dot_menu_mobile.test.tsx
+++ b/components/dot_menu/dot_menu_mobile.test.tsx
@@ -9,7 +9,6 @@ import {TestHelper} from 'utils/test_helper';
 
 jest.mock('utils/utils', () => {
     return {
-        isMobile: jest.fn(() => true),
         localizeMessage: jest.fn(),
     };
 });
@@ -51,6 +50,7 @@ describe('components/dot_menu/DotMenu on mobile view', () => {
             appBindings: [],
             pluginMenuItems: [],
             appsEnabled: false,
+            isMobileView: true,
             isReadOnly: false,
             isCollapsedThreadsEnabled: false,
             teamId: '',

--- a/components/dot_menu/index.ts
+++ b/components/dot_menu/index.ts
@@ -40,13 +40,16 @@ import {
     setEditingPost,
     markPostAsUnread,
 } from 'actions/post_actions.jsx';
+
+import {getIsMobileView} from 'selectors/views/browser';
+
 import * as PostUtils from 'utils/post_utils';
 
 import {isArchivedChannel} from 'utils/channel_utils';
 import {getSiteURL} from 'utils/url';
 
 import {Locations} from 'utils/constants';
-import {allAtMentions} from '../../utils/text_formatting';
+import {allAtMentions} from 'utils/text_formatting';
 
 import {matchUserMentionTriggersWithMessageMentions} from 'utils/post_utils';
 
@@ -141,7 +144,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         threadReplyCount,
         appBindings,
         appsEnabled: apps,
-        ...ownProps,
+        isMobileView: getIsMobileView(state),
     };
 }
 

--- a/components/post_view/floating_timestamp/floating_timestamp.test.tsx
+++ b/components/post_view/floating_timestamp/floating_timestamp.test.tsx
@@ -9,7 +9,6 @@ import FloatingTimestamp from './floating_timestamp';
 describe('components/post_view/FloatingTimestamp', () => {
     const baseProps = {
         isScrolling: true,
-        isMobile: true,
         createAt: 1234,
         toastPresent: true,
         isRhsPost: false,

--- a/components/post_view/floating_timestamp/floating_timestamp.tsx
+++ b/components/post_view/floating_timestamp/floating_timestamp.tsx
@@ -12,7 +12,6 @@ const DATE_RANGES = [
 ];
 type Props = {
     isScrolling: boolean;
-    isMobile: boolean;
     createAt: Date | number;
     toastPresent: boolean;
     isRhsPost: boolean;
@@ -20,9 +19,9 @@ type Props = {
 
 export default class FloatingTimestamp extends React.PureComponent<Props> {
     render() {
-        const {isMobile, createAt, isScrolling, isRhsPost, toastPresent} = this.props;
+        const {createAt, isScrolling, isRhsPost, toastPresent} = this.props;
 
-        if (!isMobile || createAt === 0) {
+        if (createAt === 0) {
             return null;
         }
 

--- a/components/post_view/post_list/__snapshots__/post_list.test.jsx.snap
+++ b/components/post_view/post_list/__snapshots__/post_list.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`components/post_view/post_list snapshot for loading when there are no p
         atLatestPost={false}
         autoRetryEnable={true}
         channelId="fake-id"
+        isMobileView={false}
         loadingNewerPosts={false}
         loadingOlderPosts={false}
         postListIds={Array []}
@@ -61,6 +62,7 @@ exports[`components/post_view/post_list snapshot with couple of posts 1`] = `
         atLatestPost={false}
         autoRetryEnable={true}
         channelId="fake-id"
+        isMobileView={false}
         loadingNewerPosts={false}
         loadingOlderPosts={false}
         postListIds={Array []}

--- a/components/post_view/post_list/index.js
+++ b/components/post_view/post_list/index.js
@@ -22,6 +22,7 @@ import {
     syncPostsInChannel,
     loadLatestPosts,
 } from 'actions/views/channel';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import PostList from './post_list.jsx';
 
@@ -82,6 +83,7 @@ function makeMapStateToProps() {
             postListIds: postIds,
             isPrefetchingInProcess,
             channelManuallyUnread,
+            isMobileView: getIsMobileView(state),
         };
     };
 }

--- a/components/post_view/post_list/post_list.jsx
+++ b/components/post_view/post_list/post_list.jsx
@@ -79,6 +79,8 @@ export default class PostList extends React.PureComponent {
          */
         isPrefetchingInProcess: PropTypes.bool.isRequired,
 
+        isMobileView: PropTypes.bool.isRequired,
+
         actions: PropTypes.shape({
 
             /*
@@ -315,6 +317,7 @@ export default class PostList extends React.PureComponent {
                             postListIds={this.props.formattedPostIds}
                             latestPostTimeStamp={this.props.latestPostTimeStamp}
                             latestPostId={this.props.latestPostId}
+                            isMobileView={this.props.isMobileView}
                         />
                     </div>
                 </div>

--- a/components/post_view/post_list/post_list.test.jsx
+++ b/components/post_view/post_list/post_list.test.jsx
@@ -45,6 +45,7 @@ const baseProps = {
     formattedPostIds: [],
     channelManuallyUnread: false,
     isPrefetchingInProcess: false,
+    isMobileView: false,
 };
 
 describe('components/post_view/post_list', () => {

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -575,7 +575,6 @@ export default class PostList extends React.PureComponent {
                     <React.Fragment>
                         <FloatingTimestamp
                             isScrolling={this.state.isScrolling}
-                            isMobile={true}
                             postId={this.state.topPostId}
                         />
                         <ScrollToBottomArrows

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -90,6 +90,8 @@ export default class PostList extends React.PureComponent {
 
         lastViewedAt: PropTypes.string,
 
+        isMobileView: PropTypes.bool.isRequired,
+
         actions: PropTypes.shape({
 
             /**
@@ -125,10 +127,8 @@ export default class PostList extends React.PureComponent {
         super(props);
 
         const channelIntroMessage = PostListRowListIds.CHANNEL_INTRO_MESSAGE;
-        const isMobile = Utils.isMobile();
         this.state = {
             isScrolling: false,
-            isMobile,
 
             /* Intentionally setting null so that toast can determine when the first time this state is defined */
             atBottom: null,
@@ -148,7 +148,7 @@ export default class PostList extends React.PureComponent {
 
         this.listRef = React.createRef();
         this.postListRef = React.createRef();
-        if (isMobile) {
+        if (this.props.isMobileView) {
             this.scrollStopAction = new DelayedAction(this.handleScrollStop);
         }
 
@@ -197,6 +197,10 @@ export default class PostList extends React.PureComponent {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
+        if (this.props.isMobileView && !prevProps.isMobileView) {
+            this.scrollStopAction = new DelayedAction(this.handleScrollStop);
+        }
+
         if (!this.postListRef.current) {
             return;
         }
@@ -223,7 +227,7 @@ export default class PostList extends React.PureComponent {
         EventEmitter.removeListener(EventTypes.POST_LIST_SCROLL_TO_BOTTOM, this.scrollToLatestMessages);
     }
 
-    static getDerivedStateFromProps(props) {
+    static getDerivedStateFromProps(props, state) {
         const postListIds = props.postListIds;
         let newPostListIds;
 
@@ -243,9 +247,30 @@ export default class PostList extends React.PureComponent {
             }
         }
 
-        return {
+        const nextState = {
             postListIds: newPostListIds,
         };
+
+        if (props.isMobileView !== state.isMobileView) {
+            nextState.isMobileView = props.isMobileView;
+
+            const dynamicListStyle = state.dynamicListStyle;
+            if (state.postMenuOpened) {
+                if (!props.isMobileView && dynamicListStyle.willChange === 'unset') {
+                    nextState.dynamicListStyle = {
+                        ...dynamicListStyle,
+                        willChange: 'transform',
+                    };
+                } else if (props.isMobileView && dynamicListStyle.willChange === 'transform') {
+                    nextState.dynamicListStyle = {
+                        ...dynamicListStyle,
+                        willChange: 'unset',
+                    };
+                }
+            }
+        }
+
+        return nextState;
     }
 
     getNewMessagesSeparatorIndex = (postListIds) => {
@@ -256,31 +281,16 @@ export default class PostList extends React.PureComponent {
 
     handleWindowResize = () => {
         this.props.actions.checkAndSetMobileView();
-        const isMobile = Utils.isMobile();
-        if (isMobile !== this.state.isMobile) {
-            const dynamicListStyle = this.state.dynamicListStyle;
-            if (this.state.postMenuOpened) {
-                if (!isMobile && dynamicListStyle.willChange === 'unset') {
-                    dynamicListStyle.willChange = 'transform';
-                } else if (isMobile && dynamicListStyle.willChange === 'transform') {
-                    dynamicListStyle.willChange = 'unset';
-                }
-            }
-
-            this.setState({
-                isMobile,
-                dynamicListStyle,
-            });
-            this.scrollStopAction = new DelayedAction(this.handleScrollStop);
-        }
-
         this.showSearchHintThreshold = this.getShowSearchHintThreshold();
     }
 
     togglePostMenu = (opened) => {
-        const dynamicListStyle = this.state.dynamicListStyle;
-        if (this.state.isMobile) {
-            dynamicListStyle.willChange = opened ? 'unset' : 'transform';
+        let dynamicListStyle = this.state.dynamicListStyle;
+        if (this.props.isMobileView) {
+            dynamicListStyle = {
+                ...dynamicListStyle,
+                opened: opened ? 'unset' : 'transform',
+            };
         }
 
         this.setState({
@@ -356,7 +366,7 @@ export default class PostList extends React.PureComponent {
             this.props.actions.loadNewerPosts();
         }
 
-        if (this.state.isMobile) {
+        if (this.props.isMobileView) {
             if (!this.state.isScrolling) {
                 this.setState({
                     isScrolling: true,
@@ -386,13 +396,13 @@ export default class PostList extends React.PureComponent {
             }
         }
 
-        if (this.state.isMobile && this.state.showSearchHint) {
+        if (this.props.isMobileView && this.state.showSearchHint) {
             this.setState({
                 showSearchHint: false,
             });
         }
 
-        if (!this.state.isMobile && !this.state.isSearchHintDismissed) {
+        if (!this.props.isMobileView && !this.state.isSearchHintDismissed) {
             this.setState({
                 showSearchHint: offsetFromBottom > this.showSearchHintThreshold,
             });
@@ -452,7 +462,7 @@ export default class PostList extends React.PureComponent {
     }
 
     updateFloatingTimestamp = (visibleTopItem) => {
-        if (!this.state.isMobile) {
+        if (!this.props.isMobileView) {
             return;
         }
 
@@ -561,7 +571,7 @@ export default class PostList extends React.PureComponent {
                 data-a11y-loop-navigation={false}
                 aria-label={Utils.localizeMessage('accessibility.sections.centerContent', 'message list main region')}
             >
-                {this.state.isMobile && (
+                {this.props.isMobileView && (
                     <React.Fragment>
                         <FloatingTimestamp
                             isScrolling={this.state.isScrolling}

--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
@@ -36,6 +36,7 @@ describe('PostList', () => {
         loadingOlderPosts: false,
         atOldestPost: false,
         atLatestPost: false,
+        isMobileView: false,
         actions: baseActions,
     };
 
@@ -227,8 +228,12 @@ describe('PostList', () => {
         test('should not show search channel hint on mobile', () => {
             const screenHeightSpy = jest.spyOn(window.screen, 'height', 'get').mockImplementation(() => 500);
 
-            const wrapper = shallow(<PostList {...baseProps}/>);
-            wrapper.setState({isMobile: true});
+            const props = {
+                ...baseProps,
+                isMobileView: true,
+            };
+
+            const wrapper = shallow(<PostList {...props}/>);
             const instance = wrapper.instance();
 
             const scrollHeight = 3000;
@@ -291,7 +296,10 @@ describe('PostList', () => {
 
             expect(wrapper.state('showSearchHint')).toBe(true);
 
-            wrapper.setState({isMobile: true});
+            wrapper.setProps({
+                isMobileView: true,
+            });
+
             instance.onScroll({
                 scrollDirection: 'forward',
                 scrollOffset,
@@ -529,17 +537,27 @@ describe('PostList', () => {
 
     describe('updateFloatingTimestamp', () => {
         test('should not update topPostId as is it not mobile view', () => {
-            const wrapper = shallow(<PostList {...baseProps}/>);
+            const props = {
+                ...baseProps,
+                isMobileView: false,
+            };
+
+            const wrapper = shallow(<PostList {...props}/>);
             const instance = wrapper.instance();
-            wrapper.setState({isMobile: false});
+
             instance.onItemsRendered({visibleStartIndex: 0});
             expect(wrapper.state('topPostId')).toBe('');
         });
 
         test('should update topPostId with latest visible postId', () => {
-            const wrapper = shallow(<PostList {...baseProps}/>);
+            const props = {
+                ...baseProps,
+                isMobileView: true,
+            };
+
+            const wrapper = shallow(<PostList {...props}/>);
             const instance = wrapper.instance();
-            wrapper.setState({isMobile: true});
+
             instance.onItemsRendered({visibleStartIndex: 1});
             expect(wrapper.state('topPostId')).toBe('post2');
 

--- a/components/post_view/post_time/index.ts
+++ b/components/post_view/post_time/index.ts
@@ -5,6 +5,8 @@ import {connect} from 'react-redux';
 
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 
+import {getIsMobileView} from 'selectors/views/browser';
+
 import {GlobalState} from 'types/store';
 
 import PostTime from './post_time';
@@ -15,6 +17,7 @@ type OwnProps = {
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     return {
+        isMobileView: getIsMobileView(state),
         teamUrl: ownProps.teamName ? `/${ownProps.teamName}` : getCurrentRelativeTeamUrl(state),
     };
 }

--- a/components/post_view/post_time/post_time.tsx
+++ b/components/post_view/post_time/post_time.tsx
@@ -9,7 +9,6 @@ import {Tooltip} from 'react-bootstrap';
 import * as GlobalActions from 'actions/global_actions';
 import {isMobile} from 'utils/user_agent';
 import {Locations} from 'utils/constants';
-import {isMobile as isMobileView} from 'utils/utils.jsx';
 import OverlayTrigger from 'components/overlay_trigger';
 
 import Timestamp, {RelativeRanges} from 'components/timestamp';
@@ -22,8 +21,8 @@ const POST_TOOLTIP_RANGES = [
 type Props = {
 
     /*
-         * If true, time will be rendered as a permalink to the post
-         */
+     * If true, time will be rendered as a permalink to the post
+     */
     isPermalink: boolean;
 
     /*
@@ -31,6 +30,7 @@ type Props = {
      */
     eventTime: number;
 
+    isMobileView: boolean;
     location: string;
 
     /*
@@ -48,7 +48,7 @@ export default class PostTime extends React.PureComponent<Props> {
     };
 
     handleClick = () => {
-        if (isMobileView()) {
+        if (this.props.isMobileView) {
             GlobalActions.emitCloseRightHandSide();
         }
     };

--- a/components/profile_popover/__snapshots__/profile_popover.test.tsx.snap
+++ b/components/profile_popover/__snapshots__/profile_popover.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`components/ProfilePopover should hide add-to-channel option if not on t
   isCustomStatusEnabled={true}
   isCustomStatusExpired={false}
   isInCurrentTeam={false}
+  isMobileView={false}
   placement="right"
   popoverSize="sm"
   popoverStyle="info"
@@ -174,6 +175,7 @@ exports[`components/ProfilePopover should match snapshot 1`] = `
   isCustomStatusEnabled={true}
   isCustomStatusExpired={false}
   isInCurrentTeam={true}
+  isMobileView={false}
   placement="right"
   popoverSize="sm"
   popoverStyle="info"
@@ -426,6 +428,7 @@ exports[`components/ProfilePopover should match snapshot for shared user 1`] = `
   isCustomStatusEnabled={true}
   isCustomStatusExpired={false}
   isInCurrentTeam={true}
+  isMobileView={false}
   placement="right"
   popoverSize="sm"
   popoverStyle="info"
@@ -728,6 +731,7 @@ exports[`components/ProfilePopover should match snapshot with custom status 1`] 
   isCustomStatusEnabled={true}
   isCustomStatusExpired={false}
   isInCurrentTeam={true}
+  isMobileView={false}
   placement="right"
   popoverSize="sm"
   popoverStyle="info"
@@ -1032,6 +1036,7 @@ exports[`components/ProfilePopover should match snapshot with custom status expi
   isCustomStatusEnabled={true}
   isCustomStatusExpired={true}
   isInCurrentTeam={true}
+  isMobileView={false}
   placement="right"
   popoverSize="sm"
   popoverStyle="info"
@@ -1284,6 +1289,7 @@ exports[`components/ProfilePopover should match snapshot with custom status not 
   isCustomStatusEnabled={true}
   isCustomStatusExpired={false}
   isInCurrentTeam={true}
+  isMobileView={false}
   placement="right"
   popoverSize="sm"
   popoverStyle="info"

--- a/components/profile_popover/index.ts
+++ b/components/profile_popover/index.ts
@@ -22,6 +22,7 @@ import {closeModal, openModal} from 'actions/views/modals';
 
 import {areTimezonesEnabledAndSupported, getCurrentUserTimezone} from 'selectors/general';
 import {getRhsState, getSelectedPost} from 'selectors/rhs';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import {makeGetCustomStatus, isCustomStatusEnabled, isCustomStatusExpired} from 'selectors/views/custom_status';
 import {Action} from 'mattermost-redux/types/actions';
@@ -76,6 +77,7 @@ function makeMapStateToProps() {
             isCustomStatusExpired: isCustomStatusExpired(state, customStatus),
             channelId,
             currentUserTimezone: getCurrentUserTimezone(state),
+            isMobileView: getIsMobileView(state),
         };
     };
 }

--- a/components/profile_popover/profile_popover.test.tsx
+++ b/components/profile_popover/profile_popover.test.tsx
@@ -31,6 +31,7 @@ describe('components/ProfilePopover', () => {
         canManageAnyChannelMembersInCurrentTeam: true,
         isCustomStatusEnabled: true,
         isCustomStatusExpired: false,
+        isMobileView: false,
         actions: {
             getMembershipForEntities: jest.fn(),
             openDirectChannelToUserId: jest.fn(),

--- a/components/profile_popover/profile_popover.tsx
+++ b/components/profile_popover/profile_popover.tsx
@@ -69,6 +69,7 @@ interface ProfilePopoverProps extends Omit<React.ComponentProps<typeof Popover>,
      */
     isRHS?: boolean;
     isBusy?: boolean;
+    isMobileView: boolean;
 
     /**
      * Returns state of modals in redux for determing which need to be closed
@@ -190,7 +191,7 @@ ProfilePopoverState
         this.setState({loadingDMChannel: user.id});
         actions.openDirectChannelToUserId(user.id).then((result: {error: ServerError}) => {
             if (!result.error) {
-                if (Utils.isMobile()) {
+                if (this.props.isMobileView) {
                     GlobalActions.emitCloseRightHandSide();
                 }
                 this.setState({loadingDMChannel: undefined});

--- a/components/threading/virtualized_thread_viewer/virtualized_thread_viewer.tsx
+++ b/components/threading/virtualized_thread_viewer/virtualized_thread_viewer.tsx
@@ -444,7 +444,6 @@ class ThreadViewerVirtualized extends PureComponent<Props, State> {
             <>
                 {isMobile && topRhsPostId && !this.props.useRelativeTimestamp && (
                     <FloatingTimestamp
-                        isMobile={true}
                         isRhsPost={true}
                         isScrolling={this.state.isScrolling}
                         postId={topRhsPostId}


### PR DESCRIPTION
`getIsMobileView` is the more redux-friendly, more self-explanatory, and hopefully more performant version of `Utils.isMobile` that we're wanting to be using everywhere now. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40114

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9507

#### Release Note
```release-note
NONE
```
