### PR TITLE
MM-40114 Migrate RHS and search components to use getIsMobileView

### DIFF
--- a/components/rhs_card/index.js
+++ b/components/rhs_card/index.js
@@ -7,6 +7,7 @@ import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/tea
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {getSelectedPostCard} from 'selectors/rhs';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import RhsCard from './rhs_card.jsx';
 
@@ -17,6 +18,7 @@ function mapStateToProps(state) {
 
     return {
         enablePostUsernameOverride,
+        isMobileView: getIsMobileView(state),
         selected,
         pluginPostCardTypes: state.plugins.postCardTypes,
         teamUrl: getCurrentRelativeTeamUrl(state),

--- a/components/rhs_card/rhs_card.jsx
+++ b/components/rhs_card/rhs_card.jsx
@@ -10,7 +10,6 @@ import {Link} from 'react-router-dom';
 
 import DelayedAction from 'utils/delayed_action';
 import Constants, {RHSStates} from 'utils/constants';
-import * as Utils from 'utils/utils.jsx';
 import RhsCardHeader from 'components/rhs_card_header';
 import Markdown from 'components/markdown';
 import UserProfile from 'components/user_profile';
@@ -47,6 +46,7 @@ export default class RhsCard extends React.Component {
         pluginPostCardTypes: PropTypes.object,
         previousRhsState: PropTypes.oneOf(Object.values(RHSStates)),
         enablePostUsernameOverride: PropTypes.bool,
+        isMobileView: PropTypes.bool.isRequired,
         teamUrl: PropTypes.string,
     }
 
@@ -92,7 +92,7 @@ export default class RhsCard extends React.Component {
     }
 
     handleClick = () => {
-        if (Utils.isMobile()) {
+        if (this.props.isMobileView) {
             GlobalActions.emitCloseRightHandSide();
         }
     };

--- a/components/rhs_card/rhs_card.test.jsx
+++ b/components/rhs_card/rhs_card.test.jsx
@@ -20,11 +20,16 @@ describe('comoponents/rhs_card/RhsCard', () => {
         display_name: 'Town Square',
     };
 
+    const baseProps = {
+        channel: currentChannel,
+        isMobileView: false,
+        selected: null,
+    };
+
     it('should match when no post is selected', () => {
         const wrapper = shallow(
             <RhsCard
-                selected={null}
-                channel={currentChannel}
+                {...baseProps}
             />,
         );
 
@@ -34,8 +39,8 @@ describe('comoponents/rhs_card/RhsCard', () => {
     it('should match on post when no plugin defining card types', () => {
         const wrapper = shallow(
             <RhsCard
+                {...baseProps}
                 selected={post}
-                channel={currentChannel}
             />,
         );
 
@@ -45,9 +50,9 @@ describe('comoponents/rhs_card/RhsCard', () => {
     it('should match on post when plugin defining card types don\'t match with the post type', () => {
         const wrapper = shallow(
             <RhsCard
+                {...baseProps}
                 selected={post}
                 pluginPostCardTypes={{notMatchingType: {component: () => <i/>}}}
-                channel={currentChannel}
             />,
         );
 
@@ -57,9 +62,9 @@ describe('comoponents/rhs_card/RhsCard', () => {
     it('should match on post when plugin defining card types match with the post type', () => {
         const wrapper = shallow(
             <RhsCard
+                {...baseProps}
                 selected={post}
                 pluginPostCardTypes={{test: {component: () => <i/>}}}
-                channel={currentChannel}
             />,
         );
 

--- a/components/rhs_comment/__snapshots__/rhs_comment.test.jsx.snap
+++ b/components/rhs_comment/__snapshots__/rhs_comment.test.jsx.snap
@@ -883,47 +883,6 @@ exports[`components/RhsComment should match snapshot on CRT enabled 1`] = `
             }
           />
         </div>
-        <div
-          className="col post-menu"
-          data-testid="post-menu-id"
-        >
-          <Connect(PostReaction)
-            channelId="channel_id"
-            getDotMenuRef={[Function]}
-            location="RHS_COMMENT"
-            postId="id"
-            showEmojiPicker={false}
-            teamId="team_id"
-            toggleEmojiPicker={[Function]}
-          />
-          <Connect(injectIntl(DotMenuClass))
-            enableEmojiPicker={true}
-            handleAddReactionClick={[Function]}
-            handleDropdownOpened={[Function]}
-            isFlagged={true}
-            isMenuOpen={false}
-            isReadOnly={false}
-            location="RHS_COMMENT"
-            post={
-              Object {
-                "channel_id": "channel_id",
-                "create_at": 1502715365009,
-                "delete_at": 0,
-                "edit_at": 1502715372443,
-                "id": "id",
-                "is_pinned": false,
-                "message": "post message",
-                "original_id": "",
-                "pending_post_id": "",
-                "props": Object {},
-                "root_id": "",
-                "type": "",
-                "update_at": 1502715372443,
-                "user_id": "user_id",
-              }
-            }
-          />
-        </div>
       </div>
       <div
         className="post__body"
@@ -1090,47 +1049,6 @@ exports[`components/RhsComment should match snapshot when highlighted 1`] = `
                 "style": undefined,
               }
             }
-          />
-        </div>
-        <div
-          className="col post-menu"
-          data-testid="post-menu-id"
-        >
-          <Connect(injectIntl(DotMenuClass))
-            enableEmojiPicker={true}
-            handleAddReactionClick={[Function]}
-            handleDropdownOpened={[Function]}
-            isFlagged={true}
-            isMenuOpen={false}
-            isReadOnly={false}
-            location="RHS_COMMENT"
-            post={
-              Object {
-                "channel_id": "channel_id",
-                "create_at": 1502715365009,
-                "delete_at": 0,
-                "edit_at": 1502715372443,
-                "id": "id",
-                "is_pinned": false,
-                "message": "post message",
-                "original_id": "",
-                "pending_post_id": "",
-                "props": Object {},
-                "root_id": "",
-                "type": "",
-                "update_at": 1502715372443,
-                "user_id": "user_id",
-              }
-            }
-          />
-          <Connect(PostReaction)
-            channelId="channel_id"
-            getDotMenuRef={[Function]}
-            location="RHS_COMMENT"
-            postId="id"
-            showEmojiPicker={false}
-            teamId="team_id"
-            toggleEmojiPicker={[Function]}
           />
         </div>
       </div>

--- a/components/rhs_comment/index.ts
+++ b/components/rhs_comment/index.ts
@@ -18,6 +18,7 @@ import {markPostAsUnread, emitShortcutReactToLastPostFrom} from 'actions/post_ac
 import {getShortcutReactToLastPostEmittedFrom, getOneClickReactionEmojis} from 'selectors/emojis';
 import {isEmbedVisible} from 'selectors/posts';
 import {getHighlightedPostId} from 'selectors/rhs';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import {GlobalState} from 'types/store';
 
@@ -81,6 +82,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         oneClickReactionsEnabled,
         recentEmojis: emojis,
         isExpanded: state.views.rhs.isSidebarExpanded,
+        isMobileView: getIsMobileView(state),
     };
 }
 

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -16,7 +16,6 @@ import {
 
 import Constants, {Locations, A11yCustomEventTypes} from 'utils/constants';
 import * as PostUtils from 'utils/post_utils';
-import {isMobile} from 'utils/utils.jsx';
 import DotMenu from 'components/dot_menu';
 import FileAttachmentListContainer from 'components/file_attachment_list';
 import OverlayTrigger from 'components/overlay_trigger';
@@ -92,6 +91,7 @@ export default class RhsComment extends React.PureComponent {
         recentEmojis: PropTypes.arrayOf(Emoji),
 
         isExpanded: PropTypes.bool,
+        isMobileView: PropTypes.bool.isRequired,
     };
 
     constructor(props) {
@@ -150,8 +150,16 @@ export default class RhsComment extends React.PureComponent {
 
     handleShortcutReactToLastPost = (isLastPost) => {
         if (isLastPost) {
-            const {isReadOnly, channelIsArchived, enableEmojiPicker, post,
-                actions: {emitShortcutReactToLastPostFrom}} = this.props;
+            const {
+                channelIsArchived,
+                enableEmojiPicker,
+                isMobileView,
+                isReadOnly,
+                post,
+                actions: {
+                    emitShortcutReactToLastPostFrom,
+                },
+            } = this.props;
 
             // Setting the last message emoji action to empty to clean up the redux state
             emitShortcutReactToLastPostFrom(Locations.NO_WHERE);
@@ -169,7 +177,7 @@ export default class RhsComment extends React.PureComponent {
                 boundingRectOfPostInfo.bottom < (window.innerHeight);
 
             if (isPostHeaderVisibleToUser && !isEphemeralPost && !isSystemMessage && !isReadOnly && !isFailedPost &&
-                !isAutoRespondersPost && !isDeletedPost && !channelIsArchived && !isMobile() && enableEmojiPicker) {
+                !isAutoRespondersPost && !isDeletedPost && !channelIsArchived && !isMobileView && enableEmojiPicker) {
                 this.setState({hover: true}, () => {
                     this.toggleEmojiPicker();
                 });
@@ -300,7 +308,14 @@ export default class RhsComment extends React.PureComponent {
     }
 
     render() {
-        const {post, isConsecutivePost, isReadOnly, channelIsArchived, collapsedThreadsEnabled} = this.props;
+        const {
+            channelIsArchived,
+            collapsedThreadsEnabled,
+            isConsecutivePost,
+            isMobileView,
+            isReadOnly,
+            post,
+        } = this.props;
 
         const isPostDeleted = post && post.state === Posts.POST_DELETED;
         const isEphemeral = isPostEphemeral(post);
@@ -313,7 +328,7 @@ export default class RhsComment extends React.PureComponent {
         let visibleMessage;
 
         let userProfile = null;
-        if (this.props.compactDisplay || isMobile()) {
+        if (this.props.compactDisplay || isMobileView) {
             userProfile = (
                 <UserProfile
                     userId={post.user_id}
@@ -487,7 +502,7 @@ export default class RhsComment extends React.PureComponent {
         }
 
         let flagIcon = null;
-        if (!isMobile() && (!isEphemeral && !post.failed && !isSystemMessage)) {
+        if (!isMobileView && (!isEphemeral && !post.failed && !isSystemMessage)) {
             flagIcon = (
                 <PostFlagIcon
                     location={Locations.RHS_COMMENT}
@@ -506,7 +521,7 @@ export default class RhsComment extends React.PureComponent {
             );
         } else if (isPostDeleted) {
             options = null;
-        } else if (!isSystemMessage && (isMobile() || this.state.hover || this.state.a11yActive || this.state.dropdownOpened || this.state.showEmojiPicker)) {
+        } else if (!isSystemMessage && (isMobileView || this.state.hover || this.state.a11yActive || this.state.dropdownOpened || this.state.showEmojiPicker)) {
             const dotMenu = (
                 <DotMenu
                     post={this.props.post}

--- a/components/rhs_comment/rhs_comment.test.jsx
+++ b/components/rhs_comment/rhs_comment.test.jsx
@@ -19,12 +19,7 @@ jest.mock('utils/post_utils', () => ({
     fromAutoResponder: jest.fn().mockReturnValue(false),
 }));
 
-import {isMobile} from 'utils/utils';
 import UserProfile from '../user_profile';
-
-jest.mock('utils/utils', () => ({
-    isMobile: jest.fn(),
-}));
 
 describe('components/RhsComment', () => {
     const post = {
@@ -72,6 +67,7 @@ describe('components/RhsComment', () => {
         isBot: false,
         collapsedThreadsEnabled: false,
         isInViewport: jest.fn(),
+        isMobileView: false,
     };
 
     test('should match snapshot', () => {
@@ -93,9 +89,12 @@ describe('components/RhsComment', () => {
     });
 
     test('should match snapshot mobile', () => {
-        isMobile.mockImplementation(() => true);
+        const props = {
+            ...baseProps,
+            isMobileView: true,
+        };
         const wrapper = shallow(
-            <RhsComment {...baseProps}/>,
+            <RhsComment {...props}/>,
         );
 
         expect(wrapper).toMatchSnapshot();
@@ -202,11 +201,13 @@ describe('components/RhsComment', () => {
     });
 
     test('should pass props correctly to PostFlagIcon', () => {
-        isMobile.mockImplementationOnce(() => false);
-
         const wrapper = shallow(
             <RhsComment {...baseProps}/>,
         );
+
+        wrapper.setState({
+            hover: true,
+        });
 
         const flagIcon = wrapper.find(PostFlagIcon);
         expect(flagIcon).toHaveLength(1);

--- a/components/rhs_header_post/index.ts
+++ b/components/rhs_header_post/index.ts
@@ -26,6 +26,7 @@ import {
     toggleRhsExpanded,
 } from 'actions/views/rhs';
 import {getIsRhsExpanded} from 'selectors/rhs';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import {allAtMentions} from '../../utils/text_formatting';
 
@@ -45,6 +46,7 @@ function mapStateToProps(state: GlobalState, {rootPostId}: OwnProps) {
 
     return {
         isExpanded: getIsRhsExpanded(state),
+        isMobileView: getIsMobileView(state),
         relativeTeamUrl: getCurrentRelativeTeamUrl(state),
         currentTeamId: getCurrentTeamId(state),
         currentUserId: getCurrentUserId(state),

--- a/components/rhs_header_post/rhs_header_post.tsx
+++ b/components/rhs_header_post/rhs_header_post.tsx
@@ -14,10 +14,10 @@ import FollowButton from 'components/threading/common/follow_button';
 import {browserHistory} from 'utils/browser_history';
 import Constants, {RHSStates} from 'utils/constants';
 import {t} from 'utils/i18n';
-import {isMobile} from 'utils/utils';
 
 interface RhsHeaderPostProps {
     isExpanded: boolean;
+    isMobileView: boolean;
     rootPostId: string;
     previousRhsState?: string;
     relativeTeamUrl: string;
@@ -60,7 +60,7 @@ export default class RhsHeaderPost extends React.PureComponent<RhsHeaderPostProp
     }
 
     handleJumpClick = () => {
-        if (isMobile()) {
+        if (this.props.isMobileView) {
             this.props.closeRightHandSide();
         }
 

--- a/components/rhs_root_post/index.ts
+++ b/components/rhs_root_post/index.ts
@@ -17,6 +17,7 @@ import {markPostAsUnread, emitShortcutReactToLastPostFrom} from 'actions/post_ac
 
 import {getShortcutReactToLastPostEmittedFrom, getOneClickReactionEmojis} from 'selectors/emojis';
 import {isEmbedVisible} from 'selectors/posts';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import {GlobalState} from 'types/store';
 import {FakePost} from 'types/store/rhs';
@@ -64,6 +65,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         oneClickReactionsEnabled,
         recentEmojis: emojis,
         isExpanded: state.views.rhs.isSidebarExpanded,
+        isMobileView: getIsMobileView(state),
     };
 }
 

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -74,6 +74,7 @@ export default class RhsRootPost extends React.PureComponent {
         recentEmojis: PropTypes.arrayOf(Emoji),
 
         isExpanded: PropTypes.bool,
+        isMobileView: PropTypes.bool.isRequired,
     };
 
     static defaultProps = {
@@ -97,8 +98,15 @@ export default class RhsRootPost extends React.PureComponent {
 
     handleShortcutReactToLastPost = (isLastPost) => {
         if (isLastPost) {
-            const {post, enableEmojiPicker, channelIsArchived,
-                actions: {emitShortcutReactToLastPostFrom}} = this.props;
+            const {
+                channelIsArchived,
+                enableEmojiPicker,
+                isMobileView,
+                post,
+                actions: {
+                    emitShortcutReactToLastPostFrom,
+                },
+            } = this.props;
 
             // Setting the last message emoji action to empty to clean up the redux state
             emitShortcutReactToLastPostFrom(Locations.NO_WHERE);
@@ -116,7 +124,7 @@ export default class RhsRootPost extends React.PureComponent {
                 boundingRectOfPostInfo.bottom < (window.innerHeight);
 
             if (isPostHeaderVisibleToUser) {
-                if (!isEphemeralPost && !isSystemMessage && !isDeletedPost && !isFailedPost && !Utils.isMobile() &&
+                if (!isEphemeralPost && !isSystemMessage && !isDeletedPost && !isFailedPost && !isMobileView &&
                     !channelIsArchived && !isPostsFakeParentDeleted && enableEmojiPicker) {
                     // As per issue in #2 of mattermost-webapp/pull/4478#pullrequestreview-339313236
                     // We are not not handling focus condition as we did for rhs_comment as the dot menu is already in dom and not visible
@@ -234,7 +242,15 @@ export default class RhsRootPost extends React.PureComponent {
     };
 
     render() {
-        const {post, isReadOnly, teamId, channelIsArchived, collapsedThreadsEnabled, isBot} = this.props;
+        const {
+            channelIsArchived,
+            collapsedThreadsEnabled,
+            isBot,
+            isMobileView,
+            isReadOnly,
+            post,
+            teamId,
+        } = this.props;
 
         const isPostDeleted = post && post.state === Posts.POST_DELETED;
         const isEphemeral = Utils.isPostEphemeral(post);
@@ -352,7 +368,7 @@ export default class RhsRootPost extends React.PureComponent {
         );
 
         let postFlagIcon;
-        const showFlagIcon = !isEphemeral && !post.failed && !isSystemMessage && !Utils.isMobile();
+        const showFlagIcon = !isEphemeral && !post.failed && !isSystemMessage && !isMobileView;
         if (showFlagIcon) {
             postFlagIcon = (
                 <PostFlagIcon

--- a/components/rhs_root_post/rhs_root_post.test.jsx
+++ b/components/rhs_root_post/rhs_root_post.test.jsx
@@ -62,6 +62,7 @@ describe('components/RhsRootPost', () => {
         },
         emojiMap: new EmojiMap(new Map()),
         collapsedThreadsEnabled: false,
+        isMobileView: false,
     };
 
     test('should match snapshot', () => {

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -23,9 +23,13 @@ import {
 } from 'actions/views/rhs';
 import {autocompleteChannelsForSearch} from 'actions/channel_actions';
 import {autocompleteUsersInTeam} from 'actions/user_actions';
+
 import {getRhsState, getSearchTerms, getSearchType, getIsSearchingTerm, getIsRhsOpen, getIsRhsExpanded} from 'selectors/rhs';
-import {RHSStates} from 'utils/constants';
+import {getIsMobileView} from 'selectors/views/browser';
+
 import {GlobalState} from 'types/store';
+
+import {RHSStates} from 'utils/constants';
 
 import Search from './search';
 import type {StateProps, DispatchProps, OwnProps} from './types';
@@ -46,6 +50,7 @@ function mapStateToProps(state: GlobalState) {
         isFlaggedPosts: rhsState === RHSStates.FLAG,
         isPinnedPosts: rhsState === RHSStates.PIN,
         isChannelFiles: rhsState === RHSStates.CHANNEL_FILES,
+        isMobileView: getIsMobileView(state),
     };
 }
 

--- a/components/search/search.tsx
+++ b/components/search/search.tsx
@@ -71,7 +71,15 @@ const determineVisibleSearchHintOptions = (searchTerms: string, searchType: Sear
 };
 
 const Search: React.FC<Props> = (props: Props): JSX.Element => {
-    const {actions, searchTerms, searchType, currentChannel, hideSearchBar, enableFindShortcut} = props;
+    const {
+        actions,
+        currentChannel,
+        enableFindShortcut,
+        hideSearchBar,
+        isMobileView,
+        searchTerms,
+        searchType,
+    } = props;
 
     const intl = useIntl();
     const currentChannelName = useSelector(getCurrentChannelNameForSearchShortcut);
@@ -128,16 +136,16 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
     }, [hideSearchBar, currentChannelName]);
 
     useEffect((): void => {
-        if (!Utils.isMobile()) {
+        if (!isMobileView) {
             setVisibleSearchHintOptions(determineVisibleSearchHintOptions(searchTerms, searchType));
         }
-    }, [searchTerms, searchType]);
+    }, [isMobileView, searchTerms, searchType]);
 
     useEffect((): void => {
-        if (!Utils.isMobile() && focused && keepInputFocused) {
+        if (!isMobileView && focused && keepInputFocused) {
             handleBlur();
         }
-    }, [searchTerms]);
+    }, [isMobileView, searchTerms]);
 
     useEffect((): void => {
         if (props.isFocus && !props.isRhsOpen) {
@@ -269,7 +277,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
     };
 
     const handleSearchOnSuccess = (): void => {
-        if (Utils.isMobile()) {
+        if (isMobileView) {
             handleClear();
         }
     };
@@ -460,7 +468,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
                 searchType={searchType}
                 clearSearchType={() => actions.updateSearchType('')}
             >
-                {!Utils.isMobile() && renderHintPopover()}
+                {!props.isMobileView && renderHintPopover()}
             </SearchBar>
         </>
     );

--- a/components/search/types.ts
+++ b/components/search/types.ts
@@ -34,6 +34,7 @@ export type StateProps = {
     isPinnedPosts: boolean;
     isChannelFiles: boolean;
     currentChannel?: Channel;
+    isMobileView: boolean;
 }
 
 export type DispatchProps = {

--- a/components/search_results_item/index.test.js
+++ b/components/search_results_item/index.test.js
@@ -4,7 +4,7 @@
 import {General} from 'mattermost-redux/constants';
 import {mapStateToProps} from 'components/search_results_item';
 
-import {RHSStates} from 'utils/constants';
+import {RHSStates, WindowSizes} from 'utils/constants';
 
 describe('components/SearchResultsItem/WithStore', () => {
     const team = {
@@ -99,6 +99,9 @@ describe('components/SearchResultsItem/WithStore', () => {
             },
         },
         views: {
+            browser: {
+                windowSize: WindowSizes.DESKTOP_VIEW,
+            },
             rhs: {
                 rhsState: RHSStates.SEARCH,
             },

--- a/components/search_results_item/index.ts
+++ b/components/search_results_item/index.ts
@@ -4,8 +4,6 @@
 import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
 
-import {getRhsState} from 'selectors/rhs';
-
 import {getChannel, getDirectTeammate} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {makeGetCommentCountForPost} from 'mattermost-redux/selectors/entities/posts';
@@ -24,6 +22,9 @@ import {
     selectPostCardFromRightHandSideSearch,
     setRhsExpanded,
 } from 'actions/views/rhs';
+
+import {getRhsState} from 'selectors/rhs';
+import {getIsMobileView} from 'selectors/views/browser';
 
 import {GlobalState} from 'types/store';
 
@@ -85,6 +86,7 @@ export function mapStateToProps() {
             displayName: getDisplayNameByUser(state, directTeammate),
             replyCount: getReplyCount(state, post),
             canReply,
+            isMobileView: getIsMobileView(state),
         };
     };
 }

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -82,6 +82,8 @@ export default class SearchResultsItem extends React.PureComponent {
 
         a11yIndex: PropTypes.number,
 
+        isMobileView: PropTypes.bool.isRequired,
+
         /**
         *  Function used for closing LHS
         */
@@ -142,7 +144,7 @@ export default class SearchResultsItem extends React.PureComponent {
 
     handleJumpClick = (e) => {
         e.preventDefault();
-        if (Utils.isMobile()) {
+        if (this.props.isMobileView) {
             this.props.actions.closeRightHandSide();
         }
 
@@ -299,7 +301,7 @@ export default class SearchResultsItem extends React.PureComponent {
                 </p>
             );
         } else {
-            if (!Utils.isMobile()) {
+            if (!this.props.isMobileView) {
                 flagContent = (
                     <PostFlagIcon
                         location={Locations.SEARCH}

--- a/components/search_results_item/search_results_item.test.jsx
+++ b/components/search_results_item/search_results_item.test.jsx
@@ -70,6 +70,7 @@ describe('components/SearchResultsItem', () => {
         status: 'hello',
         enablePostUsernameOverride: false,
         isBot: false,
+        isMobileView: false,
         actions: {
             closeRightHandSide: mockFunc,
             selectPost: mockFunc,


### PR DESCRIPTION
`getIsMobileView` is the more redux-friendly, more self-explanatory, and hopefully more performant version of `Utils.isMobile` that we're wanting to be using everywhere now. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40114

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9507
https://github.com/mattermost/mattermost-webapp/pull/9508
https://github.com/mattermost/mattermost-webapp/pull/9509

#### Release Note
```release-note
NONE
```
