### PR TITLE
[MM-38501] - observe showPublicLink prop when rendering file preview modal

### DIFF
--- a/components/file_preview_modal/file_preview_modal_main_actions/__snapshots__/file_preview_modal_main_actions.test.tsx.snap
+++ b/components/file_preview_modal/file_preview_modal_main_actions/__snapshots__/file_preview_modal_main_actions.test.tsx.snap
@@ -1,5 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/file_preview_modal/file_preview_modal_main_actions/FilePreviewModalMainActions should match snapshot for external image with public links enabled 1`] = `
+<div
+  className="file-preview-modal-main-actions__actions"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={400}
+    key="download"
+    overlay={
+      <Tooltip
+        id="download-icon-tooltip"
+      >
+        <Memo(MemoizedFormattedMessage)
+          defaultMessage="Download"
+          id="view_image_popover.download"
+        />
+      </Tooltip>
+    }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <a
+      className="file-preview-modal-main-actions__action-item"
+      download="img.png"
+      href="http://example.com/img.png"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <i
+        className="icon icon-download-outline"
+      />
+    </a>
+  </OverlayTrigger>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={400}
+    key="publicLink"
+    overlay={
+      <Tooltip
+        id="close-icon-tooltip"
+      >
+        <Memo(MemoizedFormattedMessage)
+          defaultMessage="Close"
+          id="full_screen_modal.close"
+        />
+      </Tooltip>
+    }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <button
+      className="file-preview-modal-main-actions__action-item"
+      onClick={[MockFunction]}
+    >
+      <i
+        className="icon icon-close"
+      />
+    </button>
+  </OverlayTrigger>
+</div>
+`;
+
 exports[`components/file_preview_modal/file_preview_modal_main_actions/FilePreviewModalMainActions should match snapshot with public links disabled 1`] = `
 <div
   className="file-preview-modal-main-actions__actions"

--- a/components/file_preview_modal/file_preview_modal_main_actions/file_preview_modal_main_actions.test.tsx
+++ b/components/file_preview_modal/file_preview_modal_main_actions/file_preview_modal_main_actions.test.tsx
@@ -28,6 +28,7 @@ describe('components/file_preview_modal/file_preview_modal_main_actions/FilePrev
             fileInfo: TestHelper.getFileInfoMock({}),
             enablePublicLink: false,
             canDownloadFiles: true,
+            showPublicLink: true,
             fileURL: 'http://example.com/img.png',
             filename: 'img.png',
             handleModalClose: jest.fn(),
@@ -71,6 +72,17 @@ describe('components/file_preview_modal/file_preview_modal_main_actions/FilePrev
         const overlayWrapper = wrapper.find(OverlayTrigger).first();
         expect(overlayWrapper.prop('overlay').type).toEqual(Tooltip);
         expect(overlayWrapper.prop('children')).toMatchSnapshot();
+    });
+
+    test('should match snapshot for external image with public links enabled', () => {
+        const props = {
+            ...defaultProps,
+            enablePublicLink: true,
+            showPublicLink: false,
+        };
+
+        const wrapper = shallow(<FilePreviewModalMainActions {...props}/>);
+        expect(wrapper).toMatchSnapshot();
     });
 
     test('should call public link callback', () => {

--- a/components/file_preview_modal/file_preview_modal_main_actions/file_preview_modal_main_actions.tsx
+++ b/components/file_preview_modal/file_preview_modal_main_actions/file_preview_modal_main_actions.tsx
@@ -25,6 +25,7 @@ interface Props {
     usedInside?: 'Header' | 'Footer';
     showOnlyClose?: boolean;
     showClose?: boolean;
+    showPublicLink?: boolean;
     filename: string;
     fileURL: string;
     fileInfo: FileInfo;
@@ -134,7 +135,7 @@ const FilePreviewModalMainActions: React.FC<Props> = (props: Props) => {
     );
     return (
         <div className='file-preview-modal-main-actions__actions'>
-            {!props.showOnlyClose && props.enablePublicLink && publicLink}
+            {!props.showOnlyClose && props.enablePublicLink && props.showPublicLink && publicLink}
             {!props.showOnlyClose && props.canDownloadFiles && download}
             {props.showClose && closeButton}
         </div>
@@ -145,6 +146,7 @@ FilePreviewModalMainActions.defaultProps = {
     showOnlyClose: false,
     usedInside: 'Header',
     showClose: true,
+    showPublicLink: true,
 };
 
 export default memo(FilePreviewModalMainActions);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR stops the "Get a Public link" button from showing in the file preview modal if the file being observed is an external image. 

There was an existing prop I noticed while testing this called `showPublicLink` which appears to be set to true if the `fileInfo.link` property exists, otherwise false. External images don't set this link property, and as a result `showPublicLink` gets set to false. So I'm adding an extra check here to make sure the public link button only shows up if `showPublicLink` is true

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-38501

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| ![mattermost-filemodal-attached](https://user-images.githubusercontent.com/26177230/145492133-8bfe9e93-7ad9-4bcf-9100-22f48cb00399.png) | ![mattermost-filemodal-external](https://user-images.githubusercontent.com/26177230/145492156-aaaf27f2-0229-4c65-ae52-a12bcf8026f3.png) |
-->
|  uploaded image  |  externally linked |
|----|----|
| ![mattermost-filemodal-attached](https://user-images.githubusercontent.com/26177230/145492133-8bfe9e93-7ad9-4bcf-9100-22f48cb00399.png) | ![mattermost-filemodal-external](https://user-images.githubusercontent.com/26177230/145492156-aaaf27f2-0229-4c65-ae52-a12bcf8026f3.png) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
'Get a Public Link' button in File Preview modal is hidden if the image is an external link
```
