### PR TITLE
fix : Emojis with default skin not changing color in recent when skin is changed

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint-disable max-lines */
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
@@ -544,7 +545,18 @@ export default class EmojiPicker extends React.PureComponent {
             return emoji;
         }
 
-        const newEmojiId = userSkinTone === 'default' ? emoji.unified.replace(`-${emojiSkin}`, '') : emoji.unified.replace(emojiSkin, userSkinTone);
+        let newEmojiId = '';
+
+        // If its a default (yellow) emoji, get the skin variation from its property
+        if (emojiSkin === 'default') {
+            newEmojiId = emoji.skin_variations[userSkinTone].unified;
+        } else if (userSkinTone === 'default') {
+            // If default (yellow) skin is selected, remove the skin code from emoji id
+            newEmojiId = emoji.unified.replace(`-${emojiSkin}`, '');
+        } else {
+            // If non default skin is selected, add the new skin selected code to emoji id
+            newEmojiId = emoji.unified.replace(emojiSkin, userSkinTone);
+        }
 
         const emojiIndex = Emoji.EmojiIndicesByUnicode.get(newEmojiId.toLowerCase());
         return Emoji.Emojis[emojiIndex];

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';


### PR DESCRIPTION
#### Summary
When a default emoji (yellow skin) is added as a reaction to a post it appears correctly in the recent emoji section, but would not change its skin when we select a different skin. The same is not the case for emoji with non default skin; when they are added, they change the skin correctly in recent emoji section

#### Ticket Link
N/A

#### Related Pull Requests
N/A




#### Screenshots

before

https://user-images.githubusercontent.com/17708702/145613667-3c8c8f2c-2c75-4f98-9f2c-0353c593f550.mov


after

https://user-images.githubusercontent.com/17708702/145613827-3aa49411-7ee5-4636-a3b6-9c4e87dc367f.mov




#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE

```
