### PR TITLE
fix : Fix custom emoji deleted puts emoji picker in search state

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+/* eslint-disable max-lines */
 
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -707,24 +708,27 @@ export default class EmojiPicker extends React.PureComponent {
             const emojis = this.getEmojisByCategory(category);
             const items = this.emojiCurrentResultsItems(i, emojis, numEmojisLoaded);
             numEmojisLoaded += items.length;
-            categoryComponents = [...categoryComponents, (
-                <EmojiPickerCategorySection
-                    key={category.id}
-                    categoryName={category.name}
-                    updateCategoryOffset={this.updateCategoryOffset}
-                    role='application'
-                >
-                    {items}
-                </EmojiPickerCategorySection>
-            )];
 
-            if (items.length === 0) {
-                return (
-                    <NoResultsIndicator
-                        variant={NoResultsVariant.ChannelSearch}
-                        titleValues={{channelName: `"${this.props.filter}"`}}
-                    />);
+            if (items.length > 0) {
+                categoryComponents = [...categoryComponents, (
+                    <EmojiPickerCategorySection
+                        key={category.id}
+                        categoryName={category.name}
+                        updateCategoryOffset={this.updateCategoryOffset}
+                        role='application'
+                    >
+                        {items}
+                    </EmojiPickerCategorySection>
+                )];
             }
+        }
+
+        if (categoryComponents.length === 0) {
+            return (
+                <NoResultsIndicator
+                    variant={NoResultsVariant.ChannelSearch}
+                    titleValues={{channelName: `"${this.props.filter}"`}}
+                />);
         }
 
         return (


### PR DESCRIPTION
#### Summary
Fixed the bug in emoji picker when custom emoji was deleted and the state of emoji picker was stuck to search one.

#### Ticket Link
None

#### Related Pull Requests
None

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
