### PR TITLE
MM-40599 - fix typo in features list

### DIFF
--- a/components/admin_console/license_settings/team_edition/team_edition_right_panel.tsx
+++ b/components/admin_console/license_settings/team_edition/team_edition_right_panel.tsx
@@ -34,7 +34,7 @@ const TeamEditionRightPanel: React.FC<TeamEditionRightPanelProps> = ({
 }: TeamEditionRightPanelProps) => {
     let upgradeButton = null;
     const upgradeAdvantages = [
-        'AD?LDAP Group Sync',
+        'AD/LDAP Group Sync',
         'High Availability',
         'Advanced compliance',
         'And more...',


### PR DESCRIPTION
#### Summary
This PR fixes a typo in the licensing pages, replacing a `?` character for the correct one `/` in the first feature list item in the right column, just before it reads `LDAP Group Sync`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40599


#### Screenshots
Before:
<img width="703" alt="Captura de pantalla 2021-12-14 a las 17 36 44" src="https://user-images.githubusercontent.com/10082627/146040417-60564dfe-e7aa-4a2c-bde6-5069ef78eda5.png">



After:
<img width="1014" alt="Captura de pantalla 2021-12-14 a las 17 37 03" src="https://user-images.githubusercontent.com/10082627/146040380-a8541747-78d5-408b-b30b-ca130a2bfdd4.png">


#### Release Note
```release-note
NONE
```
