### PR TITLE
focus user email input by default for invitation modal

### DIFF
--- a/components/invitation_modal/invite_view.tsx
+++ b/components/invitation_modal/invite_view.tsx
@@ -248,6 +248,7 @@ export default function InviteView(props: Props) {
                     onInputChange={props.onUsersInputChange}
                     inputValue={props.usersEmailsSearch}
                     emailInvitationsEnabled={props.emailInvitationsEnabled}
+                    autoFocus={true}
                 />
                 {props.canInviteGuests && props.canAddUsers &&
                 <InviteAs

--- a/components/widgets/inputs/users_emails_input.tsx
+++ b/components/widgets/inputs/users_emails_input.tsx
@@ -53,6 +53,8 @@ type Props = {
     loadingMessageDefault?: string;
     emailInvitationsEnabled: boolean;
     extraErrorText?: React.ReactNode;
+    didMountCallback?: () => void;
+    autoFocus?: boolean;
 }
 
 export type EmailInvite = {
@@ -300,6 +302,10 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
         }
     }
 
+    componentDidMount() {
+        this.props.didMountCallback?.();
+    }
+
     render() {
         const values: Array<UserProfile | EmailInvite> = this.props.value.map((v) => {
             if ((v as UserProfile).id) {
@@ -339,6 +345,7 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
                     tabSelectsValue={true}
                     value={values}
                     aria-label={this.props.ariaLabel}
+                    autoFocus={this.props.autoFocus}
                 />
                 {this.props.showError && (
                     <div className='InputErrorBox'>

--- a/components/widgets/inputs/users_emails_input.tsx
+++ b/components/widgets/inputs/users_emails_input.tsx
@@ -53,7 +53,6 @@ type Props = {
     loadingMessageDefault?: string;
     emailInvitationsEnabled: boolean;
     extraErrorText?: React.ReactNode;
-    didMountCallback?: () => void;
     autoFocus?: boolean;
 }
 
@@ -300,10 +299,6 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
         if (this.props.onBlur) {
             this.props.onBlur();
         }
-    }
-
-    componentDidMount() {
-        this.props.didMountCallback?.();
     }
 
     render() {

--- a/e2e/cypress/integration/team_settings/invite_members_spec.js
+++ b/e2e/cypress/integration/team_settings/invite_members_spec.js
@@ -103,6 +103,20 @@ describe('Invite Members', () => {
             verifyInvitationError(testTeam, userToBeInvited);
         });
     });
+
+    describe('default interface', () => {
+        it('focuses user email input by default', () => {
+            // # Login and visit
+            cy.apiLogin(testUser);
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            // # Open and select invite menu item
+            cy.uiOpenTeamMenu('Invite People');
+
+            // * Users emails input is focused by default
+            cy.get('.users-emails-input__control--is-focused').should('be.visible');
+        });
+    });
 });
 
 function verifyInvitationTable($subel, tableTitle, user, reason) {


### PR DESCRIPTION
#### Summary
Focus input by default in invitation modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40487


#### Screenshots
This one:

https://user-images.githubusercontent.com/13738432/146068884-7b8d0f69-b229-4166-9666-aabd1b655c0b.mp4

#### Release Note

```release-note
Invite to team modal auto focuses its email search input.
```