### PR TITLE
MM-40630 Update mmjstools so i18n-extract supports TypeScript

### DIFF
--- a/components/widgets/users/avatars/avatars.tsx
+++ b/components/widgets/users/avatars/avatars.tsx
@@ -21,10 +21,6 @@ import Avatar from 'components/widgets/users/avatar';
 import './avatars.scss';
 import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
 
-// These should be removed once i18n-extract properly understands TypeScript
-t('avatars.overflowUsers');
-t('avatars.overflowUnnamedOnly');
-
 type Props = {
     userIds: Array<UserProfile['id']>;
     totalUsers?: number;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2456,6 +2456,7 @@
   "apps.error.parser": "Parsing error: {error}",
   "apps.error.parser.empty_value": "empty values are not allowed",
   "apps.error.parser.execute_non_leaf": "You must select a subcommand.",
+  "apps.error.parser.missing_binding": "Missing command bindings.",
   "apps.error.parser.missing_call": "Missing binding call.",
   "apps.error.parser.missing_field_value": "Field value is missing.",
   "apps.error.parser.missing_list_end": "Expected list closing token.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,7 +183,7 @@
         "jest-junit": "12.2.0",
         "jest-watch-typeahead": "0.6.4",
         "mini-css-extract-plugin": "2.0.0",
-        "mmjstool": "github:mattermost/mattermost-utilities#40d7640e85385248773504548ef962037ac842ea",
+        "mmjstool": "github:mattermost/mattermost-utilities#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac",
         "nock": "13.2.1",
         "react-router-enzyme-context": "1.2.0",
         "redux-devtools-extension": "2.13.9",
@@ -16552,14 +16552,19 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dependencies": {
         "ms": "2.1.2"
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -20407,15 +20412,6 @@
       "version": "0.6.32",
       "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.6.32.tgz",
       "integrity": "sha512-EF1BWkhwoeLtbIlDbY/vDSLBen/E5l/f1Vg7iX5CDymQCamcx1vhlc3tIZxIDplPjgi0jhG37c67idFbjg+v+Q=="
-    },
-    "node_modules/flow-parser": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.90.0.tgz",
-      "integrity": "sha512-a6Ohgdzvf2e1/F8sI98qcPLtDIjLayRkRgAwrWHzHFMHCNq92jyRbRG0w5fGjs6xdI320Ud39HkI0Dk5OPs17g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
@@ -28972,18 +28968,92 @@
       }
     },
     "node_modules/mmjstool": {
-      "resolved": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#40d7640e85385248773504548ef962037ac842ea",
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac",
+      "integrity": "sha512-wHUORQrEsVFMgSBJvkXnRPJ1/PpcyNP9B+SHzN35/Y0tGvRqGAN+ZwIPBewIq91b5iEZWxRZX1ufrDnI0rAOwg==",
       "dev": true,
       "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.7.0",
         "estree-walk": "2.2.0",
         "filehound": "1.16.5",
-        "flow-parser": "0.90.0",
         "sort-json": "2.0.0",
         "webpack-cli": "^3.3.0",
         "yargs": "12.0.5"
       },
       "bin": {
         "mmjstool": "bin/mmjstool"
+      }
+    },
+    "node_modules/mmjstool/node_modules/@typescript-eslint/types": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.7.0.tgz",
+      "integrity": "sha512-5AeYIF5p2kAneIpnLFve8g50VyAjq7udM7ApZZ9JYjdPjkz0LvODfuSHIDUVnIuUoxafoWzpFyU7Sqbxgi79mA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/mmjstool/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.7.0.tgz",
+      "integrity": "sha512-aO1Ql+izMrTnPj5aFFlEJkpD4jRqC4Gwhygu2oHK2wfVQpmOPbyDSveJ+r/NQo+PWV43M6uEAeLVbTi09dFLhg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.7.0",
+        "@typescript-eslint/visitor-keys": "5.7.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mmjstool/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mmjstool/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.7.0.tgz",
+      "integrity": "sha512-hdohahZ4lTFcglZSJ3DGdzxQHBSxsLVqHzkiOmKi7xVAWC4y2c1bIMKmPJSrA4aOEoRUPOKQ87Y/taC7yVHpFg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.7.0",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/mmjstool/node_modules/ansi-regex": {
@@ -29028,6 +29098,15 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "node_modules/mmjstool/node_modules/eslint-visitor-keys": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/mmjstool/node_modules/find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -29038,6 +29117,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mmjstool/node_modules/globby": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mmjstool/node_modules/import-local": {
@@ -29085,6 +29184,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mmjstool/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mmjstool/node_modules/p-locate": {
@@ -29178,6 +29289,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mmjstool/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/mmjstool/node_modules/string-width": {
@@ -29286,6 +29406,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/mmjstool/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/mmjstool/node_modules/yargs": {
       "version": "12.0.5",
@@ -53151,9 +53277,9 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -56336,12 +56462,6 @@
       "version": "0.6.32",
       "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.6.32.tgz",
       "integrity": "sha512-EF1BWkhwoeLtbIlDbY/vDSLBen/E5l/f1Vg7iX5CDymQCamcx1vhlc3tIZxIDplPjgi0jhG37c67idFbjg+v+Q=="
-    },
-    "flow-parser": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.90.0.tgz",
-      "integrity": "sha512-a6Ohgdzvf2e1/F8sI98qcPLtDIjLayRkRgAwrWHzHFMHCNq92jyRbRG0w5fGjs6xdI320Ud39HkI0Dk5OPs17g==",
-      "dev": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -63078,18 +63198,61 @@
       }
     },
     "mmjstool": {
-      "version": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#40d7640e85385248773504548ef962037ac842ea",
+      "version": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac",
+      "integrity": "sha512-wHUORQrEsVFMgSBJvkXnRPJ1/PpcyNP9B+SHzN35/Y0tGvRqGAN+ZwIPBewIq91b5iEZWxRZX1ufrDnI0rAOwg==",
       "dev": true,
-      "from": "mmjstool@github:mattermost/mattermost-utilities#40d7640e85385248773504548ef962037ac842ea",
+      "from": "mmjstool@github:mattermost/mattermost-utilities#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac",
       "requires": {
+        "@typescript-eslint/typescript-estree": "5.7.0",
         "estree-walk": "2.2.0",
         "filehound": "1.16.5",
-        "flow-parser": "0.90.0",
         "sort-json": "2.0.0",
         "webpack-cli": "^3.3.0",
         "yargs": "12.0.5"
       },
       "dependencies": {
+        "@typescript-eslint/types": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.7.0.tgz",
+          "integrity": "sha512-5AeYIF5p2kAneIpnLFve8g50VyAjq7udM7ApZZ9JYjdPjkz0LvODfuSHIDUVnIuUoxafoWzpFyU7Sqbxgi79mA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.7.0.tgz",
+          "integrity": "sha512-aO1Ql+izMrTnPj5aFFlEJkpD4jRqC4Gwhygu2oHK2wfVQpmOPbyDSveJ+r/NQo+PWV43M6uEAeLVbTi09dFLhg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.7.0",
+            "@typescript-eslint/visitor-keys": "5.7.0",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.5",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.7.0.tgz",
+          "integrity": "sha512-hdohahZ4lTFcglZSJ3DGdzxQHBSxsLVqHzkiOmKi7xVAWC4y2c1bIMKmPJSrA4aOEoRUPOKQ87Y/taC7yVHpFg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.7.0",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -63126,6 +63289,12 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
+        "eslint-visitor-keys": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+          "dev": true
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -63133,6 +63302,20 @@
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
+          }
+        },
+        "globby": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
           }
         },
         "import-local": {
@@ -63165,6 +63348,15 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
           }
         },
         "p-locate": {
@@ -63231,6 +63423,12 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
         "string-width": {
@@ -63320,6 +63518,12 @@
             "string-width": "^3.0.0",
             "strip-ansi": "^5.0.0"
           }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         },
         "yargs": {
           "version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "jest-junit": "12.2.0",
     "jest-watch-typeahead": "0.6.4",
     "mini-css-extract-plugin": "2.0.0",
-    "mmjstool": "github:mattermost/mattermost-utilities#40d7640e85385248773504548ef962037ac842ea",
+    "mmjstool": "github:mattermost/mattermost-utilities#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac",
     "nock": "13.2.1",
     "react-router-enzyme-context": "1.2.0",
     "redux-devtools-extension": "2.13.9",


### PR DESCRIPTION
`make i18n-extract` used to have issues with TypeScript files. It turns out that that was because it was trying to parse all files as if they used Flow, not TypeScript, and it would silently fail as soon as it hit any TS code that wasn't also valid Flow.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40630

#### Related Pull Requests
https://github.com/mattermost/mattermost-utilities/pull/56

#### Release Note
```release-note
NONE
```
