### PR TITLE
MM-40633 Remove Storybook-related CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,37 +159,6 @@ jobs:
           paths:
             - mattermost-webapp/mattermost-webapp.tar.gz
 
-  build-storybook:
-    executor:
-      name: default
-    working_directory: ~/mattermost/mattermost-webapp
-    steps:
-      - checkout
-      - *restore_cache
-      - run: npm run build-storybook
-      - store_artifacts:
-          path: ~/mattermost/mattermost-webapp/storybook-static
-      - persist_to_workspace:
-          root: ~/mattermost
-          paths:
-            - mattermost-webapp/storybook-static
-
-  upload-storybook:
-    docker:
-      - image: circleci/python:3.6
-    working_directory: ~/mattermost/mattermost-webapp
-    steps:
-      - attach_workspace:
-          at: ~/mattermost/
-      - aws-s3/sync:
-          from: storybook-static
-          to: s3://alpha-storybook.mattermost.com/$(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/
-          arguments: --cache-control no-cache
-      - aws-s3/sync:
-          from: storybook-static
-          to: s3://alpha-storybook.mattermost.com/commit/${CIRCLE_SHA1}/
-          arguments: --cache-control no-cache
-
   upload-s3:
     docker:
       - image: circleci/python:3.6
@@ -288,13 +257,6 @@ workflows:
           context: matterbuild-docker
           requires:
             - prepare-docker-build
-      - build-storybook:
-          requires:
-            - build
-      - upload-storybook:
-          context: mattermost-s3-storybook-alpha
-          requires:
-            - build-storybook
       - test:
           requires:
             - type-check


### PR DESCRIPTION
As far as I know, no one actually uses the web app's Storybook stuff since the widgets components aren't in active development any more, so this'll speed up CI a bit. We have another ticket to fully remove the Storybook code from the web app repo, but that'll be done separately since it'll require actual code changes.

This won't affect any of the Storybook in other repos or used by other teams, and we can definitely reintroduce it later on, but we don't need it in this repo for the time being.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40633

#### Release Note
```release-note
NONE
```
