### PR TITLE
MM-40600 - use custom type and set correct value to api response

### DIFF
--- a/components/admin_console/license_settings/__snapshots__/license_settings.test.jsx.snap
+++ b/components/admin_console/license_settings/__snapshots__/license_settings.test.jsx.snap
@@ -95,7 +95,7 @@ exports[`components/admin_console/license_settings/LicenseSettings load screen a
               restartError={null}
               restarting={false}
               upgradeError={null}
-              upgradingPercentage={0}
+              upgradingPercentage={100}
             />
           </div>
           <div
@@ -213,7 +213,7 @@ exports[`components/admin_console/license_settings/LicenseSettings load screen w
               restartError={null}
               restarting={false}
               upgradeError={null}
-              upgradingPercentage={0}
+              upgradingPercentage={42}
             />
           </div>
           <div

--- a/components/admin_console/license_settings/index.ts
+++ b/components/admin_console/license_settings/index.ts
@@ -38,7 +38,7 @@ type Actions = {
     removeLicense: () => Promise<ActionResult>;
     getPrevTrialLicense: () => void;
     upgradeToE0: StatusOKFunc;
-    upgradeToE0Status: () => Promise<ActionResult>;
+    upgradeToE0Status: () => Promise<{percentage: number; error: any}>;
     restartServer: StatusOKFunc;
     ping: PromiseStatusFunc;
     requestTrialLicense: (users: number, termsAccepted: boolean, receiveEmailsAccepted: boolean, featureName: string) => Promise<ActionResult>;

--- a/components/admin_console/license_settings/license_settings.tsx
+++ b/components/admin_console/license_settings/license_settings.tsx
@@ -54,7 +54,7 @@ type Props = {
         removeLicense: () => Promise<ActionResult>;
         getPrevTrialLicense: () => void;
         upgradeToE0: () => Promise<StatusOK>;
-        upgradeToE0Status: () => Promise<ActionResult>;
+        upgradeToE0Status: () => Promise<{percentage: number; error: any}>;
         restartServer: () => Promise<StatusOK>;
         ping: () => Promise<{status: string}>;
         requestTrialLicense: (users: number, termsAccepted: boolean, receiveEmailsAccepted: boolean, featureName: string) => Promise<ActionResult>;
@@ -117,7 +117,7 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
     }
 
     reloadPercentage = async () => {
-        const {data: percentage, error} = await this.props.actions.upgradeToE0Status();
+        const {percentage, error} = await this.props.actions.upgradeToE0Status();
         if (percentage === 100 || error) {
             if (this.interval) {
                 clearInterval(this.interval);


### PR DESCRIPTION
#### Summary
This PR fixes a regression added during the migration from .js to .ts as part of the License page UX changes. The fix consist of setting a custom type instead of using the ActionResult common one. This is due since the signature of the response doesn't match with the ActionResult type.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40600

#### Screenshots

https://user-images.githubusercontent.com/10082627/146703651-ae42bb44-4114-4f13-a5fb-0f7bf19b159b.mp4



#### Release Note
```release-note
Problem description: As part of the UX redesign for the licensing pages a regression was added that prevented the upgrade button to show the progress and hence was not showing the restart button once the progress reached the 100%. This led to users not being able to restart the server directly from the UI so they can not see the upgraded enterprise version unless they manually go to the server and restart it.
Solution: the upgrade progress values were set correctly so now the component is updated once the 100% is reached and allow the users to restart the server from the UI.
```
