### PR TITLE
fix Dm name in file preview modal info bar

### DIFF
--- a/components/file_preview_modal/file_preview_modal_info/__snapshots__/file_preview_modal_info.test.tsx.snap
+++ b/components/file_preview_modal/file_preview_modal_info/__snapshots__/file_preview_modal_info.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`components/FilePreviewModalInfo should match snapshot 1`] = `
         id="file_preview_modal_info.shared_in"
         values={
           Object {
-            "name": "DN",
+            "name": "name",
           }
         }
       />

--- a/components/file_preview_modal/file_preview_modal_info/file_preview_modal_info.tsx
+++ b/components/file_preview_modal/file_preview_modal_info/file_preview_modal_info.tsx
@@ -5,7 +5,7 @@ import React, {memo} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector} from 'react-redux';
 
-import {getChannel as selectChannel} from 'mattermost-redux/selectors/entities/channels';
+import {makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
 import {
     getUser as selectUser,
     makeGetDisplayName,
@@ -31,7 +31,10 @@ const displayNameGetter = makeGetDisplayName();
 
 const FilePreviewModalInfo: React.FC<Props> = (props: Props) => {
     const user = useSelector((state: GlobalState) => selectUser(state, props.post?.user_id ?? '')) as UserProfile | undefined;
-    const channel = useSelector((state: GlobalState) => selectChannel(state, props.post?.channel_id ?? ''));
+    const channel = useSelector((state: GlobalState) => {
+        const getChannel = makeGetChannel();
+        return getChannel(state, {id: props.post?.channel_id ?? ''});
+    });
     const name = useSelector((state: GlobalState) => displayNameGetter(state, props.post?.user_id ?? '', true));
 
     let info;
@@ -40,7 +43,7 @@ const FilePreviewModalInfo: React.FC<Props> = (props: Props) => {
             id='file_preview_modal_info.shared_in'
             defaultMessage='Shared in ~{name}'
             values={{
-                name: channel.name,
+                name: channel.display_name || channel.name,
             }}
         />
     ) : null;


### PR DESCRIPTION
#### Summary
File preview modal info bar has channel id instead of channel name for DM's 

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-40460

#### Related Pull Requests
``NONE``

#### Screenshots
|  before  |  after  |
|----|----|
| ![Image Pasted at 2021-12-2 21-04](https://user-images.githubusercontent.com/16203333/146725999-b397aa2a-bec9-47be-be3b-0e5e888a808d.png) | <img width="1792" alt="Screenshot 2021-12-20 at 12 26 34 PM" src="https://user-images.githubusercontent.com/16203333/146725955-bf809953-4620-4208-9205-65dfa0985c83.png"> |

#### Release Note
```release-note
* File preview modal info bar has channel id instead of channel name for DM's
```
