### PR TITLE
use state.show & top level onExited for invitation modal

### DIFF
--- a/components/invitation_modal/index.tsx
+++ b/components/invitation_modal/index.tsx
@@ -17,9 +17,8 @@ import {regenerateTeamInviteId} from 'mattermost-redux/actions/teams';
 import {Permissions} from 'mattermost-redux/constants';
 import {InviteToTeamTreatments} from 'mattermost-redux/constants/config';
 
-import {closeModal, CloseModalType} from 'actions/views/modals';
-import {isModalOpen} from 'selectors/views/modals';
-import {ModalIdentifiers, Constants} from 'utils/constants';
+import {CloseModalType} from 'actions/views/modals';
+import {Constants} from 'utils/constants';
 import {isAdmin} from 'mattermost-redux/utils/user_utils';
 import {sendMembersInvites, sendGuestsInvites} from 'actions/invite_actions';
 import {makeAsyncComponent} from 'components/async_load';
@@ -81,7 +80,6 @@ export function mapStateToProps(state: GlobalState) {
         canAddUsers,
         isFreeTierWithNoFreeSeats,
         emailInvitationsEnabled,
-        show: isModalOpen(state, ModalIdentifiers.INVITATION),
         isCloud,
         isAdmin: isAdmin(getCurrentUser(state).roles),
         cloudUserLimit: config.ExperimentalCloudUserLimit || '10',
@@ -93,7 +91,6 @@ export function mapStateToProps(state: GlobalState) {
 }
 
 type Actions = {
-    closeModal: () => void;
     sendGuestsInvites: (teamId: string, channels: Channel[], users: UserProfile[], emails: string[], message: string) => Promise<{data: InviteResults}>;
     sendMembersInvites: (teamId: string, users: UserProfile[], emails: string[]) => Promise<{data: InviteResults}>;
     regenerateTeamInviteId: (teamId: string) => void;
@@ -104,7 +101,6 @@ type Actions = {
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc | CloseModalType>, Actions>({
-            closeModal: () => closeModal(ModalIdentifiers.INVITATION),
             sendGuestsInvites,
             sendMembersInvites,
             regenerateTeamInviteId,

--- a/components/invitation_modal/invitation_modal.test.tsx
+++ b/components/invitation_modal/invitation_modal.test.tsx
@@ -16,10 +16,8 @@ import NoPermissionsView from './no_permissions_view';
 import InvitationModal, {Props, View, InvitationModal as BaseInvitationModal} from './invitation_modal';
 
 const defaultProps: Props = deepFreeze({
-    show: true,
     inviteToTeamTreatment: InviteToTeamTreatments.NONE,
     actions: {
-        closeModal: jest.fn(),
         searchChannels: jest.fn(),
         regenerateTeamInviteId: jest.fn(),
 
@@ -42,6 +40,7 @@ const defaultProps: Props = deepFreeze({
     canInviteGuests: true,
     intl: {} as IntlShape,
     townSquareDisplayName: '',
+    onExited: jest.fn(),
 });
 
 let props = defaultProps;

--- a/components/invitation_modal/invitation_modal.tsx
+++ b/components/invitation_modal/invitation_modal.tsx
@@ -34,10 +34,8 @@ import './invitation_modal.scss';
 type Backdrop = 'static' | boolean
 
 export type Props = {
-    show: boolean;
     inviteToTeamTreatment: InviteToTeamTreatments;
     actions: {
-        closeModal: () => void;
         searchChannels: (teamId: string, term: string) => ActionFunc;
         regenerateTeamInviteId: (teamId: string) => void;
 
@@ -67,6 +65,7 @@ export type Props = {
     canAddUsers: boolean;
     canInviteGuests: boolean;
     intl: IntlShape;
+    onExited: () => void;
 }
 
 export const View = {
@@ -81,6 +80,7 @@ type State = {
     invite: InviteState;
     result: ResultState;
     termWithoutResults: string | null;
+    show: boolean;
 };
 
 const defaultState: State = deepFreeze({
@@ -88,6 +88,7 @@ const defaultState: State = deepFreeze({
     termWithoutResults: null,
     invite: defaultInviteState,
     result: defaultResultState,
+    show: true,
 });
 
 export class InvitationModal extends React.PureComponent<Props, State> {
@@ -104,7 +105,7 @@ export class InvitationModal extends React.PureComponent<Props, State> {
     }
 
     handleHide = () => {
-        this.props.actions.closeModal();
+        this.setState({show: false});
     }
 
     toggleCustomMessage = () => {
@@ -389,8 +390,9 @@ export class InvitationModal extends React.PureComponent<Props, State> {
                 data-testid='invitationModal'
                 dialogClassName='a11y__modal'
                 className='InvitationModal'
-                show={this.props.show}
+                show={this.state.show}
                 onHide={this.handleHide}
+                onExited={this.props.onExited}
                 role='dialog'
                 backdrop={this.getBackdrop()}
                 aria-modal='true'


### PR DESCRIPTION
#### Summary
use onExited & track state.show for a smoother exit transition in invitation modal

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40315

```release-note
Fix exit animation on invitation modal.
```
