### PR TITLE
Automated cherry pick of #9427

### DIFF
--- a/components/timestamp/index.test.tsx
+++ b/components/timestamp/index.test.tsx
@@ -1,0 +1,148 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {GlobalState} from 'types/store';
+import {UserTimezone} from 'mattermost-redux/types/users';
+import {PreferenceType} from 'mattermost-redux/types/preferences';
+
+import * as Timestamp from './timestamp';
+
+import {mapStateToProps} from './index';
+
+const supportsHourCycleOg = Timestamp.supportsHourCycle;
+Object.defineProperty(Timestamp, 'supportsHourCycle', {get: () => supportsHourCycleOg});
+const supportsHourCycleSpy = jest.spyOn(Timestamp, 'supportsHourCycle', 'get');
+
+describe('mapStateToProps', () => {
+    const currentUserId = 'user-id';
+
+    const initialState = {
+        entities: {
+            general: {
+                config: {
+                    ExperimentalTimezone: 'true',
+                },
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            users: {
+                currentUserId,
+                profiles: {
+                    [currentUserId]: {
+                        id: currentUserId,
+                    },
+                },
+            },
+        },
+    } as unknown as GlobalState;
+
+    describe('hourCycle', () => {
+        test('hourCycle should be h12 when military time is false and the prop was not set', () => {
+            const props = mapStateToProps(initialState, {});
+            expect(props.hourCycle).toBe('h12');
+        });
+
+        test('hourCycle should be h23 when military time is true and the prop was not set', () => {
+            const testState = {...initialState};
+            testState.entities.preferences.myPreferences['display_settings--use_military_time'] = {
+                category: 'display_settings',
+                name: 'use_military_time',
+                user_id: currentUserId,
+                value: 'true',
+            } as PreferenceType;
+
+            const props = mapStateToProps(testState, {});
+            expect(props.hourCycle).toBe('h23');
+        });
+
+        test('hourCycle should have the value of prop.hourCycle when given', () => {
+            const testState = {...initialState};
+            testState.entities.preferences.myPreferences['display_settings--use_military_time'] = {
+                category: 'display_settings',
+                name: 'use_military_time',
+                user_id: currentUserId,
+                value: 'true',
+            } as PreferenceType;
+
+            const props = mapStateToProps(testState, {hourCycle: 'h24'});
+            expect(props.hourCycle).toBe('h24');
+        });
+    });
+
+    describe('timeZone', () => {
+        test('timeZone should be the user TZ when the prop was not set', () => {
+            const testState = {...initialState};
+            testState.entities.users.profiles[currentUserId].timezone = {
+                useAutomaticTimezone: false,
+                manualTimezone: 'Europe/Paris',
+            } as UserTimezone;
+
+            const props = mapStateToProps(testState, {});
+            expect(props.timeZone).toBe('Europe/Paris');
+        });
+
+        test('timeZone should be the value of prop.timeZone when given', () => {
+            const testState = {...initialState};
+            testState.entities.users.profiles[currentUserId].timezone = {
+                useAutomaticTimezone: false,
+                manualTimezone: 'Europe/Paris',
+            } as UserTimezone;
+
+            const props = mapStateToProps(testState, {timeZone: 'America/Phoenix'});
+            expect(props.timeZone).toBe('America/Phoenix');
+        });
+
+        test('timeZone should be the value of prop.timeZone when given, even when timezone are disabled', () => {
+            const testState = {...initialState};
+            testState.entities.general.config.ExperimentalTimezone = 'false';
+
+            const props = mapStateToProps(testState, {timeZone: 'America/Chicago'});
+            expect(props.timeZone).toBe('America/Chicago');
+        });
+    });
+
+    describe('hour12, hourCycle unsupported', () => {
+        test('hour12 should be false when using military time', () => {
+            const testState = {...initialState};
+            testState.entities.preferences.myPreferences['display_settings--use_military_time'] = {
+                category: 'display_settings',
+                name: 'use_military_time',
+                user_id: currentUserId,
+                value: 'true',
+            } as PreferenceType;
+            supportsHourCycleSpy.mockReturnValueOnce(false);
+
+            const props = mapStateToProps(testState, {});
+            expect(props.hour12).toBe(false);
+        });
+
+        test('hour12 should be true when not using military time', () => {
+            const testState = {...initialState};
+            testState.entities.preferences.myPreferences['display_settings--use_military_time'] = {
+                category: 'display_settings',
+                name: 'use_military_time',
+                user_id: currentUserId,
+                value: 'false',
+            } as PreferenceType;
+            supportsHourCycleSpy.mockReturnValueOnce(false);
+
+            const props = mapStateToProps(testState, {});
+            expect(props.hour12).toBe(true);
+        });
+
+        test('hour12 should equal props.hour12 when defined', () => {
+            const testState = {...initialState};
+            testState.entities.preferences.myPreferences['display_settings--use_military_time'] = {
+                category: 'display_settings',
+                name: 'use_military_time',
+                user_id: currentUserId,
+                value: 'false',
+            } as PreferenceType;
+            supportsHourCycleSpy.mockReturnValueOnce(false);
+
+            const props = mapStateToProps(testState, {hour12: false});
+            expect(props.hour12).toBe(false);
+        });
+    });
+});

--- a/components/timestamp/index.ts
+++ b/components/timestamp/index.ts
@@ -19,9 +19,12 @@ import Timestamp, {Props as TimestampProps, supportsHourCycle} from './timestamp
 
 type Props = {
     userTimezone?: UserTimezone;
+    hour12?: TimestampProps['hour12'];
+    timeZone?: TimestampProps['timeZone'];
+    hourCycle?: TimestampProps['hourCycle'];
 }
 
-function mapStateToProps(state: GlobalState, {userTimezone}: Props) {
+export function mapStateToProps(state: GlobalState, ownProps: Props) {
     const currentUserId = getCurrentUserId(state);
 
     let timeZone: TimestampProps['timeZone'];
@@ -29,18 +32,18 @@ function mapStateToProps(state: GlobalState, {userTimezone}: Props) {
     let hour12: TimestampProps['hour12'];
 
     if (areTimezonesEnabledAndSupported(state)) {
-        timeZone = getUserCurrentTimezone(userTimezone ?? getUserTimezone(state, currentUserId)) ?? undefined;
+        timeZone = getUserCurrentTimezone(ownProps.userTimezone ?? getUserTimezone(state, currentUserId)) ?? undefined;
     }
 
     const useMilitaryTime = getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false);
 
     if (supportsHourCycle) {
-        hourCycle = useMilitaryTime ? 'h23' : 'h12';
+        hourCycle = ownProps.hourCycle || (useMilitaryTime ? 'h23' : 'h12');
     } else {
-        hour12 = !useMilitaryTime;
+        hour12 = ownProps.hour12 ?? (!useMilitaryTime);
     }
 
-    return {timeZone, hourCycle, hour12};
+    return {timeZone: ownProps.timeZone || timeZone, hourCycle, hour12};
 }
 
 export default connect(mapStateToProps)(Timestamp);


### PR DESCRIPTION
Cherry pick of #9427 on release-6.3.

/cc  @JulienTant

```release-note
NONE
```