### PR TITLE
Automated cherry pick of #9535

### DIFF
--- a/components/admin_console/license_settings/team_edition/team_edition_right_panel.tsx
+++ b/components/admin_console/license_settings/team_edition/team_edition_right_panel.tsx
@@ -34,7 +34,7 @@ const TeamEditionRightPanel: React.FC<TeamEditionRightPanelProps> = ({
 }: TeamEditionRightPanelProps) => {
     let upgradeButton = null;
     const upgradeAdvantages = [
-        'AD?LDAP Group Sync',
+        'AD/LDAP Group Sync',
         'High Availability',
         'Advanced compliance',
         'And more...',


### PR DESCRIPTION
Cherry pick of #9535 on release-6.3.

/cc  @pablovelezvidal

```release-note
NONE
```