### PR TITLE
[MM-40681] : The "Leave Channel" button doesn't work from the 3-dot menu when clicking on it second time

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
@@ -94,10 +94,10 @@ describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
 
     test('expect callback to be called when leave public channel ', () => {
         const callback = jest.fn();
-        const wrapper = shallow<SidebarBaseChannel>(<SidebarBaseChannel {...baseProps} />);
+        const wrapper = shallow<SidebarBaseChannel>(<SidebarBaseChannel {...baseProps}/>);
         wrapper.instance().handleLeavePublicChannel(callback);
         expect(callback).toBeCalled();
-    })
+    });
 
     test('expect callback to be called when leave private channel ', () => {
         const callback = jest.fn();
@@ -107,9 +107,10 @@ describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
                 ...baseProps.channel,
                 type: 'P' as ChannelType,
             },
-        }
-        const wrapper = shallow<SidebarBaseChannel>(<SidebarBaseChannel {...props} />);
-        wrapper.instance().handleLeavePublicChannel(callback);
+        };
+
+        const wrapper = shallow<SidebarBaseChannel>(<SidebarBaseChannel {...props}/>);
+        wrapper.instance().handleLeavePrivateChannel(callback);
         expect(callback).toBeCalled();
-    })
+    });
 });

--- a/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
@@ -91,4 +91,25 @@ describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('expect callback to be called when leave public channel ', () => {
+        const callback = jest.fn();
+        const wrapper = shallow<SidebarBaseChannel>(<SidebarBaseChannel {...baseProps} />);
+        wrapper.instance().handleLeavePublicChannel(callback);
+        expect(callback).toBeCalled();
+    })
+
+    test('expect callback to be called when leave private channel ', () => {
+        const callback = jest.fn();
+        const props = {
+            ...baseProps,
+            channel: {
+                ...baseProps.channel,
+                type: 'P' as ChannelType,
+            },
+        }
+        const wrapper = shallow<SidebarBaseChannel>(<SidebarBaseChannel {...props} />);
+        wrapper.instance().handleLeavePublicChannel(callback);
+        expect(callback).toBeCalled();
+    })
 });

--- a/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -36,6 +36,7 @@ export default class SidebarBaseChannel extends React.PureComponent<Props> {
 
     getCloseHandler = () => {
         const {channel} = this.props;
+
         if (channel.type === Constants.OPEN_CHANNEL && channel.name !== Constants.DEFAULT_CHANNEL) {
             return this.handleLeavePublicChannel;
         } else if (channel.type === Constants.PRIVATE_CHANNEL) {

--- a/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -22,19 +22,20 @@ interface Props extends PropsFromRedux {
 }
 
 export default class SidebarBaseChannel extends React.PureComponent<Props> {
-    handleLeavePublicChannel = () => {
+    handleLeavePublicChannel = (callback: () => void) => {
         this.props.actions.leaveChannel(this.props.channel.id);
         trackEvent('ui', 'ui_public_channel_x_button_clicked');
+        callback();
     }
 
-    handleLeavePrivateChannel = () => {
+    handleLeavePrivateChannel = (callback: () => void) => {
         this.props.actions.openModal({modalId: ModalIdentifiers.LEAVE_PRIVATE_CHANNEL_MODAL, dialogType: LeavePrivateChannelModal, dialogProps: {channel: this.props.channel}});
         trackEvent('ui', 'ui_private_channel_x_button_clicked');
+        callback();
     }
 
     getCloseHandler = () => {
         const {channel} = this.props;
-
         if (channel.type === Constants.OPEN_CHANNEL && channel.name !== Constants.DEFAULT_CHANNEL) {
             return this.handleLeavePublicChannel;
         } else if (channel.type === Constants.PRIVATE_CHANNEL) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fixed the callback from the function of `getCloseHandler`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

 
Otherwise, link the JIRA ticket.
-->
Jira ticket: https://mattermost.atlassian.net/browse/MM-40681

Fix https://github.com/mattermost/mattermost-server/issues/19209

 Fixes https://github.com/mattermost/mattermost-server/issues/40681

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```

```
-->


```
NONE
```
