### PR TITLE
[MM-40481] fix post hover menu overlap

### DIFF
--- a/sass/components/_post-menu.scss
+++ b/sass/components/_post-menu.scss
@@ -3,7 +3,7 @@
 .post-menu {
     position: absolute;
     z-index: 6;
-    top: -8px;
+    top: -12px;
     right: 0;
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
#### Summary
Fix: Post hover menu overlapping long post in the center channel and RHS
#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-40481
#### Related Pull Requests
``NONE``

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="1792" alt="Screenshot 2021-12-22 at 1 07 09 PM" src="https://user-images.githubusercontent.com/16203333/147054731-2e0f50f9-892b-49a4-a869-cc6165551d94.png">|<img width="1790" alt="Screenshot 2021-12-22 at 1 10 52 PM" src="https://user-images.githubusercontent.com/16203333/147054747-7df989d2-ebe7-4ef1-ab24-8e25a6cd8820.png">|
|<img width="1478" alt="Screenshot 2021-12-22 at 1 09 10 PM" src="https://user-images.githubusercontent.com/16203333/147054768-0e67865b-0077-467b-b779-cfc0e49be4a5.png">|<img width="974" alt="Screenshot 2021-12-22 at 1 10 25 PM" src="https://user-images.githubusercontent.com/16203333/147054786-ba58c49e-0f81-4f2d-9aa5-358f538d7ae2.png">|
<img width="498" alt="Screenshot 2021-12-22 at 1 09 20 PM" src="https://user-images.githubusercontent.com/16203333/147054802-aafb71b9-4beb-4854-99de-6a928898e1c3.png">|<img width="500" alt="Screenshot 2021-12-22 at 1 10 13 PM" src="https://user-images.githubusercontent.com/16203333/147054810-9c5d7e89-9110-482a-b715-058cc15e4a6f.png">|

#### Release Note
```release-note
* UI: Fix post hover menu overlap
```
