### PR TITLE
MM-40746 - make licensing page purchase buttons responsive

### DIFF
--- a/components/admin_console/license_settings/license_settings.scss
+++ b/components/admin_console/license_settings/license_settings.scss
@@ -69,7 +69,7 @@
 }
 
 .light-blue-btn {
-    padding: 9px 24px !important;
+    padding: 14px 24px !important;
     border: none !important;
     background: rgba(28, 88, 217, 0.08) !important;
     color: #1c58d9 !important;

--- a/components/admin_console/license_settings/starter_edition/starter_edition.scss
+++ b/components/admin_console/license_settings/starter_edition/starter_edition.scss
@@ -34,19 +34,34 @@
         }
     }
 
-    button {
-        width: 100%;
-        margin: 5px auto;
-        border-radius: 4px;
-    }
-
     .purchase_buttons {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
         margin-top: 20px;
 
         button {
-            max-height: 48px !important;
-            padding: 7px 12px !important;
-            margin: 0 5px !important;
+            width: 120px;
+            padding: 14px 12px !important;
+            border-radius: 4px;
+
+            &.contact-us {
+                width: 130px;
+                margin-left: 15px;
+            }
+        }
+
+        @media screen and (max-width: 1130px) {
+            flex-direction: column;
+
+            button {
+                width: 100% !important;
+
+                &.contact-us {
+                    margin-top: 10px;
+                    margin-left: 0 !important;
+                }
+            }
         }
     }
 

--- a/components/admin_console/license_settings/starter_edition/starter_edition.scss
+++ b/components/admin_console/license_settings/starter_edition/starter_edition.scss
@@ -45,6 +45,10 @@
             padding: 14px 12px !important;
             border-radius: 4px;
 
+            span {
+                font-size: 16px !important;
+            }
+
             &.contact-us {
                 width: 130px;
                 margin-left: 15px;

--- a/components/admin_console/license_settings/starter_edition/starter_right_panel.tsx
+++ b/components/admin_console/license_settings/starter_edition/starter_right_panel.tsx
@@ -16,24 +16,6 @@ const StarterRightPanel: React.FC = () => {
         'And more...',
     ];
 
-    const purchaseLicenseBtns = (
-        <div className='purchase-card'>
-            <PurchaseLink
-                eventID='post_trial_purchase_license'
-                buttonTextElement={
-                    <FormattedMessage
-                        id='admin.license.trialCard.purchase'
-                        defaultMessage='Purchase'
-                    />
-                }
-            />
-            <ContactUsButton
-                eventID='post_trial_contact_sales'
-                customClass='light-blue-btn'
-            />
-        </div>
-    );
-
     return (
         <div className='StarterEditionRightPannel'>
             <div className='svg-image'>
@@ -61,7 +43,19 @@ const StarterRightPanel: React.FC = () => {
                 })}
             </div>
             <div className='purchase_buttons'>
-                {purchaseLicenseBtns}
+                <PurchaseLink
+                    eventID='post_trial_purchase_license'
+                    buttonTextElement={
+                        <FormattedMessage
+                            id='admin.license.trialCard.purchase'
+                            defaultMessage='Purchase'
+                        />
+                    }
+                />
+                <ContactUsButton
+                    eventID='post_trial_contact_sales'
+                    customClass='light-blue-btn'
+                />
             </div>
         </div>
     );

--- a/components/admin_console/license_settings/starter_edition/starter_right_panel.tsx
+++ b/components/admin_console/license_settings/starter_edition/starter_right_panel.tsx
@@ -54,7 +54,6 @@ const StarterRightPanel: React.FC = () => {
                 />
                 <ContactUsButton
                     eventID='post_trial_contact_sales'
-                    customClass='light-blue-btn'
                 />
             </div>
         </div>

--- a/components/announcement_bar/contact_sales/contact_us.tsx
+++ b/components/announcement_bar/contact_sales/contact_us.tsx
@@ -23,7 +23,7 @@ const ContactUsButton: React.FC<Props> = (props: Props) => {
 
     return (
         <button
-            className={`contact-us ${props.customClass}`}
+            className={`contact-us ${props.customClass ? props.customClass : ''}`}
             onClick={(e) => handleContactUsLinkClick(e)}
         >
             {props.buttonTextElement || (


### PR DESCRIPTION
#### Summary
Buttons on the licensing page were not responsive so when resizing the screen, the buttons were showing a different padding. This PR makes those buttons responsive so in smaller screens they are displayed as block elements occupying all the available space.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40746

#### Screenshots

https://user-images.githubusercontent.com/10082627/147148025-bb749630-a80f-436c-a7b2-6aa77e48a8bb.mp4



#### Release Note
```release-note
NONE
```
