### PR TITLE
[MM-38758] loading spinner in channel switcher if no local data matches

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -381,7 +381,7 @@ export default class SwitchChannelProvider extends Provider {
             // Dispatch suggestions for local data
             const channels = getChannelsInCurrentTeam(getState()).concat(getDirectAndGroupChannels(getState()));
             const users = Object.assign([], searchProfilesMatchingWithTerm(getState(), channelPrefix, false));
-            const formattedData = this.formatList(channelPrefix, channels, users);
+            const formattedData = this.formatList(channelPrefix, channels, users, true, true);
             if (formattedData) {
                 resultsCallback(formattedData);
             }
@@ -490,7 +490,7 @@ export default class SwitchChannelProvider extends Provider {
         };
     }
 
-    formatList(channelPrefix, allChannels, users, skipNotMember = true) {
+    formatList(channelPrefix, allChannels, users, skipNotMember = true, localData = false) {
         const channels = [];
 
         const members = getMyChannelMemberships(getState());
@@ -589,6 +589,13 @@ export default class SwitchChannelProvider extends Provider {
         const channelNames = channels.
             sort(quickSwitchSorter).
             map((wrappedChannel) => wrappedChannel.channel.userId || wrappedChannel.channel.id);
+
+        if (localData && !channels.length) {
+            channels.push({
+                type: Constants.MENTION_MORE_CHANNELS,
+                loading: true,
+            });
+        }
 
         return {
             matchedPretext: channelPrefix,

--- a/sass/components/_suggestion-list.scss
+++ b/sass/components/_suggestion-list.scss
@@ -25,9 +25,10 @@
 
     .LoadingSpinner {
         position: relative;
-        top: 4px;
-        display: block;
+        display: flex;
         height: 40px;
+        align-items: center;
+        justify-content: center;
         margin: 0 24px;
     }
 


### PR DESCRIPTION
#### Summary
Channel switcher flashes no results if the search does not match the search term now it will show loading spinner instead.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-38758

#### Related Pull Requests
``None``

#### Screenshots
|  before  |  after  |
|----|----|
| https://www.loom.com/share/b5a0d09dad374d85a62601578a430c4f | https://www.loom.com/share/e683b728c6b14fcab386ae2903120ad6 |

```release-note
* add loader when fetching data from backend in channel switcher if there are no results matching local data
```
