### PR TITLE
MM-40766 unregisterComponent now removes plugin components from all associated locations

### DIFF
--- a/reducers/plugins/index.ts
+++ b/reducers/plugins/index.ts
@@ -120,6 +120,7 @@ function removePluginComponents(state: PluginsState['components'], action: Gener
 }
 
 function removePluginComponent(state: PluginsState['components'], action: GenericAction) {
+    let newState = state;
     const types = Object.keys(state);
     for (let i = 0; i < types.length; i++) {
         const componentType = types[i];
@@ -128,11 +129,11 @@ function removePluginComponent(state: PluginsState['components'], action: Generi
             if (componentList[j].id === action.id) {
                 const nextArray = [...componentList];
                 nextArray.splice(j, 1);
-                return {...state, [componentType]: nextArray};
+                newState = {...newState, [componentType]: nextArray};
             }
         }
     }
-    return state;
+    return newState;
 }
 
 function plugins(state: IDMappedObjects<ClientPluginManifest> = {}, action: GenericAction) {
@@ -175,6 +176,7 @@ const initialComponents: PluginsState['components'] = {
     FilePreview: [],
     LinkTooltip: [],
     MainMenu: [],
+    ChannelHeaderButton: [],
     MobileChannelHeaderButton: [],
     PostDropdownMenu: [],
     Product: [],

--- a/types/store/plugins.ts
+++ b/types/store/plugins.ts
@@ -21,6 +21,7 @@ export type PluginsState = {
         MainMenu: PluginComponent[];
         LinkTooltip: PluginComponent[];
         RightHandSidebarComponent: PluginComponent[];
+        ChannelHeaderButton: PluginComponent[];
         MobileChannelHeaderButton: PluginComponent[];
         AppBar: PluginComponent[];
         [componentName: string]: PluginComponent[];


### PR DESCRIPTION
#### Summary

If a component's id is associated with multiple locations (such as `ChannelHeaderButton` and `MobileChannelHeaderButton`), it will only be removed from one of those places, since we short-circuit the removal process once we find one component:

https://github.com/mattermost/mattermost-webapp/blob/53868e12c770d6da4195955cf94a5b53b82a7c86/reducers/plugins/index.ts#L122-L136

In the app bar PR https://github.com/mattermost/mattermost-webapp/pull/9273, we changed the initialization of the plugin component store to start with empty arrays for the different component types, mainly to make the stored more strongly typed. Since `MobileChannelHeaderButton` happens to be initialized first, it exists first in order of keys in the `plugins.components` object. When we iterate over this object later to unregister the component, the mobile component is removed first now (and _only_ the mobile component is removed). Before the app bar PR, the mobile component would be removed second, and actually ends up not being removed unless `unregisterComponent` is called twice with the same component id.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-40766


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
