### PR TITLE
[MM-38154] - Webapp: Change Getting Started/Tips & Next Steps to be it's own view rather than overlay on active channel

### DIFF
--- a/components/channel_layout/center_channel/center_channel.test.tsx
+++ b/components/channel_layout/center_channel/center_channel.test.tsx
@@ -23,6 +23,7 @@ describe('components/channel_layout/CenterChannel', () => {
         showNextSteps: false,
         isOnboardingHidden: true,
         showNextStepsEphemeral: false,
+        enableTipsViewRoute: false,
         actions: {
             setShowNextStepsView: jest.fn,
             getProfiles: jest.fn,

--- a/components/channel_layout/center_channel/center_channel.tsx
+++ b/components/channel_layout/center_channel/center_channel.tsx
@@ -12,6 +12,7 @@ import PermalinkView from 'components/permalink_view';
 import ChannelHeaderMobile from 'components/channel_header_mobile';
 import ChannelIdentifierRouter from 'components/channel_layout/channel_identifier_router';
 import PlaybookRunner from 'components/channel_layout/playbook_runner';
+import NextStepsView from 'components/next_steps_view';
 import {makeAsyncComponent} from 'components/async_load';
 
 const LazyGlobalThreads = makeAsyncComponent(
@@ -122,6 +123,10 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
                         >
                             <PlaybookRunner/>
                         </Route>
+                        <Route
+                            path='/:team/tips'
+                            component={NextStepsView}
+                        />
                         {isCollapsedThreadsEnabled ? (
                             <Route
                                 path='/:team/threads/:threadIdentifier?'

--- a/components/channel_layout/center_channel/center_channel.tsx
+++ b/components/channel_layout/center_channel/center_channel.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {Route, Switch, Redirect} from 'react-router-dom';
 import classNames from 'classnames';
 
-import {Action, ActionFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc} from 'mattermost-redux/types/actions';
 
 import LoadingScreen from 'components/loading_screen';
 import PermalinkView from 'components/permalink_view';
@@ -38,11 +38,8 @@ type Props = {
     rhsMenuOpen: boolean;
     isCollapsedThreadsEnabled: boolean;
     currentUserId: string;
-    showNextSteps: boolean;
-    isOnboardingHidden: boolean;
-    showNextStepsEphemeral: boolean;
+    enableTipsViewRoute: boolean;
     actions: {
-        setShowNextStepsView: (show: boolean) => Action;
         getProfiles: (page?: number, perPage?: number, options?: Record<string, string | boolean>) => ActionFunc;
     };
 };
@@ -72,22 +69,12 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
     }
 
     async componentDidMount() {
-        const {actions, showNextSteps, isOnboardingHidden} = this.props;
+        const {actions} = this.props;
         await actions.getProfiles();
-        if (showNextSteps && !isOnboardingHidden) {
-            actions.setShowNextStepsView(true);
-        }
-    }
-
-    componentDidUpdate(prevProps: Props) {
-        const {location, showNextStepsEphemeral, actions} = this.props;
-        if (location.pathname !== prevProps.location.pathname && showNextStepsEphemeral) {
-            actions.setShowNextStepsView(false);
-        }
     }
 
     render() {
-        const {lastChannelPath, isCollapsedThreadsEnabled} = this.props;
+        const {lastChannelPath, isCollapsedThreadsEnabled, enableTipsViewRoute} = this.props;
         const url = this.props.match.url;
         return (
             <div
@@ -123,10 +110,13 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
                         >
                             <PlaybookRunner/>
                         </Route>
-                        <Route
-                            path='/:team/tips'
-                            component={NextStepsView}
-                        />
+                        {enableTipsViewRoute ? (
+                            <Route
+                                path='/:team/tips'
+                                component={NextStepsView}
+                            />
+
+                        ) : null}
                         {isCollapsedThreadsEnabled ? (
                             <Route
                                 path='/:team/threads/:threadIdentifier?'

--- a/components/channel_layout/center_channel/index.ts
+++ b/components/channel_layout/center_channel/index.ts
@@ -14,8 +14,8 @@ import {setShowNextStepsView} from 'actions/views/next_steps';
 import {getIsRhsOpen, getIsRhsMenuOpen} from 'selectors/rhs';
 import {getIsLhsOpen} from 'selectors/lhs';
 import {getLastViewedChannelNameByTeamName} from 'selectors/local_storage';
-
-import {isOnboardingHidden, showNextSteps} from 'components/next_steps_view/steps';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {showNextSteps} from 'components/next_steps_view/steps';
 
 import {GlobalState} from 'types/store';
 
@@ -31,6 +31,8 @@ type Props = {
 };
 
 const mapStateToProps = (state: GlobalState, ownProps: Props) => {
+    const config = getConfig(state);
+    const enableOnboardingFlow = config.EnableOnboardingFlow === 'true';
     let channelName = getLastViewedChannelNameByTeamName(state, ownProps.match.params.team);
     if (!channelName) {
         const team = getTeamByName(state, ownProps.match.params.team);
@@ -44,9 +46,7 @@ const mapStateToProps = (state: GlobalState, ownProps: Props) => {
         rhsMenuOpen: getIsRhsMenuOpen(state),
         isCollapsedThreadsEnabled: isCollapsedThreadsEnabled(state),
         currentUserId: getCurrentUserId(state),
-        showNextSteps: showNextSteps(state),
-        isOnboardingHidden: isOnboardingHidden(state),
-        showNextStepsEphemeral: state.views.nextSteps.show,
+        enableTipsViewRoute: enableOnboardingFlow && showNextSteps(state),
     };
 };
 

--- a/components/channel_view/__snapshots__/channel_view.test.tsx.snap
+++ b/components/channel_view/__snapshots__/channel_view.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`components/channel_view Should match snapshot if channel is archived wi
     channelIsArchived={true}
     channelRolesLoading={true}
     deactivatedChannel={false}
+    enableOnboardingFlow={true}
     isCloud={false}
     isOnboardingHidden={true}
     match={
@@ -31,6 +32,7 @@ exports[`components/channel_view Should match snapshot if channel is archived wi
     showNextSteps={false}
     showNextStepsEphemeral={false}
     showTutorial={false}
+    teamUrl="/team"
     viewArchivedChannels={false}
   />
   <DeferredRenderWrapper
@@ -82,6 +84,7 @@ exports[`components/channel_view Should match snapshot if channel roles loading 
     channelIsArchived={false}
     channelRolesLoading={true}
     deactivatedChannel={false}
+    enableOnboardingFlow={true}
     isCloud={false}
     isOnboardingHidden={true}
     match={
@@ -93,6 +96,7 @@ exports[`components/channel_view Should match snapshot if channel roles loading 
     showNextSteps={false}
     showNextStepsEphemeral={false}
     showTutorial={false}
+    teamUrl="/team"
     viewArchivedChannels={false}
   />
   <DeferredRenderWrapper
@@ -121,6 +125,7 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
     channelIsArchived={false}
     channelRolesLoading={false}
     deactivatedChannel={false}
+    enableOnboardingFlow={true}
     isCloud={false}
     isOnboardingHidden={true}
     match={
@@ -132,6 +137,7 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
     showNextSteps={false}
     showNextStepsEphemeral={false}
     showTutorial={false}
+    teamUrl="/team"
     viewArchivedChannels={false}
   />
   <DeferredRenderWrapper

--- a/components/channel_view/channel_view.test.tsx
+++ b/components/channel_view/channel_view.test.tsx
@@ -19,6 +19,8 @@ describe('components/channel_view', () => {
         showNextSteps: false,
         isOnboardingHidden: true,
         showNextStepsEphemeral: false,
+        enableOnboardingFlow: true,
+        teamUrl: '/team',
         channelIsArchived: false,
         viewArchivedChannels: false,
         isCloud: false,

--- a/components/channel_view/channel_view.tsx
+++ b/components/channel_view/channel_view.tsx
@@ -9,7 +9,6 @@ import deferComponentRender from 'components/deferComponentRender';
 import ChannelHeader from 'components/channel_header';
 import CreatePost from 'components/create_post';
 import FileUploadOverlay from 'components/file_upload_overlay';
-import NextStepsView from 'components/next_steps_view';
 import PostView from 'components/post_view';
 import {clearMarks, mark, measure, trackEvent} from 'actions/telemetry_actions.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
@@ -24,7 +23,6 @@ type Props = {
             postid?: string;
         };
     };
-    showNextStepsEphemeral: boolean;
     channelIsArchived: boolean;
     viewArchivedChannels: boolean;
     isCloud: boolean;
@@ -125,12 +123,6 @@ export default class ChannelView extends React.PureComponent<Props, State> {
 
     render() {
         const {channelIsArchived} = this.props;
-
-        if (this.props.showNextStepsEphemeral) {
-            return (
-                <NextStepsView/>
-            );
-        }
 
         let createPost;
         if (this.props.deactivatedChannel) {

--- a/components/channel_view/channel_view.tsx
+++ b/components/channel_view/channel_view.tsx
@@ -13,10 +13,16 @@ import PostView from 'components/post_view';
 import {clearMarks, mark, measure, trackEvent} from 'actions/telemetry_actions.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
+import {browserHistory} from 'utils/browser_history';
+
 type Props = {
     channelId: string;
     deactivatedChannel: boolean;
     channelRolesLoading: boolean;
+    showNextStepsEphemeral: boolean;
+    enableOnboardingFlow: boolean;
+    showNextSteps: boolean;
+    teamUrl: string;
     match: {
         url: string;
         params: {
@@ -28,6 +34,7 @@ type Props = {
     isCloud: boolean;
     actions: {
         goToLastViewedChannel: () => Promise<{data: boolean}>;
+        setShowNextStepsView: (x: boolean) => void;
     };
 };
 
@@ -122,7 +129,11 @@ export default class ChannelView extends React.PureComponent<Props, State> {
     }
 
     render() {
-        const {channelIsArchived} = this.props;
+        const {channelIsArchived, enableOnboardingFlow, showNextSteps, showNextStepsEphemeral, teamUrl} = this.props;
+        if (enableOnboardingFlow && showNextSteps && !showNextStepsEphemeral) {
+            this.props.actions.setShowNextStepsView(true);
+            browserHistory.push(`${teamUrl}/tips`);
+        }
 
         let createPost;
         if (this.props.deactivatedChannel) {

--- a/components/channel_view/index.ts
+++ b/components/channel_view/index.ts
@@ -9,7 +9,6 @@ import {getCurrentChannel, getDirectTeammate} from 'mattermost-redux/selectors/e
 import {getMyChannelRoles} from 'mattermost-redux/selectors/entities/roles';
 import {getRoles} from 'mattermost-redux/selectors/entities/roles_helpers';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
-import {showNextSteps} from 'components/next_steps_view/steps';
 
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
 
@@ -35,7 +34,6 @@ function mapStateToProps(state: GlobalState) {
     const config = getConfig(state);
 
     const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
-    const enableOnboardingFlow = config.EnableOnboardingFlow === 'true';
 
     let channelRolesLoading = true;
     if (channel && channel.id) {
@@ -57,7 +55,6 @@ function mapStateToProps(state: GlobalState) {
         channelRolesLoading,
         deactivatedChannel: channel ? isDeactivatedChannel(state, channel.id) : false,
         focusedPostId: state.views.channel.focusedPostId,
-        showNextStepsEphemeral: state.views.nextSteps.show && enableOnboardingFlow && showNextSteps(state),
         channelIsArchived: channel ? channel.delete_at !== 0 : false,
         viewArchivedChannels,
         isCloud: getLicense(state).Cloud === 'true',

--- a/components/channel_view/index.ts
+++ b/components/channel_view/index.ts
@@ -9,8 +9,11 @@ import {getCurrentChannel, getDirectTeammate} from 'mattermost-redux/selectors/e
 import {getMyChannelRoles} from 'mattermost-redux/selectors/entities/roles';
 import {getRoles} from 'mattermost-redux/selectors/entities/roles_helpers';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {showNextSteps} from 'components/next_steps_view/steps';
 
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
+import {setShowNextStepsView} from 'actions/views/next_steps';
+import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 
 import {goToLastViewedChannel} from 'actions/views/channel';
 
@@ -20,6 +23,7 @@ import ChannelView from './channel_view';
 
 type Actions = {
     goToLastViewedChannel: () => Promise<{data: boolean}>;
+    setShowNextStepsView: (x: boolean) => void;
 }
 
 function isDeactivatedChannel(state: GlobalState, channelId: string) {
@@ -34,6 +38,7 @@ function mapStateToProps(state: GlobalState) {
     const config = getConfig(state);
 
     const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
+    const enableOnboardingFlow = config.EnableOnboardingFlow === 'true';
 
     let channelRolesLoading = true;
     if (channel && channel.id) {
@@ -55,9 +60,13 @@ function mapStateToProps(state: GlobalState) {
         channelRolesLoading,
         deactivatedChannel: channel ? isDeactivatedChannel(state, channel.id) : false,
         focusedPostId: state.views.channel.focusedPostId,
+        showNextStepsEphemeral: state.views.nextSteps.show,
+        enableOnboardingFlow,
+        showNextSteps: showNextSteps(state),
         channelIsArchived: channel ? channel.delete_at !== 0 : false,
         viewArchivedChannels,
         isCloud: getLicense(state).Cloud === 'true',
+        teamUrl: getCurrentRelativeTeamUrl(state),
     };
 }
 
@@ -65,6 +74,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc|GenericAction>, Actions>({
             goToLastViewedChannel,
+            setShowNextStepsView,
         }, dispatch),
     };
 }

--- a/components/global_header/center_controls/user_guide_dropdown/index.ts
+++ b/components/global_header/center_controls/user_guide_dropdown/index.ts
@@ -3,9 +3,11 @@
 
 import {connect, ConnectedProps} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
+import {withRouter} from 'react-router-dom';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {GenericAction} from 'mattermost-redux/types/actions';
+import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 
 import {GlobalState} from 'types/store';
 
@@ -13,7 +15,7 @@ import {unhideNextSteps} from 'actions/views/next_steps';
 import {openModal} from 'actions/views/modals';
 
 import {
-    showOnboarding,
+    showNextSteps,
 } from 'components/next_steps_view/steps';
 
 import UserGuideDropdown from './user_guide_dropdown';
@@ -24,7 +26,8 @@ function mapStateToProps(state: GlobalState) {
         helpLink: HelpLink || '',
         reportAProblemLink: ReportAProblemLink || '',
         enableAskCommunityLink: EnableAskCommunityLink || '',
-        showGettingStarted: showOnboarding(state),
+        showDueToStepsNotFinished: showNextSteps(state),
+        teamUrl: getCurrentRelativeTeamUrl(state),
     };
 }
 
@@ -41,4 +44,4 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 export type PropsFromRedux = ConnectedProps<typeof connector>;
 
-export default connector(UserGuideDropdown);
+export default withRouter(connector(UserGuideDropdown));

--- a/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.test.tsx
+++ b/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.test.tsx
@@ -25,6 +25,11 @@ describe('components/channel_header/components/UserGuideDropdown', () => {
         reportAProblemLink: 'reportAProblemLink',
         enableAskCommunityLink: 'true',
         showGettingStarted: false,
+        location: {
+            pathname: '/team/channel/channelId',
+        },
+        showDueToStepsNotFinished: false,
+        teamUrl: '/team',
         actions: {
             unhideNextSteps: jest.fn(),
             openModal: jest.fn(),

--- a/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.tsx
+++ b/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
 import IconButton from '@mattermost/compass-components/components/icon-button';
+import {matchPath} from 'react-router-dom';
 
 import {trackEvent} from 'actions/telemetry_actions';
 
@@ -16,11 +17,17 @@ import OverlayTrigger from 'components/overlay_trigger';
 import Tooltip from 'components/tooltip';
 import KeyboardShortcutsModal from 'components/keyboard_shortcuts/keyboard_shortcuts_modal/keyboard_shortcuts_modal';
 
+import {browserHistory} from 'utils/browser_history';
+
 import type {PropsFromRedux} from './index';
 
 const askTheCommunityUrl = 'https://mattermost.com/pl/default-ask-mattermost-community/';
 
-type Props = WrappedComponentProps & PropsFromRedux
+type Props = WrappedComponentProps & PropsFromRedux & {
+    location: {
+        pathname: string;
+    };
+}
 
 type State = {
     buttonActive: boolean;
@@ -52,8 +59,14 @@ class UserGuideDropdown extends React.PureComponent<Props, State> {
         trackEvent('ui', 'help_ask_the_community');
     }
 
+    unhideNextStepsAndNavigateToTipsView = () => {
+        this.props.actions.unhideNextSteps();
+        browserHistory.push(`${this.props.teamUrl}/tips`);
+    }
+
     renderDropdownItems = (): React.ReactNode => {
-        const {intl, showGettingStarted} = this.props;
+        const {intl, showDueToStepsNotFinished} = this.props;
+        const inTipsView = matchPath(this.props.location.pathname, {path: '/:team/tips'}) != null;
 
         return (
             <Menu.Group>
@@ -72,8 +85,8 @@ class UserGuideDropdown extends React.PureComponent<Props, State> {
                 />
                 <Menu.ItemAction
                     id='gettingStarted'
-                    show={showGettingStarted}
-                    onClick={() => this.props.actions.unhideNextSteps()}
+                    show={showDueToStepsNotFinished && !inTipsView}
+                    onClick={() => this.unhideNextStepsAndNavigateToTipsView()}
                     text={intl.formatMessage({id: 'navbar_dropdown.gettingStarted', defaultMessage: 'Getting Started'})}
                     icon={Utils.isMobile() && <i className='icon icon-play'/>}
                 />

--- a/components/main_menu/index.tsx
+++ b/components/main_menu/index.tsx
@@ -34,7 +34,7 @@ import {
 
 import {GlobalState} from 'types/store';
 
-import MainMenu, {MainMenuProps} from './main_menu';
+import MainMenu from './main_menu';
 
 function mapStateToProps(state: GlobalState) {
     const config = getConfig(state);
@@ -99,4 +99,4 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     };
 }
 
-export default withRouter<MainMenuProps, any>(connect(mapStateToProps, mapDispatchToProps)(MainMenu));
+export default withRouter<any, any>(connect(mapStateToProps, mapDispatchToProps)(MainMenu));

--- a/components/main_menu/index.tsx
+++ b/components/main_menu/index.tsx
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
+import {withRouter} from 'react-router-dom';
 
 import {GenericAction} from 'mattermost-redux/types/actions';
 
@@ -12,6 +13,7 @@ import {
 import {
     getJoinableTeamIds,
     getCurrentTeam,
+    getCurrentRelativeTeamUrl,
 } from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {haveICurrentTeamPermission, haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
@@ -76,10 +78,10 @@ function mapStateToProps(state: GlobalState) {
         currentUser,
         isMentionSearch: rhsState === RHSStates.MENTION,
         teamIsGroupConstrained: Boolean(currentTeam.group_constrained),
-        isLicensedForLDAPGroups:
-            state.entities.general.license.LDAPGroups === 'true',
+        isLicensedForLDAPGroups: state.entities.general.license.LDAPGroups === 'true',
         showGettingStarted: showOnboarding(state),
-        showNextSteps: showNextSteps(state),
+        showDueToStepsNotFinished: showNextSteps(state),
+        teamUrl: getCurrentRelativeTeamUrl(state),
     };
 }
 
@@ -97,4 +99,4 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MainMenu);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(MainMenu));

--- a/components/main_menu/index.tsx
+++ b/components/main_menu/index.tsx
@@ -34,7 +34,7 @@ import {
 
 import {GlobalState} from 'types/store';
 
-import MainMenu from './main_menu';
+import MainMenu, {MainMenuProps} from './main_menu';
 
 function mapStateToProps(state: GlobalState) {
     const config = getConfig(state);
@@ -99,4 +99,4 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     };
 }
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(MainMenu));
+export default withRouter<MainMenuProps, any>(connect(mapStateToProps, mapDispatchToProps)(MainMenu));

--- a/components/main_menu/main_menu.test.tsx
+++ b/components/main_menu/main_menu.test.tsx
@@ -58,6 +58,11 @@ describe('components/Menu', () => {
         isMentionSearch: false,
         showGettingStarted: false,
         intl: createIntl({locale: 'en', defaultLocale: 'en', timeZone: 'Etc/UTC', textComponent: 'span'}),
+        showDueToStepsNotFinished: false,
+        teamUrl: '/team',
+        location: {
+            pathname: '/team',
+        },
         actions: {
             openModal: jest.fn(),
             showMentions: jest.fn(),

--- a/components/main_menu/main_menu.tsx
+++ b/components/main_menu/main_menu.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import {injectIntl, IntlShape} from 'react-intl';
+import {matchPath} from 'react-router-dom';
 
 import {Permissions} from 'mattermost-redux/constants';
 
@@ -34,6 +35,8 @@ import {ModalData} from 'types/actions';
 import {PluginComponent} from 'types/store/plugins';
 import {UserProfile} from 'mattermost-redux/types/users';
 
+import {browserHistory} from 'utils/browser_history';
+
 export type Props = {
     mobile: boolean;
     id?: string;
@@ -56,8 +59,12 @@ export type Props = {
     isMentionSearch?: boolean;
     teamIsGroupConstrained: boolean;
     isLicensedForLDAPGroups?: boolean;
-    showGettingStarted: boolean;
+    showDueToStepsNotFinished: boolean;
     intl: IntlShape;
+    teamUrl: string;
+    location: {
+        pathname: string;
+    };
     actions: {
         openModal: <P>(modalData: ModalData<P>) => void;
         showMentions: () => void;
@@ -112,6 +119,11 @@ export class MainMenu extends React.PureComponent<Props> {
         }
     }
 
+    unhideNextStepsAndNavigateToTipsView = () => {
+        this.props.actions.unhideNextSteps();
+        browserHistory.push(`${this.props.teamUrl}/tips`);
+    }
+
     render() {
         const {
             currentUser,
@@ -140,6 +152,7 @@ export class MainMenu extends React.PureComponent<Props> {
 
         const someIntegrationEnabled = this.props.enableIncomingWebhooks || this.props.enableOutgoingWebhooks || this.props.enableCommands || this.props.enableOAuthServiceProvider || this.props.canManageSystemBots;
         const showIntegrations = !this.props.mobile && someIntegrationEnabled && this.props.canManageIntegrations;
+        const inTipsView = matchPath(this.props.location.pathname, {path: '/:team/tips'}) != null;
 
         const {formatMessage} = this.props.intl;
 
@@ -329,8 +342,8 @@ export class MainMenu extends React.PureComponent<Props> {
                     />
                     <Menu.ItemAction
                         id='gettingStarted'
-                        show={this.props.showGettingStarted}
-                        onClick={() => this.props.actions.unhideNextSteps()}
+                        show={this.props.showDueToStepsNotFinished && !inTipsView}
+                        onClick={() => this.unhideNextStepsAndNavigateToTipsView()}
                         text={formatMessage({id: 'navbar_dropdown.gettingStarted', defaultMessage: 'Getting Started'})}
                         icon={<i className='icon icon-play'/>}
                     />

--- a/components/next_steps_view/index.ts
+++ b/components/next_steps_view/index.ts
@@ -10,6 +10,7 @@ import {getProfiles} from 'mattermost-redux/actions/users';
 import {makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
+import {selectChannel} from 'mattermost-redux/actions/channels';
 
 import {setShowNextStepsView} from 'actions/views/next_steps';
 import {closeRightHandSide} from 'actions/views/rhs';
@@ -44,6 +45,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
                 setShowNextStepsView,
                 getProfiles,
                 closeRightHandSide,
+                selectChannel,
             },
             dispatch,
         ),

--- a/components/next_steps_view/next_steps_view.test.tsx
+++ b/components/next_steps_view/next_steps_view.test.tsx
@@ -67,6 +67,7 @@ describe('components/next_steps_view', () => {
             savePreferences: jest.fn(),
             closeRightHandSide: jest.fn(),
             getProfiles: jest.fn(),
+            selectChannel: jest.fn(),
         },
     };
 

--- a/components/next_steps_view/next_steps_view.tsx
+++ b/components/next_steps_view/next_steps_view.tsx
@@ -38,6 +38,7 @@ type Props = {
         setShowNextStepsView: (show: boolean) => void;
         closeRightHandSide: () => void;
         getProfiles: () => void;
+        selectChannel: (channelId: string) => void;
     };
 };
 
@@ -58,6 +59,7 @@ export default class NextStepsView extends React.PureComponent<Props, State> {
     }
 
     async componentDidMount() {
+        this.props.actions.selectChannel('');
         await this.props.actions.getProfiles();
 
         // eslint-disable-next-line react/no-did-mount-set-state

--- a/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`components/sidebar should match snapshot 1`] = `
     onDragStart={[Function]}
   />
   <Connect(DataPrefetch) />
-  <Connect(SidebarNextSteps) />
+  <withRouter(Connect(SidebarNextSteps)) />
 </div>
 `;
 
@@ -98,7 +98,7 @@ exports[`components/sidebar should match snapshot when direct channels modal is 
     onDragStart={[Function]}
   />
   <Connect(DataPrefetch) />
-  <Connect(SidebarNextSteps) />
+  <withRouter(Connect(SidebarNextSteps)) />
   <Connect(MoreDirectChannels)
     isExistingChannel={false}
     onModalDismissed={[Function]}
@@ -152,6 +152,6 @@ exports[`components/sidebar should match snapshot when more channels modal is op
     onDragStart={[Function]}
   />
   <Connect(DataPrefetch) />
-  <Connect(SidebarNextSteps) />
+  <withRouter(Connect(SidebarNextSteps)) />
 </div>
 `;

--- a/components/sidebar/sidebar_next_steps/index.ts
+++ b/components/sidebar/sidebar_next_steps/index.ts
@@ -15,7 +15,6 @@ import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/tea
 import {getSteps} from '../../next_steps_view/steps';
 
 import {openModal, closeModal} from 'actions/views/modals';
-import {setShowNextStepsView} from 'actions/views/next_steps';
 import {showNextSteps} from 'components/next_steps_view/steps';
 import {GlobalState} from 'types/store';
 import {Preferences} from 'utils/constants';
@@ -43,7 +42,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
             savePreferences,
             openModal,
             closeModal,
-            setShowNextStepsView,
         }, dispatch),
     };
 }

--- a/components/sidebar/sidebar_next_steps/index.ts
+++ b/components/sidebar/sidebar_next_steps/index.ts
@@ -3,11 +3,14 @@
 
 import {connect} from 'react-redux';
 import {Dispatch, bindActionCreators} from 'redux';
+import {withRouter} from 'react-router-dom';
 
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId, getCurrentUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 
 import {getSteps} from '../../next_steps_view/steps';
 
@@ -23,13 +26,13 @@ function makeMapStateToProps() {
     const getCategory = makeGetCategory();
 
     return (state: GlobalState) => ({
-        active: state.views.nextSteps.show,
         steps: getSteps(state),
         showNextSteps: showNextSteps(state),
         currentUser: getCurrentUser(state),
         currentUserId: getCurrentUserId(state),
         preferences: getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
         isAdmin: isCurrentUserSystemAdmin(state),
+        teamUrl: getCurrentRelativeTeamUrl(state),
         enableOnboardingFlow: getConfig(state).EnableOnboardingFlow === 'true',
     });
 }
@@ -45,4 +48,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(SidebarNextSteps);
+export default withRouter(connect(makeMapStateToProps, mapDispatchToProps)(SidebarNextSteps));

--- a/components/sidebar/sidebar_next_steps/sidebar_next_steps.tsx
+++ b/components/sidebar/sidebar_next_steps/sidebar_next_steps.tsx
@@ -4,6 +4,9 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import classNames from 'classnames';
+import {matchPath} from 'react-router-dom';
+
+import {browserHistory} from 'utils/browser_history';
 
 import {PreferenceType} from 'mattermost-redux/types/preferences';
 
@@ -24,13 +27,16 @@ import './sidebar_next_steps.scss';
 import RemoveNextStepsModal from './remove_next_steps_modal';
 
 type Props = {
-    active: boolean;
     showNextSteps: boolean;
     currentUserId: string;
     preferences: PreferenceType[];
     steps: StepType[];
     isAdmin: boolean;
     enableOnboardingFlow: boolean;
+    teamUrl: string;
+    location: {
+        pathname: string;
+    };
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => void;
         openModal: <P>(modalData: ModalData<P>) => void;
@@ -73,6 +79,7 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
     showNextSteps = () => {
         trackEvent(getAnalyticsCategory(this.props.isAdmin), 'click_getting_started');
         this.props.actions.setShowNextStepsView(true);
+        browserHistory.push(`${this.props.teamUrl}/tips`);
     }
 
     onCloseModal = () => {
@@ -90,6 +97,8 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
         this.props.actions.setShowNextStepsView(false);
 
         this.onCloseModal();
+
+        browserHistory.goBack();
     }
 
     render() {
@@ -116,6 +125,8 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
         const total = this.props.steps.length;
         const complete = this.props.preferences.filter((pref) => pref.name !== RecommendedNextSteps.HIDE && pref.value === 'true').length;
 
+        const inTipsView = matchPath(this.props.location.pathname, {path: '/:team/tips'}) != null;
+
         const header = (
             <FormattedMessage
                 id='sidebar_next_steps.gettingStarted'
@@ -137,7 +148,7 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
         return (
             <div
                 className={classNames('SidebarNextSteps', {
-                    active: this.props.active,
+                    active: inTipsView,
                 })}
                 onClick={this.showNextSteps}
             >

--- a/components/sidebar/sidebar_next_steps/sidebar_next_steps.tsx
+++ b/components/sidebar/sidebar_next_steps/sidebar_next_steps.tsx
@@ -41,7 +41,6 @@ type Props = {
         savePreferences: (userId: string, preferences: PreferenceType[]) => void;
         openModal: <P>(modalData: ModalData<P>) => void;
         closeModal: (modalId: string) => void;
-        setShowNextStepsView: (show: boolean) => void;
     };
 };
 
@@ -78,7 +77,6 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
 
     showNextSteps = () => {
         trackEvent(getAnalyticsCategory(this.props.isAdmin), 'click_getting_started');
-        // this.props.actions.setShowNextStepsView(true);
         browserHistory.push(`${this.props.teamUrl}/tips`);
     }
 
@@ -93,8 +91,6 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
             name: RecommendedNextSteps.HIDE,
             value: 'true',
         }]);
-
-        // this.props.actions.setShowNextStepsView(false);
 
         this.onCloseModal();
 

--- a/components/sidebar/sidebar_next_steps/sidebar_next_steps.tsx
+++ b/components/sidebar/sidebar_next_steps/sidebar_next_steps.tsx
@@ -78,7 +78,7 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
 
     showNextSteps = () => {
         trackEvent(getAnalyticsCategory(this.props.isAdmin), 'click_getting_started');
-        this.props.actions.setShowNextStepsView(true);
+        // this.props.actions.setShowNextStepsView(true);
         browserHistory.push(`${this.props.teamUrl}/tips`);
     }
 
@@ -94,7 +94,7 @@ export default class SidebarNextSteps extends React.PureComponent<Props, State> 
             value: 'true',
         }]);
 
-        this.props.actions.setShowNextStepsView(false);
+        // this.props.actions.setShowNextStepsView(false);
 
         this.onCloseModal();
 

--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -19,6 +19,8 @@ import {getThreads} from 'mattermost-redux/actions/threads';
 import {selectChannel} from 'mattermost-redux/actions/channels';
 
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
+import {setShowNextStepsView} from 'actions/views/next_steps';
 
 import {GlobalState} from 'types/store/index';
 
@@ -28,6 +30,8 @@ import {setSelectedThreadId} from 'actions/views/threads';
 import {suppressRHS, unsuppressRHS} from 'actions/views/rhs';
 import {loadProfilesForSidebar} from 'actions/user_actions';
 import {getSelectedThreadIdInCurrentTeam} from 'selectors/views/threads';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {showNextSteps} from 'components/next_steps_view/steps';
 
 import Header from 'components/widgets/header';
 import LoadingScreen from 'components/loading_screen';
@@ -37,6 +41,8 @@ import {useThreadRouting} from '../hooks';
 import ChatIllustration from '../common/chat_illustration';
 
 import ThreadViewer from '../thread_viewer';
+
+import {browserHistory} from 'utils/browser_history';
 
 import ThreadList, {ThreadFilter, FILTER_STORAGE_KEY} from './thread_list';
 import ThreadPane from './thread_pane';
@@ -55,6 +61,10 @@ const GlobalThreads = () => {
     const selectedThread = useSelector((state: GlobalState) => getThread(state, threadIdentifier));
     const selectedThreadId = useSelector(getSelectedThreadIdInCurrentTeam);
     const selectedPost = useSelector((state: GlobalState) => getPost(state, threadIdentifier!));
+    const showNextStepsEphemeral = useSelector((state: GlobalState) => state.views.nextSteps.show);
+    const showSteps = useSelector((state: GlobalState) => showNextSteps(state));
+    const config = useSelector(getConfig);
+    const teamUrl = useSelector((state: GlobalState) => getCurrentRelativeTeamUrl(state));
     const threadIds = useSelector((state: GlobalState) => getThreadOrderInCurrentTeam(state, selectedThread?.id), shallowEqual);
     const unreadThreadIds = useSelector((state: GlobalState) => getUnreadThreadOrderInCurrentTeam(state, selectedThread?.id), shallowEqual);
     const numUnread = counts?.total_unread_threads || 0;
@@ -130,6 +140,14 @@ const GlobalThreads = () => {
 
     const handleSelectUnread = useCallback(() => {
         setFilter(ThreadFilter.unread);
+    }, []);
+
+    useEffect(() => {
+        const enableOnboardingFlow = config.EnableOnboardingFlow === 'true';
+        if (enableOnboardingFlow && showSteps && !showNextStepsEphemeral) {
+            dispatch(setShowNextStepsView(true));
+            browserHistory.push(`${teamUrl}/tips`);
+        }
     }, []);
 
     return (

--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -28,13 +28,10 @@ import {setSelectedThreadId} from 'actions/views/threads';
 import {suppressRHS, unsuppressRHS} from 'actions/views/rhs';
 import {loadProfilesForSidebar} from 'actions/user_actions';
 import {getSelectedThreadIdInCurrentTeam} from 'selectors/views/threads';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {showNextSteps} from 'components/next_steps_view/steps';
 
 import Header from 'components/widgets/header';
 import LoadingScreen from 'components/loading_screen';
 import NoResultsIndicator from 'components/no_results_indicator';
-import NextStepsView from 'components/next_steps_view';
 
 import {useThreadRouting} from '../hooks';
 import ChatIllustration from '../common/chat_illustration';
@@ -58,9 +55,6 @@ const GlobalThreads = () => {
     const selectedThread = useSelector((state: GlobalState) => getThread(state, threadIdentifier));
     const selectedThreadId = useSelector(getSelectedThreadIdInCurrentTeam);
     const selectedPost = useSelector((state: GlobalState) => getPost(state, threadIdentifier!));
-    const showNextStepsEphemeral = useSelector((state: GlobalState) => state.views.nextSteps.show);
-    const showSteps = useSelector((state: GlobalState) => showNextSteps(state));
-    const config = useSelector(getConfig);
     const threadIds = useSelector((state: GlobalState) => getThreadOrderInCurrentTeam(state, selectedThread?.id), shallowEqual);
     const unreadThreadIds = useSelector((state: GlobalState) => getUnreadThreadOrderInCurrentTeam(state, selectedThread?.id), shallowEqual);
     const numUnread = counts?.total_unread_threads || 0;
@@ -137,11 +131,6 @@ const GlobalThreads = () => {
     const handleSelectUnread = useCallback(() => {
         setFilter(ThreadFilter.unread);
     }, []);
-
-    const enableOnboardingFlow = config.EnableOnboardingFlow === 'true';
-    if (showNextStepsEphemeral && enableOnboardingFlow && showSteps) {
-        return <NextStepsView/>;
-    }
 
     return (
         <div

--- a/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_legacy_invite_member_by_email_spec.js
+++ b/e2e/cypress/integration/enterprise/cloud/onboarding/cloud_legacy_invite_member_by_email_spec.js
@@ -59,8 +59,8 @@ describe('Cloud Onboarding - Sysadmin invite members by email for legacy cloud p
             },
         });
 
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Click Invite members to the team header
         cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').scrollIntoView().should('be.visible').click();

--- a/e2e/cypress/integration/onboarding/cloud_sysadmin_onboarding_spec.js
+++ b/e2e/cypress/integration/onboarding/cloud_sysadmin_onboarding_spec.js
@@ -52,8 +52,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3326 Sysadmin - Happy Path', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Use to grant permission to Notification
         spyNotificationAs('withNotification', 'granted');
@@ -113,8 +113,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3327 Sysadmin - Switch to Next Step', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // * Check to make sure card is expanded
         cy.get('.Card__body.expanded .CompleteProfileStep').should('be.visible');
@@ -131,8 +131,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3328 Sysadmin - Skip Getting Started', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // * Check to make sure first card is expanded
         cy.get('.Card__body.expanded .CompleteProfileStep').should('be.visible');
@@ -145,8 +145,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3329 Sysadmin - Remove Recommended Next Steps', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // * Check to make sure first card is expanded
         cy.findByText('Complete your profile').should('be.visible');
@@ -174,7 +174,7 @@ describe('Onboarding - Sysadmin', () => {
 
     it('MM-T3333 Sysadmin - Copy Invite Link', () => {
         cy.apiCreateTeam('team').then(({team}) => {
-            cy.visit(`/${team.name}/channels/town-square`);
+            cy.visit(`/${team.name}/tips`);
 
             // # Stub out clipboard
             stubClipboard().as('clipboard');
@@ -187,8 +187,8 @@ describe('Onboarding - Sysadmin', () => {
             cy.get('@clipboard').its('wasCalled').should('eq', false);
             cy.get('@clipboard').its('contents').should('eq', '');
 
-            // * Make sure channel view has loaded
-            cy.url().should('include', `/${team.name}/channels/town-square`);
+            // * Make sure tips view has loaded
+            cy.url().should('include', `/${team.name}/tips`);
 
             // # Click Invite members to the team header
             cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').scrollIntoView().should('be.visible').click();

--- a/e2e/cypress/integration/onboarding/invite_member_by_email_spec.js
+++ b/e2e/cypress/integration/onboarding/invite_member_by_email_spec.js
@@ -67,8 +67,8 @@ describe('Onboarding - Sysadmin invite members by email', () => {
             });
         });
 
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Click Invite members to the team header
         cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();
@@ -90,8 +90,8 @@ describe('Onboarding - Sysadmin invite members by email', () => {
     });
 
     it('MM-T3332_2 Invite with invalid emails', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Click Invite members to the team header
         cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();
@@ -110,8 +110,8 @@ describe('Onboarding - Sysadmin invite members by email', () => {
     });
 
     it('MM-T3332_3 Invite with invalid emails when next button is pressed', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Click Invite members to the team header
         cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();
@@ -130,8 +130,8 @@ describe('Onboarding - Sysadmin invite members by email', () => {
     });
 
     it('MM-T3332_4 Pressing next with empty input finishes the step', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Click Invite members to the team header
         cy.get('button.NextStepsView__cardHeader:contains(Invite members to the team)').should('be.visible').click();

--- a/e2e/cypress/integration/onboarding/set_profile_and_team_spec.js
+++ b/e2e/cypress/integration/onboarding/set_profile_and_team_spec.js
@@ -57,8 +57,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3330_1 Sysadmin - Set full name and profile image', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Clear full name
         cy.apiPatchUser(sysadmin.id, {first_name: '', last_name: ''}).then(() => {
@@ -89,8 +89,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3330_2 Sysadmin - Set full name and profile image - no name provided', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // * Check to make sure card is expanded
         cy.get('.Card__body.expanded .CompleteProfileStep').should('be.visible');
@@ -106,8 +106,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3330_3 Sysadmin - Set full name and profile image - upload file of wrong type', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // * Check to make sure card is expanded
         cy.get('.Card__body.expanded .CompleteProfileStep').should('be.visible');
@@ -120,8 +120,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3331_1 Sysadmin - Set team name and team icon', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Click Name your team header
         cy.get('button.NextStepsView__cardHeader:contains(Name your team)').should('be.visible').click();
@@ -146,8 +146,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3331_2 Sysadmin - Set team name and team icon - no name provided', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Click Name your team header
         cy.get('button.NextStepsView__cardHeader:contains(Name your team)').should('be.visible').click();
@@ -166,8 +166,8 @@ describe('Onboarding - Sysadmin', () => {
     });
 
     it('MM-T3331_3 Sysadmin - Set team name and team icon - upload file of wrong type', () => {
-        // * Make sure channel view has loaded
-        cy.url().should('include', townSquarePage);
+        // * Make sure tips view has loaded
+        cy.url().should('include', 'tips');
 
         // # Click Name your team header
         cy.get('button.NextStepsView__cardHeader:contains(Name your team)').should('be.visible').click();

--- a/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
+++ b/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
@@ -355,7 +355,7 @@ exports[`plugins/MainMenuActions should match snapshot in mobile view with some 
       }
       id="gettingStarted"
       onClick={[Function]}
-      show={true}
+      show={false}
       text="Getting Started"
     />
     <MenuItemExternalLink

--- a/plugins/test/main_menu_action.test.jsx
+++ b/plugins/test/main_menu_action.test.jsx
@@ -33,6 +33,11 @@ describe('plugins/MainMenuActions', () => {
         moreTeamsToJoin: true,
         teamIsGroupConstrained: true,
         showGettingStarted: true,
+        showDueToStepsNotFinished: false,
+        teamUrl: '/team',
+        location: {
+            pathname: '/team',
+        },
         actions: {
             openModal: jest.fn(),
             showMentions: jest.fn(),


### PR DESCRIPTION
#### Summary
This PR makes the next steps view component accessible on it's own route `/:team/tips`

#### Ticket Link
[MM-38154](https://mattermost.atlassian.net/browse/MM-38154)

#### Release Note

```release-note
NONE

```
