### PR TITLE
MM-40790 - Do not show license expired banner for Cloud

### DIFF
--- a/components/announcement_bar/configuration_bar/__snapshots__/configuration_bar.test.tsx.snap
+++ b/components/announcement_bar/configuration_bar/__snapshots__/configuration_bar.test.tsx.snap
@@ -40,6 +40,8 @@ exports[`components/ConfigurationBar should match snapshot, expired 1`] = `
 />
 `;
 
+exports[`components/ConfigurationBar should match snapshot, expired, cloud license, show nothing 1`] = `""`;
+
 exports[`components/ConfigurationBar should match snapshot, expired, in grace period 1`] = `
 <Connect(AnnouncementBar)
   message={
@@ -97,5 +99,7 @@ exports[`components/ConfigurationBar should match snapshot, expired, regular use
   type="critical"
 />
 `;
+
+exports[`components/ConfigurationBar should match snapshot, expiring, cloud license, show nothing 1`] = `""`;
 
 exports[`components/ConfigurationBar should match snapshot, show nothing 1`] = `""`;

--- a/components/announcement_bar/configuration_bar/configuration_bar.test.tsx
+++ b/components/announcement_bar/configuration_bar/configuration_bar.test.tsx
@@ -55,6 +55,24 @@ describe('components/ConfigurationBar', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot, expired, cloud license, show nothing', () => {
+        const props = {...baseProps, canViewSystemErrors: false, license: {Id: '1234', IsLicensed: 'true', Cloud: 'true', ExpiresAt: Date.now() - (11 * millisPerDay)}};
+        const wrapper = shallowWithIntl(
+            <ConfigurationBar {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, expiring, cloud license, show nothing', () => {
+        const props = {...baseProps, canViewSystemErrors: false, license: {Id: '1234', IsLicensed: 'true', Cloud: 'true', ExpiresAt: Date.now()}};
+        const wrapper = shallowWithIntl(
+            <ConfigurationBar {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should match snapshot, show nothing', () => {
         const props = {...baseProps, license: {Id: '1234', IsLicensed: 'true', ExpiresAt: Date.now() + (61 * millisPerDay)}};
         const wrapper = shallowWithIntl(

--- a/utils/license_utils.jsx
+++ b/utils/license_utils.jsx
@@ -20,7 +20,7 @@ export function isLicenseExpiring(license) {
 }
 
 export function daysToLicenseExpire(license) {
-    if (license.IsLicensed !== 'true') {
+    if (license.IsLicensed !== 'true' || isCloudLicense(license)) {
         return undefined;
     }
 
@@ -29,7 +29,7 @@ export function daysToLicenseExpire(license) {
 }
 
 export function isLicenseExpired(license) {
-    if (license.IsLicensed !== 'true') {
+    if (license.IsLicensed !== 'true' || isCloudLicense(license)) {
         return false;
     }
 
@@ -39,7 +39,7 @@ export function isLicenseExpired(license) {
 }
 
 export function isLicensePastGracePeriod(license) {
-    if (license.IsLicensed !== 'true') {
+    if (license.IsLicensed !== 'true' || isCloudLicense(license)) {
         return false;
     }
 

--- a/utils/license_utils.test.jsx
+++ b/utils/license_utils.test.jsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {isLicenseExpired, isLicenseExpiring, isLicensePastGracePeriod} from 'utils/license_utils.jsx';
+
+describe('license_utils', () => {
+    const millisPerDay = 24 * 60 * 60 * 1000;
+    describe('isLicenseExpiring', () => {
+        it('should return false if cloud expiring in 5 days', () => {
+            const license = {Id: '1234', IsLicensed: 'true', Cloud: 'true', ExpiresAt: Date.now() + (5 * millisPerDay)};
+
+            expect(isLicenseExpiring(license)).toBeFalsy();
+        });
+
+        it('should return True if expiring in 5 days - non Cloud', () => {
+            const license = {Id: '1234', IsLicensed: 'true', Cloud: 'false', ExpiresAt: Date.now() + (5 * millisPerDay)};
+
+            expect(isLicenseExpiring(license)).toBeTruthy();
+        });
+    });
+    describe('isLicenseExpired', () => {
+        it('should return false if cloud expired 1 day ago', () => {
+            const license = {Id: '1234', IsLicensed: 'true', Cloud: 'true', ExpiresAt: Date.now() - (Number(millisPerDay))};
+
+            expect(isLicenseExpired(license)).toBeFalsy();
+        });
+
+        it('should return True if expired 1 day ago - non Cloud', () => {
+            const license = {Id: '1234', IsLicensed: 'true', Cloud: 'false', ExpiresAt: Date.now() - (Number(millisPerDay))};
+
+            expect(isLicenseExpired(license)).toBeTruthy();
+        });
+    });
+
+    describe('isLicensePastGracePeriod', () => {
+        it('should return False if cloud expired 11 days ago', () => {
+            const license = {Id: '1234', IsLicensed: 'true', Cloud: 'true', ExpiresAt: Date.now() - (11 * millisPerDay)};
+
+            expect(isLicensePastGracePeriod(license)).toBeFalsy();
+        });
+
+        it('should return True if expired 1 day ago - non Cloud', () => {
+            const license = {Id: '1234', IsLicensed: 'true', Cloud: 'false', ExpiresAt: Date.now() - (11 * millisPerDay)};
+
+            expect(isLicensePastGracePeriod(license)).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
#### Summary

The license check and invalidation was removed server side for Cloud installations in https://github.com/mattermost/mattermost-server/pull/18921 and https://github.com/mattermost/mattermost-webapp/pull/9318 . However, it was not removed in the banner checks for already expired licenses. This PR will not show the license expired banner for any cloud installation. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40790

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
