### PR TITLE
[MM-39279] - Hide the Invite Members button when the DM category is collapsed

### DIFF
--- a/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -343,7 +343,7 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
             >
                 {(provided, snapshot) => {
                     let inviteMembersButton = null;
-                    if (category.type === 'direct_messages') {
+                    if (category.type === 'direct_messages' && !category.collapsed) {
                         inviteMembersButton = (
                             <InviteMembersButton
                                 className='followingSibling'


### PR DESCRIPTION
#### Summary
This PR adds a check to hide invitation button when DMs are collapsed from the sidebar

#### Ticket Link
[MM-39279](https://mattermost.atlassian.net/browse/MM-39279)

#### Release Note

```release-note
NONE

```
