### PR TITLE
MM-40545 Prevent ctrl+a from opening account settings modal without shift

### DIFF
--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -104,7 +104,7 @@ export default class Sidebar extends React.PureComponent<Props, State> {
                     modalId: ModalIdentifiers.KEYBOARD_SHORTCUTS_MODAL,
                     dialogType: KeyboardShortcutsModal,
                 });
-            } else if (Utils.isKeyPressed(event, Constants.KeyCodes.A)) {
+            } else if (Utils.isKeyPressed(event, Constants.KeyCodes.A) && event.shiftKey) {
                 event.preventDefault();
 
                 this.props.actions.openModal({

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_shift_a_account_settings_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_shift_a_account_settings_spec.js
@@ -16,9 +16,9 @@ describe('Keyboard Shortcuts', () => {
         });
     });
 
-    it('MM-T4441_1 CTRL/CMD+A - Settings should open in desktop view', () => {
-        // # Type CTRL/CMD+A to open 'Settings'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('A');
+    it('MM-T4441_1 CTRL/CMD+SHIFT+A - Settings should open in desktop view', () => {
+        // # Type CTRL/CMD+SHIFT+A to open 'Settings'
+        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}A');
 
         // * Ensure account settings modal is open
         cy.get('#accountSettingsModal').should('be.visible');
@@ -26,16 +26,24 @@ describe('Keyboard Shortcuts', () => {
         cy.uiClose();
     });
 
-    it('MM-T4441_2 CTRL/CMD+A - Settings should open in mobile view view', () => {
+    it('MM-T4441_2 CTRL/CMD+SHIFT+A - Settings should open in mobile view view', () => {
         // # Resize the window to mobile view
         cy.viewport('iphone-6');
 
-        // # Type CTRL/CMD+A to open 'Settings'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('A');
+        // # Type CTRL/CMD+SHIFT+A to open 'Settings'
+        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}A');
 
         // * Ensure Settings modal is open
         cy.get('#accountSettingsModal').should('be.visible');
 
         cy.uiClose();
+    });
+
+    it('CTRL+A - Should not open Settings', () => {
+        // # Type CTRL/CMD+A to select the text
+        cy.get('#post_textbox').cmdOrCtrlShortcut('A');
+
+        // * Ensure Settings modal is not open
+        cy.get('#accountSettingsModal').should('not.exist');
     });
 });


### PR DESCRIPTION
This is what I get for copying code without realizing it didn't check for shift when handling this hotkey

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40767

#### Release Note
```release-note
NONE
```
