### PR TITLE
[MM-32371] Enable desktop app to tell webapp when Back/Forward should be enabled

### DIFF
--- a/components/global_header/left_controls/history_buttons/history_buttons.tsx
+++ b/components/global_header/left_controls/history_buttons/history_buttons.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import IconButton from '@mattermost/compass-components/components/icon-button';
 
@@ -26,6 +26,9 @@ const HistoryButtonsContainer = styled.nav`
 `;
 
 const HistoryButtons = (): JSX.Element => {
+    const [canGoBack, setCanGoBack] = useState(true);
+    const [canGoForward, setCanGoForward] = useState(true);
+
     const getTooltip = (shortcut: KeyboardShortcutDescriptor) => (
         <Tooltip
             id='upload-tooltip'
@@ -40,12 +43,45 @@ const HistoryButtons = (): JSX.Element => {
     const goBack = () => {
         trackEvent('ui', 'ui_history_back');
         browserHistory.goBack();
+        window.postMessage(
+            {
+                type: 'history-button',
+            },
+            window.location.origin,
+        );
     };
 
     const goForward = () => {
         trackEvent('ui', 'ui_history_forward');
         browserHistory.goForward();
+        window.postMessage(
+            {
+                type: 'history-button',
+            },
+            window.location.origin,
+        );
     };
+
+    const handleButtonMessage = (message: {origin: string; data: {type: string; message: {enableBack: boolean; enableForward: boolean}}}) => {
+        if (message.origin !== window.location.origin) {
+            return;
+        }
+
+        switch (message.data.type) {
+        case 'history-button-return': {
+            setCanGoBack(message.data.message.enableBack);
+            setCanGoForward(message.data.message.enableForward);
+            break;
+        }
+        }
+    };
+
+    useEffect(() => {
+        window.addEventListener('message', handleButtonMessage);
+        return () => {
+            window.removeEventListener('message', handleButtonMessage);
+        };
+    }, []);
 
     return (
         <HistoryButtonsContainer>
@@ -61,6 +97,7 @@ const HistoryButtons = (): JSX.Element => {
                     size={'sm'}
                     compact={true}
                     inverted={true}
+                    disabled={!canGoBack}
                     aria-label={Utils.localizeMessage('sidebar_left.channel_navigator.goBackLabel', 'Back')}
                 />
             </OverlayTrigger>
@@ -76,6 +113,7 @@ const HistoryButtons = (): JSX.Element => {
                     size={'sm'}
                     compact={true}
                     inverted={true}
+                    disabled={!canGoForward}
                     aria-label={Utils.localizeMessage('sidebar_left.channel_navigator.goForwardLabel', 'Forward')}
                 />
             </OverlayTrigger>


### PR DESCRIPTION
#### Summary
This PR allows the history_buttons component to talk to the desktop app directly and determine whether the Back/Forward buttons should be enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32371

#### Related Pull Requests
Desktop: https://github.com/mattermost/desktop/pull/1941

```release-note
NONE
```
