### PR TITLE
MM-40751 Properly set Content-Type on API requests

### DIFF
--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -123,6 +123,7 @@ import {TelemetryHandler} from './telemetry';
 const FormData = require('form-data');
 const HEADER_AUTH = 'Authorization';
 const HEADER_BEARER = 'BEARER';
+const HEADER_CONTENT_TYPE = 'Content-Type';
 const HEADER_REQUESTED_WITH = 'X-Requested-With';
 const HEADER_USER_AGENT = 'User-Agent';
 const HEADER_X_CLUSTER_ID = 'X-Cluster-Id';
@@ -470,7 +471,7 @@ export default class Client4 {
         }
 
         if (options.body) {
-            headers['Content-Type'] = 'application/json';
+            headers[HEADER_CONTENT_TYPE] = 'application/json';
         }
 
         if (newOptions.headers) {

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint-disable max-lines */
+
 import {SystemSetting} from 'mattermost-redux/types/general';
 
 import {General} from '../constants';
@@ -465,6 +467,10 @@ export default class Client4 {
 
         if (this.userAgent) {
             headers[HEADER_USER_AGENT] = this.userAgent;
+        }
+
+        if (options.body) {
+            headers['Content-Type'] = 'application/json';
         }
 
         if (newOptions.headers) {


### PR DESCRIPTION
Turns out all API requests we make to the server from the client are made with `Content-Type: plain/text` even though we're always passing JSON through `Client4`. I looked through every Client4 call that passes a body, and every one of them calls `JSON.stringify` on an object before passing it as the `body` option

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40751
Closes https://mattermost.atlassian.net/browse/MM-40751

#### Release Note
```release-note
Changed Client4 to properly set Content-Type as application/json on API calls
```
