### PR TITLE
Add workaround for mmjstool integrity check failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ i18n-extract: ## Extract strings for translation from the source code
 node_modules: package.json package-lock.json
 	@echo Getting dependencies using npm
 
+	node skip_integrity_check.js
+
 	npm install
 	touch $@
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@mattermost/webapp",
       "version": "5.36.0-0",
-      "hasInstallScript": true,
       "dependencies": {
         "@formatjs/intl-pluralrules": "4.0.6",
         "@formatjs/intl-relativetimeformat": "6.2.3",
@@ -28971,7 +28970,6 @@
     "node_modules/mmjstool": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac",
-      "integrity": "sha512-wHUORQrEsVFMgSBJvkXnRPJ1/PpcyNP9B+SHzN35/Y0tGvRqGAN+ZwIPBewIq91b5iEZWxRZX1ufrDnI0rAOwg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@mattermost/webapp",
       "version": "5.36.0-0",
+      "hasInstallScript": true,
       "dependencies": {
         "@formatjs/intl-pluralrules": "4.0.6",
         "@formatjs/intl-relativetimeformat": "6.2.3",
@@ -63199,7 +63200,6 @@
     },
     "mmjstool": {
       "version": "git+ssh://git@github.com/mattermost/mattermost-utilities.git#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac",
-      "integrity": "sha512-wHUORQrEsVFMgSBJvkXnRPJ1/PpcyNP9B+SHzN35/Y0tGvRqGAN+ZwIPBewIq91b5iEZWxRZX1ufrDnI0rAOwg==",
       "dev": true,
       "from": "mmjstool@github:mattermost/mattermost-utilities#17ee7abdc0ccaec5d432123fcabc7fe73abe33ac",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -295,7 +295,9 @@
     "storybook": "start-storybook -p 6006 -s ./storybook/static",
     "build-storybook": "build-storybook -s ./storybook/static",
     "check-types": "tsc",
-    "make-emojis": "node --experimental-json-modules build/emoji/emoji_gen.mjs"
+    "make-emojis": "node --experimental-json-modules build/emoji/emoji_gen.mjs",
+    "preinstall": "node skip_integrity_check.js",
+    "postinstall": "node skip_integrity_check.js"
   },
   "workspaces": []
 }

--- a/package.json
+++ b/package.json
@@ -295,9 +295,7 @@
     "storybook": "start-storybook -p 6006 -s ./storybook/static",
     "build-storybook": "build-storybook -s ./storybook/static",
     "check-types": "tsc",
-    "make-emojis": "node --experimental-json-modules build/emoji/emoji_gen.mjs",
-    "preinstall": "node skip_integrity_check.js",
-    "postinstall": "node skip_integrity_check.js"
+    "make-emojis": "node --experimental-json-modules build/emoji/emoji_gen.mjs"
   },
   "workspaces": []
 }

--- a/skip_integrity_check.js
+++ b/skip_integrity_check.js
@@ -7,5 +7,6 @@ const content = JSON.parse(fs.readFileSync('package-lock.json', 'utf-8'));
 // Skip integrity check for mmjstool, which differs on Apple Silicon M1.
 // @see https://github.com/npm/cli/issues/2846
 delete content.dependencies.mmjstool.integrity;
+delete content.packages['node_modules/mmjstool'].integrity;
 
 fs.writeFileSync('package-lock.json', JSON.stringify(content, null, 2) + '\n');

--- a/skip_integrity_check.js
+++ b/skip_integrity_check.js
@@ -1,0 +1,11 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const fs = require('fs');
+const content = JSON.parse(fs.readFileSync('package-lock.json', 'utf-8'));
+
+// Skip integrity check for mmjstool, which differs on Apple Silicon M1.
+// @see https://github.com/npm/cli/issues/2846
+delete content.dependencies.mmjstool.integrity;
+
+fs.writeFileSync('package-lock.json', JSON.stringify(content, null, 2) + '\n');


### PR DESCRIPTION
Copies a workaround for the integrity check issue that we've had people reporting since we upgraded mmjstool

See https://github.com/mattermost/mattermost-plugin-playbooks/pull/868 for more details

#### Release Note
```release-note
NONE
```
