### PR TITLE
[MM-40484]Archived channels are showing the globe channel icon in channel autocomplete

### DIFF
--- a/components/suggestion/channel_mention_provider.jsx
+++ b/components/suggestion/channel_mention_provider.jsx
@@ -18,13 +18,23 @@ export class ChannelMentionSuggestion extends Suggestion {
     render() {
         const isSelection = this.props.isSelection;
         const item = this.props.item;
+        const channelIsArchived = item.channel.delete_at && item.channel.delete_at !== 0;
 
         const channelName = item.channel.display_name;
-        const channelIcon = (
-            <span className='suggestion-list__icon suggestion-list__icon--large'>
-                <i className={`icon icon--no-spacing icon-${item.channel.type === Constants.OPEN_CHANNEL ? 'globe' : 'lock'}`}/>
-            </span>
-        );
+        let channelIcon;
+        if (channelIsArchived) {
+            channelIcon = (
+                <span className='suggestion-list__icon suggestion-list__icon--large'>
+                    <i className='icon icon-archive-outline'/>
+                </span>
+            );
+        } else {
+            channelIcon = (
+                <span className='suggestion-list__icon suggestion-list__icon--large'>
+                    <i className={`icon icon--no-spacing icon-${item.channel.type === Constants.OPEN_CHANNEL ? 'globe' : 'lock'}`}/>
+                </span>
+            );
+        }
 
         let className = 'suggestion-list__item';
         if (isSelection) {


### PR DESCRIPTION
#### Summary
Fixes: Archived channels are showing the globe channel icon in channel autocomplete

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-40484

#### Related Pull Requests
``NONE``

#### Screenshots
|  before  |  after  |
|----|----|
|  ![image-2021-12-03-10-30-44-268](https://user-images.githubusercontent.com/16203333/148263744-911b73d6-14cc-42e0-ac6c-9356260bd523.png) | <img width="606" alt="Screenshot 2022-01-05 at 11 10 12 PM" src="https://user-images.githubusercontent.com/16203333/148263873-6aa11b11-137b-47d8-97f4-c3dcb69993f8.png"> |

#### Release Not

```release-note
* UI: show archived channel icon for archived channels in channel autocomplete
```
