### PR TITLE
fix:MM-405552 : JavaScript error when browsing channels and clicking Next

### DIFF
--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -128,13 +128,13 @@ export default class SearchableChannelList extends React.PureComponent {
         this.setState({page: this.state.page + 1, nextDisabled: true});
         this.nextTimeoutId = setTimeout(() => this.setState({nextDisabled: false}), NEXT_BUTTON_TIMEOUT_MILLISECONDS);
         this.props.nextPage(this.state.page + 1);
-        this.channelListScroll.current?.scrollTo(0);
+        this.channelListScroll.current?.scrollTo({top: 0});
     }
 
     previousPage = (e) => {
         e.preventDefault();
         this.setState({page: this.state.page - 1});
-        this.channelListScroll.current?.scrollTo(0);
+        this.channelListScroll.current?.scrollTo({top: 0});
     }
 
     doSearch = () => {


### PR DESCRIPTION
#### Summary
Fixed the code which call [`scrollTo`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo) on next button of browse channels modal with only single parameters instead of two.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40552

#### Related Pull Requests

~Has server changes (please link here)~
~Has mobile changes (please link here)~

#### Screenshots

https://user-images.githubusercontent.com/17708702/148368842-4c19ef58-ee2b-4da5-948d-bc4766e20742.mov

#### Release Note
```release-note
NONE
```
