### PR TITLE
Let fetch api set the correct content-type to FormData requests

### DIFF
--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -119,6 +119,7 @@ import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 import {UserThreadList, UserThread, UserThreadWithPost} from 'mattermost-redux/types/threads';
 
 import {TelemetryHandler} from './telemetry';
+import { instanceOf } from 'prop-types';
 
 const FormData = require('form-data');
 const HEADER_AUTH = 'Authorization';
@@ -471,7 +472,10 @@ export default class Client4 {
         }
 
         if (options.body) {
-            headers[HEADER_CONTENT_TYPE] = 'application/json';
+            // when the body is an instance of FormData we let fetch to set the Content-Type header so it defines a correct boundary
+            if (!(options.body instanceof FormData)) {
+                headers[HEADER_CONTENT_TYPE] = 'application/json';
+            }
         }
 
         if (newOptions.headers) {

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -119,7 +119,6 @@ import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 import {UserThreadList, UserThread, UserThreadWithPost} from 'mattermost-redux/types/threads';
 
 import {TelemetryHandler} from './telemetry';
-import { instanceOf } from 'prop-types';
 
 const FormData = require('form-data');
 const HEADER_AUTH = 'Authorization';


### PR DESCRIPTION
#### Summary
there was a recent improvement to set the correct ContentType to requests to be application/json, but it was generating an error response while uploading a license file. The solution is not add this header when the body is type of FormData since it will need a boundary and the fetch api is smart enough to add the ContentType header with a correct boundary.


#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9615

#### Screenshots
Before (by setting the contentType to app/json):


<img width="715" alt="Captura de pantalla 2022-01-07 a las 0 55 51" src="https://user-images.githubusercontent.com/10082627/148469048-fff53fa7-ffb0-4d4a-8a79-3f69da7d0466.png">
<img width="1011" alt="Captura de pantalla 2022-01-07 a las 0 56 21" src="https://user-images.githubusercontent.com/10082627/148469049-affd5e1e-e27c-41a4-8a4c-f40a4f679d0e.png">

After:


<img width="1171" alt="Captura de pantalla 2022-01-07 a las 0 54 11" src="https://user-images.githubusercontent.com/10082627/148469067-d1bfa7ce-0b02-45d0-9f17-a5cba8cd4735.png">


#### Release Note
```release-note
NONE
```
