### PR TITLE
[MM-38044] Fixes Deactivated Users Appear in Channel Popover Member List

### DIFF
--- a/components/popover_list_members/__snapshots__/popover_list_members.test.jsx.snap
+++ b/components/popover_list_members/__snapshots__/popover_list_members.test.jsx.snap
@@ -87,6 +87,7 @@ exports[`components/PopoverListMembers should match snapshot 1`] = `
             status="online"
             user={
               Object {
+                "delete_at": 0,
                 "id": "member_id_1",
               }
             }
@@ -98,6 +99,7 @@ exports[`components/PopoverListMembers should match snapshot 1`] = `
             status="offline"
             user={
               Object {
+                "delete_at": 0,
                 "id": "member_id_2",
               }
             }
@@ -196,6 +198,7 @@ exports[`components/PopoverListMembers should match snapshot with archived chann
             status="online"
             user={
               Object {
+                "delete_at": 0,
                 "id": "member_id_1",
               }
             }
@@ -207,6 +210,7 @@ exports[`components/PopoverListMembers should match snapshot with archived chann
             status="offline"
             user={
               Object {
+                "delete_at": 0,
                 "id": "member_id_2",
               }
             }
@@ -313,6 +317,7 @@ exports[`components/PopoverListMembers should match snapshot with group-constrai
             status="online"
             user={
               Object {
+                "delete_at": 0,
                 "id": "member_id_1",
               }
             }
@@ -324,6 +329,7 @@ exports[`components/PopoverListMembers should match snapshot with group-constrai
             status="offline"
             user={
               Object {
+                "delete_at": 0,
                 "id": "member_id_2",
               }
             }

--- a/components/popover_list_members/popover_list_members.test.jsx
+++ b/components/popover_list_members/popover_list_members.test.jsx
@@ -24,32 +24,37 @@ describe('components/PopoverListMembers', () => {
         id: 'channel_id',
         name: 'channel-name',
         display_name: 'Channel Name',
-        type: Constants.DM_CHANNEl || 'D',
+        type: Constants.DM_CHANNEL || 'D',
     };
-    const users = [
+
+    const usersToDisplay = [
         {id: 'member_id_1', delete_at: 0},
         {id: 'member_id_2', delete_at: 0},
     ];
+
     const statuses = {
         member_id_1: 'online',
         member_id_2: 'offline',
     };
 
     const actions = {
+        getChannelMembers: jest.fn(),
         loadProfilesAndStatusesInChannel: jest.fn(),
+        loadProfilesAndTeamMembersAndChannelMembers: jest.fn(),
         openDirectChannelToUserId: jest.fn().mockResolvedValue({data: {name: 'channelname'}}),
         openModal: jest.fn(),
     };
 
     const baseProps = {
-        channel,
-        statuses,
-        users,
-        manageMembers: true,
-        memberCount: 2,
+        usersToDisplay,
+        currentTeamId: 'current_team_id',
         currentUserId: 'current_user_id',
+        memberCount: 2,
+        statuses,
+        teamUrl: 'team_url',
+        manageMembers: true,
+        channel,
         actions,
-        sortedUsers: [{id: 'member_id_1'}, {id: 'member_id_2'}],
     };
 
     test('should match snapshot', () => {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes an issue with the channel members popover list where if a user was deactivated, they would still appear in the list. With this change, if a user is deactivated they will no longer appear in the channel members list.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://mattermost.atlassian.net/browse/MM-38044


<!--
#### Related Pull Requests
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.

- Has server changes (please link here)
- Has mobile changes (please link here)

-->

#### Screenshots
<!--

If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.
-->
|  Before  |  After  |
|----|----|
| ![MM-38044 Issue Demo](https://user-images.githubusercontent.com/23694620/149029340-6d423456-f768-44bf-b59c-08c0ed28ccbf.gif) | ![MM-38044 Fix Demo](https://user-images.githubusercontent.com/23694620/149026335-a510cbaf-4062-4316-ab41-db13e93429fb.gif) |







#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```
```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixes an issue where a user would remain in a channel's member list after the user was deactivated.
```