### PR TITLE
MM-40894 - not able to download license in desktop app

### DIFF
--- a/components/admin_console/billing/billing_history.tsx
+++ b/components/admin_console/billing/billing_history.tsx
@@ -40,7 +40,7 @@ const noBillingHistorySection = (
             />
         </div>
         <a
-            target='_new'
+            target='_blank'
             rel='noopener noreferrer'
             href={CloudLinks.BILLING_DOCS}
             className='BillingHistory__noHistory-link'
@@ -229,7 +229,7 @@ const BillingHistory: React.FC<Props> = () => {
                             </td>
                             <td className='BillingHistory__table-invoice'>
                                 <a
-                                    target='_new'
+                                    target='_blank'
                                     rel='noopener noreferrer'
                                     href={Client4.getInvoicePdfUrl(invoice.id)}
                                 >

--- a/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
+++ b/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
@@ -209,7 +209,7 @@ export const cancelSubscription = (cancelAccountLink: any, isFreeTrial: boolean,
                 <a
                     href={cancelAccountLink}
                     rel='noopener noreferrer'
-                    target='_new'
+                    target='_blank'
                     className='cancelSubscriptionSection__contactUs'
                     onClick={() => trackEvent('cloud_admin', 'click_contact_us')}
                 >

--- a/components/admin_console/billing/billing_summary/billing_summary.tsx
+++ b/components/admin_console/billing/billing_summary/billing_summary.tsx
@@ -36,7 +36,7 @@ export const noBillingHistory = (
             />
         </div>
         <a
-            target='_new'
+            target='_blank'
             rel='noopener noreferrer'
             href={CloudLinks.BILLING_DOCS}
             className='BillingSummary__noBillingHistory-link'
@@ -329,7 +329,7 @@ export const lastInvoiceInfo = (invoice: any, product: any, fullCharges: any, pa
             </div>
             <div className='BillingSummary__lastInvoice-download'>
                 <a
-                    target='_new'
+                    target='_self'
                     rel='noopener noreferrer'
                     href={Client4.getInvoicePdfUrl(invoice.id)}
                     className='BillingSummary__lastInvoice-downloadButton'

--- a/components/admin_console/billing/payment_info_edit.tsx
+++ b/components/admin_console/billing/payment_info_edit.tsx
@@ -108,7 +108,7 @@ const PaymentInfoEdit: React.FC = () => {
                                         defaultMessage='Your credit card will be charged based on the number of users you have at the end of the monthly billing cycle. '
                                     />
                                     <a
-                                        target='_new'
+                                        target='_blank'
                                         rel='noopener noreferrer'
                                         href={CloudLinks.BILLING_DOCS}
                                     >

--- a/components/admin_console/billing/plan_details/plan_details.tsx
+++ b/components/admin_console/billing/plan_details/plan_details.tsx
@@ -20,7 +20,7 @@ import {Product} from 'mattermost-redux/types/cloud';
 
 const howBillingWorksLink = (
     <a
-        target='_new'
+        target='_blank'
         rel='noopener noreferrer'
         href={CloudLinks.BILLING_DOCS}
         onClick={() => trackEvent('cloud_admin', 'click_how_billing_works', {screen: 'payment'})}
@@ -283,7 +283,7 @@ export const getPlanDetailElements = (
                     />
                 </div>
                 <a
-                    target='_new'
+                    target='_blank'
                     rel='noopener noreferrer'
                     href={CloudLinks.PRICING}
                 >

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -320,7 +320,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                     );
                 }}
                 href={this.props.contactSalesLink}
-                target='_new'
+                target='_blank'
                 rel='noopener noreferrer'
             >
                 {text}
@@ -339,7 +339,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                     );
                 }}
                 href={CloudLinks.PRORATED_PAYMENT}
-                target='_new'
+                target='_blank'
                 rel='noopener noreferrer'
             >
                 <FormattedMessage
@@ -556,7 +556,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                         }
                         href={CloudLinks.DEPLOYMENT_OPTIONS}
                         rel='noopener noreferrer'
-                        target='_new'
+                        target='_blank'
                     >
                         <FormattedMessage
                             defaultMessage={'Review your deployment options'}
@@ -623,7 +623,7 @@ export default class PurchaseModal extends React.PureComponent<Props, State> {
                             {'\u00A0'}
                             <a
                                 href={CloudLinks.BILLING_DOCS}
-                                target='_new'
+                                target='_blank'
                                 rel='noopener noreferrer'
                             >
                                 <FormattedMessage


### PR DESCRIPTION
#### Summary
This PR replaces several occurrences of the anchor property target from _new, which is an incorrect value to the property  to _blank that is the correct way of calling it. Also, replaces the _new from _self for the download invoice link that was not working on the desktop app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40894

#### Related Pull Requests

#### Screenshots

https://user-images.githubusercontent.com/10082627/149197201-fef845fb-557b-4304-bead-44d0b24d1636.mp4


#### Release Note
```release-note
NONE
```
