### PR TITLE
[MM-40750] Remove 'Status' Menu Header on Status Dropdown

### DIFF
--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -37,12 +37,6 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
     ariaLabel="Set a status"
     id="statusDropdownMenu"
   >
-    <MenuHeader>
-      <MemoizedFormattedMessage
-        defaultMessage="Status"
-        id="status_dropdown.set_your_status"
-      />
-    </MenuHeader>
     <MenuGroup>
       <MenuItemAction
         ariaLabel="out of office"
@@ -1271,12 +1265,6 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
     ariaLabel="Set a status"
     id="statusDropdownMenu"
   >
-    <MenuHeader>
-      <MemoizedFormattedMessage
-        defaultMessage="Status"
-        id="status_dropdown.set_your_status"
-      />
-    </MenuHeader>
     <MenuGroup>
       <MenuItemAction
         ariaLabel="out of office"
@@ -1492,12 +1480,6 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
     ariaLabel="Set a status"
     id="statusDropdownMenu"
   >
-    <MenuHeader>
-      <MemoizedFormattedMessage
-        defaultMessage="Status"
-        id="status_dropdown.set_your_status"
-      />
-    </MenuHeader>
     <MenuGroup>
       <MenuItemAction
         ariaLabel="out of office"

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 
 import React, {ReactNode} from 'react';
 
-import {FormattedDate, FormattedMessage, FormattedTime} from 'react-intl';
+import {FormattedDate, FormattedTime} from 'react-intl';
 
 import * as GlobalActions from 'actions/global_actions';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
@@ -391,14 +391,6 @@ export default class StatusDropdown extends React.PureComponent<Props, State> {
                     ariaLabel={localizeMessage('status_dropdown.menuAriaLabel', 'Set a status')}
                     id={'statusDropdownMenu'}
                 >
-                    {!this.props.isCustomStatusEnabled && (
-                        <Menu.Header>
-                            <FormattedMessage
-                                id='status_dropdown.set_your_status'
-                                defaultMessage='Status'
-                            />
-                        </Menu.Header>
-                    )}
                     {globalHeader && currentUser && (
                         <Menu.Header>
                             {this.renderProfilePicture('lg')}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4255,7 +4255,6 @@
   "status_dropdown.set_online": "Online",
   "status_dropdown.set_ooo": "Out of Office",
   "status_dropdown.set_ooo.extra": "Automatic Replies are enabled",
-  "status_dropdown.set_your_status": "Status",
   "string.id": "default message",
   "suggestion_list.no_matches": "No items match __{value}__",
   "suggestion.archive": "Archived Channels",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes an issue where a menu header with text 'Status' appeared when custom status was disabled. The menu header would not appear if custom status was enabled (as expected).

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes [MM-40750](https://mattermost.atlassian.net/browse/MM-40750)


<!--
#### Related Pull Requests
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.

- Has server changes (please link here)
- Has mobile changes (please link here)
-->


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.


-->

|  Before  |  After  |
|----|----|
| <img width="289" alt="MM-40750 Before" src="https://user-images.githubusercontent.com/23694620/149233961-ca5bb75d-0d74-477f-9057-2cd5bfee5127.png"> |<img width="289" alt="MM-40750 After" src="https://user-images.githubusercontent.com/23694620/149233994-7e76e467-130c-4b8c-9310-d151d333e1e1.png"> |



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
