### PR TITLE
[MM-38054] Remove the channel file related buttons if file attachments are disabled on the server

### DIFF
--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -85,6 +85,7 @@ class ChannelHeader extends React.PureComponent {
         customStatus: PropTypes.object,
         isCustomStatusEnabled: PropTypes.bool.isRequired,
         isCustomStatusExpired: PropTypes.bool.isRequired,
+        isFileAttachmentsEnabled: PropTypes.bool.isRequired,
     };
 
     constructor(props) {
@@ -476,14 +477,16 @@ class ChannelHeader extends React.PureComponent {
                         onClick={this.showPinnedPosts}
                         tooltipKey={'pinnedPosts'}
                     />
-                    <HeaderIconWrapper
-                        iconComponent={channelFilesIcon}
-                        ariaLabel={true}
-                        buttonClass={channelFilesIconClass}
-                        buttonId={'channelHeaderFilesButton'}
-                        onClick={this.showChannelFiles}
-                        tooltipKey={'channelFiles'}
-                    />
+                    {this.props.isFileAttachmentsEnabled &&
+                        <HeaderIconWrapper
+                            iconComponent={channelFilesIcon}
+                            ariaLabel={true}
+                            buttonClass={channelFilesIconClass}
+                            buttonId={'channelHeaderFilesButton'}
+                            onClick={this.showChannelFiles}
+                            tooltipKey={'channelFiles'}
+                        />
+                    }
                     {hasGuestsText}
                     <div
                         className='header-popover-text-measurer'
@@ -593,14 +596,16 @@ class ChannelHeader extends React.PureComponent {
                         onClick={this.showPinnedPosts}
                         tooltipKey={'pinnedPosts'}
                     />
-                    <HeaderIconWrapper
-                        iconComponent={channelFilesIcon}
-                        ariaLabel={true}
-                        buttonClass={channelFilesIconClass}
-                        buttonId={'channelHeaderFilesButton'}
-                        onClick={this.showChannelFiles}
-                        tooltipKey={'channelFiles'}
-                    />
+                    {this.props.isFileAttachmentsEnabled &&
+                        <HeaderIconWrapper
+                            iconComponent={channelFilesIcon}
+                            ariaLabel={true}
+                            buttonClass={channelFilesIconClass}
+                            buttonId={'channelHeaderFilesButton'}
+                            onClick={this.showChannelFiles}
+                            tooltipKey={'channelFiles'}
+                        />
+                    }
                     {hasGuestsText}
                     {editMessage}
                 </div>

--- a/components/channel_header/channel_header.test.jsx
+++ b/components/channel_header/channel_header.test.jsx
@@ -39,6 +39,7 @@ describe('components/ChannelHeader', () => {
         currentRelativeTeamUrl: '',
         isCustomStatusEnabled: false,
         isCustomStatusExpired: false,
+        isFileAttachmentsEnabled: true,
     };
 
     const populatedProps = {

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -19,6 +19,7 @@ import {
     isCurrentChannelMuted,
     getCurrentChannelStats,
 } from 'mattermost-redux/selectors/entities/channels';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentRelativeTeamUrl, getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {
@@ -42,6 +43,7 @@ import {getIsRhsOpen, getRhsState} from 'selectors/rhs';
 import {isModalOpen} from 'selectors/views/modals';
 import {getAnnouncementBarCount} from 'selectors/views/announcement_bar';
 import {ModalIdentifiers} from 'utils/constants';
+import {isFileAttachmentsEnabled} from 'utils/file_utils';
 
 import ChannelHeader from './channel_header';
 
@@ -54,6 +56,7 @@ function makeMapStateToProps() {
         const user = getCurrentUser(state);
         const teams = getMyTeams(state);
         const hasMoreThanOneTeam = teams.length > 1;
+        const config = getConfig(state);
 
         let dmUser;
         let gmMembers;
@@ -89,6 +92,7 @@ function makeMapStateToProps() {
             customStatus,
             isCustomStatusEnabled: isCustomStatusEnabled(state),
             isCustomStatusExpired: isCustomStatusExpired(state, customStatus),
+            isFileAttachmentsEnabled: isFileAttachmentsEnabled(config),
         };
     };
 }

--- a/components/search_hint/search_hint.test.tsx
+++ b/components/search_hint/search_hint.test.tsx
@@ -8,12 +8,30 @@ import {searchHintOptions} from 'utils/constants';
 
 import SearchHint from 'components/search_hint/search_hint';
 
+let mockState: any;
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux') as typeof import('react-redux'),
+    useSelector: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+}));
+
 describe('components/SearchHint', () => {
     const baseProps = {
         withTitle: false,
         onOptionSelected: jest.fn(),
         options: searchHintOptions,
     };
+    beforeEach(() => {
+        mockState = {
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'true',
+                    },
+                },
+            },
+        };
+    });
 
     test('should match snapshot, with title', () => {
         const props = {

--- a/components/search_hint/search_hint.tsx
+++ b/components/search_hint/search_hint.tsx
@@ -2,8 +2,13 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {useSelector} from 'react-redux';
+
 import {FormattedMessage, MessageDescriptor} from 'react-intl';
 import classNames from 'classnames';
+
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {isFileAttachmentsEnabled} from 'utils/file_utils';
 
 interface SearchTerm {
     searchTerm: string;
@@ -28,6 +33,8 @@ const SearchHint = (props: Props): JSX.Element => {
             props.onOptionHover(optionIndex);
         }
     };
+    const config = useSelector(getConfig);
+    const isFileAttachmentEnabled = isFileAttachmentsEnabled(config);
 
     if (props.onSearchTypeSelected) {
         if (!props.searchType) {
@@ -53,16 +60,17 @@ const SearchHint = (props: Props): JSX.Element => {
                                 defaultMessage='Messages'
                             />
                         </button>
-                        <button
-                            className={classNames({highlighted: props.highlightedIndex === 1})}
-                            onClick={() => props.onSearchTypeSelected && props.onSearchTypeSelected('files')}
-                        >
-                            <i className='icon icon-file-text-outline'/>
-                            <FormattedMessage
-                                id='search_bar.usage.search_type_files'
-                                defaultMessage='Files'
-                            />
-                        </button>
+                        { isFileAttachmentEnabled &&
+                            <button
+                                className={classNames({highlighted: props.highlightedIndex === 1})}
+                                onClick={() => props.onSearchTypeSelected && props.onSearchTypeSelected('files')}
+                            >
+                                <i className='icon icon-file-text-outline'/>
+                                <FormattedMessage
+                                    id='search_bar.usage.search_type_files'
+                                    defaultMessage='Files'
+                                />
+                            </button>}
                     </div>
                 </div>
             );

--- a/components/search_results/__snapshots__/messages_or_files_selector.test.tsx.snap
+++ b/components/search_results/__snapshots__/messages_or_files_selector.test.tsx.snap
@@ -85,3 +85,33 @@ exports[`components/search_results/MessagesOrFilesSelector should match snapshot
   </div>
 </div>
 `;
+
+exports[`components/search_results/MessagesOrFilesSelector should match snapshot, without files tab 1`] = `
+<div
+  className="MessagesOrFilesSelector"
+>
+  <div
+    className="buttons-container"
+  >
+    <button
+      className="tab messages-tab"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      <MemoizedFormattedMessage
+        defaultMessage="Messages"
+        id="search_bar.messages_tab"
+      />
+      <span
+        className="counter"
+      >
+        5
+      </span>
+    </button>
+  </div>
+  <FilesFilterMenu
+    onFilter={[MockFunction]}
+    selectedFilter="code"
+  />
+</div>
+`;

--- a/components/search_results/messages_or_files_selector.test.tsx
+++ b/components/search_results/messages_or_files_selector.test.tsx
@@ -14,6 +14,7 @@ describe('components/search_results/MessagesOrFilesSelector', () => {
                 selectedFilter='code'
                 messagesCounter='5'
                 filesCounter='10'
+                isFileAttachmentsEnabled={true}
                 onChange={jest.fn()}
                 onFilter={jest.fn()}
             />,
@@ -29,6 +30,22 @@ describe('components/search_results/MessagesOrFilesSelector', () => {
                 selectedFilter='code'
                 messagesCounter='5'
                 filesCounter='10'
+                isFileAttachmentsEnabled={true}
+                onChange={jest.fn()}
+                onFilter={jest.fn()}
+            />,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should match snapshot, without files tab', () => {
+        const wrapper: ShallowWrapper<any, any, any> = shallow(
+            <MessagesOrFilesSelector
+                selected='files'
+                selectedFilter='code'
+                messagesCounter='5'
+                filesCounter='10'
+                isFileAttachmentsEnabled={false}
                 onChange={jest.fn()}
                 onFilter={jest.fn()}
             />,

--- a/components/search_results/messages_or_files_selector.tsx
+++ b/components/search_results/messages_or_files_selector.tsx
@@ -21,6 +21,7 @@ type Props = {
     selectedFilter: SearchFilterType;
     messagesCounter: string;
     filesCounter: string;
+    isFileAttachmentsEnabled: boolean;
     onChange: (value: SearchType) => void;
     onFilter: (filter: SearchFilterType) => void;
 };
@@ -40,17 +41,19 @@ export default function MessagesOrFilesSelector(props: Props): JSX.Element {
                     />
                     <span className='counter'>{props.messagesCounter}</span>
                 </button>
-                <button
-                    onClick={() => props.onChange('files')}
-                    onKeyDown={(e: React.KeyboardEvent<HTMLSpanElement>) => Utils.isKeyPressed(e, KeyCodes.ENTER) && props.onChange('files')}
-                    className={props.selected === 'files' ? 'active tab files-tab' : 'tab files-tab'}
-                >
-                    <FormattedMessage
-                        id='search_bar.files_tab'
-                        defaultMessage='Files'
-                    />
-                    <span className='counter'>{props.filesCounter}</span>
-                </button>
+                {props.isFileAttachmentsEnabled &&
+                    <button
+                        onClick={() => props.onChange('files')}
+                        onKeyDown={(e: React.KeyboardEvent<HTMLSpanElement>) => Utils.isKeyPressed(e, KeyCodes.ENTER) && props.onChange('files')}
+                        className={props.selected === 'files' ? 'active tab files-tab' : 'tab files-tab'}
+                    >
+                        <FormattedMessage
+                            id='search_bar.files_tab'
+                            defaultMessage='Files'
+                        />
+                        <span className='counter'>{props.filesCounter}</span>
+                    </button>
+                }
             </div>
             {props.selected === 'files' &&
                 <FilesFilterMenu

--- a/components/search_results/search_results.tsx
+++ b/components/search_results/search_results.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 
 import {debounce} from 'mattermost-redux/actions/helpers';
 import {FileSearchResultItem as FileSearchResultItemType} from 'mattermost-redux/types/files';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {Post} from 'mattermost-redux/types/posts';
 
 import {getFilesDropdownPluginMenuItems} from 'selectors/plugins';
@@ -27,6 +28,7 @@ import FlagIcon from 'components/widgets/icons/flag_icon';
 import FileSearchResultItem from 'components/file_search_results';
 
 import {NoResultsVariant} from 'components/no_results_indicator/types';
+import {isFileAttachmentsEnabled} from 'utils/file_utils';
 
 import MessageOrFileSelector from './messages_or_files_selector';
 import FilesFilterMenu from './files_filter_menu';
@@ -77,6 +79,7 @@ const SearchResults: React.FC<Props> = (props: Props): JSX.Element => {
     const scrollbars = useRef<Scrollbars|null>(null);
     const [searchType, setSearchType] = useState<string>(props.searchType);
     const filesDropdownPluginMenuItems = useSelector(getFilesDropdownPluginMenuItems);
+    const config = useSelector(getConfig);
     const intl = useIntl();
 
     useEffect(() => {
@@ -320,6 +323,7 @@ const SearchResults: React.FC<Props> = (props: Props): JSX.Element => {
                 <MessageOrFileSelector
                     selected={searchType}
                     selectedFilter={searchFilterType}
+                    isFileAttachmentsEnabled={isFileAttachmentsEnabled(config)}
                     messagesCounter={isSearchAtEnd || props.searchPage === 0 ? `${results.length}` : `${results.length}+`}
                     filesCounter={isSearchFilesAtEnd || props.searchPage === 0 ? `${fileResults.length}` : `${fileResults.length}+`}
                     onChange={setSearchType}

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -21,6 +21,10 @@ export function canUploadFiles(config) {
     return true;
 }
 
+export function isFileAttachmentsEnabled(config) {
+    return config.EnableFileAttachments === 'true';
+}
+
 export function canDownloadFiles(config) {
     if (UserAgent.isMobileApp()) {
         return config.EnableMobileFileDownload === 'true';


### PR DESCRIPTION
#### Summary
Remove the channel file-related buttons if file attachments are disabled on the server.


#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-38054

#### Related Pull Requests
``None``

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="1018" alt="Screenshot 2022-01-14 at 7 56 24 PM" src="https://user-images.githubusercontent.com/16203333/149531234-f36466c7-9a0c-406e-9332-39bfb98d6ccd.png"> | <img width="1792" alt="Screenshot 2022-01-14 at 7 52 34 PM" src="https://user-images.githubusercontent.com/16203333/149531305-39b1500f-af4a-41c3-9de9-e32562abc602.png"> |

#### Release Note
```release-note
* UI: Remove the channel file related buttons if file attachments are disabled on the server
```
