### PR TITLE
chore/MM-40559 : Add memoization to getOneClickReactionEmojis

### DIFF
--- a/actions/emoji_actions.test.js
+++ b/actions/emoji_actions.test.js
@@ -1,31 +1,101 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import assert from 'assert';
-
-import {getRecentEmojis} from 'selectors/emojis';
-import * as Actions from 'actions/emoji_actions';
 import configureStore from 'store';
+import {getRecentEmojis, getEmojiMap} from 'selectors/emojis';
+import * as EmojiActions from 'actions/emoji_actions';
+import LocalStorageStore from 'stores/local_storage_store';
+
+const currentUserId = 'current_user_id';
+const initialState = {
+    entities: {
+        users: {
+            currentUserId,
+        },
+    },
+};
+
+const setRecentEmojisSpy = jest.spyOn(LocalStorageStore, 'setRecentEmojis').mockImplementation(() => {
+    return true;
+});
+
+jest.mock('selectors/emojis', () => ({
+    getRecentEmojis: jest.fn(),
+    getEmojiMap: jest.fn(),
+}));
 
 describe('Actions.Emojis', () => {
     let store;
     beforeEach(async () => {
-        store = await configureStore();
+        store = await configureStore(initialState);
     });
 
     test('Emoji alias is stored in recent emojis', async () => {
-        store.dispatch(Actions.addRecentEmoji('grinning'));
-        assert.ok(getRecentEmojis(store.getState()).includes('grinning'));
+        getRecentEmojis.mockImplementation(() => {
+            return [];
+        });
+
+        getEmojiMap.mockImplementation(() => {
+            return new Map([['grinning', {short_name: 'grinning'}]]);
+        });
+
+        store.dispatch(EmojiActions.addRecentEmoji('grinning'));
+        expect(setRecentEmojisSpy).toHaveBeenCalledWith(currentUserId, ['grinning']);
     });
 
     test('First alias is stored in recent emojis even if second alias used', async () => {
-        store.dispatch(Actions.addRecentEmoji('thumbsup'));
-        console.log(getRecentEmojis(store.getState()));
-        assert.ok(getRecentEmojis(store.getState()).includes('+1'));
+        getRecentEmojis.mockImplementation(() => {
+            return [];
+        });
+
+        getEmojiMap.mockImplementation(() => {
+            return new Map([['thumbsup', {short_name: '+1'}]]);
+        });
+
+        await store.dispatch(EmojiActions.addRecentEmoji('thumbsup'));
+        expect(setRecentEmojisSpy).toHaveBeenCalledWith(currentUserId, ['+1']);
     });
 
     test('Invalid emoji are not stored in recents', async () => {
-        store.dispatch(Actions.addRecentEmoji('joramwilander'));
-        assert.ok(!getRecentEmojis(store.getState()).includes('joramwilander'));
+        getRecentEmojis.mockImplementation(() => {
+            return [];
+        });
+
+        getEmojiMap.mockImplementation(() => {
+            return new Map([['smile', {short_name: 'smile'}]]);
+        });
+
+        store.dispatch(EmojiActions.addRecentEmoji('gamgamstyle'));
+        expect(setRecentEmojisSpy).not.toHaveBeenCalled();
+    });
+
+    test('Emoji already present in recent should be bumped on the top', async () => {
+        getRecentEmojis.mockImplementation(() => {
+            return ['smile', 'grinning', 'shell', 'ladder'];
+        });
+
+        getEmojiMap.mockImplementation(() => {
+            return new Map([['grinning', {short_name: 'grinning'}]]);
+        });
+
+        store.dispatch(EmojiActions.addRecentEmoji('grinning'));
+        expect(setRecentEmojisSpy).toHaveBeenCalledWith(currentUserId, ['smile', 'shell', 'ladder', 'grinning']);
+    });
+
+    test('Recent list lenght should always be of size less than or equal to max_recent_size', async () => {
+        const recentEmojisList = ['smile', 'grinning', 'shell', 'ladder', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
+            '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23'];
+        getRecentEmojis.mockImplementation(() => {
+            return recentEmojisList;
+        });
+
+        getEmojiMap.mockImplementation(() => {
+            return new Map([['accept', {short_name: 'accept'}]]);
+        });
+
+        store.dispatch(EmojiActions.addRecentEmoji('accept'));
+
+        const updatedRecentEmojis = [...recentEmojisList.slice(1, EmojiActions.MAX_RECENT_EMOJIS), 'accept'];
+        expect(setRecentEmojisSpy).toHaveBeenCalledWith(currentUserId, updatedRecentEmojis);
     });
 });

--- a/actions/local_storage.jsx
+++ b/actions/local_storage.jsx
@@ -18,14 +18,3 @@ export function setPreviousTeamId(teamId) {
         return {data: true};
     };
 }
-
-export function setRecentEmojis(recentEmojis = []) {
-    return (dispatch, getState) => {
-        const currentUserId = getCurrentUserId(getState());
-
-        LocalStorageStore.setRecentEmojis(currentUserId, recentEmojis);
-
-        return {data: true};
-    };
-}
-

--- a/selectors/emojis.ts
+++ b/selectors/emojis.ts
@@ -6,13 +6,12 @@ import {createSelector} from 'reselect';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
-import {Constants, Preferences} from 'utils/constants';
-import {getItemFromStorage} from 'selectors/storage';
+import {Preferences} from 'utils/constants';
 import EmojiMap from 'utils/emoji_map';
-import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import type {GlobalState} from 'types/store';
 
@@ -28,17 +27,14 @@ export const getShortcutReactToLastPostEmittedFrom = (state: GlobalState) => sta
 
 export const getRecentEmojis = createSelector(
     'getRecentEmojis',
-    (state: GlobalState) => state.storage,
-    getCurrentUserId,
-    (storage, currentUserId) => {
-        const recentEmojis: string[] = LocalStorageStore.getRecentEmojis(currentUserId) ||
-            JSON.parse(getItemFromStorage(storage.storage, Constants.RECENT_EMOJI_KEY, null)); // Prior to release v5.9, recent emojis were saved as object in localforage.
-
+    (state: GlobalState) => LocalStorageStore.getRecentEmojis(getCurrentUserId(state)),
+    (recentEmojis) => {
         if (!recentEmojis) {
             return [];
         }
 
-        return recentEmojis;
+        const recentEmojisArray: string[] = JSON.parse(recentEmojis);
+        return recentEmojisArray;
     },
 );
 

--- a/selectors/emojis.ts
+++ b/selectors/emojis.ts
@@ -51,10 +51,15 @@ export function isCustomEmojiEnabled(state: GlobalState) {
     return config && config.EnableCustomEmoji === 'true';
 }
 
-export const getOneClickReactionEmojis = (state: GlobalState) => {
-    const recentEmojis = getRecentEmojis(state).slice(-3);
-    const emojiMap = getEmojiMap(state);
+export const getOneClickReactionEmojis = createSelector(
+    'getOneClickReactionEmojis',
+    getEmojiMap,
+    getRecentEmojis,
+    (emojiMap, recentEmojis) => {
+        if (recentEmojis.length === 0) {
+            return [];
+        }
 
-    const emojis = recentEmojis.map((recentEmoji) => emojiMap.get(recentEmoji)).filter(Boolean).reverse();
-    return emojis;
-};
+        return recentEmojis.map((recentEmoji) => emojiMap.get(recentEmoji)).filter(Boolean).slice(-3).reverse();
+    },
+);

--- a/stores/local_storage_store.jsx
+++ b/stores/local_storage_store.jsx
@@ -82,13 +82,25 @@ class LocalStorageStoreClass {
         this.setItem(getPreviousTeamIdKey(userId), teamId);
     }
 
+    /**
+     * Returns the list of recently used emojis for the user in string format.
+     * @param {string} userId The user ID.
+     * @returns The list of emojis in string format. eg. '['smile','+1', 'pizza']'
+     * @memberof LocalStorageStore
+     * @example
+     * const recentEmojis = LocalStorageStore.getRecentEmojis('userId');
+     * if (recentEmojis) {
+     *  const recentEmojisArray = JSON.parse(recentEmojis);
+     * // do something with the emoji list
+     * }
+     **/
     getRecentEmojis(userId) {
         const recentEmojis = this.getItem(getRecentEmojisKey(userId));
         if (!recentEmojis) {
             return null;
         }
 
-        return JSON.parse(recentEmojis);
+        return recentEmojis;
     }
 
     setRecentEmojis(userId, recentEmojis = []) {

--- a/stores/local_storage_store.test.jsx
+++ b/stores/local_storage_store.test.jsx
@@ -51,10 +51,10 @@ describe('stores/LocalStorageStore', () => {
         LocalStorageStore.setRecentEmojis(userId1, recentEmojis1);
         LocalStorageStore.setRecentEmojis(userId2, recentEmojis2);
 
-        const recentEmojisForUser1 = LocalStorageStore.getRecentEmojis(userId1);
+        const recentEmojisForUser1 = JSON.parse(LocalStorageStore.getRecentEmojis(userId1));
         assert.deepEqual(recentEmojisForUser1, recentEmojis1);
 
-        const recentEmojisForUser2 = LocalStorageStore.getRecentEmojis(userId2);
+        const recentEmojisForUser2 = JSON.parse(LocalStorageStore.getRecentEmojis(userId2));
         assert.deepEqual(recentEmojisForUser2, recentEmojis2);
     });
 
@@ -102,21 +102,21 @@ describe('stores/LocalStorageStore', () => {
 
             // After set
             LocalStorageStore.setRecentEmojis(userId, recentEmojis1);
-            assert.deepEqual(LocalStorageStore.getRecentEmojis(userId), recentEmojis1);
+            assert.deepEqual(JSON.parse(LocalStorageStore.getRecentEmojis(userId)), recentEmojis1);
 
             // Still set when basename explicitly set
             window.basename = '/';
-            assert.deepEqual(LocalStorageStore.getRecentEmojis(userId), recentEmojis1);
+            assert.deepEqual(JSON.parse(LocalStorageStore.getRecentEmojis(userId)), recentEmojis1);
 
             // Different with different basename
             window.basename = '/subpath';
             assert.equal(LocalStorageStore.getRecentEmojis(userId), null);
             LocalStorageStore.setRecentEmojis(userId, recentEmojis2);
-            assert.deepEqual(LocalStorageStore.getRecentEmojis(userId), recentEmojis2);
+            assert.deepEqual(JSON.parse(LocalStorageStore.getRecentEmojis(userId)), recentEmojis2);
 
             // Back to old value with original basename
             window.basename = '/';
-            assert.deepEqual(LocalStorageStore.getRecentEmojis(userId), recentEmojis1);
+            assert.deepEqual(JSON.parse(LocalStorageStore.getRecentEmojis(userId)), recentEmojis1);
         });
     });
 


### PR DESCRIPTION
#### Summary
Added memoized selector for `getOneClickReactionEmojis` redux selector

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40559

#### Related Pull Requests
None

#### Screenshots
None

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
