### PR TITLE
MM-40824 - Backport support of Professional sku for channel moderation

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -6,6 +6,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {RESOURCE_KEYS} from 'mattermost-redux/constants/permissions_sysconsole';
 
+import {LicenseSkus} from 'mattermost-redux/types/general';
 import {Constants} from 'utils/constants';
 import {getSiteURL} from 'utils/url';
 import {t} from 'utils/i18n';
@@ -197,6 +198,7 @@ export const it = {
     enterpriseReady: (config, state, license, enterpriseReady) => enterpriseReady,
     licensed: (config, state, license) => license.IsLicensed === 'true',
     licensedForFeature: (feature) => (config, state, license) => license.IsLicensed && license[feature] === 'true',
+    licensedForSku: (skuName) => (config, state, license) => license.IsLicensed && license.SkuShortName === skuName,
     hidePaymentInfo: (config, state, license, enterpriseReady, consoleAccess, cloud) => {
         return cloud?.subscription?.is_paid_tier !== 'true' || cloud?.subscription?.is_free_trial === 'true';
     },
@@ -532,7 +534,10 @@ const AdminDefinition = {
             title: t('admin.sidebar.channels'),
             title_default: 'Channels',
             isHidden: it.any(
-                it.not(it.licensedForFeature('LDAPGroups')),
+                it.not(it.any(
+                    it.licensedForFeature('LDAPGroups'),
+                    it.licensedForSku(LicenseSkus.Professional),
+                )),
                 it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.CHANNELS)),
             ),
             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.CHANNELS)),
@@ -548,6 +553,7 @@ const AdminDefinition = {
             title_default: 'Channels',
             isHidden: it.any(
                 it.licensedForFeature('LDAPGroups'),
+                it.licensedForSku(LicenseSkus.Professional),
                 it.not(it.enterpriseReady),
             ),
             schema: {

--- a/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_details.test.tsx.snap
+++ b/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_details.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         className="fa fa-angle-left back"
         to="/admin_console/user_management/channels"
       />
-      <FormattedMessage
+      <MemoizedFormattedMessage
         defaultMessage="Channel Configuration"
         id="admin.channel_settings.channel_detail.channel_configuration"
       />
@@ -59,13 +59,13 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
       <ConfirmModal
         confirmButtonClass="btn btn-primary"
         confirmButtonText={
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Save and Archive Channel"
             id="admin.channel_settings.channel_detail.archive_confirm.button"
           />
         }
         message={
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Saving will archive the channel from the team and make its contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
@@ -75,7 +75,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         onConfirm={[Function]}
         show={false}
         title={
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Save and Archive Channel"
             id="admin.channel_settings.channel_detail.archive_confirm.title"
           />
@@ -113,6 +113,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         toPublic={true}
       />
       <ChannelModes
+        groupsSupported={true}
         isDefault={false}
         isDisabled={false}
         isPublic={true}
@@ -203,7 +204,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         className="fa fa-angle-left back"
         to="/admin_console/user_management/channels"
       />
-      <FormattedMessage
+      <MemoizedFormattedMessage
         defaultMessage="Channel Configuration"
         id="admin.channel_settings.channel_detail.channel_configuration"
       />
@@ -246,13 +247,13 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
       <ConfirmModal
         confirmButtonClass="btn btn-primary"
         confirmButtonText={
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Save and Archive Channel"
             id="admin.channel_settings.channel_detail.archive_confirm.button"
           />
         }
         message={
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Saving will archive the channel from the team and make its contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
@@ -262,7 +263,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         onConfirm={[Function]}
         show={false}
         title={
-          <FormattedMessage
+          <Memo(MemoizedFormattedMessage)
             defaultMessage="Save and Archive Channel"
             id="admin.channel_settings.channel_detail.archive_confirm.title"
           />
@@ -300,6 +301,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         toPublic={true}
       />
       <ChannelModes
+        groupsSupported={true}
         isDefault={false}
         isDisabled={false}
         isPublic={true}

--- a/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_details.test.tsx.snap
+++ b/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_details.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         className="fa fa-angle-left back"
         to="/admin_console/user_management/channels"
       />
-      <MemoizedFormattedMessage
+      <FormattedMessage
         defaultMessage="Channel Configuration"
         id="admin.channel_settings.channel_detail.channel_configuration"
       />
@@ -59,13 +59,13 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
       <ConfirmModal
         confirmButtonClass="btn btn-primary"
         confirmButtonText={
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Save and Archive Channel"
             id="admin.channel_settings.channel_detail.archive_confirm.button"
           />
         }
         message={
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Saving will archive the channel from the team and make its contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
@@ -75,7 +75,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         onConfirm={[Function]}
         show={false}
         title={
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Save and Archive Channel"
             id="admin.channel_settings.channel_detail.archive_confirm.title"
           />
@@ -204,7 +204,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         className="fa fa-angle-left back"
         to="/admin_console/user_management/channels"
       />
-      <MemoizedFormattedMessage
+      <FormattedMessage
         defaultMessage="Channel Configuration"
         id="admin.channel_settings.channel_detail.channel_configuration"
       />
@@ -247,13 +247,13 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
       <ConfirmModal
         confirmButtonClass="btn btn-primary"
         confirmButtonText={
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Save and Archive Channel"
             id="admin.channel_settings.channel_detail.archive_confirm.button"
           />
         }
         message={
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Saving will archive the channel from the team and make its contents inaccessible for all users. Are you sure you wish to save and archive this channel?"
             id="admin.channel_settings.channel_detail.archive_confirm.message"
           />
@@ -263,7 +263,7 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
         onConfirm={[Function]}
         show={false}
         title={
-          <Memo(MemoizedFormattedMessage)
+          <FormattedMessage
             defaultMessage="Save and Archive Channel"
             id="admin.channel_settings.channel_detail.archive_confirm.title"
           />

--- a/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_modes.test.tsx.snap
+++ b/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_modes.test.tsx.snap
@@ -15,13 +15,6 @@ exports[`admin_console/team_channel_settings/channel/ChannelModes should match s
     <div
       className="group-teams-and-channels--body"
     >
-      <SyncGroupsToggle
-        isDefault={false}
-        isDisabled={false}
-        isPublic={true}
-        isSynced={false}
-        onToggle={[MockFunction]}
-      />
       <AllowAllToggle
         isDefault={false}
         isDisabled={false}

--- a/components/admin_console/team_channel_settings/channel/details/channel_details.test.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.test.tsx
@@ -94,6 +94,7 @@ describe('admin_console/team_channel_settings/channel/ChannelDetails', () => {
         const additionalProps = {
             channelPermissions: [],
             guestAccountsEnabled: true,
+            channelGroupsEnabled: true,
             isDisabled: false,
         };
 

--- a/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
@@ -46,6 +46,7 @@ export interface ChannelDetailsProps {
     channelPermissions: ChannelPermissions[];
     teamScheme?: Scheme;
     guestAccountsEnabled: boolean;
+    channelGroupsEnabled: boolean;
     isDisabled?: boolean;
     actions: ChannelDetailsActions;
 }
@@ -734,19 +735,22 @@ export default class ChannelDetails extends React.PureComponent<ChannelDetailsPr
                     isDefault={isDefault}
                     onToggle={this.setToggles}
                     isDisabled={this.props.isDisabled}
+                    groupsSupported={this.props.channelGroupsEnabled}
                 />
 
-                <ChannelGroups
-                    synced={isSynced}
-                    channel={channel}
-                    totalGroups={totalGroups}
-                    groups={groups}
-                    removedGroups={removedGroups}
-                    onAddCallback={this.handleGroupChange}
-                    onGroupRemoved={this.handleGroupRemoved}
-                    setNewGroupRole={this.setNewGroupRole}
-                    isDisabled={this.props.isDisabled}
-                />
+                {this.props.channelGroupsEnabled &&
+                    <ChannelGroups
+                        synced={isSynced}
+                        channel={channel}
+                        totalGroups={totalGroups}
+                        groups={groups}
+                        removedGroups={removedGroups}
+                        onAddCallback={this.handleGroupChange}
+                        onGroupRemoved={this.handleGroupRemoved}
+                        setNewGroupRole={this.setNewGroupRole}
+                        isDisabled={this.props.isDisabled}
+                    />
+                }
 
                 {!isSynced &&
                     <ChannelMembers

--- a/components/admin_console/team_channel_settings/channel/details/channel_modes.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_modes.tsx
@@ -16,6 +16,7 @@ interface Props {
     isDefault: boolean;
     onToggle: (isSynced: boolean, isPublic: boolean) => void;
     isDisabled?: boolean;
+    groupsSupported?: boolean;
 }
 
 const SyncGroupsToggle: React.SFC<Props> = (props: Props): JSX.Element => {
@@ -76,13 +77,12 @@ const AllowAllToggle: React.SFC<Props> = (props: Props): JSX.Element | null => {
                     id='admin.channel_settings.channel_details.isDefaultDescr'
                     defaultMessage='This default channel cannot be converted into a private channel.'
                 />
-            ) :
-                (
-                    <FormattedMessage
-                        id='admin.channel_settings.channel_details.isPublicDescr'
-                        defaultMessage='If `public` the channel is discoverable and any user can join, or if `private` invitations are required. Toggle to convert public channels to private. When Group Sync is enabled, private channels cannot be converted to public.'
-                    />
-                )
+            ) : (
+                <FormattedMessage
+                    id='admin.channel_settings.channel_details.isPublicDescr'
+                    defaultMessage='If `public` the channel is discoverable and any user can join, or if `private` invitations are required. Toggle to convert public channels to private. When Group Sync is enabled, private channels cannot be converted to public.'
+                />
+            )
             }
             onText={(
                 <FormattedMessage
@@ -101,7 +101,7 @@ const AllowAllToggle: React.SFC<Props> = (props: Props): JSX.Element | null => {
 };
 
 export const ChannelModes: React.SFC<Props> = (props: Props): JSX.Element => {
-    const {isPublic, isSynced, isDefault, onToggle, isDisabled} = props;
+    const {isPublic, isSynced, isDefault, onToggle, isDisabled, groupsSupported} = props;
     return (
         <AdminPanel
             id='channel_manage'
@@ -112,13 +112,14 @@ export const ChannelModes: React.SFC<Props> = (props: Props): JSX.Element => {
         >
             <div className='group-teams-and-channels'>
                 <div className='group-teams-and-channels--body'>
-                    <SyncGroupsToggle
-                        isPublic={isPublic}
-                        isSynced={isSynced}
-                        isDefault={isDefault}
-                        onToggle={onToggle}
-                        isDisabled={isDisabled}
-                    />
+                    {groupsSupported &&
+                        <SyncGroupsToggle
+                            isPublic={isPublic}
+                            isSynced={isSynced}
+                            isDefault={isDefault}
+                            onToggle={onToggle}
+                            isDisabled={isDisabled}
+                        />}
                     <AllowAllToggle
                         isPublic={isPublic}
                         isSynced={isSynced}

--- a/components/admin_console/team_channel_settings/channel/details/index.ts
+++ b/components/admin_console/team_channel_settings/channel/details/index.ts
@@ -5,7 +5,7 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {connect} from 'react-redux';
 
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getChannel, getChannelModerations} from 'mattermost-redux/selectors/entities/channels';
 import {getAllGroups, getGroupsAssociatedToChannel} from 'mattermost-redux/selectors/entities/groups';
 import {getScheme} from 'mattermost-redux/selectors/entities/schemes';
@@ -39,6 +39,8 @@ import {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {setNavigationBlocked} from 'actions/admin_actions';
 
+import {LicenseSkus} from 'mattermost-redux/types/general';
+
 import ChannelDetails, {ChannelDetailsActions} from './channel_details';
 
 type OwnProps = {
@@ -51,6 +53,13 @@ type OwnProps = {
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const config = getConfig(state);
+
+    const license = getLicense(state);
+    const isLicensed = license?.IsLicensed === 'true';
+
+    // Channel Groups is only available for Enterprise and backward compatible with E20
+    const channelGroupsEnabled = isLicensed && (license.SkuShortName === LicenseSkus.Enterprise || license.SkuShortName === LicenseSkus.E20);
+
     const guestAccountsEnabled = config.EnableGuestAccounts === 'true';
     const channelID = ownProps.match.params.channel_id;
     const channel = getChannel(state, channelID) || {};
@@ -70,6 +79,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         channelPermissions,
         teamScheme,
         guestAccountsEnabled,
+        channelGroupsEnabled,
     };
 }
 

--- a/packages/mattermost-redux/src/types/general.ts
+++ b/packages/mattermost-redux/src/types/general.ts
@@ -22,3 +22,11 @@ export type SystemSetting = {
     name: string;
     value: string;
 };
+
+export enum LicenseSkus {
+    E10 = 'E10',
+    E20 = 'E20',
+    Starter = 'starter',
+    Professional = 'professional',
+    Enterprise = 'enterprise',
+}


### PR DESCRIPTION
#### Summary

The new sku of Professional license now includes support for Channel Moderation which was moved from the higher sku. However, in previous versions of v6.0, channel moderation was still checking for the `LADPGroup` feature which is not available in the mid-tier license of Professional. 

This PR adds a license check for Professional to allow to unlock the `Channels` section of the System Console. The license check function added was introduced in v6.0 here https://github.com/mattermost/mattermost-webapp/pull/8554 and was included here to backport to a 5.37 release. 

This PR also adds the restriction to `Synch Group Members` and `Groups` within channel details if only on high sku license and not in Professional. This restrictions were the changes made in https://github.com/mattermost/mattermost-webapp/pull/9046

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40824

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added support for channel moderation in Professional sku licenses. 
```
