### PR TITLE
MM-40181: fixes adding GM/DM threads to all teams

### DIFF
--- a/packages/mattermost-redux/src/actions/threads.ts
+++ b/packages/mattermost-redux/src/actions/threads.ts
@@ -83,7 +83,7 @@ export function handleThreadArrived(dispatch: DispatchFunc, getState: GetStateFu
         type: ThreadTypes.RECEIVED_THREAD,
         data: {
             thread,
-            team_id: teamId || currentTeamId,
+            team_id: teamId,
         },
     });
 

--- a/packages/mattermost-redux/src/reducers/entities/threads/threads.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/threads/threads.test.js
@@ -488,9 +488,13 @@ describe('threads', () => {
         const state = deepFreeze({
             threadsInTeam: {
                 a: ['t1', 't2'],
+                b: ['t1'],
+                c: [],
             },
             unreadThreadsInTeam: {
                 a: ['t2'],
+                b: [],
+                c: [],
             },
             threads: {
                 t1: {
@@ -507,28 +511,48 @@ describe('threads', () => {
         });
 
         test.each([
-            [{id: 't3', last_reply_at: 40, unread_mentions: 0, unread_replies: 0}, {all: ['t1', 't2', 't3'], unread: ['t2']}],
-            [{id: 't3', last_reply_at: 40, unread_mentions: 1, unread_replies: 1}, {all: ['t1', 't2', 't3'], unread: ['t2', 't3']}],
-            [{id: 't3', last_reply_at: 40, unread_mentions: 0, unread_replies: 1}, {all: ['t1', 't2', 't3'], unread: ['t2', 't3']}],
-            [{id: 't3', last_reply_at: 5, unread_mentions: 0, unread_replies: 0}, {all: ['t1', 't2'], unread: ['t2']}],
-            [{id: 't3', last_reply_at: 5, unread_mentions: 1, unread_replies: 1}, {all: ['t1', 't2'], unread: ['t2']}],
+            ['a', {id: 't3', last_reply_at: 40, unread_mentions: 0, unread_replies: 0}, {a: {all: ['t1', 't2', 't3'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't3', last_reply_at: 40, unread_mentions: 1, unread_replies: 1}, {a: {all: ['t1', 't2', 't3'], unread: ['t2', 't3']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't3', last_reply_at: 40, unread_mentions: 0, unread_replies: 1}, {a: {all: ['t1', 't2', 't3'], unread: ['t2', 't3']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't3', last_reply_at: 5, unread_mentions: 0, unread_replies: 0}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't3', last_reply_at: 5, unread_mentions: 1, unread_replies: 1}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't2', last_reply_at: 40, unread_mentions: 0, unread_replies: 0}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't2', last_reply_at: 40, unread_mentions: 1, unread_replies: 1}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't2', last_reply_at: 40, unread_mentions: 0, unread_replies: 1}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't2', last_reply_at: 5, unread_mentions: 0, unread_replies: 0}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            ['a', {id: 't2', last_reply_at: 5, unread_mentions: 1, unread_replies: 1}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
 
-            [{id: 't2', last_reply_at: 40, unread_mentions: 0, unread_replies: 0}, {all: ['t1', 't2'], unread: ['t2']}],
-            [{id: 't2', last_reply_at: 40, unread_mentions: 1, unread_replies: 1}, {all: ['t1', 't2'], unread: ['t2']}],
-            [{id: 't2', last_reply_at: 40, unread_mentions: 0, unread_replies: 1}, {all: ['t1', 't2'], unread: ['t2']}],
-            [{id: 't2', last_reply_at: 5, unread_mentions: 0, unread_replies: 0}, {all: ['t1', 't2'], unread: ['t2']}],
-            [{id: 't2', last_reply_at: 5, unread_mentions: 1, unread_replies: 1}, {all: ['t1', 't2'], unread: ['t2']}],
-        ])('should handle thread %o', (thread, expected) => {
+            // DM/GM threads
+            [undefined, {id: 't3', last_reply_at: 40, unread_mentions: 0, unread_replies: 0}, {a: {all: ['t1', 't2', 't3'], unread: ['t2']}, b: {all: ['t1', 't3'], unread: []}}],
+            [undefined, {id: 't3', last_reply_at: 40, unread_mentions: 1, unread_replies: 1}, {a: {all: ['t1', 't2', 't3'], unread: ['t2', 't3']}, b: {all: ['t1', 't3'], unread: []}}],
+            [undefined, {id: 't3', last_reply_at: 40, unread_mentions: 0, unread_replies: 1}, {a: {all: ['t1', 't2', 't3'], unread: ['t2', 't3']}, b: {all: ['t1', 't3'], unread: []}}],
+            [undefined, {id: 't3', last_reply_at: 5, unread_mentions: 0, unread_replies: 0}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            [undefined, {id: 't3', last_reply_at: 5, unread_mentions: 1, unread_replies: 1}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            [undefined, {id: 't2', last_reply_at: 40, unread_mentions: 0, unread_replies: 0}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1', 't2'], unread: []}}],
+            [undefined, {id: 't2', last_reply_at: 40, unread_mentions: 1, unread_replies: 1}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1', 't2'], unread: []}}],
+            [undefined, {id: 't2', last_reply_at: 40, unread_mentions: 0, unread_replies: 1}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1', 't2'], unread: []}}],
+            [undefined, {id: 't2', last_reply_at: 5, unread_mentions: 0, unread_replies: 0}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+            [undefined, {id: 't2', last_reply_at: 5, unread_mentions: 1, unread_replies: 1}, {a: {all: ['t1', 't2'], unread: ['t2']}, b: {all: ['t1'], unread: []}}],
+        ])('should handle "%s" team and thread %o', (teamId, thread, expected) => {
             const nextState = threadsReducer(state, {
                 type: ThreadTypes.RECEIVED_THREAD,
                 data: {
                     thread,
-                    team_id: 'a',
+                    team_id: teamId,
                 },
             });
 
-            expect(nextState.threadsInTeam.a).toEqual(expected.all);
-            expect(nextState.unreadThreadsInTeam.a).toEqual(expected.unread);
+            // team a
+            expect(nextState.threadsInTeam.a).toEqual(expected.a.all);
+            expect(nextState.unreadThreadsInTeam.a).toEqual(expected.a.unread);
+
+            // team b
+            expect(nextState.threadsInTeam.b).toEqual(expected.b.all);
+            expect(nextState.unreadThreadsInTeam.b).toEqual(expected.b.unread);
+
+            // team c
+            expect(nextState.threadsInTeam.c).toEqual([]);
+            expect(nextState.unreadThreadsInTeam.c).toEqual([]);
         });
     });
 

--- a/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
+++ b/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
@@ -45,8 +45,20 @@ function handlePostRemoved(state: State, action: GenericAction) {
     };
 }
 
-export function handleReceivedThread(state: State, action: GenericAction, extra: ExtraData) {
-    const {thread, team_id: teamId} = action.data;
+// adds thread to all teams in state
+function handleAllTeamsReceivedThread(state: State, thread: UserThread, teamId: Team['id'], extra: ExtraData) {
+    const teamIds = Object.keys(state);
+
+    let newState = {...state};
+    for (const teamId of teamIds) {
+        newState = handleSingleTeamReceivedThread(newState, thread, teamId, extra);
+    }
+
+    return newState;
+}
+
+// adds thread to single team
+function handleSingleTeamReceivedThread(state: State, thread: UserThread, teamId: Team['id'], extra: ExtraData) {
     const nextSet = new Set(state[teamId] || []);
 
     // thread exists in state
@@ -67,6 +79,16 @@ export function handleReceivedThread(state: State, action: GenericAction, extra:
     }
 
     return state;
+}
+
+export function handleReceivedThread(state: State, action: GenericAction, extra: ExtraData) {
+    const {thread, team_id: teamId} = action.data;
+
+    if (!teamId) {
+        return handleAllTeamsReceivedThread(state, thread, teamId, extra);
+    }
+
+    return handleSingleTeamReceivedThread(state, thread, teamId, extra);
 }
 
 // add the thread only if it's 'newer' than other threads


### PR DESCRIPTION
#### Summary

Threads in a GM/DM belong in all teams. 
Currently, we add a DM/GM thread only to the current team (when receiving the websocket event).

This commit fixes it by adding those threads to all teams currently in store.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-40181

#### Release Note

```release-note
NONE
```
