### PR TITLE
Fixed a bug causing team sidebar to always show up in products when running in subpath

### DIFF
--- a/utils/products.ts
+++ b/utils/products.ts
@@ -12,7 +12,7 @@ export const getCurrentProductId = (products: ProductComponent[], pathname: stri
 
     for (let i = 0; i < products.length; i++) {
         const product = products[i];
-        if (pathname.startsWith(getBasePath() + product.baseURL)) {
+        if (pathname.startsWith(product.baseURL)) {
             return product.id;
         }
     }

--- a/utils/products.ts
+++ b/utils/products.ts
@@ -3,8 +3,6 @@
 
 import {ProductComponent} from '../types/store/plugins';
 
-import {getBasePath} from './url';
-
 export const getCurrentProductId = (products: ProductComponent[], pathname: string): string | null => {
     if (!products) {
         return null;


### PR DESCRIPTION
#### Summary
Fixed a bug causing team sidebar to always show up in products when running in subpath.

#### Ticket Link
[#19343](https://github.com/mattermost/mattermost-server/issues/19343)

#### Related Pull Requests
Fixes a bug caused by #9262

#### Release Note
```release-note
NONE
```
