### PR TITLE
tests/MM-40609 : E2Es for recent custom emoji fixes 

### DIFF
--- a/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
@@ -174,4 +174,49 @@ describe('Recent Emoji', () => {
         // * Verify most recent one is the system emoji in emoji picker and not the custom emoji
         cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', 'lemon emoji');
     });
+
+    it('MM-T4438 Changing the skin of emojis should apply the same skin to emojis in recent section', () => {
+        // # Post a sample message
+        cy.postMessage(MESSAGES.TINY);
+
+        // # Post reaction to post
+        cy.clickPostReactionIcon();
+
+        cy.get('#emojiPicker').should('be.visible').within(() => {
+            // # Open skin picker
+            cy.findByAltText('emoji skin tone picker').should('exist').parent().click().wait(TIMEOUTS.ONE_SEC);
+
+            // # Select default yellow skin
+            cy.findByTestId('skin-pick-default').should('exist').parent().click();
+
+            // # Search for a system emoji with skin
+            cy.findByPlaceholderText('Search emojis').should('exist').type('thumbsup').wait(TIMEOUTS.HALF_SEC);
+
+            // # Select the emoji to add to post with default skin
+            cy.findByTestId('+1,thumbsup').parent().click();
+        });
+
+        // # Open emoji picker again to check if thumbsup emoji is present in recent section
+        cy.uiOpenEmojiPicker().wait(TIMEOUTS.TWO_SEC);
+
+        cy.get('#emojiPicker').should('be.visible').within(() => {
+            // * Verify recently used category is present in emoji picker
+            cy.findByText('Recently Used').should('exist').and('be.visible');
+
+            // * Verify most recent one is the thumbsup emoji with default skin
+            cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', '+1 emoji');
+
+            // # Open skin picker again to change the skin
+            cy.findByAltText('emoji skin tone picker').should('exist').parent().click().wait(TIMEOUTS.ONE_SEC);
+
+            // # Select a dark skin tone
+            cy.findByTestId('skin-pick-1F3FF').should('exist').parent().click();
+
+            // * Verify most recent one is the same thumbsup emoji but now with a dark skin tone
+            cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', '+1 dark skin tone emoji');
+        });
+
+        // # Close emoji picker
+        cy.get('body').type('{esc}', {force: true});
+    });
 });

--- a/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
@@ -11,14 +11,41 @@
 // Group: @emoji @timeout_error
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
+import * as MESSAGES from '../../fixtures/messages';
+
+import {getCustomEmoji} from './helpers';
 
 describe('Recent Emoji', () => {
+    const largeEmojiFile = 'gif-image-file.gif';
+
+    let testTeam;
+    let testUser;
+    let otherUser;
+    let townsquareLink;
+
     before(() => {
-        // # Login as test user and visit town-square
-        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
-            cy.visit(`/${team.name}/channels/town-square`);
-            cy.get('#channelHeaderTitle').should('be.visible').and('contain', 'Town Square');
-            cy.postMessage('hello');
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableCustomEmoji: true,
+            },
+        });
+    });
+
+    beforeEach(() => {
+        cy.apiAdminLogin();
+
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+            townsquareLink = `/${team.name}/channels/town-square`;
+        });
+
+        cy.apiCreateUser().then(({user: user1}) => {
+            otherUser = user1;
+            cy.apiAddUserToTeam(testTeam.id, otherUser.id);
+        }).then(() => {
+            cy.apiLogin(testUser);
+            cy.visit(townsquareLink);
         });
     });
 
@@ -56,5 +83,95 @@ describe('Recent Emoji', () => {
                 cy.get('.emoji-picker__item').eq(0).find('img').should('have.attr', 'class', second.attr('class'));
             });
         });
+    });
+
+    it('MM-T4463 Recently used custom emoji, when is deleted should be removed from recent emoji category and quick reactions', () => {
+        const {customEmoji, customEmojiWithColons} = getCustomEmoji();
+
+        // # Open custom emoji
+        cy.uiOpenCustomEmoji();
+
+        // # Click on add new emoji button on custom emoji page
+        cy.findByText('Add Custom Emoji').should('be.visible').click();
+
+        // # Type emoji name
+        cy.get('#name').type(customEmojiWithColons);
+
+        // # Select emoji image
+        cy.get('input#select-emoji').attachFile(largeEmojiFile).wait(TIMEOUTS.THREE_SEC);
+
+        // # Click on Save
+        cy.uiSave().wait(TIMEOUTS.THREE_SEC);
+
+        // # Go back to home channel
+        cy.findByText('Back to Mattermost').should('exist').and('be.visible').click().wait(TIMEOUTS.FIVE_SEC);
+
+        // # Post a system emoji
+        cy.postMessage(`${MESSAGES.TINY}-second :lemon:`);
+
+        // # Post a custom emoji
+        cy.postMessage(`${MESSAGES.TINY}-recent ${customEmojiWithColons}`);
+
+        // # Hover over the last post by opening dot menu on it
+        cy.clickPostDotMenu();
+
+        cy.get('#recent_reaction_0').should('exist').then((recentReaction) => {
+            // * Assert that custom emoji is present as most recent in quick reaction menu
+            expect(recentReaction[0].style.backgroundImage).to.include('api/v4/emoji');
+        });
+
+        cy.get('#recent_reaction_1').should('exist').then((recentReaction) => {
+            // * Assert that system emoji is present as second recent in quick reaction menu
+            expect(recentReaction[0].style.backgroundImage).to.include('static/emoji/');
+        });
+
+        // # Open emoji picker
+        cy.uiOpenEmojiPicker();
+
+        // * Verify recently used category is present in emoji picker
+        cy.findByText('Recently Used').should('exist').and('be.visible');
+
+        // * Verify most recent one is the custom emoji in emoji picker
+        cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'class', 'emoji-category--custom');
+
+        // * Verify second most recent one is the system emoji in emoji picker
+        cy.findAllByTestId('emojiItem').eq(1).find('img').should('have.attr', 'aria-label', 'lemon emoji');
+
+        // # Go to custom emoji page
+        cy.findByText('Custom Emoji').should('be.visible').click();
+
+        // # Search for the custom emoji
+        cy.findByPlaceholderText('Search Custom Emoji').should('be.visible').type(customEmoji).wait(TIMEOUTS.HALF_SEC);
+
+        cy.get('.emoji-list__table').should('be.visible').within(() => {
+            // * Since we are searching exactly for that custom emoji, we should get only one result
+            cy.findAllByText(customEmojiWithColons).should('have.length', 1);
+
+            // # Delete the custom emoji
+            cy.findAllByText('Delete').should('have.length', 1).click();
+        });
+
+        // # Confirm deletion and back to main channel view
+        cy.get('#confirmModalButton').should('be.visible').click();
+        cy.findByText('Back to Mattermost').should('exist').and('be.visible').click().wait(TIMEOUTS.FIVE_SEC);
+
+        cy.reload();
+
+        // # Hover over the last post by opening dot menu on it
+        cy.clickPostDotMenu();
+
+        cy.get('#recent_reaction_0').should('exist').then((recentReaction) => {
+            // * Assert that instead of custom emoji the system emoji is present as most recent in quick reaction menu
+            expect(recentReaction[0].style.backgroundImage).to.include('static/emoji/');
+        });
+
+        // # Open emoji picker again
+        cy.uiOpenEmojiPicker();
+
+        // * Verify recently used category is present in emoji picker
+        cy.findByText('Recently Used').should('exist').and('be.visible');
+
+        // * Verify most recent one is the system emoji in emoji picker and not the custom emoji
+        cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', 'lemon emoji');
     });
 });

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_shift_slash/helpers.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_shift_slash/helpers.js
@@ -40,18 +40,19 @@ export function clickSmileEmojiFromEmojiPicker() {
 }
 
 /**
- * Check if 'smile' reaction was added to a post
+ * Check if an emoji reaction was added to a post, defaults check for 'smile' emoji
  * @param {String} postId Post ID of the message
+ * @param {String} emoji (Optional) Emoji name
  */
-export function checkReactionFromPost(postId) {
+export function checkReactionFromPost(postId, emoji = 'smile') {
     if (postId) {
         cy.get(`#${postId}_message`).within(() => {
             cy.findByLabelText('reactions').should('exist');
-            cy.findByLabelText('remove reaction smile').should('exist');
+            cy.findByLabelText(`remove reaction ${emoji}`).should('exist');
         });
     } else {
         cy.findByLabelText('reactions').should('exist');
-        cy.findByLabelText('remove reaction smile').should('exist');
+        cy.findByLabelText(`remove reaction ${emoji}}`).should('exist');
     }
 }
 


### PR DESCRIPTION
#### Summary
Adds end to end tests for following scenarious
- [x] Emoji picker should show all custom emojis without overlaps.
- [x] Custom emoji - delete emoji after reacting with it on a post.
- [x] Recently used custom emoji, when is deleted should be removed from recent category of emoji picker and quick reactions.
- [x] Changing the skin of emojis should apply the same skin to emojis in recent section.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40609

#### Related Pull Requests
None

#### Screenshots
None

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
