### PR TITLE
Keyboard up/down key issue in Channel switcher due to global thread list

### DIFF
--- a/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/components/threading/global_threads/thread_list/thread_list.tsx
@@ -75,7 +75,8 @@ const ThreadList = ({
     const handleKeyDown = useCallback((e: KeyboardEvent) => {
         // Ensure that arrow keys navigation is not triggered if the textbox is focused
         const target = e.target as HTMLElement;
-        if (target?.id === 'reply_textbox') {
+        const tagName = target?.tagName?.toLowerCase();
+        if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') {
             return;
         }
 

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_channel_from_global_threads_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_channel_from_global_threads_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @keyboard_shortcuts
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_channel_from_global_threads_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_channel_from_global_threads_spec.js
@@ -1,0 +1,119 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @keyboard_shortcuts
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('Keyboard Shortcuts', () => {
+    let testTeam;
+    let testUser;
+    let otherUser;
+    let testChannel;
+
+    before(() => {
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                ThreadAutoFollow: true,
+                CollapsedThreads: 'default_off',
+            },
+        });
+        cy.apiInitSetup({loginAfter: true, promoteNewUserAsAdmin: true}).then(({team, channel, user}) => {
+            testTeam = team;
+            testUser = user;
+            testChannel = channel;
+
+            cy.apiSaveCRTPreference(testUser.id, 'on');
+            cy.apiCreateUser({prefix: 'other'}).then(({user: user1}) => {
+                otherUser = user1;
+
+                cy.apiAddUserToTeam(testTeam.id, otherUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, otherUser.id);
+                });
+            });
+        });
+    });
+
+    beforeEach(() => {
+        // # Visit channel
+        cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+    });
+
+    it('MM-T1243 CTRL/CMD+K - Create thread, Open global threads and then from find channels switch channel using arrow keys and Enter', () => {
+        // # Post message as other user
+        cy.postMessageAs({
+            sender: otherUser,
+            message: 'Root post,',
+            channelId: testChannel.id,
+        }).then(({id: rootId}) => {
+            // * Thread footer should not be visible
+            cy.get(`#post_${rootId}`).find('.ThreadFooter').should('not.exist');
+
+            // # Click on post to open RHS
+            cy.get(`#post_${rootId}`).click();
+
+            // * Button on header should say Follow as current user is not following
+            cy.get('#rhsContainer').find('.FollowButton').should('have.text', 'Follow');
+
+            // # Post a reply as current user
+            cy.postMessageReplyInRHS('Reply!');
+
+            // # Get last root post
+            cy.get(`#post_${rootId}`).
+
+                // * thread footer should exist now
+                get('.ThreadFooter').should('exist').
+                within(() => {
+                // * the button on the footer should say Following
+                    cy.get('.FollowButton').should('have.text', 'Following');
+                });
+
+            // * the button on the RHS header should now say Following
+            cy.get('#rhsContainer').find('.FollowButton').should('have.text', 'Following');
+
+            // # Visit global threads
+            cy.uiClickSidebarItem('threads');
+
+            // * There should be a thread there
+            cy.get('article.ThreadItem').should('have.have.lengthOf', 1);
+        });
+
+        // # Press CTRL/CMD+K
+        cy.get('body').cmdOrCtrlShortcut('K');
+        cy.get('#quickSwitchInput').type('T');
+
+        // # Press down arrow
+        cy.wait(TIMEOUTS.HALF_SEC);
+        cy.get('body').type('{downarrow}');
+
+        // * Confirm the offtopic channel is selected in the suggestion list
+        cy.get('#suggestionList').findByTestId('off-topic').should('be.visible').and('have.class', 'suggestion--selected');
+
+        // # Press up arrow
+        cy.wait(TIMEOUTS.HALF_SEC);
+        cy.get('body').type('{uparrow}');
+
+        // * Confirm the townsquare channel is selected in the suggestion list
+        cy.get('#suggestionList').findByTestId('town-square').should('be.visible').and('have.class', 'suggestion--selected');
+
+        // # Press down arrow
+        cy.wait(TIMEOUTS.HALF_SEC);
+        cy.get('body').type('{downarrow}');
+
+        // * Confirm the offtopic channel is selected in the suggestion list
+        cy.get('#suggestionList').findByTestId('off-topic').should('be.visible').and('have.class', 'suggestion--selected');
+
+        // # Press ENTER
+        cy.get('body').type('{enter}');
+
+        // * Confirm that channel is open, and post text box has focus
+        cy.contains('#channelHeaderTitle', 'Off-Topic');
+        cy.get('#post_textbox').should('be.focused');
+    });
+});

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_channel_from_global_threads_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_channel_from_global_threads_spec.js
@@ -45,7 +45,7 @@ describe('Keyboard Shortcuts', () => {
         cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
     });
 
-    it('MM-T1243 CTRL/CMD+K - Create thread, Open global threads and then from find channels switch channel using arrow keys and Enter', () => {
+    it('MM-T4648 CTRL/CMD+K - Create thread, Open global threads and then from find channels switch channel using arrow keys and Enter', () => {
         // # Post first message as other user
         cy.postMessageAs({
             sender: otherUser,

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_channel_from_global_threads_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_k_open_channel_from_global_threads_spec.js
@@ -46,42 +46,39 @@ describe('Keyboard Shortcuts', () => {
     });
 
     it('MM-T1243 CTRL/CMD+K - Create thread, Open global threads and then from find channels switch channel using arrow keys and Enter', () => {
-        // # Post message as other user
+        // # Post first message as other user
         cy.postMessageAs({
             sender: otherUser,
-            message: 'Root post,',
+            message: 'First post',
             channelId: testChannel.id,
         }).then(({id: rootId}) => {
-            // * Thread footer should not be visible
-            cy.get(`#post_${rootId}`).find('.ThreadFooter').should('not.exist');
-
             // # Click on post to open RHS
             cy.get(`#post_${rootId}`).click();
-
-            // * Button on header should say Follow as current user is not following
-            cy.get('#rhsContainer').find('.FollowButton').should('have.text', 'Follow');
 
             // # Post a reply as current user
             cy.postMessageReplyInRHS('Reply!');
 
-            // # Get last root post
-            cy.get(`#post_${rootId}`).
+            // # Close RHS
+            cy.uiCloseRHS();
+        });
 
-                // * thread footer should exist now
-                get('.ThreadFooter').should('exist').
-                within(() => {
-                // * the button on the footer should say Following
-                    cy.get('.FollowButton').should('have.text', 'Following');
-                });
+        // # Post second message as other user
+        cy.postMessageAs({
+            sender: otherUser,
+            message: 'Second post',
+            channelId: testChannel.id,
+        }).then(({id: rootId}) => {
+            // # Click on post to open RHS
+            cy.get(`#post_${rootId}`).click();
 
-            // * the button on the RHS header should now say Following
-            cy.get('#rhsContainer').find('.FollowButton').should('have.text', 'Following');
+            // # Post a reply as current user
+            cy.postMessageReplyInRHS('Reply!');
 
             // # Visit global threads
             cy.uiClickSidebarItem('threads');
 
             // * There should be a thread there
-            cy.get('article.ThreadItem').should('have.have.lengthOf', 1);
+            cy.get('article.ThreadItem').should('have.have.lengthOf', 2);
         });
 
         // # Press CTRL/CMD+K
@@ -92,12 +89,18 @@ describe('Keyboard Shortcuts', () => {
         cy.wait(TIMEOUTS.HALF_SEC);
         cy.get('body').type('{downarrow}');
 
+        // * should not select thread and switch thread in background
+        cy.url().should('equal', `${Cypress.config('baseUrl')}/${testTeam.name}/threads`);
+
         // * Confirm the offtopic channel is selected in the suggestion list
         cy.get('#suggestionList').findByTestId('off-topic').should('be.visible').and('have.class', 'suggestion--selected');
 
         // # Press up arrow
         cy.wait(TIMEOUTS.HALF_SEC);
         cy.get('body').type('{uparrow}');
+
+        // * should not select thread and switch thread in background
+        cy.url().should('equal', `${Cypress.config('baseUrl')}/${testTeam.name}/threads`);
 
         // * Confirm the townsquare channel is selected in the suggestion list
         cy.get('#suggestionList').findByTestId('town-square').should('be.visible').and('have.class', 'suggestion--selected');
@@ -106,14 +109,17 @@ describe('Keyboard Shortcuts', () => {
         cy.wait(TIMEOUTS.HALF_SEC);
         cy.get('body').type('{downarrow}');
 
+        // * should not select thread and switch thread in background
+        cy.url().should('equal', `${Cypress.config('baseUrl')}/${testTeam.name}/threads`);
+
         // * Confirm the offtopic channel is selected in the suggestion list
         cy.get('#suggestionList').findByTestId('off-topic').should('be.visible').and('have.class', 'suggestion--selected');
 
         // # Press ENTER
         cy.get('body').type('{enter}');
 
-        // * Confirm that channel is open, and post text box has focus
+        // * Confirm that channel is open
         cy.contains('#channelHeaderTitle', 'Off-Topic');
-        cy.get('#post_textbox').should('be.focused');
+        cy.url().should('include', '/channels/off-topic');
     });
 });


### PR DESCRIPTION
#### Summary
Moving up/down doesn’t work as expected in find channels (ctrl/cmd + k) if global threads is in background, adding more specific conditions in threads list keyboard event listener to avoid this.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-40444

#### Related Pull Requests
``NONE``

#### Screenshots
|  before  |  after  |
|----|----|
| https://user-images.githubusercontent.com/16203333/155275448-2d681acc-2eca-4822-95d9-a0c163fee270.mp4 | https://user-images.githubusercontent.com/16203333/155275473-407afcec-7249-4d47-b2f9-b1066938a271.mp4 |

#### Release Note
```release-note
*UI: up/down key in find channel when global threads are in background
```
