### PR TITLE
[MM-37245] Format the number of users in enterprise license details

### DIFF
--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.test.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.test.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
+
+import EnterpriseEditionLeftPanel, {EnterpriseEditionProps} from './enterprise_edition_left_panel';
+
+
+describe('components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel', () => {
+    const license = {
+        IsLicensed: 'true',
+        IssuedAt: '1517714643650',
+        StartsAt: '1517714643650',
+        ExpiresAt: '1620335443650',
+        SkuShortName: 'Enterprise',
+        Name: 'LicenseName',
+        Company: 'Mattermost Inc.',
+        Users: '1000000',
+    };
+
+    const props = {
+        license,
+        openEELicenseModal: jest.fn(),
+        upgradedFromTE: false,
+        isTrialLicense: false,
+        issued: <></>,
+        startsAt: <></>,
+        expiresAt: <></>,
+        handleRemove: jest.fn(),
+        isDisabled: false,
+        removing: false,
+    } as EnterpriseEditionProps;
+
+    test('should format the Users field', () => {
+        const wrapper = mountWithIntl(
+            <EnterpriseEditionLeftPanel {...props}/>,
+        );
+
+        const item = wrapper.find('.item-element').filterWhere((n) => {
+            return n.children().length === 2 &&
+                   n.childAt(0).type() === 'span' &&
+                   n.childAt(0).text().includes('USERS');
+        });
+
+        expect(item.text()).toContain('1,000,000');
+    });
+});

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.test.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.test.tsx
@@ -7,7 +7,6 @@ import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
 import EnterpriseEditionLeftPanel, {EnterpriseEditionProps} from './enterprise_edition_left_panel';
 
-
 describe('components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel', () => {
     const license = {
         IsLicensed: 'true',

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 import React from 'react';
 
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, FormattedNumber} from 'react-intl';
 
 import {ClientLicense} from 'mattermost-redux/types/config';
 import {LicenseSkus} from 'mattermost-redux/types/general';
@@ -143,6 +143,8 @@ const renderLicenseContent = (
 
     const sku = license.SkuShortName ? <>{`Mattermost ${toTitleCase(skuName)}${isTrialLicense ? ' License Trial' : ''}`}</> : null;
 
+    const nbUsers = <FormattedNumber value={parseInt(license.Users, 10)}/>;
+
     const licenseValues: Array<{
         legend: string;
         value: string;
@@ -152,7 +154,7 @@ const renderLicenseContent = (
     }> = [
         {legend: 'START DATE:', value: startsAt},
         {legend: 'EXPIRES:', value: expiresAt},
-        {legend: 'USERS:', value: license.Users},
+        {legend: 'USERS:', value: nbUsers},
         {legend: 'EDITION:', value: sku},
         {legend: 'LICENSE ISSUED:', value: issued},
         {legend: 'NAME:', value: license.Name},

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
@@ -143,7 +143,7 @@ const renderLicenseContent = (
 
     const sku = license.SkuShortName ? <>{`Mattermost ${toTitleCase(skuName)}${isTrialLicense ? ' License Trial' : ''}`}</> : null;
 
-    const nbUsers = <FormattedNumber value={parseInt(license.Users, 10)}/>;
+    const users = <FormattedNumber value={parseInt(license.Users, 10)}/>;
 
     const licenseValues: Array<{
         legend: string;
@@ -154,7 +154,7 @@ const renderLicenseContent = (
     }> = [
         {legend: 'START DATE:', value: startsAt},
         {legend: 'EXPIRES:', value: expiresAt},
-        {legend: 'USERS:', value: nbUsers},
+        {legend: 'USERS:', value: users},
         {legend: 'EDITION:', value: sku},
         {legend: 'LICENSE ISSUED:', value: issued},
         {legend: 'NAME:', value: license.Name},

--- a/components/admin_console/license_settings/modals/upload_license_modal.test.tsx
+++ b/components/admin_console/license_settings/modals/upload_license_modal.test.tsx
@@ -158,6 +158,24 @@ describe('components/admin_console/license_settings/modals/upload_license_modal'
         expect(wrapper.find('UploadLicenseModal').find('#done-button')).toHaveLength(1);
     });
 
+    test('should format users number', () => {
+        const licensedState = {
+            general: {
+                license: {...license, Users: '123456789'},
+            },
+        };
+        const localStore = {...state, entities: licensedState};
+        const mockStore = configureStore([thunk]);
+        const store = mockStore(localStore);
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <UploadLicenseModal {...props}/>
+            </Provider>,
+        );
+        const modalSubtitle = wrapper.find('UploadLicenseModal').find('.subtitle').text();
+        expect(modalSubtitle).toContain('123,456,789');
+    });
+
     test('should hide the upload modal', () => {
         const UploadLicenseModalHidden = {
             modals: {

--- a/components/admin_console/license_settings/modals/upload_license_modal.tsx
+++ b/components/admin_console/license_settings/modals/upload_license_modal.tsx
@@ -259,7 +259,7 @@ const UploadLicenseModal: React.FC<Props> = (props: Props): JSX.Element | null =
                     <div className='subtitle'>
                         <FormattedMessage
                             id='admin.license.upload-modal.successfulUpgradeText'
-                            defaultMessage='You have upgraded to the {skuName} plan for {licensedUsersNum} users. This is effective from {startsAt} until {expiresAt}. '
+                            defaultMessage='You have upgraded to the {skuName} plan for {licensedUsersNum, number} users. This is effective from {startsAt} until {expiresAt}. '
                             values={{
                                 expiresAt,
                                 startsAt,

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1270,7 +1270,7 @@
   "admin.license.upload-modal.file": "Datei",
   "admin.license.upload-modal.subtitle": "Lade eine Lizenzschlüssel für die Mattermost Enterprise Edition hoch, um den Server zu aktualisieren. ",
   "admin.license.upload-modal.successfulUpgrade": "Erfolgreiche Aktualisierung!",
-  "admin.license.upload-modal.successfulUpgradeText": "Sie haben den {skuName} Plan für {licensedUsersNum} Benutzer aktualisiert. Diese Änderung ist aktiv vom {startsAt} bis zum {expiresAt}. ",
+  "admin.license.upload-modal.successfulUpgradeText": "Sie haben den {skuName} Plan für {licensedUsersNum, number} Benutzer aktualisiert. Diese Änderung ist aktiv vom {startsAt} bis zum {expiresAt}. ",
   "admin.license.upload-modal.title": "Lizenzschlüssel hochladen",
   "admin.license.uploadFile": "Datei hochladen",
   "admin.license.warn.renew": "Erneuern",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1270,7 +1270,7 @@
   "admin.license.upload-modal.file": "File",
   "admin.license.upload-modal.subtitle": "Upload a license key for Mattermost Enterprise Edition to upgrade this server. ",
   "admin.license.upload-modal.successfulUpgrade": "Successful Upgrade!",
-  "admin.license.upload-modal.successfulUpgradeText": "You have upgraded to the {skuName} plan for {licensedUsersNum} users. This is effective from {startsAt} until {expiresAt}. ",
+  "admin.license.upload-modal.successfulUpgradeText": "You have upgraded to the {skuName} plan for {licensedUsersNum, number} users. This is effective from {startsAt} until {expiresAt}. ",
   "admin.license.upload-modal.title": "Upload a License Key",
   "admin.license.uploadFile": "Upload File",
   "admin.license.warn.renew": "Renew",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -1270,7 +1270,7 @@
   "admin.license.upload-modal.file": "File",
   "admin.license.upload-modal.subtitle": "Upload a licence key for Mattermost Enterprise Edition to upgrade this server. ",
   "admin.license.upload-modal.successfulUpgrade": "Upgrade successful!",
-  "admin.license.upload-modal.successfulUpgradeText": "You have upgraded to the {skuName} plan for {licensedUsersNum} users. This is effective from {startsAt} until {expiresAt}. ",
+  "admin.license.upload-modal.successfulUpgradeText": "You have upgraded to the {skuName} plan for {licensedUsersNum, number} users. This is effective from {startsAt} until {expiresAt}. ",
   "admin.license.upload-modal.title": "Upload a Licence Key",
   "admin.license.uploadFile": "Upload File",
   "admin.license.warn.renew": "Renew",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -1270,7 +1270,7 @@
   "admin.license.upload-modal.file": "Plik",
   "admin.license.upload-modal.subtitle": "Prześlij klucz licencyjny dla Mattermost Enterprise Edition, aby uaktualnić ten serwer. ",
   "admin.license.upload-modal.successfulUpgrade": "Udana aktualizacja!",
-  "admin.license.upload-modal.successfulUpgradeText": "Dokonałeś aktualizacji do planu {skuName} dla użytkowników {licensedUsersNum}. Obowiązuje to od {startsAt} do {expiresAt}. ",
+  "admin.license.upload-modal.successfulUpgradeText": "Dokonałeś aktualizacji do planu {skuName} dla użytkowników {licensedUsersNum, number}. Obowiązuje to od {startsAt} do {expiresAt}. ",
   "admin.license.upload-modal.title": "Prześlij klucz licencyjny",
   "admin.license.uploadFile": "Prześlij plik",
   "admin.license.warn.renew": "Ponów",


### PR DESCRIPTION
#### Summary
Format the number of users attached to a license in "System Console > About > Edition and License".

Also applied formatting in the Upload license Modal confirmation message.

**Note:** A comment in the code reminds us that the labels must not be translated (because the labels are linked to the license that must stay in English) - that's why in the screenshot below, the French locale still has English labels.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37245

#### Related Pull Requests
N/A

#### Screenshots
Locale = US (separator is `,`)
![image](https://user-images.githubusercontent.com/785518/150611802-6fe2fc7b-a8b5-4eb1-a00d-aff7adc78b7e.png)

Locale = FR (separator is a space)
![image](https://user-images.githubusercontent.com/785518/150611761-b03e8964-fb86-42eb-914d-f16c5700ad84.png)

#### Release Note
```release-note
NONE
```
