### PR TITLE
MM-36708 Using moment.js to format dates

### DIFF
--- a/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
+++ b/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
@@ -17,6 +17,13 @@ import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 import './dnd_custom_time_picker_modal.scss';
 import {toUTCUnix} from 'utils/datetime';
 
+import MomentLocaleUtils, {
+    formatDate,
+    parseDate,
+  } from 'react-day-picker/moment';
+  
+
+
 type Props = {
     onExited: () => void;
     userId: string;
@@ -50,13 +57,6 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
             dayPickerStartDate: selectedDate,
             ...this.makeTimeMenuList(selectedDate),
         };
-    }
-
-    formatDate = (date: Date): string => {
-        const month = (date.getMonth() + 1).toString().padStart(2, '0');
-        const day = date.getDate().toString().padStart(2, '0');
-        const year = date.getFullYear().toString();
-        return [year, month, day].join('-');
     }
 
     getText = () => {
@@ -180,7 +180,9 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
                             </div>
                             <i className='icon icon--no-spacing icon-calendar-outline icon--xs icon-14'/>
                             <DayPickerInput
-                                value={this.formatDate(selectedDate)}
+                                formatDate={formatDate}
+                                parseDate={parseDate}
+                                placeholder={`${formatDate(new Date())}`}
                                 onDayChange={this.handleDaySelection}
                                 dayPickerProps={{
                                     selectedDays: selectedDate,

--- a/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
+++ b/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
@@ -52,6 +52,13 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
             ...this.makeTimeMenuList(selectedDate),
         };
     }
+    
+    formatDate = (date: Date): string => {
+        const month = (date.getMonth() + 1).toString().padStart(2, '0');
+        const day = date.getDate().toString().padStart(2, '0');
+        const year = date.getFullYear().toString();
+        return [year, month, day].join('-');
+    }
 
     getText = () => {
         const modalHeaderText = (

--- a/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
+++ b/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
+import moment from "moment";
 import DayPickerInput from 'react-day-picker/DayPickerInput';
-import {formatDate, parseDate,} from 'react-day-picker/moment';
 
 import {ActionFunc} from 'mattermost-redux/types/actions';
 import {UserStatus} from 'mattermost-redux/types/users';
@@ -47,12 +47,12 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
         }
 
         this.state = {
+            dayPickerStartDate: moment().toDate(),
             selectedDate,
-            dayPickerStartDate: selectedDate,
             ...this.makeTimeMenuList(selectedDate),
         };
     }
-    
+
     formatDate = (date: Date): string => {
         const month = (date.getMonth() + 1).toString().padStart(2, '0');
         const day = date.getDate().toString().padStart(2, '0');
@@ -99,7 +99,7 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
 
     handleDaySelection = (day: Date) => {
         this.setState({
-            selectedDate: day,
+            selectedDate: moment(day).format('DD-MM-YYYY'),
             ...this.makeTimeMenuList(day),
         });
     };
@@ -181,12 +181,11 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
                             </div>
                             <i className='icon icon--no-spacing icon-calendar-outline icon--xs icon-14'/>
                             <DayPickerInput
-                                formatDate={formatDate}
-                                parseDate={parseDate}
-                                placeholder={`${formatDate(new Date())}`}
+                                dateFormat="DD-MM-YYYY"
+                                placeholder= {this.state.dayPickerStartDate}
                                 onDayChange={this.handleDaySelection}
                                 dayPickerProps={{
-                                    selectedDays: selectedDate,
+                                    selectedDays: moment(selectedDate).format('DD-MM-YYYY'),
                                     disabledDays: {
                                         before: dayPickerStartDate,
                                     },

--- a/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
+++ b/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
+import {formatDate, parseDate,} from 'react-day-picker/moment';
 
 import {ActionFunc} from 'mattermost-redux/types/actions';
 import {UserStatus} from 'mattermost-redux/types/users';
@@ -16,13 +17,6 @@ import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 
 import './dnd_custom_time_picker_modal.scss';
 import {toUTCUnix} from 'utils/datetime';
-
-import MomentLocaleUtils, {
-    formatDate,
-    parseDate,
-  } from 'react-day-picker/moment';
-  
-
 
 type Props = {
     onExited: () => void;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
I used documentation from react-day-picker to change the output of dates to DD-MM-YYYY instead of M-D-YYYY as it current is. I used this link to change the code: https://react-day-picker.js.org/examples/input-moment/

#### Ticket Link
Custom Status Expiry: Date Format #19358 https://github.com/mattermost/mattermost-server/issues/19358 

#### Related Pull Requests


#### Screenshots

#### Release Note

Imported moment.js to parse selected date using the code outlined in the react-day-picker documentation. Read more here: https://react-day-picker.js.org/examples/input-moment/

