### PR TITLE
Clarified in-product string

### DIFF
--- a/components/invitation_modal/no_permissions_view.tsx
+++ b/components/invitation_modal/no_permissions_view.tsx
@@ -32,7 +32,7 @@ export default function NoPermissionsView(props: Props) {
                     <div className='NoPermissionsView__title'>
                         <FormattedMessage
                             id='invite_modal.no_permissions.title'
-                            defaultMessage='Oops!'
+                            defaultMessage='Unable to continue'
                         />
                     </div>
                     <div className='NoPermissionsView__description'>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3519,7 +3519,7 @@
   "invite_modal.invited_members": "Members",
   "invite_modal.members": "members",
   "invite_modal.no_permissions.description": "You do not have permissions to add users or guests. If this seems like an error, please reach out to your system administrator.",
-  "invite_modal.no_permissions.title": "Oops!",
+  "invite_modal.no_permissions.title": "Unable to continue",
   "invite_modal.permanent": "**This can't be undone.**",
   "invite_modal.title": "Invite {inviteType} to {team_name}",
   "invite_modal.to": "To:",


### PR DESCRIPTION
#### Release Note

```release-note
Clarified in-product error string "Oops!" as "Unable to continue" for both translators and target audiences in cases where a user doesn't have sufficient permissions to add users or guests.
```
