### PR TITLE
MM-38332: fixes dm category menu

### DIFF
--- a/components/sidebar/sidebar_category/sidebar_category_sorting_menu/sidebar_category_sorting_menu.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category_sorting_menu/sidebar_category_sorting_menu.tsx
@@ -167,12 +167,12 @@ export class SidebarCategorySortingMenu extends React.PureComponent<Props, State
         return (
             <SidebarMenu
                 id={'SidebarCategorySortingMenu'}
-                ariaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
-                buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
+                ariaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.dropdownAriaLabel', defaultMessage: 'Category Menu'})}
+                buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.dropdownAriaLabel', defaultMessage: 'Category Menu'})}
                 isMenuOpen={isMenuOpen}
                 onToggleMenu={this.onToggleMenu}
                 onOpenDirectionChange={this.handleOpenDirectionChange}
-                tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'})}
+                tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editCategory', defaultMessage: 'Category options'})}
                 tabIndex={isCollapsed ? -1 : 0}
                 additionalClass='additionalClass'
             >

--- a/components/sidebar/sidebar_category/sidebar_category_sorting_menu/sidebar_category_sorting_menu.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category_sorting_menu/sidebar_category_sorting_menu.tsx
@@ -153,7 +153,7 @@ export class SidebarCategorySortingMenu extends React.PureComponent<Props, State
         this.props.onToggleMenu(open);
 
         if (open) {
-            trackEvent('ui', 'ui_sidebar_channel_menu_opened');
+            trackEvent('ui', 'ui_sidebar_category_menu_opened');
         }
     }
 
@@ -172,7 +172,7 @@ export class SidebarCategorySortingMenu extends React.PureComponent<Props, State
                 isMenuOpen={isMenuOpen}
                 onToggleMenu={this.onToggleMenu}
                 onOpenDirectionChange={this.handleOpenDirectionChange}
-                tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editCategory', defaultMessage: 'Category options'})}
+                tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.editCategory', defaultMessage: 'Category options'})}
                 tabIndex={isCollapsed ? -1 : 0}
                 additionalClass='additionalClass'
             >


### PR DESCRIPTION
#### Summary

Tooltip in the DM category displays the wrong text.
This commit fixes that.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38332

#### Release Note

```release-note
NONE
```
