### PR TITLE
[MM-41371]fix: user onboarding first channel tour tip heading issue

### DIFF
--- a/components/sidebar/__snapshots__/channel_tutorial_tip.test.tsx.snap
+++ b/components/sidebar/__snapshots__/channel_tutorial_tip.test.tsx.snap
@@ -2,21 +2,10 @@
 
 exports[`component/legacy_sidebar/ChannelTutorialTip should match snapshot, with firstChannelName set 1`] = `
 <Connect(TutorialTip)
-  overlayClass="tip-overlay--sidebar"
+  overlayClass="tip-overlay--sidebar first-channel"
   placement="right"
   screen={
     <React.Fragment>
-      <h4>
-        <Memo(MemoizedFormattedMessage)
-          defaultMessage="Welcome to {firstChannelName}, your first channel!"
-          id="create_first_channel.tutorialTip.title"
-          values={
-            Object {
-              "firstChannelName": "Firstchannelname",
-            }
-          }
-        />
-      </h4>
       <div
         className="handSvg svg-wrapper"
       >
@@ -38,8 +27,13 @@ exports[`component/legacy_sidebar/ChannelTutorialTip should match snapshot, with
   telemetryTag="tutorial_tip_0_first_channel"
   title={
     <Memo(MemoizedFormattedMessage)
-      defaultMessage="Organize conversations in channels"
-      id="sidebar.tutorialChannelTypes.title"
+      defaultMessage="Welcome to {firstChannelName}, your first channel!"
+      id="create_first_channel.tutorialTip.title"
+      values={
+        Object {
+          "firstChannelName": "Firstchannelname",
+        }
+      }
     />
   }
 />

--- a/components/sidebar/channel_tutorial_tip.tsx
+++ b/components/sidebar/channel_tutorial_tip.tsx
@@ -28,7 +28,8 @@ export default class ChannelTutorialTip extends React.PureComponent<Props> {
     }
 
     render = () => {
-        const title = (
+        let overlayClass = 'tip-overlay--sidebar';
+        let title = (
             <FormattedMessage
                 id='sidebar.tutorialChannelTypes.title'
                 defaultMessage={'Organize conversations in channels'}
@@ -68,15 +69,16 @@ export default class ChannelTutorialTip extends React.PureComponent<Props> {
         let telemetryTagText = 'tutorial_tip_2_channels';
         if (this.props.firstChannelName) {
             const displayFirstChannelName = this.props.firstChannelName.split('-').join(' ').trim();
+            overlayClass += ' first-channel';
+            title = (
+                <FormattedMessage
+                    id='create_first_channel.tutorialTip.title'
+                    defaultMessage='Welcome to {firstChannelName}, your first channel!'
+                    values={{firstChannelName: toTitleCase(displayFirstChannelName)}}
+                />
+            );
             screen = (
                 <>
-                    <h4>
-                        <FormattedMessage
-                            id='create_first_channel.tutorialTip.title'
-                            defaultMessage='Welcome to {firstChannelName}, your first channel!'
-                            values={{firstChannelName: toTitleCase(displayFirstChannelName)}}
-                        />
-                    </h4>
                     <div className='handSvg svg-wrapper'>
                         <HandsSvg
                             width={60}
@@ -113,7 +115,7 @@ export default class ChannelTutorialTip extends React.PureComponent<Props> {
                 placement={this.props.isMobileView ? 'bottom' : 'right'}
                 step={this.props.firstChannelName ? TutorialSteps.ADD_FIRST_CHANNEL : TutorialSteps.CHANNEL_POPOVER}
                 screen={screen}
-                overlayClass='tip-overlay--sidebar'
+                overlayClass={overlayClass}
                 telemetryTag={telemetryTagText}
                 punchOut={tutorialTipPunchout}
             />

--- a/sass/components/_tutorial.scss
+++ b/sass/components/_tutorial.scss
@@ -9,12 +9,11 @@ $tip-index: 1000;
 .tutorial-tip {
     &__header {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: flex-start;
 
         &__title {
-            flex: none;
-            flex-grow: 1;
+            flex: auto;
             order: 0;
             margin: 0;
             font-family: inherit;
@@ -261,6 +260,10 @@ $tip-index: 1000;
             top: 32px;
             left: -9px;
             margin-top: -10px;
+        }
+
+        &.first-channel {
+            margin-top: 108px;
         }
     }
 


### PR DESCRIPTION
#### Summary
User onboarding tour first channel case heading font size and showing wrong heading

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-41371

#### Related Pull Requests
Caused by: https://github.com/mattermost/mattermost-webapp/pull/9289

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="397" alt="Screenshot 2022-01-29 at 5 21 03 AM" src="https://user-images.githubusercontent.com/16203333/151637970-10745f46-f285-489b-83ba-7e9068cb54f3.png"> | <img width="360" alt="Screenshot 2022-01-29 at 5 27 02 AM" src="https://user-images.githubusercontent.com/16203333/151637998-0a973df7-1ef3-4590-ad50-f9b19b7747ed.png">|

#### Release Note

```release-note
fix: user onboarding first channel tour tip heading issue
```
