### PR TITLE
Cypress/E2E: Fix react_to_center and close_current_dm_redirect specs

### DIFF
--- a/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
@@ -96,7 +96,7 @@ describe('Image Link Preview', () => {
         cy.findAllByLabelText('file thumbnail').should('be.visible').and('have.length', 4);
     });
 
-    it('MM-T332 Image link preview - Bitly links for images and YouTube', () => {
+    it('MM-T332 Image link preview - Bitly links for images and YouTube -- KNOWN ISSUE: MM-40448', () => {
         // # Youtube link and image link
         const links = ['https://bit.ly/2NlYsOr', 'https://bit.ly/2wqEbjw'];
 

--- a/e2e/cypress/integration/files_and_attachments/upload_files_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/upload_files_spec.js
@@ -283,7 +283,7 @@ describe('Upload Files', () => {
         });
     });
 
-    it('MM-T2261 Upload SVG and post', () => {
+    it('MM-T2261 Upload SVG and post -- KNOWN ISSUE: MM-38982', () => {
         const filename = 'svg.svg';
         const aspectRatio = 1;
 

--- a/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_shift_slash/react_to_center_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/ctrl_cmd_shift_slash/react_to_center_spec.js
@@ -211,7 +211,7 @@ describe('Keyboard shortcut CTRL/CMD+Shift+\\ for adding reaction to last messag
     it('MM-T1804_4 Should add reaction to same post on which emoji picker was opened', () => {
         // # Save the post id which user initially intended to add reaction to, for later use
         cy.getLastPostId().then((lastPostId) => {
-            cy.get(`#${lastPostId}_message`).as('postIdForAddingReaction');
+            cy.wrap(lastPostId).as('postIdForAddingReaction');
         });
 
         // # Do keyboard shortcut without focus
@@ -232,8 +232,8 @@ describe('Keyboard shortcut CTRL/CMD+Shift+\\ for adding reaction to last messag
         clickSmileEmojiFromEmojiPicker();
 
         // * Check if emoji is shown as reaction to the message it initially intended
-        cy.get('@postIdForAddingReaction').within(() => {
-            checkReactionFromPost();
+        cy.get('@postIdForAddingReaction').then((postIdForAddingReaction) => {
+            checkReactionFromPost(postIdForAddingReaction);
         });
 
         // * Check if last message didn't get a reaction

--- a/e2e/cypress/integration/multi_team_and_dm/close_current_dm_redirects_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/close_current_dm_redirects_spec.js
@@ -21,7 +21,7 @@ describe('Direct messages: redirections', () => {
 
             cy.apiCreateUser().then(({user: createdUser}) => {
                 firstDMUser = createdUser;
-                cy.apiAddUserToTeam(team.id, firstDMUser.id);
+                cy.apiAddUserToTeam(testTeam.id, firstDMUser.id);
             });
 
             // # Create a second test user
@@ -32,12 +32,10 @@ describe('Direct messages: redirections', () => {
 
             // # Login as test user
             cy.apiLogin(testUser);
-        });
-    });
 
-    beforeEach(() => {
-        // # View 'off-topic' channel
-        cy.visit(offTopicChannelUrl);
+            // # View 'off-topic' channel
+            cy.visit(offTopicChannelUrl);
+        });
     });
 
     it('MM-T453_1 Closing a direct message should redirect to town square channel', () => {


### PR DESCRIPTION
#### Summary
- Fixed react_to_center_spec
- Fixed closed_current_dm_redirect spec
- Added `KNOWN ISSUE` to title of failing test cases with known issues that are currently unresolved

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2022-01-31 at 10 09 32 AM](https://user-images.githubusercontent.com/487991/151856369-1a560fc0-45b9-4ff7-b99b-27ed97c799bc.png)
![Screen Shot 2022-01-31 at 10 32 04 AM](https://user-images.githubusercontent.com/487991/151856370-2bb29f8d-2f24-4155-b160-0f7fced3ff58.png)

#### Release Note
```release-note
NONE
```