### PR TITLE
[MM-27881] Image modal is included when image on the attachment is clicked

### DIFF
--- a/components/post_view/message_attachments/message_attachment/index.ts
+++ b/components/post_view/message_attachments/message_attachment/index.ts
@@ -9,6 +9,9 @@ import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/tea
 import {GlobalState} from 'mattermost-redux/types/store';
 import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
 
+import {openModal} from 'actions/views/modals';
+import {ModalData} from 'types/actions';
+
 import MessageAttachment from './message_attachment';
 
 function mapStateToProps(state: GlobalState) {
@@ -19,12 +22,13 @@ function mapStateToProps(state: GlobalState) {
 
 type Actions = {
     doPostActionWithCookie: (postId: string, actionId: string, actionCookie: string, selectedOption?: string | undefined) => Promise<ActionResult>;
+    openModal: <P>(modalData: ModalData<P>) => void;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
-        actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Actions>({
-            doPostActionWithCookie,
+        actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc | GenericAction>, Actions>({
+            doPostActionWithCookie, openModal,
         }, dispatch),
     };
 }

--- a/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -7,11 +7,14 @@ import truncate from 'lodash/truncate';
 
 import {ActionResult} from 'mattermost-redux/types/actions';
 import {PostAction, PostActionOption} from 'mattermost-redux/types/integration_actions';
-import {MessageAttachment as MessageAttachmentType, MessageAttachmentField} from 'mattermost-redux/types/message_attachments';
+import {
+    MessageAttachment as MessageAttachmentType,
+    MessageAttachmentField,
+} from 'mattermost-redux/types/message_attachments';
 import {PostImage} from 'mattermost-redux/types/posts';
 
 import {isUrlSafe} from 'utils/url';
-import {Constants} from 'utils/constants';
+import {Constants, ModalIdentifiers} from 'utils/constants';
 import * as Utils from 'utils/utils';
 import LinkOnlyRenderer from 'utils/markdown/link_only_renderer';
 import {TextFormattingOptions} from 'utils/text_formatting';
@@ -25,6 +28,8 @@ import ActionButton from '../action_button';
 import ActionMenu from '../action_menu';
 
 import {trackEvent} from 'actions/telemetry_actions';
+import FilePreviewModal from '../../../file_preview_modal';
+import {ModalData} from 'types/actions';
 
 type Props = {
 
@@ -50,6 +55,7 @@ type Props = {
 
     actions: {
         doPostActionWithCookie: (postId: string, actionId: string, actionCookie: string, selectedOption?: string) => Promise<ActionResult>;
+        openModal: <P>(modalData: ModalData<P>) => void;
     };
 
     currentRelativeTeamUrl: string;
@@ -305,6 +311,30 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
 
     handleFormattedTextClick = (e: React.MouseEvent) => Utils.handleFormattedTextClick(e, this.props.currentRelativeTeamUrl);
 
+    getFileExtensionFromUrl = (url: string) => {
+        const index = url.lastIndexOf('.');
+        return index > 0 ? url.substring(index + 1) : null;
+    };
+
+    showModal = (e: {preventDefault: () => void}, link: string) => {
+        const extension = this.getFileExtensionFromUrl(link);
+
+        e.preventDefault();
+
+        this.props.actions.openModal({
+            modalId: ModalIdentifiers.FILE_PREVIEW_MODAL,
+            dialogType: FilePreviewModal,
+            dialogProps: {
+                postId: this.props.postId,
+                fileInfos: [{
+                    has_preview_image: false,
+                    link,
+                    extension,
+                }],
+            },
+        });
+    }
+
     render() {
         const {attachment, options} = this.props;
         let preTextClass = '';
@@ -434,6 +464,7 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                                 onImageLoaded={this.handleHeightReceivedForImageUrl}
                                 src={imageUrl}
                                 dimensions={imageMetadata}
+                                onClick={this.showModal}
                             />
                         )}
                     </ExternalImage>


### PR DESCRIPTION
#### Summary
When an image is clicked on the slack message attachment, image modal is opened to view the image similar to `post_image` and `markdown_image`

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/19407

#### Screenshots

**Before**


https://user-images.githubusercontent.com/37421564/151973741-f4bb89ae-77a6-4389-8b3b-2aabda9d777f.mp4


**After**



https://user-images.githubusercontent.com/37421564/151973801-a34b2fd4-2270-4c9a-87c2-7c14367a0b48.mp4




#### Release Note
```release-note
Fixes an issue related clicking images in the slack message attachment 
```
