### PR TITLE
Cypress/E2E: Potential fix for recently used emoji spec

### DIFF
--- a/e2e/cypress/integration/emoji/recently_used_emoji_1_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_1_spec.js
@@ -18,9 +18,6 @@ import {getCustomEmoji} from './helpers';
 describe('Recent Emoji', () => {
     const largeEmojiFile = 'gif-image-file.gif';
 
-    let testTeam;
-    let testUser;
-    let otherUser;
     let townsquareLink;
 
     before(() => {
@@ -29,20 +26,14 @@ describe('Recent Emoji', () => {
                 EnableCustomEmoji: true,
             },
         });
+    });
 
+    beforeEach(() => {
         cy.apiAdminLogin();
 
         cy.apiInitSetup().then(({team, user}) => {
-            testTeam = team;
-            testUser = user;
+            cy.apiLogin(user);
             townsquareLink = `/${team.name}/channels/town-square`;
-        });
-
-        cy.apiCreateUser().then(({user: user1}) => {
-            otherUser = user1;
-            cy.apiAddUserToTeam(testTeam.id, otherUser.id);
-        }).then(() => {
-            cy.apiLogin(testUser);
             cy.visit(townsquareLink);
         });
     });
@@ -87,7 +78,6 @@ describe('Recent Emoji', () => {
         const {customEmoji, customEmojiWithColons} = getCustomEmoji();
 
         // # Open custom emoji
-        cy.reload();
         cy.uiOpenCustomEmoji();
 
         // # Click on add new emoji button on custom emoji page
@@ -176,50 +166,5 @@ describe('Recent Emoji', () => {
 
         // * Verify most recent one is the system emoji in emoji picker and not the custom emoji
         cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', 'lemon emoji');
-    });
-
-    it('MM-T4438 Changing the skin of emojis should apply the same skin to emojis in recent section', () => {
-        // # Post a sample message
-        cy.postMessage(MESSAGES.TINY);
-
-        // # Post reaction to post
-        cy.clickPostReactionIcon();
-
-        cy.get('#emojiPicker').should('be.visible').within(() => {
-            // # Open skin picker
-            cy.findByAltText('emoji skin tone picker').should('exist').parent().click().wait(TIMEOUTS.ONE_SEC);
-
-            // # Select default yellow skin
-            cy.findByTestId('skin-pick-default').should('exist').parent().click();
-
-            // # Search for a system emoji with skin
-            cy.findByPlaceholderText('Search emojis').should('exist').type('thumbsup').wait(TIMEOUTS.HALF_SEC);
-
-            // # Select the emoji to add to post with default skin
-            cy.findByTestId('+1,thumbsup').parent().click();
-        });
-
-        // # Open emoji picker again to check if thumbsup emoji is present in recent section
-        cy.uiOpenEmojiPicker().wait(TIMEOUTS.TWO_SEC);
-
-        cy.get('#emojiPicker').should('be.visible').within(() => {
-            // * Verify recently used category is present in emoji picker
-            cy.findByText('Recently Used').should('exist').and('be.visible');
-
-            // * Verify most recent one is the thumbsup emoji with default skin
-            cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', '+1 emoji');
-
-            // # Open skin picker again to change the skin
-            cy.findByAltText('emoji skin tone picker').should('exist').parent().click().wait(TIMEOUTS.ONE_SEC);
-
-            // # Select a dark skin tone
-            cy.findByTestId('skin-pick-1F3FF').should('exist').parent().click();
-
-            // * Verify most recent one is the same thumbsup emoji but now with a dark skin tone
-            cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', '+1 dark skin tone emoji');
-        });
-
-        // # Close emoji picker
-        cy.get('body').type('{esc}', {force: true});
     });
 });

--- a/e2e/cypress/integration/emoji/recently_used_emoji_2_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_2_spec.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @emoji @timeout_error
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+import * as MESSAGES from '../../fixtures/messages';
+
+describe('Recent Emoji', () => {
+    before(() => {
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableCustomEmoji: true,
+            },
+        });
+
+        cy.apiInitSetup().then(({team, user}) => {
+            cy.apiLogin(user);
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+
+    it('MM-T4438 Changing the skin of emojis should apply the same skin to emojis in recent section', () => {
+        // # Post a sample message
+        cy.postMessage(MESSAGES.TINY);
+
+        // # Post reaction to post
+        cy.clickPostReactionIcon();
+
+        cy.get('#emojiPicker').should('be.visible').within(() => {
+            // # Open skin picker
+            cy.findByAltText('emoji skin tone picker').should('exist').parent().click().wait(TIMEOUTS.ONE_SEC);
+
+            // # Select default yellow skin
+            cy.findByTestId('skin-pick-default').should('exist').parent().click();
+
+            // # Search for a system emoji with skin
+            cy.findByPlaceholderText('Search emojis').should('exist').type('thumbsup').wait(TIMEOUTS.HALF_SEC);
+
+            // # Select the emoji to add to post with default skin
+            cy.findByTestId('+1,thumbsup').parent().click();
+        });
+
+        // # Open emoji picker again to check if thumbsup emoji is present in recent section
+        cy.uiOpenEmojiPicker().wait(TIMEOUTS.TWO_SEC);
+
+        cy.get('#emojiPicker').should('be.visible').within(() => {
+            // * Verify recently used category is present in emoji picker
+            cy.findByText('Recently Used').should('exist').and('be.visible');
+
+            // * Verify most recent one is the thumbsup emoji with default skin
+            cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', '+1 emoji');
+
+            // # Open skin picker again to change the skin
+            cy.findByAltText('emoji skin tone picker').should('exist').parent().click().wait(TIMEOUTS.ONE_SEC);
+
+            // # Select a dark skin tone
+            cy.findByTestId('skin-pick-1F3FF').should('exist').parent().click();
+
+            // * Verify most recent one is the same thumbsup emoji but now with a dark skin tone
+            cy.findAllByTestId('emojiItem').eq(0).find('img').should('have.attr', 'aria-label', '+1 dark skin tone emoji');
+        });
+
+        // # Close emoji picker
+        cy.get('body').type('{esc}', {force: true});
+    });
+});

--- a/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
@@ -29,9 +29,7 @@ describe('Recent Emoji', () => {
                 EnableCustomEmoji: true,
             },
         });
-    });
 
-    beforeEach(() => {
         cy.apiAdminLogin();
 
         cy.apiInitSetup().then(({team, user}) => {
@@ -89,6 +87,7 @@ describe('Recent Emoji', () => {
         const {customEmoji, customEmojiWithColons} = getCustomEmoji();
 
         // # Open custom emoji
+        cy.reload();
         cy.uiOpenCustomEmoji();
 
         // # Click on add new emoji button on custom emoji page

--- a/e2e/cypress/integration/mark_as_unread/mark_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_as_unread_spec.js
@@ -218,7 +218,7 @@ describe('Mark as Unread', () => {
         verifyPostNextToNewMessageSeparator('post3');
     });
 
-    it('Should show cursor pointer when holding down alt', () => {
+    it('Should show cursor pointer when holding down alt -- KNOWN ISSUE: MM-41538', () => {
         const componentIds = [
             `#post_${post1.id}`,
             `#post_${post2.id}`,


### PR DESCRIPTION
#### Summary
- recently_used_emoji_spec is passing for me locally but noticed the issue on cypress run might have something to do with calling beforeEach on every test. Modified the test so that setup is only once, hopefully fixing the finicky test on cypress run
- Added `KNOWN ISSUE: MM-41538`

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2022-02-03 at 2 35 17 PM](https://user-images.githubusercontent.com/487991/152441239-8d005678-9d02-4c9d-be67-d1a783875f42.png)
![Screen Shot 2022-02-03 at 2 37 51 PM](https://user-images.githubusercontent.com/487991/152441243-003c1c77-473c-4351-be98-ab146b69e601.png)

#### Release Note
```release-note
NONE
```