### PR TITLE
MM-41511 Fix repeated calls to makeGetCategory

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel_link/index.ts
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/index.ts
@@ -5,21 +5,21 @@ import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
 
 import {getCurrentUserId, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
-import {getInt, makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
+import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 
 import {Channel} from 'mattermost-redux/types/channels';
 import {GenericAction} from 'mattermost-redux/types/actions';
-import {PreferenceType} from 'mattermost-redux/types/preferences';
 import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
 import {getChannelsNameMapInCurrentTeam, makeGetChannelUnreadCount} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {open as openLhs} from 'actions/views/lhs.js';
 import {clearChannelSelection, multiSelectChannelAdd, multiSelectChannelTo} from 'actions/views/channel_sidebar';
+import {getFirstChannelName} from 'selectors/onboarding';
 import {isChannelSelected} from 'selectors/views/channel_sidebar';
 import {getIsMobileView} from 'selectors/views/browser';
 import {GlobalState} from 'types/store';
-import Constants, {Preferences, RecommendedNextSteps} from 'utils/constants';
+import Constants from 'utils/constants';
 
 import SidebarChannelLink from './sidebar_channel_link';
 
@@ -35,11 +35,7 @@ function makeMapStateToProps() {
 
         const unreadCount = getUnreadCount(state, ownProps.channel.id);
 
-        const getCategory = makeGetCategory();
-        const preferences = getCategory(state, Preferences.AB_TEST_PREFERENCE_VALUE);
-        const firstChannelNameFromPref = preferences.find((pref: PreferenceType) => pref.name === RecommendedNextSteps.CREATE_FIRST_CHANNEL);
-        const firstChannelNameFromRedux = state.views.channelSidebar.firstChannelName;
-        const firstChannelName = firstChannelNameFromRedux || firstChannelNameFromPref?.value;
+        const firstChannelName = getFirstChannelName(state);
 
         const channelsByName = getChannelsNameMapInCurrentTeam(state);
         const config = getConfig(state);

--- a/components/tutorial/tutorial_tip/index.ts
+++ b/components/tutorial/tutorial_tip/index.ts
@@ -7,19 +7,19 @@ import {getCurrentUser, getCurrentUserId} from 'mattermost-redux/selectors/entit
 import {
     getAutoTourTreatment,
     getInt,
-    makeGetCategory,
 } from 'mattermost-redux/selectors/entities/preferences';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {setProductMenuSwitcherOpen} from 'actions/views/product_menu';
 import {GenericAction} from 'mattermost-redux/types/actions';
-import {PreferenceType} from 'mattermost-redux/types/preferences';
 import {AutoTourTreatments} from 'mattermost-redux/constants/config';
 import {isAdmin} from 'mattermost-redux/utils/user_utils';
 
 import {closeMenu as closeRhsMenu} from 'actions/views/rhs';
 import {setFirstChannelName} from 'actions/views/channel_sidebar';
 
-import Constants, {Preferences, RecommendedNextSteps} from 'utils/constants';
+import {getFirstChannelName} from 'selectors/onboarding';
+
+import Constants, {Preferences} from 'utils/constants';
 import {GlobalState} from 'types/store';
 
 import TutorialTip from './tutorial_tip';
@@ -32,17 +32,13 @@ type OwnProps = {
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const currentUserId = getCurrentUserId(state);
     const categoryStep = ownProps.tutorialCategory || Preferences.TUTORIAL_STEP;
-    const getCategory = makeGetCategory();
-    const preferences = getCategory(state, Preferences.AB_TEST_PREFERENCE_VALUE);
-    const firstChannelNameFromPref = preferences.find((pref: PreferenceType) => pref.name === RecommendedNextSteps.CREATE_FIRST_CHANNEL);
-    const firstChannelNameFromRedux = state.views.channelSidebar.firstChannelName;
     const onBoardingAutoTourStatus = getInt(state, Preferences.TUTORIAL_STEP_AUTO_TOUR_STATUS, currentUserId, Constants.AutoTourStatus.ENABLED) === Constants.AutoTourStatus.ENABLED;
 
     return {
         currentUserId,
         currentStep: getInt(state, categoryStep, currentUserId, 0),
         autoTour: ownProps.tutorialCategory ? ownProps.autoTour : getAutoTourTreatment(state) === AutoTourTreatments.AUTO && onBoardingAutoTourStatus,
-        firstChannelName: (firstChannelNameFromRedux || firstChannelNameFromPref?.value) || '',
+        firstChannelName: getFirstChannelName(state),
         isAdmin: isAdmin(getCurrentUser(state).roles),
     };
 }

--- a/selectors/onboarding.ts
+++ b/selectors/onboarding.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {createSelector} from 'reselect';
+
+import {makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
+
+import {GlobalState} from 'types/store';
+
+import {Preferences, RecommendedNextSteps} from 'utils/constants';
+
+export const getABTestPreferences = (() => {
+    const getCategory = makeGetCategory();
+
+    return (state: GlobalState) => getCategory(state, Preferences.AB_TEST_PREFERENCE_VALUE);
+})();
+
+const getFirstChannelNamePref = createSelector(
+    'getFirstChannelNamePref',
+    getABTestPreferences,
+    (preferences) => {
+        return preferences.find((pref) => pref.name === RecommendedNextSteps.CREATE_FIRST_CHANNEL);
+    },
+);
+
+export function getFirstChannelName(state: GlobalState) {
+    let firstChannelName = state.views.channelSidebar.firstChannelName;
+    if (!firstChannelName) {
+        firstChannelName = getFirstChannelNamePref(state)?.value || '';
+    }
+
+    return firstChannelName;
+}


### PR DESCRIPTION
The main change here is to make it so that we're not calling `makeGetCategory` in the `mapStateToProps` since that creates a new instance of the selector each time which prevents it from doing any memoization. Normally, I would've moved just it out into the outer `makeMapStateToProps` to memoize it on a per-component basis, but I figured I'd pull it out into its own selector at the same time so that we only have a single instance of that selector instead of one-per-component.

This is also an effort to improve some performance issues we're seeing on community. The profiles we've collected on community contain a large number of calls which appear to be to the `clearChannelSelection` action passed to `SidebarChannelLink`, but I think there's something wrong with the source mapping there since the line number points to the `mapStateToProps` of the `SidebarChannelLink` instead. I'm hoping that this reduces the number of calls showing up there

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41511

#### Release Note
```release-note
NONE
```
