### PR TITLE
Mm 40894 not able to download license from download history

### DIFF
--- a/components/admin_console/billing/__snapshots__/billing_history.test.tsx.snap
+++ b/components/admin_console/billing/__snapshots__/billing_history.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/admin_console/billing/billing_history should match snapshot 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Subscription {
+        "handleChangeWrapper": [Function],
+        "listeners": Object {
+          "notify": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": null,
+      },
+    }
+  }
+>
+  <BillingHistory />
+</ContextProvider>
+`;

--- a/components/admin_console/billing/billing_history.test.tsx
+++ b/components/admin_console/billing/billing_history.test.tsx
@@ -1,0 +1,139 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {Provider} from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import thunk from 'redux-thunk';
+
+import {shallow} from 'enzyme';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
+
+import BillingHistory from './billing_history';
+
+describe('components/admin_console/billing/billing_history', () => {
+    // required state to mount using the provider
+    const state = {
+        entities: {
+            general: {
+                license: {
+                    IsLicensed: 'true',
+                },
+            },
+            cloud: {
+                invoices: {
+                    in_1KNb3DI67GP2qpb4ueaJYBt8: {
+                        id: 'in_1KNb3DI67GP2qpb4ueaJYBt8',
+                        number: '87030375-0015',
+                        create_at: 1643540071000,
+                        total: 1000,
+                        tax: 0,
+                        status: 'open',
+                        description: '',
+                        period_start: 1642330466000,
+                        period_end: 1643540066000,
+                        subscription_id: 'sub_1KIWNTI67GP2qpb49XXiEscG',
+                        line_items: [
+                            {
+                                price_id: 'price_1JMAbZI67GP2qpb4ADjRJwYa',
+                                total: 1000,
+                                quantity: 1,
+                                price_per_unit: 1000,
+                                description:
+                                    '1 × Cloud Professional (at $10.00 / month)',
+                                type: 'onpremise',
+                                metadata: {},
+                            },
+                        ],
+                    },
+                    in_1KIWNTI67GP2qpb4KjGj1KAy: {
+                        id: 'in_1KIWNTI67GP2qpb4KjGj1KAy',
+                        number: '87030375-0013',
+                        create_at: 1642330467000,
+                        total: 0,
+                        tax: 0,
+                        status: 'paid',
+                        description: '',
+                        period_start: 1642330466000,
+                        period_end: 1642330466000,
+                        subscription_id: 'sub_1KIWNTI67GP2qpb49XXiEscG',
+                        line_items: [
+                            {
+                                price_id: 'price_1JMAbZI67GP2qpb4ADjRJwYa',
+                                total: 0,
+                                quantity: 1,
+                                price_per_unit: 1000,
+                                description:
+                                    'Trial period for Cloud Professional',
+                                type: 'onpremise',
+                                metadata: {},
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        views: {},
+    };
+
+    const NO_INVOICES_LEGEND = 'All of your monthly payments will show here';
+
+    const mockStore = configureStore([thunk]);
+    const store = mockStore(state);
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <Provider store={store}>
+                <BillingHistory/>
+            </Provider>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Billing history section shows template when no invoices have been emmitted yet', () => {
+        const noBillingHistoryState = {
+            ...state,
+            entities: {...state.entities, cloud: {invoices: {}}},
+        };
+        const storeNoBillingHistory = mockStore(noBillingHistoryState);
+        const wrapper = mountWithIntl(
+            <Provider store={storeNoBillingHistory}>
+                <BillingHistory/>
+            </Provider>,
+        );
+
+        const legend = wrapper.find(
+            '.BillingHistory__cardHeaderText-bottom span',
+        );
+        expect(legend.text()).toBe(NO_INVOICES_LEGEND);
+    });
+
+    test('Billing history section shows two invoices to download', () => {
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <BillingHistory/>
+            </Provider>,
+        );
+
+        const invoiceTableRows = wrapper.find('table.BillingHistory__table tr.BillingHistory__table-row');
+
+        expect(invoiceTableRows.length).toBe(2);
+    });
+
+    test('Billing history section download button has the target property set as _self so it works well in desktop app', () => {
+        const wrapper = mountWithIntl(
+            <Provider store={store}>
+                <BillingHistory/>
+            </Provider>,
+        );
+
+        const invoiceTableRow = wrapper.find('table.BillingHistory__table tr.BillingHistory__table-row').at(0);
+
+        const downloadLink = invoiceTableRow.find('td.BillingHistory__table-invoice a');
+
+        expect(downloadLink.prop('target')).toBe('_self');
+    });
+});

--- a/components/admin_console/billing/billing_history.test.tsx
+++ b/components/admin_console/billing/billing_history.test.tsx
@@ -23,6 +23,12 @@ describe('components/admin_console/billing/billing_history', () => {
                     IsLicensed: 'true',
                 },
             },
+            users: {
+                currentUserId: 'current_user_id',
+                profiles: {
+                    current_user_id: {roles: 'system_role'},
+                },
+            },
             cloud: {
                 invoices: {
                     in_1KNb3DI67GP2qpb4ueaJYBt8: {

--- a/components/admin_console/billing/billing_history.tsx
+++ b/components/admin_console/billing/billing_history.tsx
@@ -211,7 +211,7 @@ const BillingHistory: React.FC<Props> = () => {
                         </td>
                         <td className='BillingHistory__table-invoice'>
                             <a
-                                target='_new'
+                                target='_self'
                                 rel='noopener noreferrer'
                                 href={Client4.getInvoicePdfUrl(invoice.id)}
                             >

--- a/components/admin_console/billing/billing_history.tsx
+++ b/components/admin_console/billing/billing_history.tsx
@@ -23,10 +23,6 @@ import InvoiceUserCount from './invoice_user_count';
 
 import './billing_history.scss';
 
-type Props = {
-
-};
-
 const PAGE_LENGTH = 4;
 
 const noBillingHistorySection = (
@@ -91,7 +87,7 @@ const getPaymentStatus = (status: string) => {
     }
 };
 
-const BillingHistory: React.FC<Props> = () => {
+const BillingHistory = () => {
     const dispatch = useDispatch();
     const invoices = useSelector((state: GlobalState) => state.entities.cloud.invoices);
 
@@ -151,75 +147,77 @@ const BillingHistory: React.FC<Props> = () => {
     const billingHistoryTable = billingHistory && (
         <>
             <table className='BillingHistory__table'>
-                <tr className='BillingHistory__table-header'>
-                    <th>
-                        <FormattedMessage
-                            id='admin.billing.history.date'
-                            defaultMessage='Date'
-                        />
-                    </th>
-                    <th>
-                        <FormattedMessage
-                            id='admin.billing.history.description'
-                            defaultMessage='Description'
-                        />
-                    </th>
-                    <th className='BillingHistory__table-headerTotal'>
-                        <FormattedMessage
-                            id='admin.billing.history.total'
-                            defaultMessage='Total'
-                        />
-                    </th>
-                    <th>
-                        <FormattedMessage
-                            id='admin.billing.history.status'
-                            defaultMessage='Status'
-                        />
-                    </th>
-                    <th>{''}</th>
-                </tr>
-                {billingHistory.map((invoice: Invoice) => (
-                    <tr
-                        className='BillingHistory__table-row'
-                        key={invoice.id}
-                    >
-                        <td>
-                            <FormattedDate
-                                value={new Date(invoice.period_start)}
-                                month='2-digit'
-                                day='2-digit'
-                                year='numeric'
-                                timeZone='UTC'
+                <tbody>
+                    <tr className='BillingHistory__table-header'>
+                        <th>
+                            <FormattedMessage
+                                id='admin.billing.history.date'
+                                defaultMessage='Date'
                             />
-                        </td>
-                        <td>
-                            <div>{invoice.current_product_name}</div>
-                            <div className='BillingHistory__table-bottomDesc'>
-                                <InvoiceUserCount invoice={invoice}/>
-                            </div>
-                        </td>
-                        <td className='BillingHistory__table-total'>
-                            <FormattedNumber
-                                value={(invoice.total / 100.0)}
-                                // eslint-disable-next-line react/style-prop-object
-                                style='currency'
-                                currency='USD'
+                        </th>
+                        <th>
+                            <FormattedMessage
+                                id='admin.billing.history.description'
+                                defaultMessage='Description'
                             />
-                        </td>
-                        <td>
-                            {getPaymentStatus(invoice.status)}
-                        </td>
-                        <td className='BillingHistory__table-invoice'>
-                            <a
-                                target='_self'
-                                rel='noopener noreferrer'
-                                href={Client4.getInvoicePdfUrl(invoice.id)}
-                            >
-                                <i className='icon icon-file-pdf-outline'/>
-                            </a>
-                        </td>
+                        </th>
+                        <th className='BillingHistory__table-headerTotal'>
+                            <FormattedMessage
+                                id='admin.billing.history.total'
+                                defaultMessage='Total'
+                            />
+                        </th>
+                        <th>
+                            <FormattedMessage
+                                id='admin.billing.history.status'
+                                defaultMessage='Status'
+                            />
+                        </th>
+                        <th>{''}</th>
                     </tr>
-                ))}
+                    {billingHistory.map((invoice: Invoice) => (
+                        <tr
+                            className='BillingHistory__table-row'
+                            key={invoice.id}
+                        >
+                            <td>
+                                <FormattedDate
+                                    value={new Date(invoice.period_start)}
+                                    month='2-digit'
+                                    day='2-digit'
+                                    year='numeric'
+                                    timeZone='UTC'
+                                />
+                            </td>
+                            <td>
+                                <div>{invoice.current_product_name}</div>
+                                <div className='BillingHistory__table-bottomDesc'>
+                                    <InvoiceUserCount invoice={invoice}/>
+                                </div>
+                            </td>
+                            <td className='BillingHistory__table-total'>
+                                <FormattedNumber
+                                    value={(invoice.total / 100.0)}
+                                    // eslint-disable-next-line react/style-prop-object
+                                    style='currency'
+                                    currency='USD'
+                                />
+                            </td>
+                            <td>
+                                {getPaymentStatus(invoice.status)}
+                            </td>
+                            <td className='BillingHistory__table-invoice'>
+                                <a
+                                    target='_self'
+                                    rel='noopener noreferrer'
+                                    href={Client4.getInvoicePdfUrl(invoice.id)}
+                                >
+                                    <i className='icon icon-file-pdf-outline'/>
+                                </a>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
             </table>
             {paging}
         </>


### PR DESCRIPTION
#### Summary
This PR removes the value _new from anchor target property. _new is not a valid value, it just works to open a new tab window because it tries to open an existing tab named _new, since it fails to find it, it results in opening a new empty tab. Also, replacing it to _self so it works fine for downloading invoices from the desktop app which is the place where originally the problem was found.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40894

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9645

#### Screenshots

https://user-images.githubusercontent.com/10082627/152431906-80358f2c-9f7e-4fd5-927d-f4a274fa035e.mp4

#### Release Note
```release-note
NONE
```
