### PR TITLE
Fix and update channel switch performance telemetry tracking

### DIFF
--- a/actions/telemetry_actions.jsx
+++ b/actions/telemetry_actions.jsx
@@ -14,9 +14,9 @@ const SUPPORTS_MEASURE_METHODS = isSupported([
     performance.clearMeasures,
 ]);
 
-export function trackEvent(category, event, props = {}) {
+export function trackEvent(category, event, props) {
     Client4.trackEvent(category, event, props);
-    if (isDevMode() && category === 'performance') {
+    if (isDevMode() && category === 'performance' && props) {
         // eslint-disable-next-line no-console
         console.log(`${event}: ${props.duration}ms, fresh: ${props.fresh}`);
     }

--- a/actions/telemetry_actions.jsx
+++ b/actions/telemetry_actions.jsx
@@ -14,8 +14,12 @@ const SUPPORTS_MEASURE_METHODS = isSupported([
     performance.clearMeasures,
 ]);
 
-export function trackEvent(category, event, props) {
+export function trackEvent(category, event, props = {}) {
     Client4.trackEvent(category, event, props);
+    if (isDevMode() && category === 'performance') {
+        // eslint-disable-next-line no-console
+        console.log(`${event}: ${props.duration}ms, fresh: ${props.fresh}`);
+    }
 }
 
 export function pageVisited(category, name) {

--- a/components/channel_view/channel_view.tsx
+++ b/components/channel_view/channel_view.tsx
@@ -10,7 +10,6 @@ import ChannelHeader from 'components/channel_header';
 import CreatePost from 'components/create_post';
 import FileUploadOverlay from 'components/file_upload_overlay';
 import PostView from 'components/post_view';
-import {clearMarks, mark, measure, trackEvent} from 'actions/telemetry_actions.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 import {browserHistory} from 'utils/browser_history';
@@ -105,23 +104,6 @@ export default class ChannelView extends React.PureComponent<Props, State> {
 
     componentDidUpdate(prevProps: Props) {
         if (prevProps.channelId !== this.props.channelId || prevProps.channelIsArchived !== this.props.channelIsArchived) {
-            mark('ChannelView#componentDidUpdate');
-
-            const [dur1] = measure('SidebarChannelLink#click', 'ChannelView#componentDidUpdate');
-            const [dur2] = measure('TeamLink#click', 'ChannelView#componentDidUpdate');
-
-            clearMarks([
-                'SidebarChannelLink#click',
-                'ChannelView#componentDidUpdate',
-                'TeamLink#click',
-            ]);
-
-            if (dur1 !== -1) {
-                trackEvent('performance', 'channel_switch', {duration: Math.round(dur1)});
-            }
-            if (dur2 !== -1) {
-                trackEvent('performance', 'team_switch', {duration: Math.round(dur2)});
-            }
             if (this.props.channelIsArchived && !this.props.viewArchivedChannels) {
                 this.props.actions.goToLastViewedChannel();
             }

--- a/components/post_view/post_list/post_list.jsx
+++ b/components/post_view/post_list/post_list.jsx
@@ -8,11 +8,34 @@ import LoadingScreen from 'components/loading_screen';
 import {PostRequestTypes} from 'utils/constants';
 
 import {getOldestPostId, getLatestPostId} from 'utils/post_utils';
+import {clearMarks, mark, measure, trackEvent} from 'actions/telemetry_actions.jsx';
 
 import VirtPostList from 'components/post_view/post_list_virtualized/post_list_virtualized';
 
 const MAX_NUMBER_OF_AUTO_RETRIES = 3;
 export const MAX_EXTRA_PAGES_LOADED = 10;
+
+// Measures the time between channel or team switch started and the post list component rendering posts.
+// Set "fresh" to true when the posts have not been loaded before.
+function markAndMeasureChannelSwitchEnd(fresh = false) {
+    mark('PostList#component');
+
+    const [dur1] = measure('SidebarChannelLink#click', 'PostList#component');
+    const [dur2] = measure('TeamLink#click', 'PostList#component');
+
+    clearMarks([
+        'SidebarChannelLink#click',
+        'TeamLink#click',
+        'PostList#component',
+    ]);
+
+    if (dur1 !== -1) {
+        trackEvent('performance', 'channel_switch', {duration: Math.round(dur1), fresh});
+    }
+    if (dur2 !== -1) {
+        trackEvent('performance', 'team_switch', {duration: Math.round(dur2), fresh});
+    }
+}
 
 export default class PostList extends React.PureComponent {
     static propTypes = {
@@ -131,7 +154,6 @@ export default class PostList extends React.PureComponent {
         };
 
         this.autoRetriesCount = 0;
-        this.loadingMorePosts = null;
         this.actionsForPostList = {
             loadOlderPosts: this.getPostsBefore,
             loadNewerPosts: this.getPostsAfter,
@@ -146,12 +168,18 @@ export default class PostList extends React.PureComponent {
         this.mounted = true;
         if (this.props.channelId) {
             this.postsOnLoad(this.props.channelId);
+            if (this.props.postListIds) {
+                markAndMeasureChannelSwitchEnd();
+            }
         }
     }
 
     componentDidUpdate(prevProps) {
         if (this.props.channelId !== prevProps.channelId) {
             this.postsOnLoad(this.props.channelId);
+        }
+        if (this.props.postListIds != null && prevProps.postListIds == null) {
+            markAndMeasureChannelSwitchEnd(true);
         }
     }
 

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -139,7 +139,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
     removeTooltipLink = (): void => this.gmItemRef.current?.removeAttribute?.('aria-describedby');
 
     handleChannelClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
-        mark('SidebarLink#click');
+        mark('SidebarChannelLink#click');
         trackEvent('ui', 'ui_channel_selected_v2');
 
         this.handleSelectChannel(event);


### PR DESCRIPTION
#### Summary
I noticed two things in the telemetry data we were receiving:

1. The `channel_switch` events were no longer being reported.
2. The old `channel_switch` and existing `team_switch` data was reporting seemed low at around 200ms.

It was easy to spot that 1) was broken because of a mismatched name when marking the `channel_switch` event.

For 2) we were measuring when ChannelView updated which didn't mean that posts had been loaded and rendered. I moved that measuring to PostList and ensured that the posts had been loaded/mounted before marking the switch as complete. I also introduced the idea of `fresh` switches into the telemetry which indicates whether the posts for that channel had been loaded previously or not. This still isn't a perfect measurement but it will be more accurate to what the user perceives as the performance and gives us a bit more insight than we had before.

I also started console logging the performance events in developer mode and removed one dead line of code.

#### Release Note
```release-note
NONE
```
