### PR TITLE
MM-41342 Revert fixes related to using team sidebar in products

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -447,46 +447,44 @@ export default class Root extends React.PureComponent {
                     <CompassThemeProvider theme={this.props.theme}>
                         <ModalController/>
                         <GlobalHeader/>
-                        <div className='mainContentRow d-flex flex-row'>
-                            <TeamSidebar/>
-                            <Switch>
-                                {this.props.products?.map((product) => (
-                                    <Route
-                                        key={product.id}
-                                        path={product.baseURL}
-                                        render={(props) => (
-                                            <LoggedIn {...props}>
-                                                <div className={classNames(['product-wrapper', {wide: !product.showTeamSidebar}])}>
-                                                    <Pluggable
-                                                        pluggableName={'Product'}
-                                                        subComponentName={'mainComponent'}
-                                                        pluggableId={product.id}
-                                                        webSocketClient={webSocketClient}
-                                                    />
-                                                </div>
-                                            </LoggedIn>
-                                        )}
-                                    />
-                                ))}
-                                {this.props.plugins?.map((plugin) => (
-                                    <Route
-                                        key={plugin.id}
-                                        path={'/plug/' + plugin.route}
-                                        render={() => (
-                                            <Pluggable
-                                                pluggableName={'CustomRouteComponent'}
-                                                pluggableId={plugin.id}
-                                            />
-                                        )}
-                                    />
-                                ))}
-                                <LoggedInRoute
-                                    path={'/:team'}
-                                    component={NeedsTeam}
+                        <TeamSidebar/>
+                        <Switch>
+                            {this.props.products?.map((product) => (
+                                <Route
+                                    key={product.id}
+                                    path={product.baseURL}
+                                    render={(props) => (
+                                        <LoggedIn {...props}>
+                                            <div className={classNames(['product-wrapper', {wide: !product.showTeamSidebar}])}>
+                                                <Pluggable
+                                                    pluggableName={'Product'}
+                                                    subComponentName={'mainComponent'}
+                                                    pluggableId={product.id}
+                                                    webSocketClient={webSocketClient}
+                                                />
+                                            </div>
+                                        </LoggedIn>
+                                    )}
                                 />
-                                <RootRedirect/>
-                            </Switch>
-                        </div>
+                            ))}
+                            {this.props.plugins?.map((plugin) => (
+                                <Route
+                                    key={plugin.id}
+                                    path={'/plug/' + plugin.route}
+                                    render={() => (
+                                        <Pluggable
+                                            pluggableName={'CustomRouteComponent'}
+                                            pluggableId={plugin.id}
+                                        />
+                                    )}
+                                />
+                            ))}
+                            <LoggedInRoute
+                                path={'/:team'}
+                                component={NeedsTeam}
+                            />
+                            <RootRedirect/>
+                        </Switch>
                         <Pluggable pluggableName='Global'/>
                     </CompassThemeProvider>
                 </Switch>

--- a/sass/base/_structure.scss
+++ b/sass/base/_structure.scss
@@ -82,7 +82,6 @@ body {
 
     position: relative;
     height: 100%;
-    flex: 1;
 
     #root {
         display: flex;
@@ -96,8 +95,4 @@ body {
 
 img {
     max-width: 100%;
-}
-
-.mainContentRow {
-    height: 100%;
 }

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -22,7 +22,7 @@
 }
 
 #SidebarContainer {
-    position: absolute;
+    position: fixed;
     z-index: 16;
     left: 0;
     display: flex;
@@ -1318,10 +1318,10 @@
 
 .multi-teams {
     #SidebarContainer {
-        left: 0;
+        left: 65px;
 
         + .inner-wrap #app-content {
-            margin-left: 240px;
+            margin-left: 305px;
         }
     }
 }
@@ -1365,6 +1365,8 @@
 @media screen and (min-width: 769px) {
     // adjust height of sidebar to account for global header
     #SidebarContainer {
+        height: calc(100% - 40px);
+
         .SidebarChannelNavigator {
             margin-top: 0;
             margin-bottom: 11px;

--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -1,4 +1,5 @@
 .team-sidebar {
+    position: fixed;
     z-index: 17;
     bottom: 0;
     left: 0;
@@ -161,13 +162,15 @@
         --sidebar-teambar-bg-rgb: var(--sidebar-header-bg-rgb);
         --sidebar-header-text-color-rgb: var(--sidebar-text-rgb);
 
+        // adjust height of team sidebar
+        height: calc(100% - 40px);
         border-right: solid 1px rgba(var(--center-channel-color-rgb), 0.08);
     }
 }
 
 .product-wrapper {
-    height: 100%;
-    flex: 1;
+    width: calc(100% - 65px);
+    height: calc(100% - 40px);
     margin-left: auto;
 
     &.wide {

--- a/sass/routes/_backstage.scss
+++ b/sass/routes/_backstage.scss
@@ -1,5 +1,4 @@
 .backstage {
-    position: absolute;
     width: 100vw;
     height: 100vh;
 }
@@ -556,6 +555,7 @@
 // global header style adjustments
 @media screen and (min-width: 769px) {
     .backstage {
+        position: relative;
         z-index: 110;
         margin-top: -40px;
     }


### PR DESCRIPTION
As discussed in https://community-daily.mattermost.com/core/pl/7rqqd1g1pig4xb1pp4j7ybnmqo, we're reverting these changes since the root CSS for the page is fragile, and those changes ended up breaking the position of some elements (notably the centre pane in Playbooks/Boards and the announcement bar/sidebar in Channels)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41342

#### Related Pull Requests
https://github.com/mattermost/focalboard/pull/2263

#### Screenshots
||Before|After|
|-|-|-|
|Desktop View*|![Screen Shot 2022-02-04 at 1 40 40 PM](https://user-images.githubusercontent.com/3277310/152585003-1b85d1c7-ea1c-428b-92b4-1b6be9c80cb5.png)|![Screen Shot 2022-02-04 at 1 40 52 PM](https://user-images.githubusercontent.com/3277310/152585019-c26bc7f3-149d-4684-93e7-0eaf60dbe8dd.png)|
|Mobile View|![Screen Shot 2022-02-04 at 1 40 24 PM](https://user-images.githubusercontent.com/3277310/152584908-d130dd48-b387-455b-858c-84a66a4d06fb.png)|![Screen Shot 2022-02-04 at 1 40 09 PM](https://user-images.githubusercontent.com/3277310/152584929-94256e91-93c1-44b4-a6b1-6e6ab52193e7.png)|

*: Note that the overlap of the team sidebar is a pre-existing issue with the announcement bar (https://mattermost.atlassian.net/browse/MM-40887)



#### Release Note
```release-note
NONE
```
