### PR TITLE
MM-40887 Fix team sidebar covered by global header with announcement bar visible

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -165,6 +165,10 @@
         // adjust height of team sidebar
         height: calc(100% - 40px);
         border-right: solid 1px rgba(var(--center-channel-color-rgb), 0.08);
+
+        body.announcement-bar--fixed & {
+            height: calc(100% - #{$announcement-bar-height} - 40px);
+        }
     }
 }
 


### PR DESCRIPTION
Based on https://github.com/mattermost/mattermost-webapp/pull/9755. Changes exclusive to it are in the latest commit

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40887

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9755

#### Screenshots

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/3277310/152589775-5fa18eff-a478-4158-869f-0209071eeaf8.png)|![Screen Shot 2022-02-04 at 2 15 28 PM](https://user-images.githubusercontent.com/3277310/152589821-c42b5811-b4ff-4b91-8407-315fa1c466ba.png)|
||![Screen Shot 2022-02-04 at 2 13 47 PM](https://user-images.githubusercontent.com/3277310/152589853-c9f2f7cd-7a0c-4966-9461-262c94c38a4f.png)|
||![Screen Shot 2022-02-04 at 2 15 55 PM](https://user-images.githubusercontent.com/3277310/152590008-483d3b4b-13f0-45b5-9fc1-8c6f89c4c355.png)|
||![Screen Shot 2022-02-04 at 2 13 54 PM](https://user-images.githubusercontent.com/3277310/152589953-e44d6761-ceb4-4444-a263-5896ab0cc4ea.png)|

#### Release Note
```release-note
Fixed team sidebar getting covered with announcement bar enabled
```
