### PR TITLE
[MM-36643] Have rudder use the domain given on SiteURL for its cookies.

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -185,12 +185,14 @@ export default class Root extends React.PureComponent {
         if (rudderKey != null && rudderKey !== '' && this.props.telemetryEnabled) {
             Client4.setTelemetryHandler(new RudderTelemetryHandler());
 
-            const siteURL = getConfig(store.getState()).SiteURL;
             const rudderCfg = {};
-            try {
-                rudderCfg.setCookieDomain = new URL(siteURL).hostname;
+            const siteURL = getConfig(store.getState()).SiteURL;
+            if (siteURL !== '') {
+                try {
+                    rudderCfg.setCookieDomain = new URL(siteURL).hostname;
                 // eslint-disable-next-line no-empty
-            } catch (e) {}
+                } catch (_) {}
+            }
             rudderAnalytics.load(rudderKey, rudderUrl, rudderCfg);
 
             rudderAnalytics.identify(telemetryId, {}, {

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -185,7 +185,13 @@ export default class Root extends React.PureComponent {
         if (rudderKey != null && rudderKey !== '' && this.props.telemetryEnabled) {
             Client4.setTelemetryHandler(new RudderTelemetryHandler());
 
-            rudderAnalytics.load(rudderKey, rudderUrl);
+            const siteURL = getConfig(store.getState()).SiteURL;
+            const rudderCfg = {};
+            try {
+                rudderCfg.setCookieDomain = new URL(siteURL).hostname;
+                // eslint-disable-next-line no-empty
+            } catch (e) {}
+            rudderAnalytics.load(rudderKey, rudderUrl, rudderCfg);
 
             rudderAnalytics.identify(telemetryId, {}, {
                 context: {


### PR DESCRIPTION
#### Summary
When mattermost is installed on a subdomain (e.g. mattermost.example.com), rudder parses the top-level domain and sets their cookies using a general `.example.com` making the cookie available in every subdomain. This PR ensures the cookie is set to the actual subdomain by parsing SiteURL from the config

(you'll find this part as a comment bellow also)
After further investigation, it appears that focalboard are doing their own telemetry on the side (enabled with their own config.json), so while this fixes the problem with the webapp, having focalboard enabled will make the issue reappear. I'm working on implementing the same code on focalboard.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36643

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
```release-note
Fixed a bug causing rudder to create their cookies on the top-level domain when mattermost is installed on a subdomain.
```
