### PR TITLE
#19517 Emoji picker render performance improvement

### DIFF
--- a/actions/emoji_actions.js
+++ b/actions/emoji_actions.js
@@ -35,6 +35,18 @@ export function loadRecentlyUsedCustomEmojis() {
     };
 }
 
+export function setCategoryOffset(category, offset) {
+    return async (dispatch) => {
+        dispatch({
+            type: ActionTypes.SET_CATEGORY_OFFSET,
+            category,
+            offset,
+        });
+
+        return {data: true};
+    };
+}
+
 export function incrementEmojiPickerPage() {
     return async (dispatch) => {
         dispatch({

--- a/components/emoji_picker/components/emoji_picker_category.tsx
+++ b/components/emoji_picker/components/emoji_picker_category.tsx
@@ -2,8 +2,10 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {connect} from 'react-redux';
 import {injectIntl, FormattedMessage, IntlShape} from 'react-intl';
 
+import type {ViewsState} from 'types/store/views';
 import OverlayTrigger from 'components/overlay_trigger';
 import Tooltip from 'components/tooltip';
 import {Constants} from 'utils/constants';
@@ -19,8 +21,9 @@ type Category = {
 type Props = {
     intl: IntlShape;
     category: Category;
+    categoryOffsets: ViewsState['emoji']['categoryOffsets'];
     icon: React.ReactNode;
-    onCategoryClick: (categoryName: string) => void;
+    onCategoryClick: (categoryName: string, categoryOffsets: ViewsState['emoji']['categoryOffsets']) => void;
     selected: boolean;
     enable: boolean;
 }
@@ -33,7 +36,7 @@ class EmojiPickerCategory extends React.Component<Props> {
 
     handleClick = (e: React.MouseEvent) => {
         e.preventDefault();
-        this.props.onCategoryClick(this.props.category.name);
+        this.props.onCategoryClick(this.props.category.name, this.props.categoryOffsets);
     }
 
     render() {
@@ -79,4 +82,11 @@ class EmojiPickerCategory extends React.Component<Props> {
     }
 }
 
-export default injectIntl(EmojiPickerCategory);
+function mapStateToProps(state: { views: { emoji: { categoryOffsets: ViewsState['emoji']['categoryOffsets']}}}) {
+    return {
+        categoryOffsets: state.views.emoji.categoryOffsets,
+    };
+}
+
+export default injectIntl(
+    connect(mapStateToProps, null, null, {forwardRef: true})(EmojiPickerCategory));

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -66,7 +66,6 @@ function createCategory(name) {
         id: Emoji.CategoryTranslations.get(name, `emoji_picker.${name}`),
         className: categoryClass.get(name, DEFAULT_CLASS),
         message: Emoji.CategoryMessage.get(name, name),
-        offset: 0,
     };
 }
 
@@ -109,6 +108,7 @@ export default class EmojiPicker extends React.PureComponent {
             getCustomEmojis: PropTypes.func.isRequired,
             searchCustomEmojis: PropTypes.func.isRequired,
             incrementEmojiPickerPage: PropTypes.func.isRequired,
+            setCategoryOffset: PropTypes.func.isRequired,
             setUserSkinTone: PropTypes.func.isRequired,
         }).isRequired,
         filter: PropTypes.string.isRequired,
@@ -310,13 +310,13 @@ export default class EmojiPicker extends React.PureComponent {
         this.searchInput = input;
     };
 
-    handleCategoryClick = (categoryName) => {
+    handleCategoryClick = (categoryName, categoryOffsets) => {
         this.setState({
             cursor: [Object.keys(this.state.categories).indexOf(categoryName), 0],
         });
-        if (this.state.categories[categoryName]) {
-            this.updateEmojisToShow(this.state.categories[categoryName].offset);
-            this.emojiPickerContainer.scrollTop = this.state.categories[categoryName].offset;
+        if (categoryOffsets[categoryName]) {
+            this.updateEmojisToShow(categoryOffsets[categoryName]);
+            this.emojiPickerContainer.scrollTop = categoryOffsets[categoryName];
         }
     }
 
@@ -799,15 +799,7 @@ export default class EmojiPicker extends React.PureComponent {
 
     updateCategoryOffset = (categoryName, offset) => {
         if (categoryName !== CATEGORY_SEARCH_RESULTS) {
-            this.setState((state) => ({
-                categories: {
-                    ...state.categories,
-                    [categoryName]: {
-                        ...state.categories[categoryName],
-                        offset,
-                    },
-                },
-            }));
+            this.props.actions.setCategoryOffset(categoryName, offset);
         }
     }
 

--- a/components/emoji_picker/emoji_picker.test.jsx
+++ b/components/emoji_picker/emoji_picker.test.jsx
@@ -43,6 +43,7 @@ describe('components/emoji_picker/EmojiPicker', () => {
         getCustomEmojis: jest.fn(),
         incrementEmojiPickerPage: jest.fn(),
         searchCustomEmojis: jest.fn(),
+        setCategoryOffset: jest.fn(),
         setUserSkinTone: jest.fn(),
     };
 

--- a/components/emoji_picker/index.js
+++ b/components/emoji_picker/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import {getCustomEmojis, searchCustomEmojis} from 'mattermost-redux/actions/emojis';
 
-import {incrementEmojiPickerPage, setUserSkinTone} from 'actions/emoji_actions';
+import {setCategoryOffset, incrementEmojiPickerPage, setUserSkinTone} from 'actions/emoji_actions';
 import {getEmojiMap, getRecentEmojis, getUserSkinTone} from 'selectors/emojis';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
@@ -30,6 +30,7 @@ function mapDispatchToProps(dispatch) {
             getCustomEmojis,
             searchCustomEmojis,
             incrementEmojiPickerPage,
+            setCategoryOffset,
             setUserSkinTone,
         }, dispatch),
     };

--- a/reducers/views/emoji.ts
+++ b/reducers/views/emoji.ts
@@ -8,6 +8,18 @@ import type {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes, Locations} from 'utils/constants';
 
+function categoryOffsets(state = {}, action: GenericAction) {
+    switch (action.type) {
+    case ActionTypes.SET_CATEGORY_OFFSET:
+        return {
+            ...state,
+            [action.category]: action.offset,
+        };
+    default:
+        return state;
+    }
+}
+
 function emojiPickerCustomPage(state = 0, action: GenericAction) {
     switch (action.type) {
     case ActionTypes.INCREMENT_EMOJI_PICKER_PAGE:
@@ -39,6 +51,7 @@ function shortcutReactToLastPostEmittedFrom(state = '', action: GenericAction) {
 }
 
 export default combineReducers({
+    categoryOffsets,
     emojiPickerCustomPage,
     shortcutReactToLastPostEmittedFrom,
 });

--- a/types/store/views.ts
+++ b/types/store/views.ts
@@ -90,6 +90,9 @@ export type ViewsState = {
     };
 
     emoji: {
+        categoryOffsets: {
+            [category: string]: number;
+        };
         emojiPickerCustomPage: 0;
         shortcutReactToLastPostEmittedFrom: string;
     };

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -205,6 +205,7 @@ export const ActionTypes = keyMirror({
     UPDATE_CHANNEL_LAST_VIEWED_AT: null,
 
     INCREMENT_EMOJI_PICKER_PAGE: null,
+    SET_CATEGORY_OFFSET: null,
     SET_RECENT_SKIN: null,
 
     STATUS_DROPDOWN_TOGGLE: null,


### PR DESCRIPTION
#### Summary
Improved emoji picker performance by reducing renders by utilizing the redux store. 

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/19517

#### Related Pull Requests

#### Screenshots


|before|

<img width="1275" alt="Flamegraph Ranked" src="https://user-images.githubusercontent.com/19939186/152886143-3dfd6f38-5753-4667-99b5-85a60571ae43.png">

|after|
<img width="1273" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/19939186/152886156-49182d4e-8bb1-49f7-8fc3-11573f5e2c4b.png">|


#### Release Note

```
Improved emoji picker performance
```
