### PR TITLE
hide accordion items with status 'OK'

### DIFF
--- a/components/admin_console/workspace-optimization/dashboard.tsx
+++ b/components/admin_console/workspace-optimization/dashboard.tsx
@@ -187,31 +187,6 @@ const WorkspaceOptimizationDashboard = (props: Props) => {
             if (item.status === undefined) {
                 return;
             }
-            items.push((
-                <AccordionItem
-                    key={`${accordionKey}-item_${item.id}`}
-                    iconColor={item.status}
-                >
-                    <h5>
-                        <i
-                            className={classNames(`icon ${item.status}`, {
-                                'icon-check-circle-outline': item.status === 'ok',
-                                'icon-alert-outline': item.status === 'warning',
-                                'icon-alert-circle-outline': item.status === 'error',
-                                'icon-information-outline': item.status === 'info',
-                            })}
-                        />
-                        {item.title}
-                    </h5>
-                    <p>{item.description}</p>
-                    <CtaButtons
-                        learnMoreLink={item.infoUrl}
-                        learnMoreText={learnMoreText}
-                        actionLink={item.configUrl}
-                        actionText={item.configText}
-                    />
-                </AccordionItem>
-            ));
 
             // add the items impact to the overall score here
             overallScore.max += item.scoreImpact;
@@ -219,6 +194,31 @@ const WorkspaceOptimizationDashboard = (props: Props) => {
 
             // chips will only be displayed for info aka Success, warning and error aka Problems
             if (item.status && item.status !== 'none' && item.status !== 'ok') {
+                items.push((
+                    <AccordionItem
+                        key={`${accordionKey}-item_${item.id}`}
+                        iconColor={item.status}
+                    >
+                        <h5>
+                            <i
+                                className={classNames(`icon ${item.status}`, {
+                                    'icon-alert-outline': item.status === 'warning',
+                                    'icon-alert-circle-outline': item.status === 'error',
+                                    'icon-information-outline': item.status === 'info',
+                                })}
+                            />
+                            {item.title}
+                        </h5>
+                        <p>{item.description}</p>
+                        <CtaButtons
+                            learnMoreLink={item.infoUrl}
+                            learnMoreText={learnMoreText}
+                            actionLink={item.configUrl}
+                            actionText={item.configText}
+                        />
+                    </AccordionItem>
+                ));
+
                 accordionDataChips[item.status] += 1;
                 overallScoreChips[item.status] += 1;
             }

--- a/components/common/accordion/accordion.tsx
+++ b/components/common/accordion/accordion.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 import React, {RefObject, useState} from 'react';
 
-import AccordionItem from './accordion_item';
+import AccordionCard from './accordion_card';
 import './accordion.scss';
 
 export type AccordionItemType = {
@@ -47,7 +47,7 @@ const Accordion = ({
             {accordionItemsData.map((accordionItem, index) => {
                 const isExpanded = Boolean((expandMultiple ? (currentIndexes.includes(index)) : (index === currentIndex)));
                 return (
-                    <AccordionItem
+                    <AccordionCard
                         key={index.toString()}
                         data={accordionItem}
                         isExpanded={isExpanded}

--- a/components/common/accordion/accordion_card.tsx
+++ b/components/common/accordion/accordion_card.tsx
@@ -13,7 +13,7 @@ type Props = {
     onHeaderClick?: <T>(ref: RefObject<HTMLLIElement>) => T | void;
 }
 
-const AccordionItem = ({
+const AccordionCard = ({
     data,
     isExpanded,
     onButtonClick,
@@ -23,7 +23,6 @@ const AccordionItem = ({
     const itemRef = useRef<HTMLLIElement>(null);
 
     const [height, setHeight] = useState(0);
-
     const [open, setOpen] = useState(isExpanded);
 
     const toggle = () => {
@@ -49,6 +48,8 @@ const AccordionItem = ({
         setOpen(isExpanded);
     }, [isExpanded]);
 
+    const hasItems = data.items.length > 0;
+
     return (
         <li
             className={`accordion-item ${open ? 'active' : ''}`}
@@ -56,28 +57,34 @@ const AccordionItem = ({
         >
             <div
                 className='accordion-item-header'
-                onClick={toggle}
-                role='button'
+                onClick={hasItems ? toggle : undefined}
+                role={hasItems ? 'button' : undefined}
             >
-                {data.icon && <div className='accordion-item-header__icon'>
-                    {data.icon}
-                </div>}
+                {data.icon && (
+                    <div className='accordion-item-header__icon'>
+                        {data.icon}
+                    </div>
+                )}
                 <div className='accordion-item-header__body'>
                     <div className='accordion-item-header__body__title'>
                         {data.title}
                     </div>
-                    {data.description && <div className='accordion-item-header__body__description'>
-                        {data.description}
-                    </div>}
+                    {data.description && (
+                        <div className='accordion-item-header__body__description'>
+                            {data.description}
+                        </div>
+                    )}
                 </div>
                 {data.extraContent && (
                     <div className='accordion-item-header__extraContent'>
                         {data.extraContent}
                     </div>
                 )}
-                {data.items.length > 0 && <div className='accordion-item-header__chevron'>
-                    <i className='icon-chevron-down'/>
-                </div>}
+                {hasItems && (
+                    <div className='accordion-item-header__chevron'>
+                        <i className='icon-chevron-down'/>
+                    </div>
+                )}
             </div>
             <div
                 className='accordion-item-container'
@@ -94,4 +101,4 @@ const AccordionItem = ({
     );
 };
 
-export default AccordionItem;
+export default AccordionCard;


### PR DESCRIPTION
#### Summary
title says it all. Items that have status `'ok'` or `'none'` get hidden from the `AccordionCard`. They still get counted in the overall score.

#### Ticket Link
n/a

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
