### PR TITLE
[MM-41544] Ensure that a default sound is always sent for desktop notifications

### DIFF
--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -18,7 +18,7 @@ import {isThreadOpen} from 'selectors/views/threads';
 import {browserHistory} from 'utils/browser_history';
 import Constants, {NotificationLevels, UserStatuses} from 'utils/constants';
 import {showNotification} from 'utils/notifications';
-import {isDesktopApp, isMacApp, isMobileApp, isWindowsApp} from 'utils/user_agent';
+import {isDesktopApp, isMobileApp} from 'utils/user_agent';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
 import {stripMarkdown} from 'utils/markdown';
@@ -169,7 +169,7 @@ export function sendDesktopNotification(post, msgProps) {
         }
         notify = notify || !state.views.browser.focused;
 
-        const soundName = user.notify_props !== undefined && user.notify_props.desktop_notification_sound !== undefined ? user.notify_props.desktop_notification_sound : 'None';
+        const soundName = user.notify_props !== undefined && user.notify_props.desktop_notification_sound !== undefined ? user.notify_props.desktop_notification_sound : 'Bing';
 
         if (notify) {
             const updatedState = getState();
@@ -182,7 +182,7 @@ export function sendDesktopNotification(post, msgProps) {
             dispatch(notifyMe(title, body, channel, teamId, !sound, soundName, url));
 
             //Don't add extra sounds on native desktop clients
-            if (sound && !isWindowsApp() && !isMacApp() && !isMobileApp()) {
+            if (sound && !isDesktopApp() && !isMobileApp()) {
                 Utils.ding(soundName);
             }
         }

--- a/actions/notification_actions.test.js
+++ b/actions/notification_actions.test.js
@@ -6,6 +6,7 @@ import testConfigureStore from 'tests/test_store';
 import {browserHistory} from 'utils/browser_history';
 import Constants, {NotificationLevels, UserStatuses} from 'utils/constants';
 import * as utils from 'utils/notifications';
+import * as baseUtils from 'utils/utils';
 
 import {sendDesktopNotification} from './notification_actions';
 
@@ -21,6 +22,7 @@ describe('notification_actions', () => {
 
         beforeEach(() => {
             spy = jest.spyOn(utils, 'showNotification');
+            baseUtils.ding = jest.fn();
 
             crt = {
                 user_id: 'current_user_id',
@@ -293,6 +295,25 @@ describe('notification_actions', () => {
             const store = testConfigureStore(baseState);
             return store.dispatch(sendDesktopNotification(post, msgProps)).then(() => {
                 expect(spy).toHaveBeenCalled();
+            });
+        });
+
+        test('should default sound when no sound is specified', () => {
+            const dingSpy = jest.spyOn(baseUtils, 'ding');
+            baseState.entities.users.profiles.current_user_id.notify_props.desktop_sound = 'true';
+            const store = testConfigureStore(baseState);
+            return store.dispatch(sendDesktopNotification(post, msgProps)).then(() => {
+                expect(dingSpy).toHaveBeenCalledWith('Bing');
+            });
+        });
+
+        test('should use specified sound when specified', () => {
+            const dingSpy = jest.spyOn(baseUtils, 'ding');
+            baseState.entities.users.profiles.current_user_id.notify_props.desktop_sound = 'true';
+            baseState.entities.users.profiles.current_user_id.notify_props.desktop_notification_sound = 'Crackle';
+            const store = testConfigureStore(baseState);
+            return store.dispatch(sendDesktopNotification(post, msgProps)).then(() => {
+                expect(dingSpy).toHaveBeenCalledWith('Crackle');
             });
         });
 


### PR DESCRIPTION
#### Summary
On the Linux Desktop App, we were noticing that users would receive duplicate notification sounds. We traced it to that we weren't excluding the Linux Desktop App from webapp based notification sounds (as the Desktop App generates its own).

Once that was fixed, I noticed that new accounts wouldn't get any sounds at all. Apparently we weren't defaulting the notification sound at all for Desktop, so that has now defaulted to `Bing` for Desktop, just like the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41544

```release-note
Fixed an issue where notification sounds wouldn't trigger on the Desktop App
Fixed an issue where you would get multiple sounds for one notification on the Linux Desktop App
```
