### PR TITLE
Pin the FROM in dockerfiles

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:14.16
+FROM node:14.16@sha256:e77e35d3b873500c10ce8969fe2ce5e0901516f77c8365d029c4b42b22ee4bac
 RUN apt-get update && apt-get install -y make gcc nasm libpng-dev
 CMD [ "node" ]

--- a/e2e/Dockerfile.webhook
+++ b/e2e/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-alpine@sha256:9a2aa545388a135b496bd55cef2be920b96c4526c99c140170e05a8de3fce653
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh


### PR DESCRIPTION
This prevents supply chain attacks where the latest image is replaced with a malicious version.

Pinning done by using https://github.com/Jille/dockpin (pins to the latest hash when run)
