### PR TITLE
MM-40770: Edited indicator icon overlapping is fixed

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1047,6 +1047,10 @@
         > i {
             margin-right: 2px;
         }
+
+        > i::before {
+            letter-spacing: 0;
+        }
     }
 
     .emoticon {


### PR DESCRIPTION
#### Summary
Fixes an issue on "Edited" indicator icon overlaps text on certain browsers
Note for tests: please check it on all major browsers: Safari, Firefox, Chrome

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/19252

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="317" alt="Screen Shot 2022-02-09 at 23 19 26" src="https://user-images.githubusercontent.com/37421564/153300854-9ce50ece-73a3-4fad-a50a-5ac88aefef41.png"> | <img width="317" alt="Screen Shot 2022-02-09 at 23 17 20" src="https://user-images.githubusercontent.com/37421564/153300847-c3d11186-a52e-485c-8462-5f8aa9f9009c.png"> |

#### Release Note
-->
```release-note
NONE
```
