### PR TITLE
[MM-29724] Allow plugin to add menu items to the user guide dropdown

### DIFF
--- a/components/global_header/center_controls/user_guide_dropdown/__snapshots__/user_guide_dropdown.test.tsx.snap
+++ b/components/global_header/center_controls/user_guide_dropdown/__snapshots__/user_guide_dropdown.test.tsx.snap
@@ -158,3 +158,92 @@ exports[`components/channel_header/components/UserGuideDropdown should match sna
   </Menu>
 </MenuWrapper>
 `;
+
+exports[`components/channel_header/components/UserGuideDropdown should match snapshot when have plugin menu items 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className="userGuideHelp"
+  id="helpMenuPortal"
+  onToggle={[Function]}
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={500}
+    overlay={
+      <Tooltip
+        className="hidden-xs"
+        id="userGuideHelpTooltip"
+      >
+        <Memo(MemoizedFormattedMessage)
+          defaultMessage="Help"
+          id="channel_header.userHelpGuide"
+        />
+      </Tooltip>
+    }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <ForwardRef
+      active={false}
+      aria-label="Select to toggle the help menu."
+      compact={true}
+      icon="help-circle-outline"
+      inverted={true}
+      onClick={[Function]}
+      size="sm"
+    />
+  </OverlayTrigger>
+  <Menu
+    ariaLabel="Add Channel Dropdown"
+    id="AddChannelDropdown"
+    openLeft={true}
+    openUp={false}
+  >
+    <MenuGroup>
+      <MenuItemExternalLink
+        id="askTheCommunityLink"
+        onClick={[Function]}
+        show={true}
+        text="Ask the community"
+        url="https://mattermost.com/pl/default-ask-mattermost-community/"
+      />
+      <MenuItemExternalLink
+        id="helpResourcesLink"
+        show={true}
+        text="Help resources"
+        url="helpLink"
+      />
+      <MenuItemAction
+        icon={false}
+        id="gettingStarted"
+        onClick={[Function]}
+        show={false}
+        text="Getting Started"
+      />
+      <MenuItemExternalLink
+        id="reportAProblemLink"
+        show={true}
+        text="Report a problem"
+        url="reportAProblemLink"
+      />
+      <MenuItemAction
+        id="keyboardShortcuts"
+        onClick={[Function]}
+        show={true}
+        text="Keyboard shortcuts"
+      />
+      <MenuItemAction
+        id="testId_pluginmenuitem"
+        key="testId_pluginmenuitem"
+        show={true}
+        text="Test Item"
+      />
+    </MenuGroup>
+  </Menu>
+</MenuWrapper>
+`;

--- a/components/global_header/center_controls/user_guide_dropdown/__snapshots__/user_guide_dropdown.test.tsx.snap
+++ b/components/global_header/center_controls/user_guide_dropdown/__snapshots__/user_guide_dropdown.test.tsx.snap
@@ -240,6 +240,7 @@ exports[`components/channel_header/components/UserGuideDropdown should match sna
       <MenuItemAction
         id="testId_pluginmenuitem"
         key="testId_pluginmenuitem"
+        onClick={[Function]}
         show={true}
         text="Test Item"
       />

--- a/components/global_header/center_controls/user_guide_dropdown/index.ts
+++ b/components/global_header/center_controls/user_guide_dropdown/index.ts
@@ -9,6 +9,8 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {GenericAction} from 'mattermost-redux/types/actions';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 
+import {getUserGuideDropdownPluginMenuItems} from 'selectors/plugins';
+
 import {GlobalState} from 'types/store';
 
 import {unhideNextSteps} from 'actions/views/next_steps';
@@ -32,6 +34,7 @@ function mapStateToProps(state: GlobalState) {
         enableAskCommunityLink: EnableAskCommunityLink || '',
         showDueToStepsNotFinished: showNextSteps(state),
         teamUrl: getCurrentRelativeTeamUrl(state),
+        pluginMenuItems: getUserGuideDropdownPluginMenuItems(state),
     };
 }
 

--- a/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.test.tsx
+++ b/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.test.tsx
@@ -35,6 +35,7 @@ describe('components/channel_header/components/UserGuideDropdown', () => {
             unhideNextSteps: jest.fn(),
             openModal: jest.fn(),
         },
+        pluginMenuItems: [],
     };
 
     test('should match snapshot', () => {
@@ -49,6 +50,20 @@ describe('components/channel_header/components/UserGuideDropdown', () => {
         const props = {
             ...baseProps,
             enableAskCommunityLink: 'false',
+        };
+
+        const wrapper = shallowWithIntl(
+            <UserGuideDropdown {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when have plugin menu items', () => {
+        const props = {
+            ...baseProps,
+            pluginMenuItems: [{id: 'testId', pluginId: 'testPluginId', text: 'Test Item', action: () => {}},
+            ],
         };
 
         const wrapper = shallowWithIntl(
@@ -84,5 +99,21 @@ describe('components/channel_header/components/UserGuideDropdown', () => {
 
         wrapper.find(Menu.ItemExternalLink).find('#askTheCommunityLink').prop('onClick')!({} as unknown as React.MouseEvent);
         expect(trackEvent).toBeCalledWith('ui', 'help_ask_the_community');
+    });
+
+    test('should have plugin menu items appended to the menu', () => {
+        const props = {
+            ...baseProps,
+            pluginMenuItems: [{id: 'testId', pluginId: 'testPluginId', text: 'Test Plugin Item', action: () => {}},
+            ],
+        };
+
+        const wrapper = shallowWithIntl(
+            <UserGuideDropdown {...props}/>,
+        );
+
+        // pluginMenuItems are appended, so our entry must be the last one.
+        const pluginMenuItem = wrapper.find(Menu.ItemAction).last();
+        expect(pluginMenuItem.prop('text')).toEqual('Test Plugin Item');
     });
 });

--- a/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.tsx
+++ b/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.tsx
@@ -68,8 +68,20 @@ class UserGuideDropdown extends React.PureComponent<Props, State> {
             intl,
             isMobileView,
             showDueToStepsNotFinished,
+            pluginMenuItems,
         } = this.props;
         const inTipsView = matchPath(this.props.location.pathname, {path: '/:team/tips'}) != null;
+
+        const pluginItems = pluginMenuItems?.map((item) => {
+            return (
+                <Menu.ItemAction
+                    id={item.id + '_pluginmenuitem'}
+                    key={item.id + '_pluginmenuitem'}
+                    onClick={item.action}
+                    text={item.text}
+                />
+            );
+        });
 
         return (
             <Menu.Group>
@@ -103,6 +115,7 @@ class UserGuideDropdown extends React.PureComponent<Props, State> {
                     onClick={this.openKeyboardShortcutsModal}
                     text={intl.formatMessage({id: 'userGuideHelp.keyboardShortcuts', defaultMessage: 'Keyboard shortcuts'})}
                 />
+                {pluginItems}
             </Menu.Group>
         );
     }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -349,6 +349,28 @@ export default class PluginRegistry {
         return id;
     }
 
+    // Register a user guide dropdown list item by providing some text and an action function.
+    // Accepts the following:
+    // - text - A string or React element to display in the menu
+    // - action - A function that receives the fileInfo and is called when the menu items is clicked.
+    // Returns a unique identifier.
+    registerUserGuideDropdownMenuAction(text, action) {
+        const id = generateId();
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
+            name: 'UserGuideDropdown',
+            data: {
+                id,
+                pluginId: this.id,
+                text: resolveReactElement(text),
+                action,
+            },
+        });
+
+        return id;
+    }
+
     // Register a post menu list item by providing some text and an action function.
     // Accepts the following:
     // - text - A string or React element to display in the menu

--- a/reducers/plugins/index.ts
+++ b/reducers/plugins/index.ts
@@ -184,6 +184,7 @@ const initialComponents: PluginsState['components'] = {
     PostDropdownMenu: [],
     Product: [],
     RightHandSidebarComponent: [],
+    UserGuideDropdownItem: [],
 };
 
 function components(state: PluginsState['components'] = initialComponents, action: GenericAction) {

--- a/selectors/plugins.ts
+++ b/selectors/plugins.ts
@@ -7,13 +7,21 @@ import {AppBinding} from 'mattermost-redux/types/apps';
 import {appBarEnabled, getAppBarAppBindings} from 'mattermost-redux/selectors/entities/apps';
 
 import {GlobalState} from 'types/store';
-import {FileDropdownPluginComponent, PluginComponent} from '../types/store/plugins';
+import {FileDropdownPluginComponent, UserGuideDropdownPluginComponent, PluginComponent} from '../types/store/plugins';
 
 export const getFilesDropdownPluginMenuItems = createSelector(
     'getFilesDropdownPluginMenuItems',
     (state: GlobalState) => state.plugins.components.FilesDropdown,
     (components) => {
         return (components || []) as unknown as FileDropdownPluginComponent[];
+    },
+);
+
+export const getUserGuideDropdownPluginMenuItems = createSelector(
+    'getUserGuideDropdownPluginMenuItems',
+    (state: GlobalState) => state.plugins.components.UserGuideDropdown,
+    (components) => {
+        return (components || []) as unknown as UserGuideDropdownPluginComponent[];
     },
 );
 

--- a/selectors/plugins.ts
+++ b/selectors/plugins.ts
@@ -7,7 +7,7 @@ import {AppBinding} from 'mattermost-redux/types/apps';
 import {appBarEnabled, getAppBarAppBindings} from 'mattermost-redux/selectors/entities/apps';
 
 import {GlobalState} from 'types/store';
-import {FileDropdownPluginComponent, UserGuideDropdownPluginComponent, PluginComponent} from '../types/store/plugins';
+import {FileDropdownPluginComponent, PluginComponent} from '../types/store/plugins';
 
 export const getFilesDropdownPluginMenuItems = createSelector(
     'getFilesDropdownPluginMenuItems',
@@ -21,7 +21,7 @@ export const getUserGuideDropdownPluginMenuItems = createSelector(
     'getUserGuideDropdownPluginMenuItems',
     (state: GlobalState) => state.plugins.components.UserGuideDropdown,
     (components) => {
-        return (components || []) as unknown as UserGuideDropdownPluginComponent[];
+        return components;
     },
 );
 

--- a/types/store/plugins.ts
+++ b/types/store/plugins.ts
@@ -85,6 +85,13 @@ export type FileDropdownPluginComponent = {
     action: (fileInfo: FileInfo) => void;
 };
 
+export type UserGuideDropdownPluginComponent = {
+    id: string;
+    pluginId: string;
+    text: string | React.ReactElement;
+    action: () => void;
+};
+
 export type PostPluginComponent = {
     id: string;
     pluginId: string;

--- a/types/store/plugins.ts
+++ b/types/store/plugins.ts
@@ -24,6 +24,7 @@ export type PluginsState = {
         ChannelHeaderButton: PluginComponent[];
         MobileChannelHeaderButton: PluginComponent[];
         AppBar: PluginComponent[];
+        UserGuideDropdownItem: PluginComponent[];
         [componentName: string]: PluginComponent[];
     };
 
@@ -83,13 +84,6 @@ export type FileDropdownPluginComponent = {
     text: string | React.ReactElement;
     match: (fileInfo: FileInfo) => boolean;
     action: (fileInfo: FileInfo) => void;
-};
-
-export type UserGuideDropdownPluginComponent = {
-    id: string;
-    pluginId: string;
-    text: string | React.ReactElement;
-    action: () => void;
 };
 
 export type PostPluginComponent = {


### PR DESCRIPTION
#### Summary
As part of MM-29724, I have to give the `nps` plugin the ability the register a new menu item in the user guide dropdown.

**TODO:**
- [ ] make a PR to the documentation when the dev review is done

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29724

#### Related Pull Requests
- nps plugin PR: https://github.com/mattermost/mattermost-plugin-nps/pull/87

#### Screenshots

<details>
<summary>Give feedback has been added by a plugin</summary>
![image](https://user-images.githubusercontent.com/785518/153511278-997b870e-6de8-4261-a5d8-63cb2fde9935.png)
</details>

#### Release Note
```release-note
Added a new plugin registry entry to append menu items to the user guide dropdown
```
