### PR TITLE
MM-40755 : Editing the text in the channel switcher does not work as expected

### DIFF
--- a/components/quick_switch_modal/__snapshots__/quick_switch_modal.test.tsx.snap
+++ b/components/quick_switch_modal/__snapshots__/quick_switch_modal.test.tsx.snap
@@ -90,6 +90,7 @@ exports[`components/QuickSwitchModal should match snapshot 1`] = `
           ]
         }
         renderDividers={true}
+        shouldSearchCompleteText={true}
         spellCheck="false"
         value=""
       />

--- a/components/quick_switch_modal/quick_switch_modal.tsx
+++ b/components/quick_switch_modal/quick_switch_modal.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable react/no-string-refs */
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
@@ -9,18 +8,18 @@ import {FormattedMessage} from 'react-intl';
 import {Channel} from 'mattermost-redux/types/channels';
 import {ActionResult} from 'mattermost-redux/types/actions';
 
-import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+import {NoResultsVariant} from 'components/no_results_indicator/types';
+
 import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
 import * as UserAgent from 'utils/user_agent';
+import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import SuggestionBox from 'components/suggestion/suggestion_box';
 import SuggestionBoxComponent from 'components/suggestion/suggestion_box/suggestion_box';
 import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 import SwitchChannelProvider from 'components/suggestion/switch_channel_provider.jsx';
 import NoResultsIndicator from 'components/no_results_indicator/no_results_indicator';
-
-import {NoResultsVariant} from 'components/no_results_indicator/types';
 
 const CHANNEL_MODE = 'channel';
 
@@ -178,7 +177,6 @@ export default class QuickSwitchModal extends React.PureComponent<Props, State> 
         return (
             <Modal
                 dialogClassName='a11y__modal channel-switcher'
-                ref='modal'
                 show={true}
                 onHide={this.onHide}
                 enforceFocus={false}
@@ -223,12 +221,13 @@ export default class QuickSwitchModal extends React.PureComponent<Props, State> 
                             onSuggestionsReceived={this.handleSuggestionsReceived}
                             forceSuggestionsWhenBlur={true}
                             renderDividers={true}
+                            shouldSearchCompleteText={true}
                         />
                         {!this.state.shouldShowLoadingSpinner && !this.state.hasSuggestions && this.state.text &&
-                        <NoResultsIndicator
-                            variant={NoResultsVariant.ChannelSearch}
-                            titleValues={{channelName: `"${this.state.pretext}"`}}
-                        />
+                            <NoResultsIndicator
+                                variant={NoResultsVariant.ChannelSearch}
+                                titleValues={{channelName: `"${this.state.pretext}"`}}
+                            />
                         }
                     </div>
                 </Modal.Body>
@@ -236,4 +235,3 @@ export default class QuickSwitchModal extends React.PureComponent<Props, State> 
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -771,6 +771,7 @@ export default class SuggestionBox extends React.PureComponent {
         Reflect.deleteProperty(props, 'forceSuggestionsWhenBlur');
         Reflect.deleteProperty(props, 'onSuggestionsReceived');
         Reflect.deleteProperty(props, 'actions');
+        Reflect.deleteProperty(props, 'shouldSearchCompleteText');
 
         // This needs to be upper case so React doesn't think it's an html tag
         const SuggestionListComponent = listComponent;

--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -64,6 +64,11 @@ export default class SuggestionBox extends React.PureComponent {
         renderNoResults: PropTypes.bool,
 
         /**
+         * Set to true if we want the suggestions to take in the complete word as the pretext, defaults to false
+         */
+        shouldSearchCompleteText: PropTypes.bool,
+
+        /**
          * Set to allow TAB to select an item in the list, defaults to true
          */
         completeOnTab: PropTypes.bool,
@@ -159,6 +164,7 @@ export default class SuggestionBox extends React.PureComponent {
         containerClass: '',
         renderDividers: false,
         renderNoResults: false,
+        shouldSearchCompleteText: false,
         completeOnTab: true,
         isRHS: false,
         requiredCharacters: 1,
@@ -328,7 +334,7 @@ export default class SuggestionBox extends React.PureComponent {
 
     handleChange = (e) => {
         const textbox = this.getTextbox();
-        const pretext = textbox.value.substring(0, textbox.selectionEnd);
+        const pretext = this.props.shouldSearchCompleteText ? textbox.value.trim() : textbox.value.substring(0, textbox.selectionEnd);
 
         if (!this.composing && this.pretext !== pretext) {
             this.handlePretextChanged(pretext);


### PR DESCRIPTION
#### Summary
Added a new prop `shouldSearchCompleteText` to suggestion box. When this is true suggestion box component will treat whole word as search input text.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40755

#### Related Pull Requests
N/A

#### Screenshots

Before

https://user-images.githubusercontent.com/17708702/153572530-0e92ce31-c556-45dd-b05a-f1b6e8fb82e8.mov

After 

https://user-images.githubusercontent.com/17708702/153572627-edd33c4e-555d-490c-82b7-40afe2016cc3.mov

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Bug fix in channel switcher not searching when few starting characters are removed. 
```
