### PR TITLE
MM-40415 : Feature flags are not reloaded client-side when server restarts

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -44,7 +44,7 @@ import {
     decrementThreadCounts,
 } from 'mattermost-redux/actions/threads';
 
-import {setServerVersion} from 'mattermost-redux/actions/general';
+import {setServerVersion, getClientConfig} from 'mattermost-redux/actions/general';
 import {
     getCustomEmojiForReaction,
     getPosts,
@@ -158,7 +158,7 @@ export function initialize() {
     WebSocketClient.setEventCallback(handleEvent);
     WebSocketClient.setFirstConnectCallback(handleFirstConnect);
     WebSocketClient.setReconnectCallback(() => reconnect(false));
-    WebSocketClient.setMissedEventCallback(() => reconnect(false));
+    WebSocketClient.setMissedEventCallback(restart);
     WebSocketClient.setCloseCallback(handleClose);
     WebSocketClient.initialize(connUrl);
 }
@@ -180,6 +180,13 @@ export function registerPluginReconnectHandler(pluginId, handler) {
 
 export function unregisterPluginReconnectHandler(pluginId) {
     Reflect.deleteProperty(pluginReconnectHandlers, pluginId);
+}
+
+function restart() {
+    reconnect(false);
+
+    // We fetch the client config again on the server restart.
+    getClientConfig()(dispatch, getState);
 }
 
 export function reconnect(includeWebSocket = true) {

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -186,7 +186,7 @@ function restart() {
     reconnect(false);
 
     // We fetch the client config again on the server restart.
-    getClientConfig()(dispatch, getState);
+    dispatch(getClientConfig());
 }
 
 export function reconnect(includeWebSocket = true) {


### PR DESCRIPTION
#### Summary
On server restart web socket event, client config are fetched again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40415

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Feature flags are automatically refreshed when server undergoes restart
```
