### PR TITLE
MM-41327 : Avoid re-rendering of TextboxLinks component on typing (#9697) (6.3)

### DIFF
--- a/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -67,7 +67,6 @@ exports[`components/CreateComment should match snapshot when cannot post 1`] = `
           className="col col-auto"
         >
           <Connect(TextboxLinks)
-            characterLimit={4000}
             showPreview={false}
             updatePreview={[Function]}
           />
@@ -194,7 +193,6 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
           className="col col-auto"
         >
           <Connect(TextboxLinks)
-            characterLimit={4000}
             showPreview={false}
             updatePreview={[Function]}
           />
@@ -297,7 +295,6 @@ exports[`components/CreateComment should match snapshot, emoji picker disabled 1
           className="col col-auto"
         >
           <Connect(TextboxLinks)
-            characterLimit={4000}
             showPreview={false}
             updatePreview={[Function]}
           />
@@ -436,7 +433,6 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
           className="col col-auto"
         >
           <Connect(TextboxLinks)
-            characterLimit={4000}
             showPreview={false}
             updatePreview={[Function]}
           />
@@ -563,7 +559,6 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
           className="col col-auto"
         >
           <Connect(TextboxLinks)
-            characterLimit={4000}
             showPreview={false}
             updatePreview={[Function]}
           />

--- a/components/create_comment/create_comment.tsx
+++ b/components/create_comment/create_comment.tsx
@@ -1265,7 +1265,6 @@ class CreateComment extends React.PureComponent<Props, State> {
                             </div>
                             <div className='col col-auto'>
                                 <TextboxLinks
-                                    characterLimit={this.props.maxPostSize}
                                     showPreview={this.props.shouldShowPreview}
                                     updatePreview={this.setShowPreview}
                                 />

--- a/components/create_post/__snapshots__/create_post.test.jsx.snap
+++ b/components/create_post/__snapshots__/create_post.test.jsx.snap
@@ -126,8 +126,8 @@ exports[`components/create_post Show tutorial 1`] = `
           postId=""
         />
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -254,8 +254,8 @@ exports[`components/create_post should match snapshot for center textbox 1`] = `
           postId=""
         />
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -382,8 +382,8 @@ exports[`components/create_post should match snapshot when cannot post 1`] = `
           postId=""
         />
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -510,8 +510,8 @@ exports[`components/create_post should match snapshot when file upload disabled 
           postId=""
         />
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -638,8 +638,8 @@ exports[`components/create_post should match snapshot, init 1`] = `
           postId=""
         />
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />

--- a/components/create_post/create_post.tsx
+++ b/components/create_post/create_post.tsx
@@ -1531,10 +1531,10 @@ class CreatePost extends React.PureComponent<Props, State> {
                                 postId=''
                             />
                             <TextboxLinks
-                                characterLimit={this.props.maxPostSize}
+                                hasExceededCharacterLimit={readOnlyChannel ? false : this.state.message.length > this.props.maxPostSize}
                                 showPreview={this.props.shouldShowPreview}
                                 updatePreview={this.setShowPreview}
-                                message={readOnlyChannel ? '' : this.state.message}
+                                hasText={readOnlyChannel ? false : this.state.message.length > 0}
                             />
                         </div>
                         <div>

--- a/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.tsx.snap
+++ b/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.tsx.snap
@@ -82,8 +82,8 @@ exports[`components/EditChannelHeaderModal edit direct message channel 1`] = `
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={1024}
-          message="Fake Channel"
+          hasExceededCharacterLimit={false}
+          hasText={true}
           previewMessageLink="Edit Header"
           showPreview={false}
           updatePreview={[Function]}
@@ -208,8 +208,8 @@ exports[`components/EditChannelHeaderModal error with intl message 1`] = `
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={1024}
-          message="Fake Channel"
+          hasExceededCharacterLimit={false}
+          hasText={true}
           previewMessageLink="Edit Header"
           showPreview={false}
           updatePreview={[Function]}
@@ -352,8 +352,8 @@ exports[`components/EditChannelHeaderModal error without intl message 1`] = `
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={1024}
-          message="Fake Channel"
+          hasExceededCharacterLimit={false}
+          hasText={true}
           previewMessageLink="Edit Header"
           showPreview={false}
           updatePreview={[Function]}
@@ -488,8 +488,8 @@ exports[`components/EditChannelHeaderModal should match snapshot, init 1`] = `
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={1024}
-          message="Fake Channel"
+          hasExceededCharacterLimit={false}
+          hasText={true}
           previewMessageLink="Edit Header"
           showPreview={false}
           updatePreview={[Function]}
@@ -614,8 +614,8 @@ exports[`components/EditChannelHeaderModal submitted 1`] = `
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={1024}
-          message="Fake Channel"
+          hasExceededCharacterLimit={false}
+          hasText={true}
           previewMessageLink="Edit Header"
           showPreview={false}
           updatePreview={[Function]}

--- a/components/edit_channel_header_modal/edit_channel_header_modal.tsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.tsx
@@ -263,10 +263,10 @@ export default class EditChannelHeaderModal extends React.PureComponent<Props, S
                         </div>
                         <div className='post-create-footer'>
                             <TextboxLinks
-                                characterLimit={1024}
                                 showPreview={this.props.shouldShowPreview}
                                 updatePreview={this.setShowPreview}
-                                message={this.state.header}
+                                hasText={this.state.header ? this.state.header.length > 0 : false}
+                                hasExceededCharacterLimit={this.state.header ? this.state.header.length > 1024 : false}
                                 previewMessageLink={localizeMessage('edit_channel_header.previewHeader', 'Edit Header')}
                             />
                         </div>

--- a/components/edit_post_modal/__snapshots__/edit_post_modal.test.tsx.snap
+++ b/components/edit_post_modal/__snapshots__/edit_post_modal.test.tsx.snap
@@ -121,8 +121,8 @@ exports[`components/EditPostModal should disable the button on not canDeletePost
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -283,8 +283,8 @@ exports[`components/EditPostModal should disable the button on not canEditPost a
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message="new message"
+          hasExceededCharacterLimit={false}
+          hasText={true}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -445,8 +445,8 @@ exports[`components/EditPostModal should match snapshot with useChannelMentions 
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -607,8 +607,8 @@ exports[`components/EditPostModal should match when editing post is undefined 1`
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -769,8 +769,8 @@ exports[`components/EditPostModal should match with default config 1`] = `
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -905,8 +905,8 @@ exports[`components/EditPostModal should match without emoji picker 1`] = `
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -1067,8 +1067,8 @@ exports[`components/EditPostModal should not disable the button on not canDelete
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message="new message"
+          hasExceededCharacterLimit={false}
+          hasText={true}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -1229,8 +1229,8 @@ exports[`components/EditPostModal should not disable the button on not canEditPo
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -1391,8 +1391,8 @@ exports[`components/EditPostModal should not disable the save button on not canD
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -1553,8 +1553,8 @@ exports[`components/EditPostModal should show emojis on emojis click 1`] = `
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />
@@ -1715,8 +1715,8 @@ exports[`components/EditPostModal should show errors when it is set in the state
         className="post-create-footer"
       >
         <Connect(TextboxLinks)
-          characterLimit={4000}
-          message=""
+          hasExceededCharacterLimit={false}
+          hasText={false}
           showPreview={false}
           updatePreview={[Function]}
         />

--- a/components/edit_post_modal/edit_post_modal.tsx
+++ b/components/edit_post_modal/edit_post_modal.tsx
@@ -631,10 +631,10 @@ export class EditPostModal extends React.PureComponent<Props, State> {
                         </div>
                         <div className='post-create-footer'>
                             <TextboxLinks
-                                characterLimit={this.props.maxPostSize}
+                                hasExceededCharacterLimit={this.state.editText.length > this.props.maxPostSize}
                                 showPreview={this.props.shouldShowPreview}
                                 updatePreview={this.setShowPreview}
-                                message={this.state.editText}
+                                hasText={this.state.editText.length > 0}
                             />
                             <div className={errorBoxClass}>{postError}</div>
                         </div>

--- a/components/textbox/textbox_links/textbox_links.tsx
+++ b/components/textbox/textbox_links/textbox_links.tsx
@@ -7,34 +7,33 @@ import {Link} from 'react-router-dom';
 
 type Props = {
     showPreview?: boolean;
-    characterLimit: number;
     previewMessageLink?: string;
-    updatePreview?: (showPreview: boolean) => void;
-    message?: string;
+    hasText?: boolean;
+    hasExceededCharacterLimit?: boolean;
     isMarkdownPreviewEnabled: boolean;
     currentLocale: string;
+    updatePreview?: (showPreview: boolean) => void;
 };
 
-const TextboxLinks: React.FC<Props> = ({
+function TextboxLinks({
     showPreview,
-    characterLimit,
     previewMessageLink,
-    updatePreview,
-    message = '',
+    hasText = false,
+    hasExceededCharacterLimit = false,
     isMarkdownPreviewEnabled,
     currentLocale,
-}: Props) => {
+    updatePreview,
+}: Props) {
     const togglePreview = (e: MouseEvent) => {
         e.preventDefault();
         updatePreview?.(!showPreview);
     };
 
-    const hasText = message && message.length > 0;
     let editHeader;
 
     let helpTextClass = '';
 
-    if (message && message.length > characterLimit) {
+    if (hasExceededCharacterLimit) {
         helpTextClass = 'hidden';
     }
 
@@ -138,6 +137,6 @@ const TextboxLinks: React.FC<Props> = ({
             </Link>
         </div>
     );
-};
+}
 
 export default TextboxLinks;


### PR DESCRIPTION
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41327

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9697

#### Release Note
```release-note
NONE
```
