### PR TITLE
MM-42369 - restrict add members btn to roles with permissions

### DIFF
--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -152,7 +152,7 @@ export default class PopoverListMembers extends React.PureComponent {
                 );
             }
 
-            if (this.props.addMembersABTest === AddMembersToChanneltreatments.BOTTOM) {
+            if (this.props.addMembersABTest === AddMembersToChanneltreatments.BOTTOM && this.props.manageMembers) {
                 handleButtonOnClick = () => this.onAddNewMembersButton(AddMembersToChanneltreatments.BOTTOM);
                 membersName = (
                     <FormattedMessage
@@ -173,7 +173,7 @@ export default class PopoverListMembers extends React.PureComponent {
                         />
                     </button>
                 );
-            } else if (this.props.addMembersABTest === AddMembersToChanneltreatments.TOP) {
+            } else if (this.props.addMembersABTest === AddMembersToChanneltreatments.TOP && this.props.manageMembers) {
                 editButton = (
                     <button
                         className='btn btn-link'

--- a/components/popover_list_members/popover_list_members.test.jsx
+++ b/components/popover_list_members/popover_list_members.test.jsx
@@ -124,6 +124,30 @@ describe('components/PopoverListMembers', () => {
         expect(addBtn).toHaveLength(1);
     });
 
+    test('should SHOW the Add button when there are no permissions to manage members', () => {
+        const props = {...baseProps, addMembersABTest: 'top', channel: {...channel, delete_at: 0}, manageMembers: true};
+
+        const wrapper = shallow(
+            <PopoverListMembers {...props}/>,
+        );
+
+        const addBtn = wrapper.find('button#addBtn');
+
+        expect(addBtn).toHaveLength(1);
+    });
+
+    test('should HIDE the Add button when there are no permissions to manage members', () => {
+        const props = {...baseProps, addMembersABTest: 'top', channel: {...channel, delete_at: 0}, manageMembers: false};
+
+        const wrapper = shallow(
+            <PopoverListMembers {...props}/>,
+        );
+
+        const addBtn = wrapper.find('button#addBtn');
+
+        expect(addBtn).toHaveLength(0);
+    });
+
     test('should place the edit button at the top when the flag for placement is BOTTOM', () => {
         const props = {...baseProps, addMembersABTest: 'bottom', channel: {...channel, delete_at: 0}};
 

--- a/components/popover_list_members/popover_list_members.test.jsx
+++ b/components/popover_list_members/popover_list_members.test.jsx
@@ -52,6 +52,18 @@ describe('components/PopoverListMembers', () => {
         sortedUsers: [{id: 'member_id_1'}, {id: 'member_id_2'}],
     };
 
+    const bottomProps = {
+        ...baseProps,
+        addMembersABTest: 'bottom',
+        channel: {...channel, delete_at: 0},
+    };
+
+    const topProps = {
+        ...baseProps,
+        addMembersABTest: 'top',
+        channel: {...channel, delete_at: 0},
+    };
+
     test('should match snapshot', () => {
         const wrapper = shallow(
             <PopoverListMembers {...baseProps}/>,
@@ -113,10 +125,8 @@ describe('components/PopoverListMembers', () => {
     });
 
     test('should place the Add button at the top when the flag for placement is TOP', () => {
-        const props = {...baseProps, addMembersABTest: 'top', channel: {...channel, delete_at: 0}};
-
         const wrapper = shallow(
-            <PopoverListMembers {...props}/>,
+            <PopoverListMembers {...topProps}/>,
         );
 
         const addBtn = wrapper.find('button#addBtn');
@@ -124,8 +134,8 @@ describe('components/PopoverListMembers', () => {
         expect(addBtn).toHaveLength(1);
     });
 
-    test('should SHOW the Add button when there are no permissions to manage members', () => {
-        const props = {...baseProps, addMembersABTest: 'top', channel: {...channel, delete_at: 0}, manageMembers: true};
+    test('should SHOW the Add button when there are permissions to manage members', () => {
+        const props = {...topProps, manageMembers: true};
 
         const wrapper = shallow(
             <PopoverListMembers {...props}/>,
@@ -137,7 +147,7 @@ describe('components/PopoverListMembers', () => {
     });
 
     test('should HIDE the Add button when there are no permissions to manage members', () => {
-        const props = {...baseProps, addMembersABTest: 'top', channel: {...channel, delete_at: 0}, manageMembers: false};
+        const props = {...topProps, manageMembers: false};
 
         const wrapper = shallow(
             <PopoverListMembers {...props}/>,
@@ -148,11 +158,32 @@ describe('components/PopoverListMembers', () => {
         expect(addBtn).toHaveLength(0);
     });
 
-    test('should place the edit button at the top when the flag for placement is BOTTOM', () => {
-        const props = {...baseProps, addMembersABTest: 'bottom', channel: {...channel, delete_at: 0}};
+    test('should SHOW the Add button when there are permissions to manage members and the placement is BOTTTOM', () => {
+        const props = {...bottomProps, manageMembers: true};
 
         const wrapper = shallow(
             <PopoverListMembers {...props}/>,
+        );
+
+        const addBtn = wrapper.find('.more-modal__button button').findWhere((button) => button.text() === 'Add Members');
+
+        expect(addBtn).toHaveLength(0);
+    });
+    test('should HIDE the Add button when there are no permissions to manage members and the placement is BOTTTOM', () => {
+        const props = {...bottomProps, manageMembers: false};
+
+        const wrapper = shallow(
+            <PopoverListMembers {...props}/>,
+        );
+
+        const addBtn = wrapper.find('.more-modal__button button').findWhere((button) => button.text() === 'Add Members');
+
+        expect(addBtn).toHaveLength(0);
+    });
+
+    test('should place the edit button at the top when the flag for placement is BOTTOM', () => {
+        const wrapper = shallow(
+            <PopoverListMembers {...bottomProps}/>,
         );
 
         const addBtn = wrapper.find('button#editBtn');


### PR DESCRIPTION
#### Summary
This PR adds a conditional logic based on the manage_private_channel_members permission to the `Add +` members to channel button that appears in the channel pop-up.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41369

#### Related Pull Requests

#### Screenshots

Before:
*without the manage_private_channel_members permissions it was still showing the button.

<img width="969" alt="Captura de pantalla 2022-02-15 a las 10 02 54" src="https://user-images.githubusercontent.com/10082627/154028966-5b5d3e0a-28bd-4e6a-ad4f-a6bf8efc82d2.png">


<img width="1225" alt="Captura de pantalla 2022-02-15 a las 10 03 30" src="https://user-images.githubusercontent.com/10082627/154028970-4c729543-7c35-423d-807e-951718ba24c8.png">


After:

With the permission enabled:
<img width="1508" alt="Captura de pantalla 2022-02-15 a las 10 02 20" src="https://user-images.githubusercontent.com/10082627/154028947-e0b9593d-0223-4e68-a059-53d172e103e8.png">

With the permission disabled:
<img width="1475" alt="Captura de pantalla 2022-02-15 a las 10 02 42" src="https://user-images.githubusercontent.com/10082627/154028961-ec1c75ce-199c-46b7-9cd5-e33b3fae5b81.png">


#### Release Note

```release-note
NONE
```
