### PR TITLE
Add First Contentful Paint telemetry

### DIFF
--- a/components/autosize_textarea.tsx
+++ b/components/autosize_textarea.tsx
@@ -115,6 +115,7 @@ export class AutosizeTextarea extends React.PureComponent<Props> {
                     {...otherProps as any}
                     data-testid={`${id}_placeholder`}
                     style={style.placeholder}
+                    id={`${id}_lcp_element`}
                 >
                     {placeholder}
                 </div>


### PR DESCRIPTION
#### Summary
This add console log telemetry for measuring FCP. The element in consideration is post textbox, which measures the time it takes to paint on the screen. As soon as its done the performance observer is disconnected to free up performance buffer. It currently works for Chrome.

#### Ticket Link


#### Related Pull Requests
N/A

#### Screenshots
<img width="325" alt="image" src="https://user-images.githubusercontent.com/17708702/154069508-5ef45839-01f7-45e1-a4b0-3d6e7550534f.png">


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
