### PR TITLE
MM-41280 - refactor the payment page layout so the content fits well

### DIFF
--- a/components/purchase_modal/icon_message.scss
+++ b/components/purchase_modal/icon_message.scss
@@ -64,10 +64,6 @@
             font-weight: 600;
             line-height: 14px;
             text-align: center;
-
-            &.error {
-                width: 176px;
-            }
         }
 
         .IconMessage-link {

--- a/components/purchase_modal/icon_message.scss
+++ b/components/purchase_modal/icon_message.scss
@@ -1,27 +1,15 @@
 .IconMessage {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    display: block;
-    overflow: auto;
-    width: 100%;
-    height: 100%;
-    margin: auto;
-    text-align: center;
-
     .content {
         &.success {
             padding-bottom: 2px;
             padding-left: 7px;
         }
 
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        margin: 0;
-        transform: translate(-50%, -50%);
+        display: flex;
+        flex-direction: column;
+        align-content: center;
+        justify-content: center;
+        text-align: center;
 
         .IconMessage-h3 {
             margin-top: 43px;
@@ -90,6 +78,15 @@
             font-weight: 600;
             line-height: 14px;
             text-align: center;
+        }
+
+        svg {
+            align-self: center;
+            margin-left: 60px;
+
+            @media screen and (max-width: 600px) {
+                width: 150%;
+            }
         }
     }
 }

--- a/components/purchase_modal/purchase.scss
+++ b/components/purchase_modal/purchase.scss
@@ -14,9 +14,11 @@
         flex-direction: row;
         flex-grow: 1;
         flex-wrap: wrap;
+        align-content: center;
+        justify-content: center;
         padding: 77px 107px;
         color: var(--center-channel-color);
-        font-family: 'Open Sans';
+        font-family: "Open Sans";
         font-size: 16px;
         font-weight: 600;
 


### PR DESCRIPTION
#### Summary
This PR adds the code to refactor the payment page layout so the content fits well  no matter the language.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41280

#### Related Pull Requests

#### Screenshots
<img width="1665" alt="Captura de pantalla 2022-02-16 a las 13 15 55" src="https://user-images.githubusercontent.com/10082627/154272392-1acefa10-6e0c-4183-a9f2-311c7808b65a.png">
<img width="1357" alt="Captura de pantalla 2022-02-16 a las 13 16 22" src="https://user-images.githubusercontent.com/10082627/154272402-910df03a-0d4d-4de5-97df-5bff0a6e713f.png">
<img width="1228" alt="Captura de pantalla 2022-02-16 a las 13 16 45" src="https://user-images.githubusercontent.com/10082627/154272405-5f5e2092-3013-4336-8055-8c426a15755f.png">
<img width="1110" alt="Captura de pantalla 2022-02-16 a las 13 17 14" src="https://user-images.githubusercontent.com/10082627/154272408-f4097424-a5a5-4381-ae2f-189cec79e5e1.png">
<img width="921" alt="Captura de pantalla 2022-02-16 a las 13 28 58" src="https://user-images.githubusercontent.com/10082627/154272409-1aca9576-d16c-4088-a605-581d65ee5212.png">


#### Release Note
```release-note
NONE
```
