### PR TITLE
Fixed a bug that causing gap to appear in products using team sidebar…

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -151,6 +151,10 @@
     .app__content {
         margin-left: 285px;
     }
+
+    .product-wrapper {
+        width: calc(100% - 65px)
+    }
 }
 
 @media screen and (min-width: 769px) {
@@ -173,7 +177,7 @@
 }
 
 .product-wrapper {
-    width: calc(100% - 65px);
+    width: 100%;
     height: calc(100% - 40px);
     margin-left: auto;
 

--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -153,7 +153,7 @@
     }
 
     .product-wrapper {
-        width: calc(100% - 65px)
+        width: calc(100% - 65px);
     }
 }
 


### PR DESCRIPTION
#### Summary
Fixed a bug that caused a gap to appear in products using team sidebar when user had only 1 team

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/19309

#### Related Pull Requests
None

#### Screenshots
Before:
<img width="800" alt="Screenshot 2022-01-11 at 4 58 31 PM" src="https://user-images.githubusercontent.com/18575143/148934757-17fef5e9-79dd-4364-a929-2514d028239a.png">

After:
<img width="800" alt="Screenshot 2022-01-11 at 5 03 28 PM" src="https://user-images.githubusercontent.com/18575143/148935451-ad6284c2-5e17-4b9a-917e-8c7fb2f888ee.png">

#### Release Note
```release-note
Fixed a bug that caused a gap to appear on the left in products using the team sidebar.
```
