### PR TITLE
MM-41273 : Restore main menu items added by plugins

### DIFF
--- a/components/main_menu/__snapshots__/main_menu.test.tsx.snap
+++ b/components/main_menu/__snapshots__/main_menu.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`components/Menu should match snapshot with guest access disabled and no
       />
     </Connect(SystemPermissionGate)>
   </MenuGroup>
+  <MenuGroup />
 </Menu>
 `;
 
@@ -384,6 +385,7 @@ exports[`components/Menu should match snapshot with id 1`] = `
       />
     </Connect(SystemPermissionGate)>
   </MenuGroup>
+  <MenuGroup />
 </Menu>
 `;
 
@@ -586,6 +588,7 @@ exports[`components/Menu should match snapshot with most of the thing disabled 1
       />
     </Connect(SystemPermissionGate)>
   </MenuGroup>
+  <MenuGroup />
 </Menu>
 `;
 
@@ -1196,6 +1199,7 @@ exports[`components/Menu should match snapshot with most of the thing enabled 1`
       />
     </Connect(SystemPermissionGate)>
   </MenuGroup>
+  <MenuGroup />
 </Menu>
 `;
 
@@ -1807,6 +1811,22 @@ exports[`components/Menu should match snapshot with plugins 1`] = `
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={false}
+      id="plugin-id-1_pluginmenuitem"
+      key="plugin-id-1_pluginmenuitem"
+      onClick={[Function]}
+      show={true}
+    />
+    <MenuItemAction
+      icon={false}
+      id="plugind-id-2_pluginmenuitem"
+      key="plugind-id-2_pluginmenuitem"
+      onClick={[Function]}
+      show={true}
+    />
   </MenuGroup>
 </Menu>
 `;

--- a/components/main_menu/main_menu.tsx
+++ b/components/main_menu/main_menu.tsx
@@ -482,6 +482,9 @@ export class MainMenu extends React.PureComponent<Props> {
                         />
                     </SystemPermissionGate>
                 </Menu.Group>
+                <Menu.Group>
+                    {pluginItems}
+                </Menu.Group>
             </Menu>
         );
     }

--- a/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
+++ b/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
@@ -575,5 +575,15 @@ exports[`plugins/MainMenuActions should match snapshot in web view 1`] = `
       />
     </Connect(SystemPermissionGate)>
   </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={false}
+      id="someplugin_pluginmenuitem"
+      key="someplugin_pluginmenuitem"
+      onClick={[Function]}
+      show={true}
+      text="some plugin text"
+    />
+  </MenuGroup>
 </Menu>
 `;

--- a/plugins/test/main_menu_action.test.jsx
+++ b/plugins/test/main_menu_action.test.jsx
@@ -65,7 +65,7 @@ describe('plugins/MainMenuActions', () => {
         wrapper = wrapper.find('MainMenu').shallow();
 
         expect(wrapper).toMatchSnapshot();
-        expect(wrapper.findWhere((node) => node.key() === 'someplugin_pluginmenuitem')).toHaveLength(0);
+        expect(wrapper.findWhere((node) => node.key() === 'someplugin_pluginmenuitem')).toHaveLength(1);
     });
 
     test('should match snapshot in mobile view with some plugin and ability to click plugin', () => {


### PR DESCRIPTION
#### Summary
Render main menu items added by plugins.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41273

#### Release Note

```release-note
Restored rendering of main menu items from plugins in non-mobile view
```

#### Screenshot

![image](https://user-images.githubusercontent.com/179599/154777389-aabfae57-f7d1-4b84-aaf3-98882777f41a.png)
