### PR TITLE
Catch errors from plugin reconnect handlers

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -196,7 +196,11 @@ export function reconnect(includeWebSocket = true) {
 
     Object.values(pluginReconnectHandlers).forEach((handler) => {
         if (handler && typeof handler === 'function') {
-            handler();
+            try {
+                handler();
+            } catch (e) {
+                console.error('Error calling plugin reconnect handler: ' + e.message);
+            }
         }
     });
 

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -199,7 +199,7 @@ export function reconnect(includeWebSocket = true) {
             try {
                 handler();
             } catch (e) {
-                console.error('Error calling plugin reconnect handler: ' + e.message);
+                console.error('Error calling plugin reconnect handler: ' + e.message); //eslint-disable-line no-console
             }
         }
     });


### PR DESCRIPTION
#### Summary

There was an issue with the todo plugin throwing an exception in its reconnect handler https://github.com/mattermost/mattermost-plugin-todo/issues/155. This made it so the webapp didn't finish the rest of its reconnect logic.

This PR makes it so the webapp catches any errors thrown by the plugin reconnect handlers. It now logs the error and moves on with other reconnect logic.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-41975

#### Related Pull Requests

https://github.com/mattermost/mattermost-plugin-todo/pull/156

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
The webapp is able to properly handle errors occuring in plugin reconnect handlers.
```
