### PR TITLE
[MM-T2086] Cypress test for changing password and checking email and timestamp

### DIFF
--- a/e2e/cypress/integration/account_settings/security/password_spec.js
+++ b/e2e/cypress/integration/account_settings/security/password_spec.js
@@ -127,7 +127,7 @@ describe('Profile', () => {
         // # Create expected timestamp
         const timestamp = `Last updated ${date} at ${time}`;
 
-        // # Verify that password description field contains valid timestamp
+        // * Verify that password description field contains valid timestamp
         cy.get('#passwordDesc').should('have.text', timestamp);
 
         // # Wait for the mail to be sent out.

--- a/e2e/cypress/integration/account_settings/security/password_spec.js
+++ b/e2e/cypress/integration/account_settings/security/password_spec.js
@@ -10,11 +10,20 @@
 // Stage: @prod
 // Group: @account_setting
 
+import moment from 'moment-timezone';
+
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
 describe('Profile', () => {
+    let siteName;
     let testUser;
     let offTopic;
 
     before(() => {
+        cy.apiGetConfig().then(({config}) => {
+            siteName = config.TeamSettings.SiteName;
+        });
+
         // # Login as new user and visit off-topic
         cy.apiInitSetup({loginAfter: true}).then(({user, offTopicUrl}) => {
             testUser = user;
@@ -99,6 +108,37 @@ describe('Profile', () => {
         cy.apiLogin(testUser);
         cy.visit(offTopic);
         cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+    });
+
+    it('MM-T2086 Password: Timestamp and email', () => {
+        // # Enter valid values in password change fields
+        enterPasswords(testUser.password, 'passwd', 'passwd');
+
+        // # Get current date
+        const now = moment(Date.now());
+
+        // # Save the settings
+        cy.uiSave();
+
+        // # Create expected date and time formats
+        const date = now.format('MMM DD, YYYY');
+        const time = now.format('hh:mm A');
+
+        // # Create expected timestamp
+        const timestamp = `Last updated ${date} at ${time}`;
+
+        // # Verify that password description field contains valid timestamp
+        cy.get('#passwordDesc').should('have.text', timestamp);
+
+        // # Wait for the mail to be sent out.
+        cy.wait(TIMEOUTS.FIVE_SEC);
+
+        cy.getRecentEmail(testUser).then(({subject}) => {
+            // * Verify the subject
+            expect(subject).to.equal(
+                `[${siteName}] Your password has been updated`,
+            );
+        });
     });
 });
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Cypress test for MM-T2086:

Check that password setting _(in profile settings)_ shows password was updated at current time.

Additionally, check that an email notification about the password update is received.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/18818
