### PR TITLE
[MM-41408] Remove FF for auto tour

### DIFF
--- a/components/tutorial/tutorial_tip_legacy/index.ts
+++ b/components/tutorial/tutorial_tip_legacy/index.ts
@@ -4,14 +4,10 @@ import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
 
 import {getCurrentUser, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {
-    getAutoTourTreatment,
-    getInt,
-} from 'mattermost-redux/selectors/entities/preferences';
+import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {setProductMenuSwitcherOpen} from 'actions/views/product_menu';
 import {GenericAction} from 'mattermost-redux/types/actions';
-import {AutoTourTreatments} from 'mattermost-redux/constants/config';
 import {isAdmin} from 'mattermost-redux/utils/user_utils';
 
 import {closeMenu as closeRhsMenu} from 'actions/views/rhs';
@@ -19,7 +15,7 @@ import {setFirstChannelName} from 'actions/views/channel_sidebar';
 
 import {getFirstChannelName} from 'selectors/onboarding';
 
-import Constants, {Preferences} from 'utils/constants';
+import {Preferences} from 'utils/constants';
 import {GlobalState} from 'types/store';
 
 import TutorialTip from './tutorial_tip';
@@ -32,12 +28,11 @@ type OwnProps = {
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const currentUserId = getCurrentUserId(state);
     const categoryStep = ownProps.tutorialCategory || Preferences.TUTORIAL_STEP;
-    const onBoardingAutoTourStatus = getInt(state, Preferences.TUTORIAL_STEP_AUTO_TOUR_STATUS, currentUserId, Constants.AutoTourStatus.ENABLED) === Constants.AutoTourStatus.ENABLED;
 
     return {
         currentUserId,
         currentStep: getInt(state, categoryStep, currentUserId, 0),
-        autoTour: ownProps.tutorialCategory ? ownProps.autoTour : getAutoTourTreatment(state) === AutoTourTreatments.AUTO && onBoardingAutoTourStatus,
+        autoTour: ownProps.autoTour,
         firstChannelName: getFirstChannelName(state),
         isAdmin: isAdmin(getCurrentUser(state).roles),
     };

--- a/packages/mattermost-redux/src/constants/config.ts
+++ b/packages/mattermost-redux/src/constants/config.ts
@@ -6,11 +6,6 @@ export enum CollapsedThreads {
     DEFAULT_OFF = 'default_off',
 }
 
-export enum AutoTourTreatments {
-    NONE = 'none',
-    AUTO = 'auto',
-}
-
 export enum AddMembersToChanneltreatments {
     TOP = 'top',
     BOTTOM = 'bottom',

--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -7,10 +7,7 @@ import {General, Preferences} from 'mattermost-redux/constants';
 
 import {getConfig, getFeatureFlagValue, getLicense} from 'mattermost-redux/selectors/entities/general';
 
-import {
-    AutoTourTreatments,
-    AddMembersToChanneltreatments,
-} from 'mattermost-redux/constants/config';
+import {AddMembersToChanneltreatments} from 'mattermost-redux/constants/config';
 import {PreferenceType} from 'mattermost-redux/types/preferences';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {Theme} from 'mattermost-redux/types/themes';
@@ -204,10 +201,6 @@ export function isCollapsedThreadsEnabled(state: GlobalState): boolean {
 
 export function isGroupChannelManuallyVisible(state: GlobalState, channelId: string): boolean {
     return getBool(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channelId, false);
-}
-
-export function getAutoTourTreatment(state: GlobalState): AutoTourTreatments | undefined {
-    return getFeatureFlagValue(state, 'AutoTour') as AutoTourTreatments | undefined;
 }
 
 export function getCreateGuidedChannel(state: GlobalState): boolean {

--- a/packages/mattermost-redux/src/types/config.ts
+++ b/packages/mattermost-redux/src/types/config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {CollapsedThreads, AutoTourTreatments} from '../constants/config';
+import {CollapsedThreads} from '../constants/config';
 
 import {ThemeKey} from './themes';
 
@@ -15,7 +15,6 @@ export type ClientConfig = {
     AndroidMinVersion: string;
     AppDownloadLink: string;
     AsymmetricSigningPublicKey: string;
-    AutoTour: AutoTourTreatments;
     AvailableLocales: string;
     BannerColor: string;
     BannerText: string;


### PR DESCRIPTION
#### Summary
Removes the AutoTour Feature flag.

As commented on the Jira ticket, while the tasks required to remove the Autotour feature because it lost the AB test, it's been used heavily in the Usecase Onboarding Growth Spike, so I did not touch the feature.

@stevemudie : the main changes applies to a component that is not really used anymore, So I think just making sure that the tutorials still works is the best way to QA this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41408

#### Related Pull Requests
- Has server changes https://github.com/mattermost/mattermost-server/pull/19495

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
