### PR TITLE
[MM-42003]: fixed nav tab hover state on emoji picker while active

### DIFF
--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -141,6 +141,10 @@
                 margin-right: 5px;
                 margin-left: 5px;
                 outline: none;
+
+                &:hover {
+                    background: transparent;
+                }
             }
         }
 
@@ -152,6 +156,10 @@
                 margin-left: 5px;
                 border-radius: 0;
                 opacity: 1;
+
+                &:hover {
+                    background: transparent;
+                }
             }
         }
 


### PR DESCRIPTION
#### Summary
active nav-tab in emoji picker (with gif picker enabled) now gets the right background color when hovering in active state

#### Ticket Link
[MM-42003](https://mattermost.atlassian.net/browse/MM-42003)

#### Related Pull Requests
n/a

#### Screenshots
|  before  |  after  |
|----|----|
| ![Screenshot 2022-02-24 at 11 29 30](https://user-images.githubusercontent.com/32863416/155507184-6ac594a0-914b-4f8a-8370-b8f8ca0a45f0.png) | ![Screenshot 2022-02-24 at 11 28 57](https://user-images.githubusercontent.com/32863416/155507119-c9a026d6-60ee-4b7d-a831-224548ff30c0.png) |

#### Release Note
```release-note
NONE
```
