### PR TITLE
[MM-42068] Adding source query param to team and channel group endpoints

### DIFF
--- a/packages/mattermost-redux/src/actions/groups.ts
+++ b/packages/mattermost-redux/src/actions/groups.ts
@@ -7,9 +7,10 @@ import {Client4} from 'mattermost-redux/client';
 import {Action, ActionFunc, batchActions, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import {GroupPatch, SyncableType, SyncablePatch, GroupCreateWithUserIds, CustomGroupPatch, GroupSearachParams} from 'mattermost-redux/types/groups';
 
+import Constants from 'utils/constants';
+
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
-import Constants from 'utils/constants';
 
 export function linkGroupSyncable(groupID: string, syncableID: string, syncableType: SyncableType, patch: SyncablePatch): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {

--- a/packages/mattermost-redux/src/actions/groups.ts
+++ b/packages/mattermost-redux/src/actions/groups.ts
@@ -9,6 +9,7 @@ import {GroupPatch, SyncableType, SyncablePatch, GroupCreateWithUserIds, CustomG
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
+import Constants from 'utils/constants';
 
 export function linkGroupSyncable(groupID: string, syncableID: string, syncableType: SyncableType, patch: SyncablePatch): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -168,7 +169,7 @@ export function getGroups(filterAllowReference: false, page = 0, perPage = 10, i
     });
 }
 
-export function getGroupsNotAssociatedToTeam(teamID: string, q = '', page = 0, perPage: number = General.PAGE_SIZE_DEFAULT): ActionFunc {
+export function getGroupsNotAssociatedToTeam(teamID: string, q = '', page = 0, perPage: number = General.PAGE_SIZE_DEFAULT, source = Constants.LDAP_SERVICE): ActionFunc {
     return bindClientFunc({
         clientFunc: Client4.getGroupsNotAssociatedToTeam,
         onSuccess: [GroupTypes.RECEIVED_GROUPS],
@@ -177,11 +178,12 @@ export function getGroupsNotAssociatedToTeam(teamID: string, q = '', page = 0, p
             q,
             page,
             perPage,
+            source,
         ],
     });
 }
 
-export function getGroupsNotAssociatedToChannel(channelID: string, q = '', page = 0, perPage: number = General.PAGE_SIZE_DEFAULT, filterParentTeamPermitted = false): ActionFunc {
+export function getGroupsNotAssociatedToChannel(channelID: string, q = '', page = 0, perPage: number = General.PAGE_SIZE_DEFAULT, filterParentTeamPermitted = false, source = Constants.LDAP_SERVICE): ActionFunc {
     return bindClientFunc({
         clientFunc: Client4.getGroupsNotAssociatedToChannel,
         onSuccess: [GroupTypes.RECEIVED_GROUPS],
@@ -191,6 +193,7 @@ export function getGroupsNotAssociatedToChannel(channelID: string, q = '', page 
             page,
             perPage,
             filterParentTeamPermitted,
+            source,
         ],
     });
 }

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -122,8 +122,9 @@ import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 
 import {UserThreadList, UserThread, UserThreadWithPost} from 'mattermost-redux/types/threads';
 
-import {TelemetryHandler} from './telemetry';
 import Constants from 'utils/constants';
+
+import {TelemetryHandler} from './telemetry';
 
 const FormData = require('form-data');
 const HEADER_AUTH = 'Authorization';

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -123,6 +123,7 @@ import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 import {UserThreadList, UserThread, UserThreadWithPost} from 'mattermost-redux/types/threads';
 
 import {TelemetryHandler} from './telemetry';
+import Constants from 'utils/constants';
 
 const FormData = require('form-data');
 const HEADER_AUTH = 'Authorization';
@@ -3421,15 +3422,15 @@ export default class Client4 {
         );
     };
 
-    getGroupsNotAssociatedToTeam = (teamID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getGroupsNotAssociatedToTeam = (teamID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT, source = Constants.LDAP_SERVICE) => {
         this.trackEvent('api', 'api_groups_get_not_associated_to_team', {team_id: teamID});
         return this.doFetch<Group[]>(
-            `${this.getGroupsRoute()}${buildQueryString({not_associated_to_team: teamID, page, per_page: perPage, q, include_member_count: true})}`,
+            `${this.getGroupsRoute()}${buildQueryString({not_associated_to_team: teamID, page, per_page: perPage, q, include_member_count: true, group_source: source})}`,
             {method: 'get'},
         );
     };
 
-    getGroupsNotAssociatedToChannel = (channelID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT, filterParentTeamPermitted = false) => {
+    getGroupsNotAssociatedToChannel = (channelID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT, filterParentTeamPermitted = false, source = Constants.LDAP_SERVICE) => {
         this.trackEvent('api', 'api_groups_get_not_associated_to_channel', {channel_id: channelID});
         const query = {
             not_associated_to_channel: channelID,
@@ -3438,6 +3439,7 @@ export default class Client4 {
             q,
             include_member_count: true,
             filter_parent_team_permitted: filterParentTeamPermitted,
+            group_source: source,
         };
         return this.doFetch<Group[]>(
             `${this.getGroupsRoute()}${buildQueryString(query)}`,

--- a/packages/mattermost-redux/src/selectors/entities/groups.test.js
+++ b/packages/mattermost-redux/src/selectors/entities/groups.test.js
@@ -17,6 +17,9 @@ describe('Selectors.Groups', () => {
     const expectedAssociatedGroupID3 = 'xos794c6tfb57eog481acokozc';
     const expectedAssociatedGroupID4 = 'tnd8zod9f3fdtqosxjmhwucbth';
     const channelAssociatedGroupIDs = [expectedAssociatedGroupID3, expectedAssociatedGroupID4];
+
+    const expectedAssociatedGroupID5 = 'pak66a8raibpmn6r3w8r7mf35a';
+
     const group1 = {
         id: expectedAssociatedGroupID1,
         name: '9uobsi3xb3y5tfjb3ze7umnh1o',
@@ -60,7 +63,7 @@ describe('Selectors.Groups', () => {
         allow_reference: false,
     };
     const group4 = {
-        id: [expectedAssociatedGroupID4],
+        id: expectedAssociatedGroupID4,
         name: 'nobctj4brfgtpj3a1peiyq47tc',
         display_name: 'engineering',
         description: '',
@@ -73,6 +76,21 @@ describe('Selectors.Groups', () => {
         member_count: 8,
         allow_reference: true,
     };
+    const group5 = {
+        id: expectedAssociatedGroupID5,
+        name: 'group5',
+        display_name: 'R&D',
+        description: '',
+        source: 'custom',
+        create_at: 1553808971099,
+        remote_id: null,
+        update_at: 1553808971099,
+        delete_at: 0,
+        has_syncables: false,
+        member_count: 8,
+        allow_reference: true,
+    };
+
     const user1 = TestHelper.fakeUserWithId();
     const user2 = TestHelper.fakeUserWithId();
     const user3 = TestHelper.fakeUserWithId();
@@ -92,6 +110,7 @@ describe('Selectors.Groups', () => {
                     [expectedAssociatedGroupID3]: group3,
                     [expectedAssociatedGroupID4]: group4,
                     [expectedAssociatedGroupID2]: group2,
+                    [expectedAssociatedGroupID5]: group5,
                 },
                 myGroups: [
                     group1.id,
@@ -132,7 +151,8 @@ describe('Selectors.Groups', () => {
         const groupsByName = Selectors.getAssociatedGroupsByName(testState, teamID, channelID);
         assert.equal(groupsByName[group1.name], group1);
         assert.equal(groupsByName[group4.name], group4);
-        assert.equal(Object.keys(groupsByName).length, 2);
+        assert.equal(groupsByName[group5.name], group5);
+        assert.equal(Object.keys(groupsByName).length, 3);
     });
 
     it('getGroupsAssociatedToTeam', () => {
@@ -144,7 +164,10 @@ describe('Selectors.Groups', () => {
     });
 
     it('getGroupsNotAssociatedToTeam', () => {
-        const expected = Object.entries(testState.entities.groups.groups).filter(([groupID]) => !teamAssociatedGroupIDs.includes(groupID)).map(([, group]) => group);
+        const expected = [
+            group3,
+            group4,
+        ];
         assert.deepEqual(Selectors.getGroupsNotAssociatedToTeam(testState, teamID), expected);
     });
 
@@ -157,7 +180,10 @@ describe('Selectors.Groups', () => {
     });
 
     it('getGroupsNotAssociatedToChannel', () => {
-        let expected = Object.values(testState.entities.groups.groups).filter((group) => !channelAssociatedGroupIDs.includes(group.id));
+        const expected = [
+            group1,
+            group2,
+        ];
         assert.deepEqual(Selectors.getGroupsNotAssociatedToChannel(testState, channelID, teamID), expected);
 
         let cloneState = JSON.parse(JSON.stringify(testState));
@@ -165,8 +191,7 @@ describe('Selectors.Groups', () => {
         cloneState.entities.teams.groupsAssociatedToTeam[teamID].ids = [expectedAssociatedGroupID1];
         cloneState = deepFreezeAndThrowOnMutation(cloneState);
 
-        expected = Object.values(cloneState.entities.groups.groups).filter((group) => !channelAssociatedGroupIDs.includes(group.id) && cloneState.entities.teams.groupsAssociatedToTeam[teamID].ids.includes(group.id));
-        assert.deepEqual(Selectors.getGroupsNotAssociatedToChannel(cloneState, channelID, teamID), expected);
+        assert.deepEqual(Selectors.getGroupsNotAssociatedToChannel(cloneState, channelID, teamID), [group1]);
     });
 
     it('getGroupsAssociatedToTeamForReference', () => {
@@ -187,6 +212,7 @@ describe('Selectors.Groups', () => {
         const expected = [
             group1,
             group4,
+            group5,
         ];
         assert.deepEqual(Selectors.getAllAssociatedGroupsForReference(testState), expected);
     });

--- a/packages/mattermost-redux/src/selectors/entities/groups.ts
+++ b/packages/mattermost-redux/src/selectors/entities/groups.ts
@@ -10,6 +10,8 @@ import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {UserMentionKey} from 'mattermost-redux/selectors/entities/users';
 import {GlobalState} from 'mattermost-redux/types/store';
 
+import Constants from 'utils/constants';
+
 import {getCurrentUserLocale} from './i18n';
 
 const emptyList: any[] = [];
@@ -148,7 +150,7 @@ export const getGroupsNotAssociatedToTeam: (state: GlobalState, teamID: string) 
     getAllGroups,
     (state: GlobalState, teamID: string) => getTeamGroupIDSet(state, teamID),
     (allGroups, teamGroupIDSet) => {
-        return Object.entries(allGroups).filter(([groupID]) => !teamGroupIDSet.has(groupID)).map((entry) => entry[1]);
+        return Object.entries(allGroups).filter(([groupID]) => !teamGroupIDSet.has(groupID)).filter((entry) => (entry[1].source === Constants.LDAP_SERVICE)).map((entry) => entry[1]);
     },
 );
 
@@ -168,7 +170,7 @@ export const getGroupsNotAssociatedToChannel: (state: GlobalState, channelID: st
     (state: GlobalState, channelID: string, teamID: string) => getTeam(state, teamID),
     (state: GlobalState, channelID: string, teamID: string) => getGroupsAssociatedToTeam(state, teamID),
     (allGroups, channelGroupIDSet, team, teamGroups) => {
-        let result = Object.values(allGroups).filter((group) => !channelGroupIDSet.has(group.id));
+        let result = Object.values(allGroups).filter((group) => !channelGroupIDSet.has(group.id) && group.source === Constants.LDAP_SERVICE);
         if (team.group_constrained) {
             const gids = teamGroups.map((group) => group.id);
             result = result.filter((group) => gids?.includes(group.id));

--- a/packages/mattermost-redux/src/selectors/entities/groups.ts
+++ b/packages/mattermost-redux/src/selectors/entities/groups.ts
@@ -150,7 +150,7 @@ export const getGroupsNotAssociatedToTeam: (state: GlobalState, teamID: string) 
     getAllGroups,
     (state: GlobalState, teamID: string) => getTeamGroupIDSet(state, teamID),
     (allGroups, teamGroupIDSet) => {
-        return Object.entries(allGroups).filter(([groupID]) => !teamGroupIDSet.has(groupID)).filter((entry) => (entry[1].source === Constants.LDAP_SERVICE)).map((entry) => entry[1]);
+        return Object.entries(allGroups).filter(([groupID, group]) => !teamGroupIDSet.has(groupID) && group.source === Constants.LDAP_SERVICE).map((entry) => entry[1]);
     },
 );
 


### PR DESCRIPTION
#### Summary
Adding `group_source` to the query parameters in order to filter out custom groups

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42068
https://mattermost.atlassian.net/browse/MM-42070

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixes a bug where custom groups were appearing in the UI when linking groups to channels/teams
```
