### PR TITLE
Read from myTeams if there is no currentTeam

### DIFF
--- a/components/preparing_workspace/preparing_workspace.tsx
+++ b/components/preparing_workspace/preparing_workspace.tsx
@@ -135,6 +135,9 @@ export default function PreparingWorkspace(props: Props) {
     const isSelfHosted = useSelector(getLicense).Cloud !== 'true';
     const currentTeam = useSelector(getCurrentTeam);
     const myTeams = useSelector(getMyTeams);
+    // In cloud instances created from portal,
+    // new admin user has a team in myTeams but not in currentTeam.
+    const inferredTeam = currentTeam || myTeams?.[0];
     const config = useSelector(getConfig);
     const configSiteUrl = config.SiteURL;
     const isConfigSiteUrlDefault = config.SiteURL === '' || Boolean(config.SiteURL && config.SiteURL === Constants.DEFAULT_SITE_URL);
@@ -233,9 +236,7 @@ export default function PreparingWorkspace(props: Props) {
             return;
         }
 
-        // In cloud instances created from portal,
-        // new admin user has a team in myTeams but not in currentTeam.
-        let team = (currentTeam || myTeams?.[0]);
+        let team = inferredTeam;
 
         if (form.organization) {
             try {
@@ -649,7 +650,7 @@ export default function PreparingWorkspace(props: Props) {
                             },
                         });
                     }}
-                    teamInviteId={(currentTeam || myTeams?.[0])?.invite_id || ''}
+                    teamInviteId={inferredTeam?.invite_id || ''}
                     configSiteUrl={configSiteUrl}
                     formUrl={form.url}
                     browserSiteUrl={browserSiteUrl}
@@ -661,7 +662,7 @@ export default function PreparingWorkspace(props: Props) {
                     step={currentStep}
                     transitionDirection={getTransitionDirectionMultiStep([WizardSteps.Channel, WizardSteps.InviteMembers])}
                     channelName={form.channel.name || 'Channel name'}
-                    teamName={isSelfHosted ? form.organization || 'Team name' : (currentTeam || myTeams?.[0])?.display_name || 'Team name'}
+                    teamName={isSelfHosted ? form.organization || 'Team name' : inferredTeam?.display_name || 'Team name'}
                 />
                 <LaunchingWorkspace
                     onPageView={onPageViews[WizardSteps.LaunchingWorkspace]}

--- a/components/preparing_workspace/preparing_workspace.tsx
+++ b/components/preparing_workspace/preparing_workspace.tsx
@@ -233,7 +233,9 @@ export default function PreparingWorkspace(props: Props) {
             return;
         }
 
-        let team = currentTeam;
+        // In cloud instances created from portal,
+        // new admin user has a team in myTeams but not in currentTeam.
+        let team = (currentTeam || myTeams?.[0]);
 
         if (form.organization) {
             try {

--- a/components/preparing_workspace/preparing_workspace.tsx
+++ b/components/preparing_workspace/preparing_workspace.tsx
@@ -135,6 +135,7 @@ export default function PreparingWorkspace(props: Props) {
     const isSelfHosted = useSelector(getLicense).Cloud !== 'true';
     const currentTeam = useSelector(getCurrentTeam);
     const myTeams = useSelector(getMyTeams);
+
     // In cloud instances created from portal,
     // new admin user has a team in myTeams but not in currentTeam.
     const inferredTeam = currentTeam || myTeams?.[0];


### PR DESCRIPTION
#### Summary
For instances created from cloud portal,  read from `myTeams` as a back up as `currentTeam` does not yet have data. This was causing separate errors for both the paths that:
* tried to create channels
* tried to redirect user to the main channels view

Opting to defer QA until this is running from instances created from test portal, as this is where the issue was observed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42019

#### Screenshots
Was able to find this out on an instance created from test portal:

![myTeams-but-no-current-team](https://user-images.githubusercontent.com/13738432/155598672-a3d716eb-eb29-484b-ab10-edfc2da515f0.png)

#### Release Note
```release-note
NONE
```
