### PR TITLE
MM-42094 Rework handling of uncaught JS errors

### DIFF
--- a/components/announcement_bar/default_announcement_bar/announcement_bar.tsx
+++ b/components/announcement_bar/default_announcement_bar/announcement_bar.tsx
@@ -80,6 +80,8 @@ export default class AnnouncementBar extends React.PureComponent<Props> {
             barStyle.backgroundColor = this.props.color;
             barStyle.color = this.props.textColor;
             linkStyle.color = this.props.textColor;
+        } else if (this.props.type === AnnouncementBarTypes.DEVELOPER) {
+            barClass = 'announcement-bar announcement-bar-critical';
         } else if (this.props.type === AnnouncementBarTypes.CRITICAL) {
             barClass = 'announcement-bar announcement-bar-critical';
         } else if (this.props.type === AnnouncementBarTypes.SUCCESS) {

--- a/packages/mattermost-redux/src/actions/errors.ts
+++ b/packages/mattermost-redux/src/actions/errors.ts
@@ -35,7 +35,7 @@ export function getLogErrorAction(error: ErrorObject, displayable = false) {
     };
 }
 
-export function logError(error: ServerError, displayable = false): ActionFunc {
+export function logError(error: ServerError, displayable = false, consoleError = false): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         if (error.server_error_id === 'api.context.session_expired.app_error') {
             return {data: true};
@@ -59,6 +59,10 @@ export function logError(error: ServerError, displayable = false): ActionFunc {
                 // avoid crashing the app if an error sending
                 // the error occurs.
             }
+        }
+
+        if (consoleError) {
+            serializedError.message = 'A JavaScript error has occurred. Please use the JavaScript console to capture and report the error';
         }
 
         EventEmitter.emit(ErrorTypes.LOG_ERROR, error);

--- a/packages/mattermost-redux/src/actions/errors.ts
+++ b/packages/mattermost-redux/src/actions/errors.ts
@@ -7,6 +7,7 @@ import {ErrorTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 import {DispatchFunc, ActionFunc} from 'mattermost-redux/types/actions';
+import {LogLevel} from 'mattermost-redux/types/client4';
 import {ServerError} from 'mattermost-redux/types/errors';
 
 export function dismissErrorObject(index: number) {
@@ -43,7 +44,7 @@ export function logError(error: ServerError, displayable = false): ActionFunc {
         const serializedError = serializeError(error);
 
         let sendToServer = true;
-        if (error.stack && error.stack.includes('TypeError: Failed to fetch')) {
+        if (error.stack?.includes('TypeError: Failed to fetch')) {
             sendToServer = false;
         }
         if (error.server_error_id) {
@@ -53,7 +54,7 @@ export function logError(error: ServerError, displayable = false): ActionFunc {
         if (sendToServer) {
             try {
                 const stringifiedSerializedError = JSON.stringify(serializedError).toString();
-                await Client4.logClientError(stringifiedSerializedError);
+                await Client4.logClientError(stringifiedSerializedError, LogLevel.Debug);
             } catch (err) {
                 // avoid crashing the app if an error sending
                 // the error occurs.

--- a/packages/mattermost-redux/src/actions/general.ts
+++ b/packages/mattermost-redux/src/actions/general.ts
@@ -101,7 +101,7 @@ export function getLicenseConfig(): ActionFunc {
     });
 }
 
-export function logClientError(message: string, level: LogLevel = 'ERROR') {
+export function logClientError(message: string, level = LogLevel.Error) {
     return bindClientFunc({
         clientFunc: Client4.logClientError,
         onRequest: GeneralTypes.LOG_CLIENT_ERROR_REQUEST,

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -28,7 +28,7 @@ import {
     ChannelSearchOpts,
     ServerChannel,
 } from 'mattermost-redux/types/channels';
-import {Options, StatusOK, ClientResponse} from 'mattermost-redux/types/client4';
+import {Options, StatusOK, ClientResponse, LogLevel} from 'mattermost-redux/types/client4';
 import {Compliance} from 'mattermost-redux/types/compliance';
 import {
     ClientConfig,
@@ -2272,7 +2272,7 @@ export default class Client4 {
         );
     }
 
-    logClientError = (message: string, level = 'ERROR') => {
+    logClientError = (message: string, level = LogLevel.Error) => {
         const url = `${this.getBaseRoute()}/logs`;
 
         if (!this.enableLogging) {

--- a/packages/mattermost-redux/src/types/client4.ts
+++ b/packages/mattermost-redux/src/types/client4.ts
@@ -1,8 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// I assume these are the log levels
-export type LogLevel = 'ERROR' | 'WARNING' | 'INFO';
+export enum LogLevel {
+    Error = 'ERROR',
+    Warning = 'WARNING',
+    Info = 'INFO',
+    Debug = 'DEBUG',
+}
 
 export type ClientResponse<T> = {
     response: Response;

--- a/root.jsx
+++ b/root.jsx
@@ -35,11 +35,12 @@ function preRenderSetup(callwhendone) {
         store.dispatch(
             logError({
                 type: AnnouncementBarTypes.DEVELOPER,
-                message: 'A JavaScript error has occurred. Please use the JavaScript console to capture and report the error (msg: ' + msg + ', row: ' + line + ', col: ' + column + ').',
+                message: 'A JavaScript error in the webapp client has occurred. (msg: ' + msg + ', row: ' + line + ', col: ' + column + ').',
                 stack,
                 url,
             },
             displayable,
+            true,
             ),
         );
     };

--- a/root.jsx
+++ b/root.jsx
@@ -15,6 +15,7 @@ import 'katex/dist/katex.min.css';
 import '@mattermost/compass-icons/css/compass-icons.css';
 
 import {isDevMode, setCSRFFromCookie} from 'utils/utils';
+import {AnnouncementBarTypes} from 'utils/constants';
 import store from 'stores/redux_store.jsx';
 import App from 'components/app';
 
@@ -25,18 +26,22 @@ function preRenderSetup(callwhendone) {
         if (msg === 'ResizeObserver loop limit exceeded') {
             return;
         }
-        var l = {};
-        l.level = 'ERROR';
-        l.message = 'msg: ' + msg + ' row: ' + line + ' col: ' + column + ' stack: ' + stack + ' url: ' + url;
 
-        const req = new XMLHttpRequest();
-        req.open('POST', '/api/v4/logs');
-        req.setRequestHeader('Content-Type', 'application/json');
-        req.send(JSON.stringify(l));
-
+        let displayable = false;
         if (isDevMode()) {
-            store.dispatch(logError({type: 'developer', message: 'DEVELOPER MODE: A JavaScript error has occurred.  Please use the JavaScript console to capture and report the error (row: ' + line + ' col: ' + column + ').'}, true));
+            displayable = true;
         }
+
+        store.dispatch(
+            logError({
+                type: AnnouncementBarTypes.DEVELOPER,
+                message: 'A JavaScript error has occurred. Please use the JavaScript console to capture and report the error (msg: ' + msg + ', row: ' + line + ', col: ' + column + ').',
+                stack,
+                url,
+            },
+            displayable,
+            ),
+        );
     };
     setCSRFFromCookie();
     callwhendone();


### PR DESCRIPTION
#### Summary
This PR reworks how the webapp handles uncaught JS errors.

Firstly, it removes the unnecessary request in the `onerror` handlers, which causes an 401 anyway, as it doesn't contain a CSRF token.

Secondly, all JS errors now get logged - on `debug` level. This should help support with debugging issues.

If developers mode is enabled, the announcement banner shows the error information. The error message was added back. The background color is back to red.

Example log message on the server:
```
debug [2022-02-25 11:25:13.147 +01:00] Client Logs API Endpoint Message: {"type":"developer","message":"A JavaScript error has occurred. Please use the JavaScript console to capture and report the error (msg: Uncaught foo, row: 37, col: 159561).","stack":"foo","url":"http://localhost:8065/static/plugins/com.mattermost.plugin-todo/com.mattermost.plugin-todo_2dcd215ae8d8470e_bundle.js"} caller="api4/system.go:371" type=client_message user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
```

#### Screenshots
![Screenshot from 2022-02-25 11-22-58](https://user-images.githubusercontent.com/16541325/155699961-d25bb5b6-58dd-485e-b0e8-602841f8674f.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42094

#### Release Note
```release-note
NONE
```
