### PR TITLE
only first admin sees preparing-workspace screen

### DIFF
--- a/components/preparing_workspace/index.tsx
+++ b/components/preparing_workspace/index.tsx
@@ -6,6 +6,7 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {Action} from 'mattermost-redux/types/actions';
 import {checkIfTeamExists, createTeam} from 'mattermost-redux/actions/teams';
+import {getProfiles} from 'mattermost-redux/actions/users';
 
 import PreparingWorkspace, {Actions} from './preparing_workspace';
 
@@ -13,6 +14,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<Action>, Actions>({
             createTeam,
+            getProfiles,
             checkIfTeamExists,
         }, dispatch),
     };

--- a/components/preparing_workspace/preparing_workspace.tsx
+++ b/components/preparing_workspace/preparing_workspace.tsx
@@ -7,6 +7,7 @@ import {RouterProps} from 'react-router-dom';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import {GeneralTypes} from 'mattermost-redux/action_types';
+import {General} from 'mattermost-redux/constants';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {createChannel} from 'mattermost-redux/actions/channels';
 import {getFirstAdminSetupComplete as getFirstAdminSetupCompleteAction} from 'mattermost-redux/actions/general';
@@ -81,6 +82,7 @@ const WAIT_FOR_REDIRECT_TIME = 2000 - START_TRANSITIONING_OUT;
 export type Actions = {
     createTeam: (team: Team) => ActionResult;
     checkIfTeamExists: (teamName: string) => ActionResult;
+    getProfiles: (page: number, perPage: number, options: Record<string, any>) => ActionResult;
 }
 
 type Props = RouterProps & {
@@ -168,6 +170,7 @@ export default function PreparingWorkspace(props: Props) {
     const [submitError, setSubmitError] = useState<string | null>(null);
     useEffect(() => {
         showOnMountTimeout.current = setTimeout(() => setShowFirstPage(true), 40);
+        props.actions.getProfiles(0, General.PROFILE_CHUNK_SIZE, {roles: General.SYSTEM_ADMIN_ROLE});
         dispatch(getFirstAdminSetupCompleteAction());
         document.body.classList.add('admin-onboarding');
         return () => {

--- a/components/root/index.js
+++ b/components/root/index.js
@@ -9,6 +9,7 @@ import {shouldShowTermsOfService, getCurrentUserId, isFirstAdmin} from 'mattermo
 import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getFirstAdminSetupComplete} from 'mattermost-redux/actions/general';
 import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getProfiles} from 'mattermost-redux/actions/users';
 
 import {loadMeAndConfig} from 'actions/views/root';
 import {emitBrowserWindowResized} from 'actions/views/browser';
@@ -52,6 +53,7 @@ function mapDispatchToProps(dispatch) {
             loadMeAndConfig,
             emitBrowserWindowResized,
             getFirstAdminSetupComplete,
+            getProfiles,
         }, dispatch),
     };
 }

--- a/components/root/root.test.jsx
+++ b/components/root/root.test.jsx
@@ -57,6 +57,7 @@ describe('components/Root', () => {
                 type: GeneralTypes.FIRST_ADMIN_COMPLETE_SETUP_RECEIVED,
                 data: true,
             })),
+            getProfiles: jest.fn(),
         },
         location: {
             pathname: '/',

--- a/components/root/root_redirect/index.ts
+++ b/components/root/root_redirect/index.ts
@@ -5,7 +5,7 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
 
 import {getFirstAdminSetupComplete} from 'mattermost-redux/actions/general';
-import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, isCurrentUserSystemAdmin, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferences';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
@@ -22,6 +22,7 @@ function mapStateToProps(state: GlobalState) {
     return {
         currentUserId: getCurrentUserId(state),
         isElegibleForFirstAdmingOnboarding,
+        isFirstAdmin: isFirstAdmin(state),
     };
 }
 

--- a/components/root/root_redirect/root_redirect.tsx
+++ b/components/root/root_redirect/root_redirect.tsx
@@ -11,6 +11,7 @@ export type Props = {
     isElegibleForFirstAdmingOnboarding: boolean;
     currentUserId: string;
     location: Location;
+    isFirstAdmin: boolean;
     actions: {
         getFirstAdminSetupComplete: () => Promise<{data: boolean; error: any}>;
     };
@@ -21,7 +22,8 @@ export default function RootRedirect(props: Props) {
         if (props.currentUserId) {
             if (props.isElegibleForFirstAdmingOnboarding) {
                 props.actions.getFirstAdminSetupComplete().then((firstAdminCompletedSignup) => {
-                    if (firstAdminCompletedSignup.data === false) {
+                    // root.jsx ensures admin profiles are eventually loaded
+                    if (firstAdminCompletedSignup.data === false && props.isFirstAdmin) {
                         browserHistory.push('/preparing-workspace');
                     } else {
                         GlobalActions.redirectUserToDefaultTeam();

--- a/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -699,9 +699,7 @@ export function checkIsFirstAdmin(currentUser: UserProfile, users: IDMappedObjec
     if (!currentUser.roles.includes('system_admin')) {
         return false;
     }
-    const userIds = Object.keys(users);
-    for (const userId of userIds) {
-        const user = users[userId];
+    for (const user of Object.values(users)) {
         if (user.roles.includes('system_admin') && user.create_at < currentUser.create_at) {
             // If the user in the list is an admin with create_at less than our user, than that user is older than the current one, so it can't be the first admin.
             return false;

--- a/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -692,25 +692,27 @@ export function searchProfilesInGroup(state: GlobalState, groupId: Group['id'], 
     return profiles;
 }
 
+export function checkIsFirstAdmin(currentUser: UserProfile, users: IDMappedObjects<UserProfile>): boolean {
+    if (!currentUser) {
+        return false;
+    }
+    if (!currentUser.roles.includes('system_admin')) {
+        return false;
+    }
+    const userIds = Object.keys(users);
+    for (const userId of userIds) {
+        const user = users[userId];
+        if (user.roles.includes('system_admin') && user.create_at < currentUser.create_at) {
+            // If the user in the list is an admin with create_at less than our user, than that user is older than the current one, so it can't be the first admin.
+            return false;
+        }
+    }
+    return true;
+}
+
 export const isFirstAdmin = createSelector(
     'isFirstAdmin',
     (state: GlobalState) => getCurrentUser(state),
     (state: GlobalState) => getUsers(state),
-    (currentUser, users) => {
-        if (!currentUser) {
-            return false;
-        }
-        if (!currentUser.roles.includes('system_admin')) {
-            return false;
-        }
-        const userIds = Object.keys(users);
-        for (const userId of userIds) {
-            const user = users[userId];
-            if (user.roles.includes('system_admin') && user.create_at < currentUser.create_at) {
-            // If the user in the list is an admin with create_at less than our user, than that user is older than the current one, so it can't be the first admin.
-                return false;
-            }
-        }
-        return true;
-    },
+    checkIsFirstAdmin,
 );


### PR DESCRIPTION
#### Summary
Second admin should not see use case onboarding.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42103 , but only the `First admin vs second admin scenario:` scenario listed in the QA description.

#### Related Pull Requests
Not related in the code sense, but there is a separate server PR that addresses the `>= 10` posts part of the bug:
* https://github.com/mattermost/mattermost-server/pull/19642

#### Screenshots

https://user-images.githubusercontent.com/13738432/155773390-6c3f863e-dab5-4549-9689-a076534c113c.mp4


#### Release Note

```release-note
NONE
```
