### PR TITLE
MM-40662: Fix non-emoji text in markdown not rendered as emoji but added to recent emojis

### DIFF
--- a/utils/emoticons.tsx
+++ b/utils/emoticons.tsx
@@ -26,12 +26,13 @@ export const emoticonPatterns: { [key: string]: RegExp } = {
 export const EMOJI_PATTERN = /(:([a-zA-Z0-9_+-]+):)/g;
 
 export function matchEmoticons(text: string): RegExpMatchArray | null {
-    let emojis = text.match(EMOJI_PATTERN);
+    const markdownCleanedText = text.replace(/`(.*?)`/g, '');
+    let emojis = markdownCleanedText.match(EMOJI_PATTERN);
 
     for (const name of Object.keys(emoticonPatterns)) {
         const pattern = emoticonPatterns[name];
 
-        const matches = text.match(pattern);
+        const matches = markdownCleanedText.match(pattern);
         if (matches) {
             if (emojis) {
                 emojis = emojis.concat(matches);


### PR DESCRIPTION
#### Summary
This fixes an issue related to emoji such as ':smile:' is written within markdown. This is not rendered as emoji in the message but it is added to recently used emojis' list. With the changes, the emoji is not added to recently used emojis' list

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/19175


#### Screenshots
**before**

https://user-images.githubusercontent.com/37421564/156071033-9b4cd72e-4a9b-454c-a738-6100acd38061.mov

**after**

https://user-images.githubusercontent.com/37421564/156071062-8b1320b9-1e44-4b85-af47-80b94900cecb.mov



#### Release Note
```release-note
Fixes an issue related to when emoji shortcode is written in markdown, the emoji wasn't rendered as emoji in the message but it was added to recently used emojis.
```
