### PR TITLE
[MM-40486] CRT beta warning modal

### DIFF
--- a/components/collapsed_reply_threads_beta_modal/collapsed_reply_threads_beta_modal.scss
+++ b/components/collapsed_reply_threads_beta_modal/collapsed_reply_threads_beta_modal.scss
@@ -1,0 +1,31 @@
+@charset 'UTF-8';
+
+.GenericModal.CollapsedReplyThreadsBetaModal {
+    width: 692px;
+
+    .modal-content {
+        padding: 16px 15px;
+    }
+
+    .CollapsedReplyThreadsModal__img {
+        border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+        margin-top: 40px;
+        border-radius: 4px;
+    }
+
+    .modal-footer {
+        margin-top: 20px;
+    }
+}
+
+// Styles to override global styles
+.modal {
+    .GenericModal.CollapsedReplyThreadsBetaModal.modal-dialog {
+        height: unset;
+        margin-top: calc(50vh - 307px);
+    }
+
+    .GenericModal.CollapsedReplyThreadsBetaModal .modal-footer {
+        position: relative;
+    }
+}

--- a/components/collapsed_reply_threads_beta_modal/collapsed_reply_threads_beta_modal.tsx
+++ b/components/collapsed_reply_threads_beta_modal/collapsed_reply_threads_beta_modal.tsx
@@ -26,13 +26,13 @@ function CollapsedReplyThreadsBetaModal(props: Props) {
             onExited={props.onExited}
             modalHeaderText={(
                 <FormattedMessage
-                    id='collapsed_reply_threads_modal.title'
+                    id='collapsed_reply_threads_beta_modal.title'
                     defaultMessage={'You\'re accessing an early beta of Collapsed Reply Threads'}
                 />
             )}
             confirmButtonText={(
                 <FormattedMessage
-                    id={'collapsed_reply_threads_modal.confirm'}
+                    id={'collapsed_reply_threads_beta_modal.confirm'}
                     defaultMessage='Got it'
                 />
             )}

--- a/components/collapsed_reply_threads_beta_modal/collapsed_reply_threads_beta_modal.tsx
+++ b/components/collapsed_reply_threads_beta_modal/collapsed_reply_threads_beta_modal.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {memo} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import crtBetaImg from 'images/crt-beta.gif';
+
+import GenericModal from 'components/generic_modal';
+import AlertBanner from 'components/alert_banner';
+import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+import {ModalIdentifiers} from 'utils/constants';
+
+import './collapsed_reply_threads_beta_modal.scss';
+
+type Props = {
+    onExited: () => void;
+}
+
+function CollapsedReplyThreadsBetaModal(props: Props) {
+    return (
+        <GenericModal
+            className='CollapsedReplyThreadsBetaModal'
+            id={ModalIdentifiers.COLLAPSED_REPLY_THREADS_BETA_MODAL}
+            enforceFocus={false}
+            onExited={props.onExited}
+            modalHeaderText={(
+                <FormattedMessage
+                    id='collapsed_reply_threads_modal.title'
+                    defaultMessage={'You\'re accessing an early beta of Collapsed Reply Threads'}
+                />
+            )}
+            confirmButtonText={(
+                <FormattedMessage
+                    id={'collapsed_reply_threads_modal.confirm'}
+                    defaultMessage='Got it'
+                />
+            )}
+            handleConfirm={props.onExited}
+        >
+            <div>
+                <AlertBanner
+                    variant='app'
+                    mode='info'
+                    title={(
+                        <FormattedMarkdownMessage
+                            id='collapsed_reply_threads_beta_modal.banner.title'
+                            defaultMessage='Please  [review the list of known issues](!https://docs.mattermost.com/messaging/organizing-conversations.html#known-issues) as we work on stabilizing the feature.'
+                        />
+                    )}
+                    message={(
+                        <FormattedMessage
+                            id='collapsed_reply_threads_beta_modal.banner.message'
+                            defaultMessage='In particular, you may notice a number of channels and threads appear as unread when you enable Collapsed Reply Threads for the first time.'
+                        />
+                    )}
+                />
+
+                <img
+                    src={crtBetaImg}
+                    className='CollapsedReplyThreadsModal__img'
+                />
+            </div>
+        </GenericModal>
+    );
+}
+
+export default memo(CollapsedReplyThreadsBetaModal);

--- a/components/collapsed_reply_threads_beta_modal/index.ts
+++ b/components/collapsed_reply_threads_beta_modal/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export {default} from './collapsed_reply_threads_beta_modal';

--- a/components/user_settings/modal/index.ts
+++ b/components/user_settings/modal/index.ts
@@ -7,7 +7,9 @@ import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
 import {sendVerificationEmail} from 'mattermost-redux/actions/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {GlobalState} from 'types/store';
+import {openModal} from 'actions/views/modals';
 import {Action} from 'mattermost-redux/types/actions';
 
 import UserSettingsModal, {Props} from './user_settings_modal';
@@ -17,11 +19,13 @@ function mapStateToProps(state: GlobalState) {
 
     const sendEmailNotifications = config.SendEmailNotifications === 'true';
     const requireEmailVerification = config.RequireEmailVerification === 'true';
+    const collapsedThreads = isCollapsedThreadsEnabled(state);
 
     return {
         currentUser: getCurrentUser(state),
         sendEmailNotifications,
         requireEmailVerification,
+        collapsedThreads,
     };
 }
 
@@ -29,6 +33,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<Action>, Props['actions']>({
             sendVerificationEmail,
+            openModal,
         }, dispatch),
     };
 }

--- a/components/user_settings/modal/user_settings_modal.tsx
+++ b/components/user_settings/modal/user_settings_modal.tsx
@@ -18,10 +18,12 @@ import {StatusOK} from 'mattermost-redux/types/client4';
 
 import store from 'stores/redux_store.jsx';
 
-import Constants from 'utils/constants';
+import CollapsedReplyThreadsBetaModal from 'components/collapsed_reply_threads_beta_modal';
+import {ModalData} from 'types/actions';
+import Constants, {ModalIdentifiers} from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
-import ConfirmModal from '../../confirm_modal';
+import ConfirmModal from 'components/confirm_modal';
 
 const UserSettings = React.lazy(() => import(/* webpackPrefetch: true */ 'components/user_settings'));
 const SettingsSidebar = React.lazy(() => import(/* webpackPrefetch: true */ '../../settings_sidebar'));
@@ -73,8 +75,10 @@ export type Props = {
     currentUser: UserProfile;
     onExited: () => void;
     intl: IntlShape;
+    collapsedThreads: boolean;
     isContentProductSettings: boolean;
     actions: {
+        openModal: <P>(modalData: ModalData<P>) => void;
         sendVerificationEmail: (email: string) => Promise<{
             data: StatusOK;
             error: {
@@ -95,6 +99,7 @@ type State = {
 
 class UserSettingsModal extends React.PureComponent<Props, State> {
     private requireConfirm: boolean;
+    private showCRTBetaModal: boolean;
     private customConfirmAction: ((handleConfirm: () => void) => void) | null;
     private modalBodyRef: React.RefObject<Modal>;
     private afterConfirm: (() => void) | null;
@@ -112,6 +117,7 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
         };
 
         this.requireConfirm = false;
+        this.showCRTBetaModal = false;
 
         // Used when settings want to override the default confirm modal with their own
         // If set by a child, it will be called in place of showing the regular confirm
@@ -147,6 +153,14 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
             const el = ReactDOM.findDOMNode(this.modalBodyRef.current) as any;
             el.scrollTop = 0;
         }
+
+        // we use the showCRTBetaModal to track change of collapsedThreads between states
+        // but NOT when both prev and current collapsedThreads prop is the same
+        if (this.props.collapsedThreads && !prevProps.collapsedThreads) {
+            this.showCRTBetaModal = true;
+        } else if (!this.props.collapsedThreads && prevProps.collapsedThreads) {
+            this.showCRTBetaModal = false;
+        }
     }
 
     handleKeyDown = (e: KeyboardEvent) => {
@@ -175,6 +189,13 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
             active_section: '',
         });
         this.props.onExited();
+
+        if (this.showCRTBetaModal) {
+            this.props.actions.openModal({
+                modalId: ModalIdentifiers.COLLAPSED_REPLY_THREADS_BETA_MODAL,
+                dialogType: CollapsedReplyThreadsBetaModal,
+            });
+        }
     }
 
     // Called to hide the settings pane when on mobile

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2860,6 +2860,8 @@
   "cloud_subscribe.select_plan": "Select a plan",
   "collapsed_reply_threads_beta_modal.banner.message": "In particular, you may notice a number of channels and threads appear as unread when you enable Collapsed Reply Threads for the first time.",
   "collapsed_reply_threads_beta_modal.banner.title": "Please  [review the list of known issues](!https://docs.mattermost.com/messaging/organizing-conversations.html#known-issues) as we work on stabilizing the feature.",
+  "collapsed_reply_threads_beta_modal.confirm": "Got it",
+  "collapsed_reply_threads_beta_modal.title": "You're accessing an early beta of Collapsed Reply Threads",
   "collapsed_reply_threads_modal.confirm": "Got it",
   "collapsed_reply_threads_modal.description": "Threads have been revamped to help you create organized conversation around specific messages. Now, channels will appear less cluttered as replies are collapsed under the original message, and all the conversations you're following are available in your **Threads** view. Take the tour to see what's new.",
   "collapsed_reply_threads_modal.skip_tour": "Skip Tour",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2858,6 +2858,8 @@
   "claim.oauth_to_email.title": "Switch {type} Account to Email",
   "cloud_subscribe.contact_support": "Compare plans",
   "cloud_subscribe.select_plan": "Select a plan",
+  "collapsed_reply_threads_beta_modal.banner.message": "In particular, you may notice a number of channels and threads appear as unread when you enable Collapsed Reply Threads for the first time.",
+  "collapsed_reply_threads_beta_modal.banner.title": "Please  [review the list of known issues](!https://docs.mattermost.com/messaging/organizing-conversations.html#known-issues) as we work on stabilizing the feature.",
   "collapsed_reply_threads_modal.confirm": "Got it",
   "collapsed_reply_threads_modal.description": "Threads have been revamped to help you create organized conversation around specific messages. Now, channels will appear less cluttered as replies are collapsed under the original message, and all the conversations you're following are available in your **Threads** view. Take the tour to see what's new.",
   "collapsed_reply_threads_modal.skip_tour": "Skip Tour",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -355,6 +355,7 @@ export const ModalIdentifiers = {
     NO_INTERNET_CONNECTION: 'no_internet_connection',
     JOIN_CHANNEL_PROMPT: 'join_channel_prompt',
     COLLAPSED_REPLY_THREADS_MODAL: 'collapsed_reply_threads_modal',
+    COLLAPSED_REPLY_THREADS_BETA_MODAL: 'collapsed_reply_threads_beta_modal',
     NOTIFY_CONFIRM_MODAL: 'notify_confirm_modal',
     CONFIRM_LICENSE_REMOVAL: 'confirm_license_removal',
     CONFIRM: 'confirm',


### PR DESCRIPTION
#### Summary
Adding CRT beta modal which was removed as part of https://github.com/mattermost/mattermost-webapp/pull/9289 (needs to be removed as soon CRT is ready for GA).
Fixes : CRT modal not showing the "Got It" Button in the Modal Footer.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-40486

#### Related Pull Requests
NONE

#### Screenshots

<img width="724" alt="Screenshot 2022-03-03 at 9 32 20 PM" src="https://user-images.githubusercontent.com/16203333/156602922-e7977f93-4322-4dd2-bce9-285acfdc2146.png">



#### Release Note
```release-note
UI: CRT Beta warning modal 
```
