### PR TITLE
[MM-40267] Fixes: Channel keyboard navigation breaks when in the Threads view

### DIFF
--- a/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/components/threading/global_threads/thread_list/thread_list.tsx
@@ -82,8 +82,8 @@ const ThreadList = ({
         if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') {
             return;
         }
-
-        if (!Utils.isKeyPressed(e, Constants.KeyCodes.DOWN) && !Utils.isKeyPressed(e, Constants.KeyCodes.UP)) {
+        const comboKeyPressed = e.altKey || e.metaKey || e.shiftKey || e.ctrlKey;
+        if (comboKeyPressed || (!Utils.isKeyPressed(e, Constants.KeyCodes.DOWN) && !Utils.isKeyPressed(e, Constants.KeyCodes.UP))) {
             return;
         }
 


### PR DESCRIPTION
#### Summary
Fixes: Channel keyboard navigation breaks when in the Threads view
Note: Repro on Desktop app only

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-40267

#### Related Pull Requests
``NONE``

#### Screenshots
|  before  |  after  |
|----|----|
| https://user-images.githubusercontent.com/16203333/156151927-51d8940f-07f1-427e-98d6-15f4854cc133.mp4 | https://user-images.githubusercontent.com/16203333/156151683-3c63bdca-b5b0-4890-a5ab-71c814af441c.mp4 | 



#### Release Note
```release-note
Fixes: Channel keyboard navigation breaks when in the Threads view
```
