### PR TITLE
MM-42131 Fix accidental change to PostList positioning

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -289,7 +289,7 @@ export default class PostList extends React.PureComponent {
         if (this.props.isMobileView) {
             dynamicListStyle = {
                 ...dynamicListStyle,
-                opened: opened ? 'unset' : 'transform',
+                willChange: opened ? 'unset' : 'transform',
             };
         }
 


### PR DESCRIPTION
This is a fix for a typo I introduced here: https://github.com/mattermost/mattermost-webapp/commit/286fb6dad8f7bb848d817ddbee30af915a388469#diff-ec9be19b2c781da350707675e6fe6a8483f55db7deaee8737edb55cc8ba79637L283

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42131

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/9508

#### Release Note
```release-note
Fixed positioning of the post menu in mobile web view
```
