### PR TITLE
MM-41952 : Unread channels names and sidebar item render on top of channel options menu

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1105,7 +1105,6 @@ $sidebarOpacityAnimationDuration: 0.15s;
         &.expanded {
             animation-direction: normal;
             animation-duration: $sidebarOpacityAnimationDuration;
-            animation-fill-mode: forwards;
             animation-iteration-count: 1;
             animation-name: toOpaqueAnimation;
             animation-play-state: running;
@@ -1115,7 +1114,6 @@ $sidebarOpacityAnimationDuration: 0.15s;
             height: 0 !important;
             animation-direction: normal;
             animation-duration: $sidebarOpacityAnimationDuration;
-            animation-fill-mode: forwards;
             animation-iteration-count: 1;
             animation-name: toTransparentAnimation;
             animation-play-state: running;


### PR DESCRIPTION
#### Summary
Removed `animation-fill-mode` css property on sidebar links for them to not overflow over to side bar menus

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41952

#### Related Pull Requests
N/A

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="521" alt="image" src="https://user-images.githubusercontent.com/17708702/156352786-2db8dbd9-4d22-494a-aeb2-86bc40ff2dae.png"> | <img width="521" alt="image" src="https://user-images.githubusercontent.com/17708702/156352474-ecac9dab-da38-450d-8090-3572a0c69d75.png"> |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Channel links on hover overlapping channels menus fixed
```
