### PR TITLE
[MM-40072] Fix Groups Pagination in System Console

### DIFF
--- a/components/admin_console/group_settings/groups_list/groups_list.test.tsx
+++ b/components/admin_console/group_settings/groups_list/groups_list.test.tsx
@@ -296,8 +296,15 @@ describe('components/admin_console/group_settings/GroupsList.tsx', () => {
                     {primary_key: 'test1', name: 'test1'},
                     {primary_key: 'test2', name: 'test2', mattermost_group_id: 'group-id-1', has_syncables: false},
                     {primary_key: 'test3', name: 'test3', mattermost_group_id: 'group-id-2', has_syncables: true},
+                    {primary_key: 'test4', name: 'test4'},
+                    {primary_key: 'test5', name: 'test5'},
+                    {primary_key: 'test6', name: 'test6'},
+                    {primary_key: 'test7', name: 'test7'},
+                    {primary_key: 'test8', name: 'test8'},
+                    {primary_key: 'test9', name: 'test9'},
+                    {primary_key: 'test10', name: 'test10'},
                 ]}
-                total={13}
+                total={20}
                 actions={{
                     getLdapGroups,
                     link: jest.fn(),
@@ -305,11 +312,17 @@ describe('components/admin_console/group_settings/GroupsList.tsx', () => {
                 }}
             />,
         );
-        wrapper.setState({page: 1, checked: {test1: true, test2: true}});
+        wrapper.setState({page: 2, checked: {test1: true, test2: true}});
 
         await wrapper.instance().previousPage({preventDefault: jest.fn()});
 
-        const state = wrapper.instance().state;
+        let state = wrapper.instance().state;
+        expect(state.checked).toEqual({});
+        expect(state.page).toBe(1);
+        expect(state.loading).toBe(false);
+
+        await wrapper.instance().previousPage({preventDefault: jest.fn()});
+        state = wrapper.state();
         expect(state.checked).toEqual({});
         expect(state.page).toBe(0);
         expect(state.loading).toBe(false);
@@ -369,9 +382,15 @@ describe('components/admin_console/group_settings/GroupsList.tsx', () => {
         wrapper.setState({page: 0, checked: {test1: true, test2: true}});
 
         await wrapper.instance().nextPage({preventDefault: jest.fn()});
-        const state = wrapper.state();
+        let state = wrapper.state();
         expect(state.checked).toEqual({});
         expect(state.page).toBe(1);
+        expect(state.loading).toBe(false);
+
+        await wrapper.instance().nextPage({preventDefault: jest.fn()});
+        state = wrapper.state();
+        expect(state.checked).toEqual({});
+        expect(state.page).toBe(2);
         expect(state.loading).toBe(false);
     });
 

--- a/components/admin_console/group_settings/groups_list/groups_list.tsx
+++ b/components/admin_console/group_settings/groups_list/groups_list.tsx
@@ -99,15 +99,17 @@ export default class GroupsList extends React.PureComponent<Props, State> {
     public async previousPage(e: any): Promise<void> {
         e.preventDefault();
         const page = this.state.page < 1 ? 0 : this.state.page - 1;
-        this.setState({checked: {}, page, loading: true});
-        this.searchGroups(page);
+        this.setState({checked: {}, page, loading: true}, () => {
+            this.searchGroups(page);
+        });
     }
 
     public async nextPage(e: any): Promise<void> {
         e.preventDefault();
         const page = this.state.page + 1;
-        this.setState({checked: {}, page, loading: true});
-        this.searchGroups(page);
+        this.setState({checked: {}, page, loading: true}, () => {
+            this.searchGroups(page);
+        });
     }
 
     public onCheckToggle(key: string) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Fixes an issue with pagination for groups in system console.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes [MM-40072](https://mattermost.atlassian.net/browse/MM-40072)


<!--
#### Related Pull Requests
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
- Has server changes (please link here)
- Has mobile changes (please link here)
-->


#### Screenshots
<!--

If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->


https://user-images.githubusercontent.com/23694620/156460326-e86a1a83-6fb2-4d53-a73c-4035258e235e.mov



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
