### PR TITLE
MM-42274 : Remove event listener "resize" on unmount of DataGrid component

### DIFF
--- a/components/admin_console/data_grid/data_grid.tsx
+++ b/components/admin_console/data_grid/data_grid.tsx
@@ -104,6 +104,10 @@ class DataGrid extends React.PureComponent<Props, State> {
         window.addEventListener('resize', this.handleResize);
     }
 
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleResize);
+    }
+
     private handleResize = () => {
         if (!this.ref?.current) {
             return;


### PR DESCRIPTION
#### Summary
Removed resize js event listener on unmount of data grid component which is used in admin console's channels, teams pages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42274

#### Related Pull Requests
N/A

#### Screenshots
https://community-daily.mattermost.com/core/pl/4y8qph3g87nm7kfx4bf9556zua

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Minute memory leak in admin console fixed.
```
