### PR TITLE
MM-42127_Search row should not appear in the unreads tab

### DIFF
--- a/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
+++ b/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`components/threading/global_threads/thread_list should match snapshot 1
     className="threads"
   >
     <Memo(VirtualizedThreadList)
-      hasLoaded={false}
+      addNoMoreResultsItem={false}
       ids={
         Array [
           "1",

--- a/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/components/threading/global_threads/thread_list/thread_list.tsx
@@ -225,7 +225,7 @@ const ThreadList = ({
                     selectedThreadId={selectedThreadId}
                     total={unread ? totalUnread : total}
                     isLoading={isLoading}
-                    hasLoaded={hasLoaded}
+                    addNoMoreResultsItem={hasLoaded && !unread}
                 />
                 {showListTutorialTip && !isMobileView && <CRTListTutorialTip autoTour={tutorialTipAutoTour}/>}
                 {unread && !someUnread && isEmpty(unreadIds) ? (

--- a/components/threading/global_threads/thread_list/virtualized_thread_list.test.tsx
+++ b/components/threading/global_threads/thread_list/virtualized_thread_list.test.tsx
@@ -19,7 +19,7 @@ describe('components/threading/global_threads/thread_list/virtualized_thread_lis
             selectedThreadId: '1',
             total: 3,
             isLoading: false,
-            hasLoaded: false,
+            addNoMoreResultsItem: false,
         };
     });
 

--- a/components/threading/global_threads/thread_list/virtualized_thread_list.tsx
+++ b/components/threading/global_threads/thread_list/virtualized_thread_list.tsx
@@ -18,7 +18,7 @@ type Props = {
     selectedThreadId?: UserThread['id'];
     total: number;
     isLoading?: boolean;
-    hasLoaded?: boolean;
+    addNoMoreResultsItem?: boolean;
 };
 
 const style = {
@@ -31,7 +31,7 @@ function VirtualizedThreadList({
     loadMoreItems,
     total,
     isLoading,
-    hasLoaded,
+    addNoMoreResultsItem,
 }: Props) {
     const infiniteLoaderRef = React.useRef<any>();
     const startIndexRef = React.useRef<number>(0);
@@ -58,11 +58,11 @@ function VirtualizedThreadList({
     const data = useMemo(
         () => (
             {
-                ids: hasLoaded && ids.length === total ? [...ids, Constants.THREADS_NO_RESULTS_ITEM_ID] : (isLoading && ids.length !== total && [...ids, Constants.THREADS_LOADING_INDICATOR_ITEM_ID]) || ids,
+                ids: addNoMoreResultsItem && ids.length === total ? [...ids, Constants.THREADS_NO_RESULTS_ITEM_ID] : (isLoading && ids.length !== total && [...ids, Constants.THREADS_LOADING_INDICATOR_ITEM_ID]) || ids,
                 selectedThreadId,
             }
         ),
-        [ids, selectedThreadId, isLoading, hasLoaded, total],
+        [ids, selectedThreadId, isLoading, addNoMoreResultsItem, total],
     );
 
     const isItemLoaded = useCallback((index) => {
@@ -123,7 +123,7 @@ function areEqual(prevProps: Props, nextProps: Props) {
         prevProps.selectedThreadId === nextProps.selectedThreadId &&
         prevProps.ids.join() === nextProps.ids.join() &&
         prevProps.isLoading === nextProps.isLoading &&
-        prevProps.hasLoaded === nextProps.hasLoaded
+        prevProps.addNoMoreResultsItem === nextProps.addNoMoreResultsItem
     );
 }
 

--- a/e2e/cypress/integration/collapsed_reply_threads/following_spec.js
+++ b/e2e/cypress/integration/collapsed_reply_threads/following_spec.js
@@ -203,7 +203,16 @@ describe('Collapsed Reply Threads', () => {
     it('MM-38891 should show search guidance at the end of the list after scroll loading', () => {
         // # Create more than 25 threads so we can use scroll loading in the Threads list
         for (let i = 1; i <= 30; i++) {
-            postMessageWithReply(testChannel.id, otherUser, `Another interesting post ${i}`, testUser, `Another reply ${i}!`);
+            postMessageWithReply(testChannel.id, otherUser, `Another interesting post ${i}`, testUser, `Another reply ${i}!`).then(({rootId}) => {
+                // # Mark last thread as Unread
+                if (i === 30) {
+                    // # Click on root post to open thread
+                    cy.get(`#post_${rootId}`).click();
+
+                    // # Click on the reply's dot menu and mark as unread
+                    cy.uiClickPostDropdownMenu(rootId, 'Mark as Unread', 'RHS_ROOT');
+                }
+            });
         }
 
         cy.uiClickSidebarItem('threads');
@@ -222,6 +231,12 @@ describe('Collapsed Reply Threads', () => {
                 cy.findByText('F').should('be.visible');
             });
         });
+
+        // # Click Unreads button
+        cy.findByText('Unreads').click();
+
+        // # Search guidance item should not be shown at the end of the Unreads threads list
+        cy.get('.ThreadList .no-results__wrapper').should('not.exist');
     });
 });
 

--- a/e2e/cypress/integration/collapsed_reply_threads/following_spec.js
+++ b/e2e/cypress/integration/collapsed_reply_threads/following_spec.js
@@ -221,9 +221,9 @@ describe('Collapsed Reply Threads', () => {
         const maxScrolls = 3;
         scrollThreadsListToEnd(maxScrolls);
 
-        // # Search guidance item should be shown at the end of the threads list
+        // * Search guidance item should be shown at the end of the threads list
         cy.get('.ThreadList .no-results__wrapper').should('be.visible').within(() => {
-            // # Title, subtitle and shortcut keys should be shown
+            // * Title, subtitle and shortcut keys should be shown
             cy.findByText('That’s the end of the list').should('be.visible');
             cy.contains('If you’re looking for older conversations, try searching with ').should('be.visible').within(() => {
                 cy.findByText(isMac() ? '⌘' : 'Ctrl').should('be.visible');
@@ -235,7 +235,7 @@ describe('Collapsed Reply Threads', () => {
         // # Click Unreads button
         cy.findByText('Unreads').click();
 
-        // # Search guidance item should not be shown at the end of the Unreads threads list
+        // * Search guidance item should not be shown at the end of the Unreads threads list
         cy.get('.ThreadList .no-results__wrapper').should('not.exist');
     });
 });


### PR DESCRIPTION
#### Summary
CRT: Ensure the Search Guidance row only appears on the “All your threads” tab

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42127

#### Screenshots
![CRT-unreads](https://user-images.githubusercontent.com/79058848/156599212-08b20aa6-a7ee-464f-a7c8-0051eb0966d5.gif)


#### Release Note
```release-note
NONE
```
