### PR TITLE
[MM-42207] Revert changes to wake up code where websocket is automatically reconnected

### DIFF
--- a/components/needs_team/needs_team.tsx
+++ b/components/needs_team/needs_team.tsx
@@ -106,7 +106,7 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
             const currentTime = (new Date()).getTime();
             if (currentTime > (lastTime + WAKEUP_THRESHOLD)) { // ignore small delays
                 console.log('computer woke up - fetching latest'); //eslint-disable-line no-console
-                reconnect(true);
+                reconnect(false);
             }
             lastTime = currentTime;
         }, WAKEUP_CHECK_INTERVAL);


### PR DESCRIPTION
#### Summary
Whenever the app goes inactive, after 5 minutes of inactivity the app will set the users status to Away. A short time after the websocket will disconnect. We have an interval check that tries to fetch missing data after the computer wakes up from sleep, which we amended to also reconnect the websocket in order to get more missing data.

Unfortunately this causes an issue where the interval still runs if the user is Away, but the computer is still on and the app is inactive (but still running), thus the websocket keeps reconnecting and users are automatically set back to Online when this happens, meaning they might miss mobile notifications since the server still thinks they're Online.

This PR reverts that fix for the time being, and we'll need to come up with something else to address the original issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42207

```release-note
NONE
```
