### PR TITLE
[MM-42298] Fix bugs introduced with console validation

### DIFF
--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -1093,6 +1093,12 @@ export default class SchemaAdminSettings extends React.PureComponent {
         }
 
         for (const setting of this.props.schema.settings) {
+            // Some settings are actually not settings (banner)
+            // and don't have a key, skip those ones
+            if (!('key' in setting)) {
+                continue;
+            }
+
             // don't validate elements set by env.
             if (this.isSetByEnv(setting.key)) {
                 continue;

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -1107,14 +1107,10 @@ export default class SchemaAdminSettings extends React.PureComponent {
             if (setting.validate) {
                 const result = setting.validate(this.state[setting.key]);
                 if (!result.isValid()) {
-                    this.setState({clientWarning: result.error()});
                     return false;
                 }
             }
         }
-        this.setState({
-            clientWarning: '',
-        });
 
         return true;
     }

--- a/components/admin_console/schema_admin_settings.test.jsx
+++ b/components/admin_console/schema_admin_settings.test.jsx
@@ -331,6 +331,7 @@ describe('components/admin_console/SchemaAdminSettings', () => {
                 // won't validate because no key
                 label: 'a banner',
                 type: 'banner',
+                validate: mockValidate,
             },
         ];
         const props = {

--- a/components/admin_console/schema_admin_settings.test.jsx
+++ b/components/admin_console/schema_admin_settings.test.jsx
@@ -327,6 +327,7 @@ describe('components/admin_console/SchemaAdminSettings', () => {
         const localSchema = {...schema};
         localSchema.settings = [
             {
+
                 // won't validate because no key
                 label: 'a banner',
                 type: 'banner',
@@ -353,6 +354,7 @@ describe('components/admin_console/SchemaAdminSettings', () => {
         const localSchema = {...schema};
         localSchema.settings = [
             {
+
                 // will validate because it has a key AND a validate method
                 key: 'field1',
                 label: 'with key and validation',

--- a/components/admin_console/schema_admin_settings.test.jsx
+++ b/components/admin_console/schema_admin_settings.test.jsx
@@ -8,6 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import SchemaText from 'components/admin_console/schema_text';
 
 import SchemaAdminSettings from './schema_admin_settings';
+import ValidationResult from './validation';
 
 describe('components/admin_console/SchemaAdminSettings', () => {
     let schema = null;
@@ -316,5 +317,59 @@ describe('components/admin_console/SchemaAdminSettings', () => {
                 defaultMessage='Plugin Not Found'
             />,
         )).toEqual(true);
+    });
+
+    test('should not try to validate when a setting does not contain a key', () => {
+        const mockValidate = jest.fn(() => {
+            return new ValidationResult(true, '', '');
+        });
+
+        const localSchema = {...schema};
+        localSchema.settings = [
+            {
+                // won't validate because no key
+                label: 'a banner',
+                type: 'banner',
+            },
+        ];
+        const props = {
+            config,
+            environmentConfig,
+            schema: localSchema,
+            updateConfig: jest.fn(),
+        };
+
+        const wrapper = shallow(<SchemaAdminSettings {...props}/>);
+
+        expect(wrapper.instance().canSave()).toBe(true);
+        expect(mockValidate).not.toHaveBeenCalled();
+    });
+
+    test('should validate when a setting contains a key and a validation method', () => {
+        const mockValidate = jest.fn(() => {
+            return new ValidationResult(true, '', '');
+        });
+
+        const localSchema = {...schema};
+        localSchema.settings = [
+            {
+                // will validate because it has a key AND a validate method
+                key: 'field1',
+                label: 'with key and validation',
+                type: 'text',
+                validate: mockValidate,
+            },
+        ];
+        const props = {
+            config,
+            environmentConfig,
+            schema: localSchema,
+            updateConfig: jest.fn(),
+        };
+
+        const wrapper = shallow(<SchemaAdminSettings {...props}/>);
+
+        expect(wrapper.instance().canSave()).toBe(true);
+        expect(mockValidate).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
#### Summary
- The console would crash when trying to validate a page containing an item that is not a real 'setting' (=that does not contain the `key` attribute, example: the banner in the `Web Server`)
- The warning message next to the save button was wrongfully erased.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42298

#### Related Pull Requests
N/A

#### Screenshots
The warning message works as expected (next to the save button at the bottom left):

![image](https://user-images.githubusercontent.com/785518/156671939-7bf9f118-d3f2-4c65-8518-6227cfd44b60.png)

The Web Server page (which contains a banner) now doesn't crash when changing values (previously, it would turn into a blank page).

https://user-images.githubusercontent.com/785518/156672159-aeb8773f-cb9a-422a-9f7d-e9e8ed5a1649.mp4

It does **not impact** the fields marked as required, they still display their own error message and block the save button:

![image](https://user-images.githubusercontent.com/785518/156673039-d7dc3357-2099-410a-9a14-4842be217ac2.png)

#### Release Note
```release-note
- Fixed a bug causing the administration console to crash
```
