### PR TITLE
MM-41745 refactor upload license flow

### DIFF
--- a/components/admin_console/license_settings/__snapshots__/license_settings.test.jsx.snap
+++ b/components/admin_console/license_settings/__snapshots__/license_settings.test.jsx.snap
@@ -265,8 +265,13 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
                   Current Plan
                 </div>
               }
+              fileInputRef={
+                Object {
+                  "current": null,
+                }
+              }
+              handleChange={[Function]}
               openEELicenseModal={[Function]}
-              openUploadModal={[Function]}
               upgradedFromTE={false}
             />
           </div>
@@ -1336,8 +1341,13 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
                   Current Plan
                 </div>
               }
+              fileInputRef={
+                Object {
+                  "current": null,
+                }
+              }
+              handleChange={[Function]}
               openEELicenseModal={[Function]}
-              openUploadModal={[Function]}
               upgradedFromTE={false}
             />
           </div>
@@ -1445,8 +1455,13 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
                   Current Plan
                 </div>
               }
+              fileInputRef={
+                Object {
+                  "current": null,
+                }
+              }
+              handleChange={[Function]}
               openEELicenseModal={[Function]}
-              openUploadModal={[Function]}
               upgradedFromTE={true}
             />
           </div>
@@ -1761,8 +1776,13 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
                   Current Plan
                 </div>
               }
+              fileInputRef={
+                Object {
+                  "current": null,
+                }
+              }
+              handleChange={[Function]}
               openEELicenseModal={[Function]}
-              openUploadModal={[Function]}
               upgradedFromTE={false}
             />
           </div>

--- a/components/admin_console/license_settings/license_settings.tsx
+++ b/components/admin_console/license_settings/license_settings.tsx
@@ -62,7 +62,7 @@ type Props = {
 
 type State = {
     fileSelected: boolean;
-    fileName: string | null;
+    file: File | null;
     serverError: string | null;
     gettingTrialError: string | null;
     gettingTrial: boolean;
@@ -75,14 +75,14 @@ type State = {
 };
 export default class LicenseSettings extends React.PureComponent<Props, State> {
     private interval: ReturnType<typeof setInterval> | null;
-
+    private fileInputRef: React.RefObject<HTMLInputElement>;
     constructor(props: Props) {
         super(props);
 
         this.interval = null;
         this.state = {
             fileSelected: false,
-            fileName: null,
+            file: null,
             serverError: null,
             gettingTrialError: null,
             gettingTrial: false,
@@ -93,6 +93,7 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
             restartError: null,
             clickNormalUpgradeBtn: false,
         };
+        this.fileInputRef = React.createRef();
     }
 
     componentDidMount() {
@@ -103,6 +104,20 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
         }
         this.props.actions.getLicenseConfig();
         AdminActions.getStandardAnalytics();
+    }
+
+    componentDidUpdate(prevProps: Props, prevState: State) {
+        if (prevState.fileSelected !== this.state.fileSelected && this.state.fileSelected) {
+            this.props.actions.openModal({
+                modalId: ModalIdentifiers.UPLOAD_LICENSE,
+                dialogType: UploadLicenseModal,
+                dialogProps: {
+                    fileObjFromProps: this.state.file,
+                },
+            });
+        }
+        // eslint-disable-next-line react/no-did-update-set-state
+        this.setState({fileSelected: false, file: null});
     }
 
     componentWillUnmount() {
@@ -129,17 +144,19 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
         this.setState({upgradingPercentage: percentage || 0, upgradeError: error as string});
     }
 
+    handleChange = () => {
+        const element = this.fileInputRef.current;
+        if (element !== null && element.files !== null) {
+            if (element.files.length > 0) {
+                this.setState({fileSelected: true, file: element.files[0]});
+            }
+        }
+    }
+
     openEELicenseModal = async () => {
         this.props.actions.openModal({
             modalId: ModalIdentifiers.ENTERPRISE_EDITION_LICENSE,
             dialogType: EELicenseModal,
-        });
-    };
-
-    openUploadModal = async () => {
-        this.props.actions.openModal({
-            modalId: ModalIdentifiers.UPLOAD_LICENSE,
-            dialogType: UploadLicenseModal,
         });
     };
 
@@ -328,9 +345,10 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
             leftPanel = (
                 <StarterLeftPanel
                     openEELicenseModal={this.openEELicenseModal}
-                    openUploadModal={this.openUploadModal}
                     currentPlan={this.currentPlan}
                     upgradedFromTE={this.props.upgradedFromTE}
+                    fileInputRef={this.fileInputRef}
+                    handleChange={this.handleChange}
                 />
             );
 

--- a/components/admin_console/license_settings/license_settings.tsx
+++ b/components/admin_console/license_settings/license_settings.tsx
@@ -146,10 +146,8 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
 
     handleChange = () => {
         const element = this.fileInputRef.current;
-        if (element !== null && element.files !== null) {
-            if (element.files.length > 0) {
-                this.setState({fileSelected: true, file: element.files[0]});
-            }
+        if (element?.files?.length) {
+            this.setState({fileSelected: true, file: element.files[0]});
         }
     }
 

--- a/components/admin_console/license_settings/modals/__snapshots__/upload_license_modal.test.tsx.snap
+++ b/components/admin_console/license_settings/modals/__snapshots__/upload_license_modal.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`components/admin_console/license_settings/modals/upload_license_modal s
   }
 >
   <UploadLicenseModal
+    fileObjFromProps={Object {}}
     onExited={[MockFunction]}
   />
 </ContextProvider>
@@ -71,6 +72,7 @@ exports[`components/admin_console/license_settings/modals/upload_license_modal s
   }
 >
   <UploadLicenseModal
+    fileObjFromProps={Object {}}
     onExited={[MockFunction]}
   />
 </ContextProvider>

--- a/components/admin_console/license_settings/modals/upload_license_modal.test.tsx
+++ b/components/admin_console/license_settings/modals/upload_license_modal.test.tsx
@@ -58,6 +58,7 @@ describe('components/admin_console/license_settings/modals/upload_license_modal'
 
     const props = {
         onExited: mockOnExited,
+        fileObjFromProps: {} as File,
     };
 
     const mockStore = configureStore([thunk]);

--- a/components/admin_console/license_settings/modals/upload_license_modal.tsx
+++ b/components/admin_console/license_settings/modals/upload_license_modal.tsx
@@ -25,7 +25,7 @@ import HandsSvg from 'components/common/svg_images_components/hands_svg';
 import FileSvg from 'components/common/svg_images_components/file_svg';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
 
-import {ModalIdentifiers} from 'utils/constants';
+import {FileTypes, ModalIdentifiers} from 'utils/constants';
 
 import {closeModal} from 'actions/views/modals';
 
@@ -51,8 +51,6 @@ const UploadLicenseModal = (props: Props): JSX.Element | null => {
 
     const currentLicense: ClientLicense = useSelector(getLicense);
     const locale = useSelector(getCurrentLocale);
-
-    const LICENSE_EXTENSION = '.mattermost-license';
 
     const handleChange = () => {
         const element = fileInputRef.current;
@@ -105,10 +103,10 @@ const UploadLicenseModal = (props: Props): JSX.Element | null => {
     };
 
     const displayFileName = (fileName: string) => {
-        const extLen = LICENSE_EXTENSION.length;
-        let fileNameWithoutExt = fileName.split(LICENSE_EXTENSION)[0];
+        const extLen = FileTypes.LICENSE_EXTENSION.length;
+        let fileNameWithoutExt = fileName.split(FileTypes.LICENSE_EXTENSION)[0];
         fileNameWithoutExt = fileNameWithoutExt.length < (40 - extLen) ? fileNameWithoutExt : `${fileNameWithoutExt.substr(0, (37 - extLen))}...`;
-        return `${fileNameWithoutExt}${LICENSE_EXTENSION}`;
+        return `${fileNameWithoutExt}${FileTypes.LICENSE_EXTENSION}`;
     };
 
     let uploadLicenseContent = (
@@ -176,7 +174,7 @@ const UploadLicenseModal = (props: Props): JSX.Element | null => {
                                     <input
                                         ref={fileInputRef}
                                         type='file'
-                                        accept={LICENSE_EXTENSION}
+                                        accept={FileTypes.LICENSE_EXTENSION}
                                         onChange={handleChange}
                                     />
                                     <a

--- a/components/admin_console/license_settings/modals/upload_license_modal.tsx
+++ b/components/admin_console/license_settings/modals/upload_license_modal.tsx
@@ -38,12 +38,13 @@ import './upload_license_modal.scss';
 
 type Props = {
     onExited?: () => void;
+    fileObjFromProps: File | null;
 }
 
-const UploadLicenseModal: React.FC<Props> = (props: Props): JSX.Element | null => {
+const UploadLicenseModal = (props: Props): JSX.Element | null => {
     const dispatch = useDispatch<DispatchFunc>();
 
-    const [fileObj, setFileObj] = React.useState<File | null>(null);
+    const [fileObj, setFileObj] = React.useState<File | null>(props.fileObjFromProps);
     const [isUploading, setIsUploading] = React.useState(false);
     const [serverError, setServerError] = React.useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);

--- a/components/admin_console/license_settings/starter_edition/starter_left_panel.tsx
+++ b/components/admin_console/license_settings/starter_edition/starter_left_panel.tsx
@@ -4,6 +4,8 @@ import React, {RefObject} from 'react';
 
 import {FormattedMessage} from 'react-intl';
 
+import {FileTypes} from 'utils/constants';
+
 import './starter_edition.scss';
 export interface StarterEditionProps {
     openEELicenseModal: () => void;
@@ -75,7 +77,7 @@ const StarterLeftPanel: React.FC<StarterEditionProps> = ({
                 <div className='uploadButtons'>
                     <button
                         className='btn btn-upload light-blue-btn'
-                        onClick={() => fileInputRef.current !== null && fileInputRef.current.click()}
+                        onClick={() => fileInputRef.current?.click()}
                         id='open-modal'
                     >
                         <FormattedMessage
@@ -86,7 +88,7 @@ const StarterLeftPanel: React.FC<StarterEditionProps> = ({
                     <input
                         ref={fileInputRef}
                         type='file'
-                        accept='.mattermost-license'
+                        accept={FileTypes.LICENSE_EXTENSION}
                         onChange={handleChange}
                         style={{display: 'none'}}
                     />

--- a/components/admin_console/license_settings/starter_edition/starter_left_panel.tsx
+++ b/components/admin_console/license_settings/starter_edition/starter_left_panel.tsx
@@ -9,14 +9,16 @@ export interface StarterEditionProps {
     openEELicenseModal: () => void;
     currentPlan: JSX.Element;
     upgradedFromTE: boolean;
-    openUploadModal: () => void;
+    fileInputRef: any;
+    handleChange: () => void;
 }
 
 const StarterLeftPanel: React.FC<StarterEditionProps> = ({
     openEELicenseModal,
     currentPlan,
     upgradedFromTE,
-    openUploadModal,
+    fileInputRef,
+    handleChange,
 }: StarterEditionProps) => {
     return (
         <div className='StarterLeftPanel'>
@@ -73,7 +75,7 @@ const StarterLeftPanel: React.FC<StarterEditionProps> = ({
                 <div className='uploadButtons'>
                     <button
                         className='btn btn-upload light-blue-btn'
-                        onClick={openUploadModal}
+                        onClick={() => fileInputRef.current.click()}
                         id='open-modal'
                     >
                         <FormattedMessage
@@ -81,6 +83,13 @@ const StarterLeftPanel: React.FC<StarterEditionProps> = ({
                             defaultMessage='Upload File'
                         />
                     </button>
+                    <input
+                        ref={fileInputRef}
+                        type='file'
+                        accept='.mattermost-license'
+                        onChange={handleChange}
+                        style={{display: 'none'}}
+                    />
                 </div>
             </div>
         </div>

--- a/components/admin_console/license_settings/starter_edition/starter_left_panel.tsx
+++ b/components/admin_console/license_settings/starter_edition/starter_left_panel.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React from 'react';
+import React, {RefObject} from 'react';
 
 import {FormattedMessage} from 'react-intl';
 
@@ -9,7 +9,7 @@ export interface StarterEditionProps {
     openEELicenseModal: () => void;
     currentPlan: JSX.Element;
     upgradedFromTE: boolean;
-    fileInputRef: any;
+    fileInputRef: RefObject<HTMLInputElement>;
     handleChange: () => void;
 }
 
@@ -75,7 +75,7 @@ const StarterLeftPanel: React.FC<StarterEditionProps> = ({
                 <div className='uploadButtons'>
                     <button
                         className='btn btn-upload light-blue-btn'
-                        onClick={() => fileInputRef.current.click()}
+                        onClick={() => fileInputRef.current !== null && fileInputRef.current.click()}
                         id='open-modal'
                     >
                         <FormattedMessage

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -767,6 +767,7 @@ export const FileTypes = {
     PATCH: 'patch',
     SVG: 'svg',
     OTHER: 'other',
+    LICENSE_EXTENSION: '.mattermost-license',
 };
 
 export const NotificationLevels = {


### PR DESCRIPTION
#### Summary
Change the UI flow for the upload license process. This PR removes a step from the UI flow for uploading a license. With these changes when you click the upload button, the OS file selector window is shown and when you select the file THEN the upload modal is shown with the file information.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41745

#### Screenshots

https://user-images.githubusercontent.com/10082627/156860041-010a3be3-3e4c-44e6-85d5-75d2d066e617.mp4

#### Release Note
```release-note
NONE
```
