### PR TITLE
Makefile: run the client in the foreground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ mattermost-webapp.iml
 .vscode/
 junit.xml
 coverage
+config.override.mk
 
 # Environment variables
 .env*

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ MM_UTILITIES_DIR = ../mattermost-utilities
 EMOJI_TOOLS_DIR = ./build/emoji
 export NODE_OPTIONS=--max-old-space-size=4096
 
+-include config.override.mk
+include config.mk
+
+RUN_IN_BACKGROUND ?=
+ifeq ($(RUN_CLIENT_IN_BACKGROUND),true)
+	RUN_IN_BACKGROUND := &
+endif
+
 build-storybook: node_modules ## Build the storybook
 	@echo Building storybook
 
@@ -78,7 +86,7 @@ build: node_modules ## Builds the app
 run: node_modules ## Runs app
 	@echo Running mattermost Webapp for development
 
-	npm run run &
+	npm run run $(RUN_IN_BACKGROUND)
 
 dev: node_modules ## Runs webpack-dev-server
 	npm run dev-server
@@ -86,7 +94,7 @@ dev: node_modules ## Runs webpack-dev-server
 run-fullmap: node_modules ## Legacy alias to run
 	@echo Running mattermost Webapp for development
 
-	npm run run &
+	npm run run $(RUN_IN_BACKGROUND)
 
 stop: ## Stops webpack
 	@echo Stopping changes watching

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,6 @@
+# Do not modify this file, if you want to configure your own environment copy
+# this file in config.override.mk and modify that file, or defining environment
+# variables using the same names found here.
+
+# Run the client in the background
+RUN_CLIENT_IN_BACKGROUND ?= true


### PR DESCRIPTION
#### Summary
This is a dev QOL PR, no new feature.

This PR changes the Makefile to add a `RUN_CLIENT_IN_BACKGROUND` variable defaulting to `true` (current behavior), allowing devs to decide if they wanna run the client in foreground or background.

To make sure we have a smooth experience between projects: 
- I copied the configuration model of `mattermost-server` (`config.mk` + optional and ignored  `config.override.mk`).
- The way to deal with the new variable has been copied from `mattermost-server`
https://github.com/mattermost/mattermost-server/blob/dd100a3a697b39a83ca7c62b00ed9aaedc9bed10/Makefile#L161-L164

#### Ticket Link
N/A

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
