### PR TITLE
MM-42316: Error message when clicking on test connection button without saving

### DIFF
--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -383,6 +383,10 @@ export default class SchemaAdminSettings extends React.PureComponent {
 
     buildButtonSetting = (setting) => {
         const handleRequestAction = (success, error) => {
+            if (this.state.saveNeeded !== false) {
+                error({message: Utils.localizeMessage('admin_settings.save_unsaved_changes', 'Please save unsaved changes first')});
+                return;
+            }
             const successCallback = (data) => {
                 const metadata = new Map(Object.entries(data));
                 const settings = (this.props.schema && this.props.schema.settings) || [];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -194,6 +194,7 @@
   "add_user_to_channel_modal.title": "Add {name} to a Channel",
   "add_users_to_role.title": "Add users to {roleName}",
   "add_users_to_team.title": "Add New Members to {teamName} Team",
+  "admin_settings.save_unsaved_changes": "Please save unsaved changes first",
   "admin.advance.cluster": "High Availability",
   "admin.advance.metrics": "Performance Monitoring",
   "admin.announcement_banner_feature_discovery.copy": "Create announcement banners to notify all members of important information.",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.



Otherwise, link the JIRA ticket.
-->

  Fixes https://github.com/mattermost/mattermost-server/issues/19691

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
