### PR TITLE
[FIX] admin_console/licence_settings: fix of referencing to a button

### DIFF
--- a/components/admin_console/license_settings/trial_banner/trial_banner.tsx
+++ b/components/admin_console/license_settings/trial_banner/trial_banner.tsx
@@ -209,7 +209,7 @@ const TrialBanner: React.FC<TrialBannerProps> = ({
                 <p className='upgrade-legal-terms'>
                     <FormattedMarkdownMessage
                         id='admin.license.upgrade-and-trial-request.accept-terms-initial-part'
-                        defaultMessage='By selecting **Upgrade And Start trial**, I agree to the [Mattermost Software Evaluation Agreement](!https://mattermost.com/software-evaluation-agreement/), [Privacy Policy](!https://mattermost.com/privacy-policy/), and receiving product emails. '
+                        defaultMessage='By selecting **Upgrade Server And Start trial**, I agree to the [Mattermost Software Evaluation Agreement](!https://mattermost.com/software-evaluation-agreement/), [Privacy Policy](!https://mattermost.com/privacy-policy/), and receiving product emails. '
                     />
                     <FormattedMessage
                         id='admin.license.upgrade-and-trial-request.accept-terms-final-part'

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1268,7 +1268,7 @@
   "admin.license.trialCard.purchase_license": "Purchase a license",
   "admin.license.trialUpgradeAndRequest.submit": "Upgrade Server And Start trial",
   "admin.license.upgrade-and-trial-request.accept-terms-final-part": "Also, I agree to the terms of the Mattermost {eeModalTerms}. Upgrading will download the binary and update your Team Edition instance.",
-  "admin.license.upgrade-and-trial-request.accept-terms-initial-part": "By selecting **Upgrade And Start trial**, I agree to the [Mattermost Software Evaluation Agreement](!https://mattermost.com/software-evaluation-agreement/), [Privacy Policy](!https://mattermost.com/privacy-policy/), and receiving product emails. ",
+  "admin.license.upgrade-and-trial-request.accept-terms-initial-part": "By selecting **Upgrade Server And Start trial**, I agree to the [Mattermost Software Evaluation Agreement](!https://mattermost.com/software-evaluation-agreement/), [Privacy Policy](!https://mattermost.com/privacy-policy/), and receiving product emails. ",
   "admin.license.upgrade-and-trial-request.title": "Upgrade to Enterprise Edition and Experience Mattermost Enterprise Edition for free for the next 30 days. No obligation to buy or credit card required. ",
   "admin.license.upgraded-restart": "You have upgraded your binary to mattermost enterprise, please restart the server to start using the new binary. You can do it right here:",
   "admin.license.upgradeTitle": "Upgrade to the Professional Plan",


### PR DESCRIPTION
#### Summary
The button's text is "Upgrade Server And Start trial", and not "Upgrade
And Start trial"

#### Ticket Link
I just found this error, there are no ticket exists.

#### Screenshots
Here it shows, that the button text is not matching with the help text.
![image](https://user-images.githubusercontent.com/210099/157022316-5c64477e-90e9-4b92-b358-517aeb50b8c4.png)

#### Release Note
```
NONE
```