### PR TITLE
MM-41830 Add metrics for plugin loading

### DIFF
--- a/actions/telemetry_actions.jsx
+++ b/actions/telemetry_actions.jsx
@@ -132,6 +132,7 @@ export function trackPluginInitialization(plugins) {
 
     let startTime = Infinity;
     let endTime = 0;
+    let totalDuration = 0;
     let totalSize = 0;
 
     for (const plugin of plugins) {
@@ -145,12 +146,14 @@ export function trackPluginInitialization(plugins) {
 
         startTime = Math.min(resource.startTime, startTime);
         endTime = Math.max(resource.startTime + resource.duration, endTime);
+        totalDuration += resource.duration;
         totalSize += resource.encodedBodySize;
     }
 
     trackEvent('performance', 'plugins_load', {
         count: plugins.length,
         duration: endTime - startTime,
+        totalDuration,
         totalSize,
     });
 }

--- a/actions/telemetry_actions.jsx
+++ b/actions/telemetry_actions.jsx
@@ -122,3 +122,35 @@ function isSupported(checks) {
     }
     return true;
 }
+
+export function trackPluginInitialization(plugins) {
+    if (!shouldTrackPerformance()) {
+        return;
+    }
+
+    const resourceEntries = performance.getEntriesByType('resource');
+
+    let startTime = Infinity;
+    let endTime = 0;
+    let totalSize = 0;
+
+    for (const plugin of plugins) {
+        const filename = plugin.webapp.bundle_path.substring(plugin.webapp.bundle_path.lastIndexOf('/'));
+        const resource = resourceEntries.find((r) => r.name.endsWith(filename));
+
+        if (!resource) {
+            // This should never happen, but handle it just in case
+            continue;
+        }
+
+        startTime = Math.min(resource.startTime, startTime);
+        endTime = Math.max(resource.startTime + resource.duration, endTime);
+        totalSize += resource.encodedBodySize;
+    }
+
+    trackEvent('performance', 'plugins_load', {
+        count: plugins.length,
+        duration: endTime - startTime,
+        totalSize,
+    });
+}

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -17,6 +17,7 @@ import PluginRegistry from 'plugins/registry';
 import {unregisterAllPluginWebSocketEvents, unregisterPluginReconnectHandler} from 'actions/websocket_actions.jsx';
 import {unregisterPluginTranslationsSource} from 'actions/views/root';
 import {unregisterAdminConsolePlugin} from 'actions/admin_actions';
+import {trackPluginInitialization} from 'actions/telemetry_actions';
 
 import {removeWebappPlugin} from './actions';
 
@@ -83,6 +84,8 @@ export async function initializePlugins() {
             console.error(loadErr.message); //eslint-disable-line no-console
         });
     }));
+
+    trackPluginInitialization(data);
 }
 
 // getPlugins queries the server for all enabled plugins


### PR DESCRIPTION
With this, we'll be tracking:
1. How many plugins are loaded
2. How much JS is transferred while loading them
3. How long it takes to load the plugins, both in real time and the total time taken to load them all

I think having both real time and total duration is interesting since it could let us compare how long each takes to load on average while also being able to see how long the overall load takes if we're finding that the app is getting bottlenecked while loading a dozen plugins at once

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41830

#### Release Note
```release-note
Added performance metrics related to plugin loading on page load
```
