### PR TITLE
[MM-41299] Change code block theme to Solarized Dark for mm indigo theme

### DIFF
--- a/packages/mattermost-redux/src/constants/preferences.ts
+++ b/packages/mattermost-redux/src/constants/preferences.ts
@@ -163,7 +163,7 @@ const Preferences = {
             errorTextColor: '#d24b4e',
             mentionHighlightBg: '#133a91',
             mentionHighlightLink: '#a4f4f4',
-            codeTheme: 'github',
+            codeTheme: 'solarized-dark',
         },
         onyx: {
             type: 'Onyx',


### PR DESCRIPTION
#### Summary
Change code block theme to Solarized Dark for mm indigo theme

#### Ticket Link

 Fixes https://mattermost.atlassian.net/browse/MM-41299
 Fixes https://github.com/mattermost/mattermost-server/issues/19559

#### Related Pull Requests
NONE

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="1680" alt="Screenshot 2022-03-08 at 6 58 22 PM" src="https://user-images.githubusercontent.com/96474572/157248423-da418c3b-3fe8-4987-b558-8cb0db3b0f43.png"> | <img width="1680" alt="Screenshot 2022-03-08 at 7 03 02 PM" src="https://user-images.githubusercontent.com/96474572/157248409-bbfb0666-c8a9-44a1-9594-eb3557675657.png"> |



#### Release Note
```release-note
UI: Change code block theme to Solarized Dark for mm indigo theme
```
