### PR TITLE
Cypress/E2E: fixed cypess test cases

### DIFF
--- a/e2e/cypress/fixtures/markdown/markdown_inline_images_6.md
+++ b/e2e/cypress/fixtures/markdown/markdown_inline_images_6.md
@@ -1,3 +1,3 @@
 ### In-line Images
 
-![test image](https://mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png)
+![test image](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/image-small-height.png)

--- a/e2e/cypress/integration/files_and_attachments/image_link_preview_new_window_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/image_link_preview_new_window_spec.js
@@ -30,7 +30,7 @@ describe('Image Link Preview', () => {
     });
 
     it('MM-T329 Image link preview', () => {
-        const link = 'https://mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png';
+        const link = 'https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/image-small-height.png';
         const baseUrl = Cypress.config('baseUrl');
         const encodedIconUrl = encodeURIComponent(link);
 
@@ -51,8 +51,8 @@ describe('Image Link Preview', () => {
 
             cy.uiGetContentFilePreviewModal().find('img').should((img) => {
                 // * Verify image is rendered
-                expect(img.height()).to.be.closeTo(165, 2);
-                expect(img.width()).to.be.closeTo(1041, 2);
+                expect(img.height()).to.be.closeTo(25, 2);
+                expect(img.width()).to.be.closeTo(340, 2);
             });
 
             // * Verify "Get Public Link" icon does not exist

--- a/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
@@ -38,7 +38,7 @@ describe('Image Link Preview', () => {
     });
 
     it('MM-T331 Image link preview - Collapse and expand', () => {
-        const link = 'https://mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png';
+        const link = 'https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/small-image.png';
 
         // # Post a link to an externally hosted image
         cy.postMessage(link);
@@ -201,7 +201,7 @@ describe('Image Link Preview', () => {
             {
                 filename: 'image-40x400.jpg',
                 originalSize: {width: 40, height: 400},
-                thumbnailSize: {width: 35, height: 350},
+                thumbnailSize: {width: 40, height: 400},
                 containerSize: {width: 46},
             },
             {

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_2_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_2_spec.js
@@ -122,11 +122,11 @@ describe('Integrations', () => {
             cy.get(`#postMessageText_${postId}`).
                 should('have.text', `Could not find the channel ${invalidChannel}. Please use the channel handle to identify channels.`).
 
-                // * Channel handle links to: https://docs.mattermost.com/help/getting-started/organizing-conversations.html#naming-a-channel
+                // * Channel handle links to: https://docs.mattermost.com/messaging/managing-channels.html?&redirect_source=about-mm-com
                 contains('a', 'channel handle').then((link) => {
                     const href = link.prop('href');
                     cy.request(href).its('allRequestResponses').then((response) => {
-                        cy.wrap(response[1]['Request URL']).should('equal', 'https://docs.mattermost.com/help/getting-started/organizing-conversations.html#naming-a-channel');
+                        cy.wrap(response[1]['Request URL']).should('equal', 'https://docs.mattermost.com/messaging/managing-channels.html?&redirect_source=about-mm-com');
                     });
                 });
         });

--- a/e2e/cypress/integration/integrations/slash_commands_spec.js
+++ b/e2e/cypress/integration/integrations/slash_commands_spec.js
@@ -195,7 +195,7 @@ describe('Integrations', () => {
         cy.getLastPost().should('contain', 'Image links now expand by default').and('contain', 'System');
 
         // # Post message
-        cy.postMessage('http://mattermost.org/wp-content/uploads/2016/04/icon_WS.png');
+        cy.postMessage('https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/png-image-file.png');
         cy.getLastPostId().as('postID');
 
         cy.get('@postID').then((postID) => {
@@ -215,7 +215,7 @@ describe('Integrations', () => {
         cy.visit(offTopicUrl1);
 
         // # Post message
-        cy.postMessage('http://www.mattermost.org/wp-content/uploads/2016/04/icon_WS.png');
+        cy.postMessage('https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/png-image-file.png');
         cy.getLastPostId().as('postID');
 
         // # Open RHS

--- a/e2e/cypress/integration/markdown/markdown_image_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_image_spec.js
@@ -86,8 +86,8 @@ describe('Markdown', () => {
             cy.get('.markdown-inline-img').
                 should('be.visible').
                 and((inlineImg) => {
-                    expect(inlineImg.height()).to.be.closeTo(151, 2);
-                    expect(inlineImg.width()).to.be.closeTo(951, 2);
+                    expect(inlineImg.height()).to.be.closeTo(25, 2);
+                    expect(inlineImg.width()).to.be.closeTo(340, 2);
                 }).
                 click();
         });
@@ -122,7 +122,7 @@ describe('Markdown', () => {
 
     it('channel header is markdown image', () => {
         // # Update channel header
-        cy.updateChannelHeader('![MM Logo](https://mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png)').wait(TIMEOUTS.TWO_SEC);
+        cy.updateChannelHeader('![MM Logo](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/small-image.png)').wait(TIMEOUTS.TWO_SEC);
 
         // * Verify image in header
         cy.get('#channelHeaderDescription').find('div.markdown__paragraph-inline').as('imageDiv');
@@ -145,7 +145,7 @@ describe('Markdown', () => {
 
     it('channel header is markdown image that is also a link', () => {
         // # Update channel header
-        cy.updateChannelHeader('[![Build Status](https://mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png)](https://mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png)').wait(TIMEOUTS.TWO_SEC);
+        cy.updateChannelHeader('[![Build Status](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/small-image.png)](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/small-image.png)').wait(TIMEOUTS.TWO_SEC);
 
         // * Verify image in header
         cy.get('#channelHeaderDescription').find('div.markdown__paragraph-inline').as('imageDiv');

--- a/e2e/cypress/integration/messaging/image_attachment_spec.js
+++ b/e2e/cypress/integration/messaging/image_attachment_spec.js
@@ -77,7 +77,7 @@ describe('Image attachment', () => {
         verifyFileThumbnail({
             filename,
             actualImage: {height: 350, width: 21},
-            container: {height: 348, width: 46},
+            container: {height: 352, width: 46},
         });
     });
 

--- a/e2e/cypress/integration/messaging/inline_images_open_preview_window_spec.js
+++ b/e2e/cypress/integration/messaging/inline_images_open_preview_window_spec.js
@@ -31,7 +31,7 @@ describe('Messaging', () => {
         });
 
         // # Post the image link to the channel
-        cy.postMessage('Hello ![test image](https://mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png)');
+        cy.postMessage('Hello ![test image](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/image-small-height.png)');
 
         // * Confirm the image container is visible
         cy.uiWaitUntilMessagePostedIncludes('Hello');


### PR DESCRIPTION
#### Summary
fixed ```image_link_preview_new_window``` test case
fixed ```image_link_preview``` test case
fixed ```slash_commands``` test case
fixed ```markdown_image``` test case
fixed ```common_commands_2``` test case
fixed ```image_attachment``` test case
fixed ```inline_images_open_preview_window``` test case

#### Screenshots
![image](https://user-images.githubusercontent.com/6909890/157304437-3056a5f9-5f6f-4832-a9c3-372043218b61.png)
![image](https://user-images.githubusercontent.com/6909890/157304493-3948a5fe-b4c8-4a4d-bdc0-880bc4ef4a91.png)
![image](https://user-images.githubusercontent.com/6909890/157304572-318ce936-d8dd-4f50-a88c-b01a912d2250.png)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
