### PR TITLE
Fix emoji picker clickable area

### DIFF
--- a/components/emoji_picker/components/emoji_picker_item.tsx
+++ b/components/emoji_picker/components/emoji_picker_item.tsx
@@ -71,7 +71,10 @@ function EmojiPickerItem({emoji, rowIndex, isSelected, onClick, onMouseOver}: Pr
     const emojiUnified = emoji.unified ? emoji.unified.toLowerCase() : emoji.name.toLowerCase();
 
     return (
-        <div className={itemClassName}>
+        <div
+            className={itemClassName}
+            onClick={handleClick}
+        >
             <div data-testid='emojiItem'>
                 <img
                     alt={'emoji image'}
@@ -79,7 +82,6 @@ function EmojiPickerItem({emoji, rowIndex, isSelected, onClick, onMouseOver}: Pr
                     onMouseOver={throttledMouseOver}
                     src={imgTrans}
                     className={`emojisprite emoji-category-${emoji.category} emoji-${emojiUnified}`}
-                    onClick={handleClick}
                     id={`emoji-${emojiUnified}`}
                     aria-label={formatMessage(
                         {


### PR DESCRIPTION
The hover effect for emojis in the picker didn't line up with the div with the onClick handler which leads to clicks that wouldn't do anything.

#### Ticket Link
TODO

#### Release Note
```release-note
Increased clickable area for emojis in emoji picker to match visuals
```
