### PR TITLE
use channel display name in onboarding tip. Remove toTitleCase calls …

### DIFF
--- a/components/onboarding_tour/channels_and_direct_messages_tour_tip.tsx
+++ b/components/onboarding_tour/channels_and_direct_messages_tour_tip.tsx
@@ -7,7 +7,6 @@ import {useSelector} from 'react-redux';
 
 import {useMeasurePunchouts} from 'components/widgets/tour_tip';
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
-import {toTitleCase} from 'utils/utils';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 import {GlobalState} from 'types/store';
 import Constants from 'utils/constants';
@@ -20,13 +19,12 @@ type Props = {
 }
 
 const FirstChannel = ({firstChannelName}: {firstChannelName: string}) => {
-    const displayFirstChannelName = firstChannelName.split('-').join(' ').trim();
     return (
         <>
             <FormattedMarkdownMessage
                 id='onboardingTour.ChannelsAndDirectMessagesTour.firstChannel'
                 defaultMessage='Hey look, there’s your **{firstChannelName}** channel! '
-                values={{firstChannelName: toTitleCase(displayFirstChannelName)}}
+                values={{firstChannelName}}
             />
             <br/>
         </>
@@ -57,7 +55,7 @@ export const ChannelsAndDirectMessagesTour = ({firstChannelName}: Props) => {
                 <FormattedMarkdownMessage
                     id='onboardingTour.ChannelsAndDirectMessagesTour.townSquare'
                     defaultMessage={'We’ve also added the **{townSquare}** and **{offTopic}** channels for everyone on your team.'}
-                    values={{townSquare: toTitleCase(townSquareDisplayName), offTopic: toTitleCase(offTopicDisplayName)}}
+                    values={{townSquare: townSquareDisplayName, offTopic: offTopicDisplayName}}
                 />
             </p>
             <p>

--- a/components/onboarding_tour/channels_and_direct_messages_tour_tip.tsx
+++ b/components/onboarding_tour/channels_and_direct_messages_tour_tip.tsx
@@ -20,14 +20,11 @@ type Props = {
 
 const FirstChannel = ({firstChannelName}: {firstChannelName: string}) => {
     return (
-        <>
-            <FormattedMarkdownMessage
-                id='onboardingTour.ChannelsAndDirectMessagesTour.firstChannel'
-                defaultMessage='Hey look, there’s your **{firstChannelName}** channel! '
-                values={{firstChannelName}}
-            />
-            <br/>
-        </>
+        <FormattedMarkdownMessage
+            id='onboardingTour.ChannelsAndDirectMessagesTour.firstChannel'
+            defaultMessage='Hey look, there’s your **{firstChannelName}** channel! '
+            values={{firstChannelName}}
+        />
     );
 };
 

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -173,6 +173,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         } = this.props;
 
         let channelsTutorialTip: JSX.Element | null = null;
+
         // firstChannelName is based on channel.name,
         // but we want to display `display_name` to the user, so we check against `.name` for channel equality but pass in the .display_name value
         if (firstChannelName === channel.name || (!firstChannelName && showChannelsTutorialStep && channel.name === Constants.DEFAULT_CHANNEL)) {

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -177,7 +177,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         // firstChannelName is based on channel.name,
         // but we want to display `display_name` to the user, so we check against `.name` for channel equality but pass in the .display_name value
         if (firstChannelName === channel.name || (!firstChannelName && showChannelsTutorialStep && channel.name === Constants.DEFAULT_CHANNEL)) {
-            channelsTutorialTip = (<ChannelsAndDirectMessagesTour firstChannelName={channel.display_name}/>);
+            channelsTutorialTip = firstChannelName ? (<ChannelsAndDirectMessagesTour firstChannelName={channel.display_name}/>) : (<ChannelsAndDirectMessagesTour>);
         }
 
         let labelElement: JSX.Element = (

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -177,7 +177,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         // firstChannelName is based on channel.name,
         // but we want to display `display_name` to the user, so we check against `.name` for channel equality but pass in the .display_name value
         if (firstChannelName === channel.name || (!firstChannelName && showChannelsTutorialStep && channel.name === Constants.DEFAULT_CHANNEL)) {
-            channelsTutorialTip = firstChannelName ? (<ChannelsAndDirectMessagesTour firstChannelName={channel.display_name}/>) : (<ChannelsAndDirectMessagesTour>);
+            channelsTutorialTip = firstChannelName ? (<ChannelsAndDirectMessagesTour firstChannelName={channel.display_name}/>) : <ChannelsAndDirectMessagesTour/>;
         }
 
         let labelElement: JSX.Element = (

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -173,8 +173,10 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         } = this.props;
 
         let channelsTutorialTip: JSX.Element | null = null;
+        // firstChannelName is based on channel.name,
+        // but we want to display `display_name` to the user, so we check against `.name` for channel equality but pass in the .display_name value
         if (firstChannelName === channel.name || (!firstChannelName && showChannelsTutorialStep && channel.name === Constants.DEFAULT_CHANNEL)) {
-            channelsTutorialTip = (<ChannelsAndDirectMessagesTour firstChannelName={firstChannelName}/>);
+            channelsTutorialTip = (<ChannelsAndDirectMessagesTour firstChannelName={channel.display_name}/>);
         }
 
         let labelElement: JSX.Element = (


### PR DESCRIPTION
#### Summary
For the onboarding tour tip, we were inferring an acceptable display name from what the url name of the channel was. We have access to the `display_name`, so its preferrable to use that since that is what the user will see in the sidebar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42056

#### Screenshots
before:
![before](https://user-images.githubusercontent.com/13738432/157551277-9f6fd0c6-a840-4714-8d59-f666f8e960f9.png)

after:
![after](https://user-images.githubusercontent.com/13738432/157551283-2b1ba3ca-bde1-436a-a801-5a1955569f5f.png)

#### Release Note

```release-note
Fix issue with displayed channel name in channel tutorial tip.
```
