### PR TITLE
adjust svg positioning for cloud case with no previous button

### DIFF
--- a/components/preparing_workspace/use_case.tsx
+++ b/components/preparing_workspace/use_case.tsx
@@ -56,7 +56,7 @@ const UseCase = (props: Props) => {
                 <LeftCol/>
                 <div className='UseCase-right-col'>
                     <div className='UseCase-form-wrapper'>
-                        <ProgressPath style={{top: '15px'}}>
+                        <ProgressPath style={{top: props.previous ? '15px' : '-28px'}}>
                             <LaptopSVG/>
                         </ProgressPath>
                         {props.previous}


### PR DESCRIPTION
#### Summary
Missed adjusting svg positioning for cloud workspaces. For cloud workspaces, there is no previous button on the use case screen because it is the first step for the cloud admin.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42291


#### Release Note
```release-note
Fix svg positioning in admin onboarding when screen does not have a previous button.
```
