### PR TITLE
MM-42321 : Client crashed on typing text in the Gif picker search

### DIFF
--- a/components/emoji_picker/utils/index.ts
+++ b/components/emoji_picker/utils/index.ts
@@ -356,9 +356,17 @@ export function getCursorProperties(cursorRowIndex: EmojiCursor['rowIndex'], cur
         return ['', -1, -1];
     }
 
-    const cursorCategory = categoryOrEmojisRows[cursorRowIndex].items[0].categoryName;
-    const cursorCategoryIndex = categoryOrEmojisRows[cursorRowIndex].items[0].categoryIndex;
-    const cursorEmojiIndex = categoryOrEmojisRows[cursorRowIndex].items.find((emojiItem) => {
+    const emojisRowOfCursor = categoryOrEmojisRows?.[cursorRowIndex]?.items ?? [];
+
+    // The row should atleast contain one emoji
+    if (emojisRowOfCursor.length < 1) {
+        return ['', -1, -1];
+    }
+
+    const cursorCategory = emojisRowOfCursor[0]?.categoryName ?? '';
+    const cursorCategoryIndex = emojisRowOfCursor[0]?.categoryIndex ?? -1;
+
+    const cursorEmojiIndex = emojisRowOfCursor.find((emojiItem) => {
         return emojiItem.emojiId === cursorEmojiId;
     })?.emojiIndex ?? -1;
 


### PR DESCRIPTION
#### Summary
Added safety checks in `getCursorProperties` function to return early in case of undefined or nulls. Currently the emoji picker and gif picker both renders on either tab is selected since they supposedly share the same search text.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42321

#### Related Pull Requests
N/A

#### Screenshots
https://user-images.githubusercontent.com/17708702/158060417-87b60e77-6446-4909-a509-1e8fe4939082.mov

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed client app crash when typing into search of Gif picker.
```
