### PR TITLE
MM-41820 Report least effective selectors as telemetry

### DIFF
--- a/actions/telemetry_actions.jsx
+++ b/actions/telemetry_actions.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {getSortedTrackedSelectors} from 'reselect';
+
 import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
@@ -181,4 +183,27 @@ export function trackPluginInitialization(plugins) {
         totalDuration,
         totalSize,
     });
+}
+
+export function trackSelectorMetrics() {
+    if (!shouldTrackPerformance()) {
+        return;
+    }
+
+    setTimeout(() => {
+        const selectors = getSortedTrackedSelectors();
+
+        trackEvent('performance', 'least_effective_selectors', {
+            after: 'one_minute',
+            first: selectors[0]?.name || '',
+            first_effectiveness: selectors[0]?.effectiveness,
+            first_recomputations: selectors[0]?.recomputations,
+            second: selectors[1]?.name || '',
+            second_effectiveness: selectors[1]?.effectiveness,
+            second_recomputations: selectors[1]?.recomputations,
+            third: selectors[2]?.name || '',
+            third_effectiveness: selectors[2]?.effectiveness,
+            third_recomputations: selectors[2]?.recomputations,
+        });
+    }, 60000);
 }

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -22,7 +22,7 @@ import {getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferen
 
 import {loadRecentlyUsedCustomEmojis} from 'actions/emoji_actions';
 import * as GlobalActions from 'actions/global_actions';
-import {measurePageLoadTelemetry} from 'actions/telemetry_actions.jsx';
+import {measurePageLoadTelemetry, trackSelectorMetrics} from 'actions/telemetry_actions.jsx';
 
 import {makeAsyncComponent} from 'components/async_load';
 import CompassThemeProvider from 'components/compass_theme_provider/compass_theme_provider';
@@ -334,6 +334,7 @@ export default class Root extends React.PureComponent {
         });
 
         measurePageLoadTelemetry();
+        trackSelectorMetrics();
 
         if (this.desktopMediaQuery.addEventListener) {
             this.desktopMediaQuery.addEventListener('change', this.handleMediaQueryChangeEvent);

--- a/components/root/root.test.jsx
+++ b/components/root/root.test.jsx
@@ -22,9 +22,7 @@ jest.mock('rudder-sdk-js', () => ({
     track: jest.fn(),
 }));
 
-jest.mock('actions/telemetry_actions', () => ({
-    measurePageLoadTelemetry: jest.fn(),
-}));
+jest.mock('actions/telemetry_actions');
 
 jest.mock('actions/global_actions', () => ({
     redirectUserToDefaultTeam: jest.fn(),

--- a/packages/reselect/src/index.js
+++ b/packages/reselect/src/index.js
@@ -163,12 +163,28 @@ function resetTrackedSelectors() {
 }
 
 // getSortedTrackedSelectors returns an array, sorted by effectivness, containing mesaurement data on all tracked selectors.
-function getSortedTrackedSelectors() {
+export function getSortedTrackedSelectors() {
     let selectors = Object.values(trackedSelectors);
     // Filter out any selector not called
     selectors = selectors.filter(selector => selector.calls > 0);
     const selectorsData = selectors.map((selector) => ({name: selector.name, effectiveness: effectiveness(selector), recomputations: selector.recomputations, calls: selector.calls}));
-    selectorsData.sort((a, b) => a.effectiveness - b.effectiveness);
+    selectorsData.sort((a, b) => {
+        // Sort effectiveness ascending
+        if (a.effectiveness !== b.effectiveness) {
+            return a.effectiveness - b.effectiveness;
+        }
+
+        // And everything else descending
+        if (a.recomputations !== b.recomputations) {
+            return b.recomputations - a.recomputations;
+        }
+
+        if (a.calls !== b.calls) {
+            return b.calls - a.calls;
+        }
+
+        return a.name.localeCompare(b.name);
+    });
     return selectorsData;
 }
 


### PR DESCRIPTION
Hopefully this is something we can work with on Looker. I'd like to report the 3 least effective selectors so that we can see how they change over time to watch out for either:
1. A new selector suddenly becoming the worst or
2. An existing selector getting better as we make improvements to it

I also included some numeric data since that might be helpful if we start to focus more on individual selectors, but I could remove that in case we're worried about the data getting bloated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41820

#### Release Note
```release-note
Added telemetry for selector performance
```
