### PR TITLE
MM-42132 - add styles to a wrapper div to prevent svg cut off by bad …

### DIFF
--- a/components/purchase_modal/icon_message.scss
+++ b/components/purchase_modal/icon_message.scss
@@ -4,8 +4,14 @@
             padding-bottom: 2px;
             padding-left: 7px;
 
-            > svg {
+            > .IconMessage__svg-wrapper {
                 margin-left: 68px;
+            }
+        }
+
+        &.failed {
+            > .IconMessage__svg-wrapper {
+                margin-left: 60px;
             }
         }
 
@@ -79,11 +85,12 @@
             line-height: 14px;
             text-align: center;
         }
+    }
+
+    &__svg-wrapper {
+        align-self: center;
 
         svg {
-            align-self: center;
-            margin-left: 60px;
-
             @media screen and (max-width: 600px) {
                 width: 150%;
             }

--- a/components/purchase_modal/icon_message.tsx
+++ b/components/purchase_modal/icon_message.tsx
@@ -79,7 +79,9 @@ export default function IconMessage(props: Props) {
             className='IconMessage'
         >
             <div className={classNames('content', className || '')}>
-                {icon}
+                <div className='IconMessage__svg-wrapper'>
+                    {icon}
+                </div>
                 <h3 className='IconMessage-h3'>
                     {title ? <FormattedMessage id={title}/> : null}
                     {formattedTitle || null}


### PR DESCRIPTION
#### Summary
There was a recent change to center align the images shown in the purchase modal processing section where a margin was set directly to the svg and that was causing some browsers to bad interpret the svg alignment and cutting of those same pixels from the svg. This change adds the margin to a div wrapper to prevent this browser bad interpretation. SVGs are definitely special :( .

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42132


#### Screenshots


#### Release Note
```release-note
NONE
```
