### PR TITLE
MM-35594 Add post menu item to copy text

### DIFF
--- a/components/dot_menu/__snapshots__/dot_menu.test.tsx.snap
+++ b/components/dot_menu/__snapshots__/dot_menu.test.tsx.snap
@@ -169,6 +169,18 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
     <MenuItemAction
       icon={
         <span
+          className="icon-content-copy MenuItem__compass-icon"
+        />
+      }
+      id="copy_post_id_1"
+      onClick={[Function]}
+      rightDecorator="C"
+      show={true}
+      text="Copy Text"
+    />
+    <MenuItemAction
+      icon={
+        <span
           className="icon-trash-can-outline MenuItem__compass-icon-dangerous"
         />
       }
@@ -354,6 +366,18 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
       rightDecorator="E"
       show={true}
       text="Edit"
+    />
+    <MenuItemAction
+      icon={
+        <span
+          className="icon-content-copy MenuItem__compass-icon"
+        />
+      }
+      id="copy_post_id_1"
+      onClick={[Function]}
+      rightDecorator="C"
+      show={true}
+      text="Copy Text"
     />
     <MenuItemAction
       icon={

--- a/components/dot_menu/dot_menu.test.tsx
+++ b/components/dot_menu/dot_menu.test.tsx
@@ -7,7 +7,7 @@ import {PostType} from 'mattermost-redux/types/posts';
 
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
-import {Locations, PostTypes} from 'utils/constants';
+import {Locations} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
 import DotMenu, {DotMenuClass} from './dot_menu';
@@ -75,42 +75,6 @@ describe('components/dot_menu/DotMenu', () => {
         );
 
         expect(wrapper).toMatchSnapshot();
-    });
-
-    test('should have divider when able to edit or delete post', () => {
-        const props = {
-            ...baseProps,
-            canEdit: true,
-            canDelete: true,
-        };
-        const wrapper = shallowWithIntl(
-            <DotMenu {...props}/>,
-        );
-
-        expect(wrapper.state('canEdit')).toBe(true);
-        expect(wrapper.state('canDelete')).toBe(true);
-        expect(wrapper.find('#divider_post_post_id_1_edit').exists()).toBe(true);
-
-        wrapper.setProps({isReadOnly: true});
-
-        expect(wrapper.state('canEdit')).toBe(false);
-        expect(wrapper.state('canDelete')).toBe(false);
-        expect(wrapper.find('#divider_post_post_id_1_edit').exists()).toBe(false);
-    });
-
-    test('should not have divider when able to edit or delete a system message', () => {
-        const props = {
-            ...baseProps,
-            post: TestHelper.getPostMock({
-                ...baseProps.post,
-                type: PostTypes.JOIN_CHANNEL as PostType,
-            }),
-        };
-        const wrapper = shallowWithIntl(
-            <DotMenu {...props}/>,
-        );
-
-        expect(wrapper.find('#divider_post_post_id_1_edit').exists()).toBe(false);
     });
 
     test('should show mark as unread when channel is not archived', () => {

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -211,6 +211,10 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         Utils.copyToClipboard(`${this.props.teamUrl}/pl/${this.props.post.id}`);
     }
 
+    copyText = () => {
+        Utils.copyToClipboard(this.props.post.message);
+    }
+
     handlePinMenuItemActivated = (): void => {
         if (this.props.post.is_pinned) {
             this.props.actions.unpinPost(this.props.post.id);
@@ -347,6 +351,13 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         case Utils.isKeyPressed(e, Constants.KeyCodes.K):
             this.trackShortcutEvent(TELEMETRY_LABELS.COPY_LINK);
             this.copyLink();
+            this.props.handleDropdownOpened(false);
+            break;
+
+        // copy text
+        case Utils.isKeyPressed(e, Constants.KeyCodes.C):
+            this.trackShortcutEvent(TELEMETRY_LABELS.COPY_TEXT);
+            this.copyText();
             this.props.handleDropdownOpened(false);
             break;
 
@@ -542,7 +553,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                             this.handleOnClick(TELEMETRY_LABELS.COPY_LINK, this.copyLink);
                         }}
                     />
-                    {!isSystemMessage && (this.state.canEdit || this.state.canDelete) && this.renderDivider('edit')}
+                    {!isSystemMessage && this.renderDivider('edit')}
                     <Menu.ItemAction
                         id={`edit_post_${this.props.post.id}`}
                         show={this.state.canEdit}
@@ -551,6 +562,16 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         rightDecorator={'E'}
                         onClick={() => {
                             this.handleOnClick(TELEMETRY_LABELS.EDIT, this.handleEditMenuItemActivated);
+                        }}
+                    />
+                    <Menu.ItemAction
+                        id={`copy_${this.props.post.id}`}
+                        show={!isSystemMessage}
+                        text={Utils.localizeMessage('post_info.copy', 'Copy Text')}
+                        icon={Utils.getMenuItemIcon('icon-content-copy')}
+                        rightDecorator={'C'}
+                        onClick={() => {
+                            this.handleOnClick(TELEMETRY_LABELS.COPY_TEXT, this.copyText);
                         }}
                     />
                     <Menu.ItemAction

--- a/e2e/cypress/integration/messaging/copy_post_text_spec.js
+++ b/e2e/cypress/integration/messaging/copy_post_text_spec.js
@@ -23,7 +23,7 @@ describe('Permalink message edit', () => {
         });
     });
 
-    it('Copy Text menu item should copy post message to clipboard', () => {
+    it('MM-T4688 Copy Text menu item should copy post message to clipboard', () => {
         stubClipboard().as('clipboard');
 
         // # Go to test channel

--- a/e2e/cypress/integration/messaging/copy_post_text_spec.js
+++ b/e2e/cypress/integration/messaging/copy_post_text_spec.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// [#] indicates a test step (e.g. # Go to a page)
+// [*] indicates an assertion (e.g. * Check the title)
+// Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @messaging
+
+import {stubClipboard} from '../../utils';
+
+describe('Permalink message edit', () => {
+    let testTeam;
+    let testChannel;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, channel}) => {
+            testTeam = team;
+            testChannel = channel;
+        });
+    });
+
+    it('Copy Text menu item should copy post message to clipboard', () => {
+        stubClipboard().as('clipboard');
+
+        // # Go to test channel
+        cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', testChannel.display_name || testChannel.name);
+
+        // # Post a message
+        const message = Date.now().toString();
+        cy.postMessage(message);
+
+        cy.getLastPostId().then((postId) => {
+            // # Copy message
+            cy.uiClickPostDropdownMenu(postId, 'Copy Text');
+
+            // * Ensure that the clipboard contents are correct
+            cy.get('@clipboard').its('wasCalled').should('eq', true);
+            cy.location().then(() => {
+                cy.get('@clipboard').its('contents').should('eq', message);
+            });
+        });
+    });
+});

--- a/e2e/cypress/integration/messaging/copy_post_text_spec.js
+++ b/e2e/cypress/integration/messaging/copy_post_text_spec.js
@@ -35,13 +35,29 @@ describe('Permalink message edit', () => {
         cy.postMessage(message);
 
         cy.getLastPostId().then((postId) => {
-            // # Copy message
+            // # Copy message by clicking
             cy.uiClickPostDropdownMenu(postId, 'Copy Text');
 
             // * Ensure that the clipboard contents are correct
             cy.get('@clipboard').its('wasCalled').should('eq', true);
             cy.location().then(() => {
                 cy.get('@clipboard').its('contents').should('eq', message);
+            });
+        });
+
+        // # Post another message
+        const message2 = Date.now().toString();
+        cy.postMessage(message2);
+
+        cy.getLastPostId().then((postId) => {
+            // # Copy by keyboard shortcut
+            cy.clickPostDotMenu(postId, 'CENTER');
+            cy.findAllByTestId(`post-menu-${postId}`).eq(0).type('c');
+
+            // * Ensure that the clipboard contents are correct
+            cy.get('@clipboard').its('wasCalled').should('eq', true);
+            cy.location().then(() => {
+                cy.get('@clipboard').its('contents').should('eq', message2);
             });
         });
     });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4062,6 +4062,7 @@
   "post_info.auto_responder": "AUTOMATIC REPLY",
   "post_info.bot": "BOT",
   "post_info.comment_icon.tooltip.reply": "Reply",
+  "post_info.copy": "Copy Text",
   "post_info.del": "Delete",
   "post_info.dot_menu.tooltip.more_actions": "More",
   "post_info.edit": "Edit",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -572,6 +572,7 @@ export const TELEMETRY_CATEGORIES = {
 
 export const TELEMETRY_LABELS = {
     COPY_LINK: 'copy_link',
+    COPY_TEXT: 'copy_text',
     DELETE: 'delete',
     EDIT: 'edit',
     FOLLOW: 'follow',


### PR DESCRIPTION
#### Summary
Adds a post menu item with the keyboard shortcut "C" that will copy the post's raw message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35594

#### Screenshots
<img width="1173" alt="Screen Shot 2022-03-17 at 4 05 37 PM" src="https://user-images.githubusercontent.com/2672098/158886795-d11b178e-a754-4ff4-8463-b2a6544fa5bc.png">


#### Release Note
```release-note
Add post menu item to copy raw text
```
