### PR TITLE
MM 42614 fix e2e broken tests

### DIFF
--- a/components/__snapshots__/generic_modal.test.tsx.snap
+++ b/components/__snapshots__/generic_modal.test.tsx.snap
@@ -31,28 +31,33 @@ exports[`components/GenericModal should match snapshot for base case 1`] = `
   role="dialog"
   show={true}
 >
-  <ModalHeader
-    bsClass="modal-header"
-    closeButton={true}
-    closeLabel="Close"
-  />
-  <ModalBody
-    bsClass="modal-body"
-    componentClass="div"
+  <div
+    onKeyDown={[Function]}
+    tabIndex={0}
   >
-    <div
-      className="GenericModal__header"
-    >
-      <h1
-        id="genericModalLabel"
-      >
-        Modal Header Text
-      </h1>
-    </div>
-    <div
-      className="GenericModal__body"
+    <ModalHeader
+      bsClass="modal-header"
+      closeButton={true}
+      closeLabel="Close"
     />
-  </ModalBody>
+    <ModalBody
+      bsClass="modal-body"
+      componentClass="div"
+    >
+      <div
+        className="GenericModal__header"
+      >
+        <h1
+          id="genericModalLabel"
+        >
+          Modal Header Text
+        </h1>
+      </div>
+      <div
+        className="GenericModal__body"
+      />
+    </ModalBody>
+  </div>
 </Modal>
 `;
 
@@ -87,53 +92,58 @@ exports[`components/GenericModal should match snapshot with both buttons 1`] = `
   role="dialog"
   show={true}
 >
-  <ModalHeader
-    bsClass="modal-header"
-    closeButton={true}
-    closeLabel="Close"
-  />
-  <ModalBody
-    bsClass="modal-body"
-    componentClass="div"
+  <div
+    onKeyDown={[Function]}
+    tabIndex={0}
   >
-    <div
-      className="GenericModal__header"
-    >
-      <h1
-        id="genericModalLabel"
-      >
-        Modal Header Text
-      </h1>
-    </div>
-    <div
-      className="GenericModal__body"
+    <ModalHeader
+      bsClass="modal-header"
+      closeButton={true}
+      closeLabel="Close"
     />
-  </ModalBody>
-  <ModalFooter
-    bsClass="modal-footer"
-    componentClass="div"
-  >
-    <button
-      className="GenericModal__button cancel"
-      onClick={[Function]}
-      type="button"
+    <ModalBody
+      bsClass="modal-body"
+      componentClass="div"
     >
-      <MemoizedFormattedMessage
-        defaultMessage="Cancel"
-        id="generic_modal.cancel"
+      <div
+        className="GenericModal__header"
+      >
+        <h1
+          id="genericModalLabel"
+        >
+          Modal Header Text
+        </h1>
+      </div>
+      <div
+        className="GenericModal__body"
       />
-    </button>
-    <button
-      className="GenericModal__button confirm undefined"
-      onClick={[Function]}
-      type="submit"
+    </ModalBody>
+    <ModalFooter
+      bsClass="modal-footer"
+      componentClass="div"
     >
-      <MemoizedFormattedMessage
-        defaultMessage="Confirm"
-        id="generic_modal.confirm"
-      />
-    </button>
-  </ModalFooter>
+      <button
+        className="GenericModal__button cancel"
+        onClick={[Function]}
+        type="button"
+      >
+        <MemoizedFormattedMessage
+          defaultMessage="Cancel"
+          id="generic_modal.cancel"
+        />
+      </button>
+      <button
+        className="GenericModal__button confirm undefined"
+        onClick={[Function]}
+        type="submit"
+      >
+        <MemoizedFormattedMessage
+          defaultMessage="Confirm"
+          id="generic_modal.confirm"
+        />
+      </button>
+    </ModalFooter>
+  </div>
 </Modal>
 `;
 
@@ -168,43 +178,48 @@ exports[`components/GenericModal should match snapshot with disabled confirm but
   role="dialog"
   show={true}
 >
-  <ModalHeader
-    bsClass="modal-header"
-    closeButton={true}
-    closeLabel="Close"
-  />
-  <ModalBody
-    bsClass="modal-body"
-    componentClass="div"
+  <div
+    onKeyDown={[Function]}
+    tabIndex={0}
   >
-    <div
-      className="GenericModal__header"
-    >
-      <h1
-        id="genericModalLabel"
-      >
-        Modal Header Text
-      </h1>
-    </div>
-    <div
-      className="GenericModal__body"
+    <ModalHeader
+      bsClass="modal-header"
+      closeButton={true}
+      closeLabel="Close"
     />
-  </ModalBody>
-  <ModalFooter
-    bsClass="modal-footer"
-    componentClass="div"
-  >
-    <button
-      className="GenericModal__button confirm undefined disabled"
-      disabled={true}
-      onClick={[Function]}
-      type="submit"
+    <ModalBody
+      bsClass="modal-body"
+      componentClass="div"
     >
-      <MemoizedFormattedMessage
-        defaultMessage="Confirm"
-        id="generic_modal.confirm"
+      <div
+        className="GenericModal__header"
+      >
+        <h1
+          id="genericModalLabel"
+        >
+          Modal Header Text
+        </h1>
+      </div>
+      <div
+        className="GenericModal__body"
       />
-    </button>
-  </ModalFooter>
+    </ModalBody>
+    <ModalFooter
+      bsClass="modal-footer"
+      componentClass="div"
+    >
+      <button
+        className="GenericModal__button confirm undefined disabled"
+        disabled={true}
+        onClick={[Function]}
+        type="submit"
+      >
+        <MemoizedFormattedMessage
+          defaultMessage="Confirm"
+          id="generic_modal.confirm"
+        />
+      </button>
+    </ModalFooter>
+  </div>
 </Modal>
 `;

--- a/components/__snapshots__/generic_modal.test.tsx.snap
+++ b/components/__snapshots__/generic_modal.test.tsx.snap
@@ -32,13 +32,8 @@ exports[`components/GenericModal should match snapshot for base case 1`] = `
   show={true}
 >
   <div
+    className="GenericModal__wrapper-enter-key-press-catcher"
     onKeyDown={[Function]}
-    style={
-      Object {
-        "height": "100%",
-        "width": "100%",
-      }
-    }
     tabIndex={0}
   >
     <ModalHeader
@@ -99,13 +94,8 @@ exports[`components/GenericModal should match snapshot with both buttons 1`] = `
   show={true}
 >
   <div
+    className="GenericModal__wrapper-enter-key-press-catcher"
     onKeyDown={[Function]}
-    style={
-      Object {
-        "height": "100%",
-        "width": "100%",
-      }
-    }
     tabIndex={0}
   >
     <ModalHeader
@@ -191,13 +181,8 @@ exports[`components/GenericModal should match snapshot with disabled confirm but
   show={true}
 >
   <div
+    className="GenericModal__wrapper-enter-key-press-catcher"
     onKeyDown={[Function]}
-    style={
-      Object {
-        "height": "100%",
-        "width": "100%",
-      }
-    }
     tabIndex={0}
   >
     <ModalHeader

--- a/components/__snapshots__/generic_modal.test.tsx.snap
+++ b/components/__snapshots__/generic_modal.test.tsx.snap
@@ -33,6 +33,12 @@ exports[`components/GenericModal should match snapshot for base case 1`] = `
 >
   <div
     onKeyDown={[Function]}
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
     tabIndex={0}
   >
     <ModalHeader
@@ -94,6 +100,12 @@ exports[`components/GenericModal should match snapshot with both buttons 1`] = `
 >
   <div
     onKeyDown={[Function]}
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
     tabIndex={0}
   >
     <ModalHeader
@@ -180,6 +192,12 @@ exports[`components/GenericModal should match snapshot with disabled confirm but
 >
   <div
     onKeyDown={[Function]}
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
     tabIndex={0}
   >
     <ModalHeader

--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -326,6 +326,7 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
             id='custom_status_modal'
             className={'StatusModal'}
             handleConfirm={handleSetStatus}
+            handleEnterKeyPress={handleSetStatus}
             handleCancel={handleClearStatus}
             confirmButtonClassName='btn btn-primary'
             ariaLabel={localizeMessage('custom_status.set_status', 'Set a status')}

--- a/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
+++ b/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
@@ -168,6 +168,7 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
                 modalHeaderText={modalHeaderText}
                 confirmButtonText={confirmButtonText}
                 handleConfirm={this.handleConfirm}
+                handleEnterKeyPress={this.handleConfirm}
                 id='dndCustomTimePickerModal'
                 className={'DndModal modal-overflow'}
             >

--- a/components/edit_category_modal/edit_category_modal.tsx
+++ b/components/edit_category_modal/edit_category_modal.tsx
@@ -125,6 +125,7 @@ export default class EditCategoryModal extends React.PureComponent<Props, State>
                 onExited={this.props.onExited}
                 modalHeaderText={modalHeaderText}
                 handleConfirm={this.handleConfirm}
+                handleEnterKeyPress={this.handleConfirm}
                 handleCancel={this.handleCancel}
                 confirmButtonText={editButtonText}
                 isConfirmDisabled={this.isConfirmDisabled()}

--- a/components/generic_modal.scss
+++ b/components/generic_modal.scss
@@ -98,6 +98,11 @@
         border: none;
         border-radius: 4px;
     }
+
+    &__wrapper-enter-key-press-catcher {
+        width: 100%;
+        height: 100%;
+    }
 }
 
 .GenericModal__header {

--- a/components/generic_modal.tsx
+++ b/components/generic_modal.tsx
@@ -151,6 +151,7 @@ export default class GenericModal extends React.PureComponent<Props, State> {
                 <div
                     onKeyDown={this.onEnterKeyDown}
                     tabIndex={0}
+                    style={{width: '100%', height: '100%'}}
                 >
                     <Modal.Header
                         closeButton={true}

--- a/components/generic_modal.tsx
+++ b/components/generic_modal.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
+import Constants from 'utils/constants';
+
 import './generic_modal.scss';
 
 type Props = {
@@ -74,7 +76,7 @@ export default class GenericModal extends React.PureComponent<Props, State> {
     }
 
     private onEnterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.key === 'Enter') {
+        if (event.key === Constants.KeyCodes.ENTER[0]) {
             if (this.props.autoCloseOnConfirmButton) {
                 this.onHide();
             }
@@ -151,7 +153,7 @@ export default class GenericModal extends React.PureComponent<Props, State> {
                 <div
                     onKeyDown={this.onEnterKeyDown}
                     tabIndex={0}
-                    style={{width: '100%', height: '100%'}}
+                    className='GenericModal__wrapper-enter-key-press-catcher'
                 >
                     <Modal.Header
                         closeButton={true}

--- a/components/generic_modal.tsx
+++ b/components/generic_modal.tsx
@@ -15,6 +15,7 @@ type Props = {
     show?: boolean;
     handleCancel?: () => void;
     handleConfirm?: () => void;
+    handleEnterKeyPress?: () => void;
     confirmButtonText?: React.ReactNode;
     confirmButtonClassName?: string;
     cancelButtonText?: React.ReactNode;
@@ -69,6 +70,17 @@ export default class GenericModal extends React.PureComponent<Props, State> {
         }
         if (this.props.handleConfirm) {
             this.props.handleConfirm();
+        }
+    }
+
+    private onEnterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+            if (this.props.autoCloseOnConfirmButton) {
+                this.onHide();
+            }
+            if (this.props.handleEnterKeyPress) {
+                this.props.handleEnterKeyPress();
+            }
         }
     }
 
@@ -136,23 +148,29 @@ export default class GenericModal extends React.PureComponent<Props, State> {
                 id={this.props.id}
                 container={this.props.container}
             >
-                <Modal.Header
-                    closeButton={true}
-                />
-                <Modal.Body>
-                    {this.props.modalHeaderText && <div className='GenericModal__header'>
-                        <h1 id='genericModalLabel'>
-                            {this.props.modalHeaderText}
-                        </h1>
-                    </div>}
-                    <div className='GenericModal__body'>
-                        {this.props.children}
-                    </div>
-                </Modal.Body>
-                {(cancelButton || confirmButton) && <Modal.Footer>
-                    {cancelButton}
-                    {confirmButton}
-                </Modal.Footer>}
+                <div
+                    onKeyDown={this.onEnterKeyDown}
+                    tabIndex={0}
+                >
+                    <Modal.Header
+                        closeButton={true}
+                    />
+                    <Modal.Body>
+                        {this.props.modalHeaderText && <div className='GenericModal__header'>
+                            <h1 id='genericModalLabel'>
+                                {this.props.modalHeaderText}
+                            </h1>
+                        </div>}
+                        <div className='GenericModal__body'>
+                            {this.props.children}
+                        </div>
+                    </Modal.Body>
+                    {(cancelButton || confirmButton) && <Modal.Footer>
+                        {cancelButton}
+                        {confirmButton}
+                    </Modal.Footer>}
+                </div>
+
             </Modal>
         );
     }

--- a/components/product_notices_modal/__snapshots__/product_notices.test.tsx.snap
+++ b/components/product_notices_modal/__snapshots__/product_notices.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`ProductNoticesModal Match snapshot for single notice 1`] = `
   }
   enforceFocus={true}
   handleConfirm={[Function]}
+  handleEnterKeyPress={[Function]}
   id="genericModal"
   modalHeaderText={
     <span>
@@ -63,6 +64,7 @@ exports[`ProductNoticesModal Match snapshot for user notice 1`] = `
   enforceFocus={true}
   handleCancel={[Function]}
   handleConfirm={[Function]}
+  handleEnterKeyPress={[Function]}
   id="genericModal"
   modalHeaderText={
     <span>
@@ -134,6 +136,7 @@ exports[`ProductNoticesModal Should match snapshot for system admin notice 1`] =
   }
   enforceFocus={true}
   handleConfirm={[Function]}
+  handleEnterKeyPress={[Function]}
   id="genericModal"
   modalHeaderText={
     <span>

--- a/components/product_notices_modal/product_notices_modal.tsx
+++ b/components/product_notices_modal/product_notices_modal.tsx
@@ -260,6 +260,7 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
             <GenericModal
                 onExited={this.onModalDismiss}
                 handleConfirm={this.handleNextButton}
+                handleEnterKeyPress={this.handleNextButton}
                 handleCancel={handlePreviousButton}
                 modalHeaderText={(
                     <span>

--- a/components/sidebar/sidebar_next_steps/remove_next_steps_modal.tsx
+++ b/components/sidebar/sidebar_next_steps/remove_next_steps_modal.tsx
@@ -51,6 +51,7 @@ export default function RemoveNextStepsModal(props: Props) {
                 className='RemoveNextStepsModal'
                 onExited={onCancel}
                 handleConfirm={onConfirm}
+                handleEnterKeyPress={onConfirm}
                 handleCancel={onCancel}
                 container={modalRoot}
                 modalHeaderText={(


### PR DESCRIPTION
#### Summary
As part of [PR9862](https://github.com/mattermost/mattermost-webapp/pull/9862) a `<form>` wrapping tag was removed and with that unintentionally was removed the functionality of submit forms that were using the generic modal component when pressing the Enter key. This PR enhances the GenericModal component by providing a handler event for the Enter key press, that way we add back that functionality without the extra problems that was giving the wrapper form tag by default given that now every component using the generic modal will be able to define if want to perform a particular action by the enter key press.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42614

#### Release Note
```release-note
NONE
```
