### PR TITLE
[MM-42324]: adjusted paste handling while editing posts

### DIFF
--- a/components/textbox/textbox.tsx
+++ b/components/textbox/textbox.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {ChangeEvent, ElementType, FocusEvent, KeyboardEvent, MouseEvent} from 'react';
+import React, {ChangeEvent, ClipboardEventHandler, ElementType, FocusEvent, KeyboardEvent, MouseEvent} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {Channel} from 'mattermost-redux/types/channels';
@@ -40,6 +40,7 @@ type Props = {
     onBlur?: (e: FocusEvent) => void;
     supportsCommands: boolean;
     handlePostError?: (message: JSX.Element | null) => void;
+    onPaste?: ClipboardEventHandler;
     suggestionList?: React.ComponentProps<typeof SuggestionBox>['listComponent'];
     suggestionListPosition?: React.ComponentProps<typeof SuggestionList>['position'];
     emojiEnabled?: boolean;
@@ -297,6 +298,7 @@ export default class Textbox extends React.PureComponent<Props> {
                     onComposition={this.props.onComposition}
                     onBlur={this.handleBlur}
                     onHeightChange={this.handleHeightChange}
+                    onPaste={this.props.onPaste}
                     style={{visibility: this.props.preview ? 'hidden' : 'visible'}}
                     inputComponent={this.props.inputComponent}
                     listComponent={this.props.suggestionList}


### PR DESCRIPTION
#### Summary
getting rid of the `useEffect` surrounding the paste-handling function and using the built in `onPaste` handler did fix the issues.

#### Ticket Link
[MM-42324](https://mattermost.atlassian.net/browse/MM-42324)

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
pasting special content (e.g. HTML tables) now works as expected
```
