### PR TITLE
MM-41808: fixes negative unread counts for threads

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
@@ -27,7 +27,7 @@ function handleAllTeamThreadsRead(state: ThreadsState['counts'], action: Generic
 
 function isEqual(state: ThreadsState['counts'], action: GenericAction) {
     const counts = state[action.data.team_id] ?? {};
-    const newCounts = omit(action.data, ['threads']);
+    const newCounts = omit(action.data, ['threads', 'teamId']);
 
     return shallowEqual(counts, newCounts);
 }

--- a/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
@@ -27,7 +27,7 @@ function handleAllTeamThreadsRead(state: ThreadsState['counts'], action: Generic
 
 function isEqual(state: ThreadsState['counts'], action: GenericAction) {
     const counts = state[action.data.team_id] ?? {};
-    const newCounts = omit(action.data, ['threads', 'teamId']);
+    const newCounts = omit(action.data, ['threads', 'team_id']);
 
     return shallowEqual(counts, newCounts);
 }

--- a/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
@@ -139,6 +139,15 @@ export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {},
     case ChannelTypes.RECEIVED_CHANNEL_DELETED:
     case ChannelTypes.LEAVE_CHANNEL:
         return handleLeaveChannel(state, action, extra);
+    case ThreadTypes.RECEIVED_UNREAD_THREADS:
+        return {
+            ...state,
+            [action.data.team_id]: {
+                ...state[action.data.team_id],
+                total_unread_threads: action.data.total_unread_threads,
+                total_unread_mentions: action.data.total_unread_mentions,
+            },
+        };
     case ThreadTypes.RECEIVED_THREADS:
         return {
             ...state,


### PR DESCRIPTION
#### Summary

Upon reconnecting the websocket we are fetching unread threads,
but we don't update unread counts when we do that.

This PR adds those updates on the counts reducer.

This is done to fix the negative counts that can happen when:

  While disconnected you might receive a new thread.
  If you view the new thread before reconnecting,
  and then view an old thread,
  that would set the count to a negative value.
  Showing "you have -1 unread threads".

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-41808

#### Release Note

```release-note
NONE
```
