### PR TITLE
[MM-42604] - Status menu items are misaligned

### DIFF
--- a/components/dot_menu/__snapshots__/dot_menu.test.tsx.snap
+++ b/components/dot_menu/__snapshots__/dot_menu.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
 <MenuWrapper
   animationComponent={[Function]}
-  className=""
+  className="status-dropdown-menu-global-header"
   onToggle={[Function]}
 >
   <OverlayTrigger
@@ -55,7 +55,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
         />
       }
       onClick={[Function]}
-      rightDecorator="R"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          R
+        </span>
+      }
       show={true}
       text="Reply"
     />
@@ -82,7 +88,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
       }
       id="follow_post_thread_post_id_1"
       onClick={[Function]}
-      rightDecorator="F"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          F
+        </span>
+      }
       show={false}
       text="Follow message"
     />
@@ -94,7 +106,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
       }
       id="unread_post_post_id_1"
       onClick={[Function]}
-      rightDecorator="U"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          U
+        </span>
+      }
       show={true}
       text="Mark as Unread"
     />
@@ -116,7 +134,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
       }
       id="unpin_post_post_id_1"
       onClick={[Function]}
-      rightDecorator="P"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          P
+        </span>
+      }
       show={false}
       text="Unpin"
     />
@@ -128,7 +152,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
       }
       id="pin_post_post_id_1"
       onClick={[Function]}
-      rightDecorator="P"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          P
+        </span>
+      }
       show={true}
       text="Pin"
     />
@@ -145,7 +175,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
       }
       id="permalink_post_id_1"
       onClick={[Function]}
-      rightDecorator="K"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          K
+        </span>
+      }
       show={true}
       text="Copy Link"
     />
@@ -162,7 +198,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
       }
       id="edit_post_post_id_1"
       onClick={[Function]}
-      rightDecorator="E"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          E
+        </span>
+      }
       show={true}
       text="Edit"
     />
@@ -174,7 +216,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
       }
       id="copy_post_id_1"
       onClick={[Function]}
-      rightDecorator="C"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          C
+        </span>
+      }
       show={true}
       text="Copy Text"
     />
@@ -204,7 +252,7 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
 exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
 <MenuWrapper
   animationComponent={[Function]}
-  className=""
+  className="status-dropdown-menu-global-header"
   onToggle={[Function]}
 >
   <OverlayTrigger
@@ -256,7 +304,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
         />
       }
       onClick={[Function]}
-      rightDecorator="R"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          R
+        </span>
+      }
       show={true}
       text="Reply"
     />
@@ -283,7 +337,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
       }
       id="follow_post_thread_post_id_1"
       onClick={[Function]}
-      rightDecorator="F"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          F
+        </span>
+      }
       show={false}
       text="Follow message"
     />
@@ -295,7 +355,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
       }
       id="unread_post_post_id_1"
       onClick={[Function]}
-      rightDecorator="U"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          U
+        </span>
+      }
       show={true}
       text="Mark as Unread"
     />
@@ -317,7 +383,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
       }
       id="unpin_post_post_id_1"
       onClick={[Function]}
-      rightDecorator="P"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          P
+        </span>
+      }
       show={false}
       text="Unpin"
     />
@@ -329,7 +401,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
       }
       id="pin_post_post_id_1"
       onClick={[Function]}
-      rightDecorator="P"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          P
+        </span>
+      }
       show={true}
       text="Pin"
     />
@@ -346,7 +424,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
       }
       id="permalink_post_id_1"
       onClick={[Function]}
-      rightDecorator="K"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          K
+        </span>
+      }
       show={true}
       text="Copy Link"
     />
@@ -363,7 +447,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
       }
       id="edit_post_post_id_1"
       onClick={[Function]}
-      rightDecorator="E"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          E
+        </span>
+      }
       show={true}
       text="Edit"
     />
@@ -375,7 +465,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
       }
       id="copy_post_id_1"
       onClick={[Function]}
-      rightDecorator="C"
+      rightDecorator={
+        <span
+          className="MenuItem__opacity MenuItem__right-decorator"
+        >
+          C
+        </span>
+      }
       show={true}
       text="Copy Text"
     />

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -398,6 +398,21 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
             openUp: (spaceOnTop > spaceOnBottom),
         });
     }
+    shortcutKey = (key: string) => {
+        return (
+            <span
+                className={classNames([
+                    'MenuItem__opacity',
+                    'MenuItem__right-decorator',
+                    {
+                        'MenuItem__text-color': !true,
+                    },
+                ])}
+            >
+                {key}
+            </span>
+        );
+    };
 
     render(): JSX.Element {
         const isMobile = this.props.isMobileView;
@@ -411,6 +426,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         return (
             <MenuWrapper
                 open={this.props.isMenuOpen}
+                className={classNames('status-dropdown-menu-global-header')}
                 onToggle={this.handleDropdownOpened}
             >
                 <OverlayTrigger
@@ -443,7 +459,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         show={!isSystemMessage && this.props.location === Locations.CENTER}
                         text={Utils.localizeMessage('post_info.reply', 'Reply')}
                         icon={Utils.getMenuItemIcon('icon-reply-outline')}
-                        rightDecorator={'R'}
+                        rightDecorator={this.shortcutKey('R')}
                         onClick={this.handleCommentClick}
                     />
                     <ChannelPermissionGate
@@ -460,7 +476,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                     <Menu.ItemAction
                         id={`follow_post_thread_${this.props.post.id}`}
                         onClick={this.handleSetThreadFollow}
-                        rightDecorator={'F'}
+                        rightDecorator={this.shortcutKey('F')}
                         show={(
                             !isSystemMessage &&
                             this.props.isCollapsedThreadsEnabled &&
@@ -483,7 +499,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         show={!isSystemMessage && !this.props.channelIsArchived && this.props.location !== Locations.SEARCH}
                         text={Utils.localizeMessage('post_info.unread', 'Mark as Unread')}
                         icon={Utils.getMenuItemIcon('icon-mark-as-unread')}
-                        rightDecorator={'U'}
+                        rightDecorator={this.shortcutKey('U')}
                         onClick={this.handleMarkPostAsRead}
                     />
                     <Menu.ItemAction
@@ -501,7 +517,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         show={!isSystemMessage && !this.props.isReadOnly && this.props.post.is_pinned}
                         text={Utils.localizeMessage('post_info.unpin', 'Unpin')}
                         icon={Utils.getMenuItemIcon('icon-pin')}
-                        rightDecorator={'P'}
+                        rightDecorator={this.shortcutKey('P')}
                         onClick={this.handlePinMenuItemActivated}
                     />
                     <Menu.ItemAction
@@ -509,7 +525,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         show={!isSystemMessage && !this.props.isReadOnly && !this.props.post.is_pinned}
                         text={Utils.localizeMessage('post_info.pin', 'Pin')}
                         icon={Utils.getMenuItemIcon('icon-pin-outline')}
-                        rightDecorator={'P'}
+                        rightDecorator={this.shortcutKey('P')}
                         onClick={this.handlePinMenuItemActivated}
                     />
                     {!isSystemMessage && (this.state.canEdit || this.state.canDelete) && this.renderDivider('edit')}
@@ -518,7 +534,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         show={!isSystemMessage}
                         text={Utils.localizeMessage('post_info.permalink', 'Copy Link')}
                         icon={Utils.getMenuItemIcon('icon-link-variant')}
-                        rightDecorator={'K'}
+                        rightDecorator={this.shortcutKey('K')}
                         onClick={this.copyLink}
                     />
                     {!isSystemMessage && this.renderDivider('edit')}
@@ -527,7 +543,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         show={this.state.canEdit}
                         text={Utils.localizeMessage('post_info.edit', 'Edit')}
                         icon={Utils.getMenuItemIcon('icon-pencil-outline')}
-                        rightDecorator={'E'}
+                        rightDecorator={this.shortcutKey('E')}
                         onClick={this.handleEditMenuItemActivated}
                     />
                     <Menu.ItemAction
@@ -535,7 +551,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         show={!isSystemMessage}
                         text={Utils.localizeMessage('post_info.copy', 'Copy Text')}
                         icon={Utils.getMenuItemIcon('icon-content-copy')}
-                        rightDecorator={'C'}
+                        rightDecorator={this.shortcutKey('C')}
                         onClick={this.copyText}
                     />
                     <Menu.ItemAction

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -317,10 +317,6 @@ export default class RhsRootPost extends React.PureComponent {
         this.setState({showActionTip: false});
     };
 
-    handleActionsMenuOpened = (open) => {
-        this.setState({showActionsMenu: open});
-    };
-
     handleFileDropdownOpened = (open) => {
         this.setState({fileDropdownOpened: open});
     };

--- a/components/widgets/menu/menu_items/menu_item_action.test.tsx
+++ b/components/widgets/menu/menu_items/menu_item_action.test.tsx
@@ -25,9 +25,6 @@ describe('components/MenuItemAction', () => {
               >
                 Whatever
               </span>
-              <span
-                className="MenuItem__right-decorator MenuItem__text-color"
-              />
             </button>
         `);
     });
@@ -49,14 +46,6 @@ describe('components/MenuItemAction', () => {
                 className="MenuItem__primary-text"
               >
                 Whatever
-              </span>
-              <span
-                className="MenuItem__right-decorator MenuItem__text-color"
-              />
-              <span
-                className="MenuItem__help-text"
-              >
-                Extra Text
               </span>
             </button>
         `);

--- a/components/widgets/menu/menu_items/menu_item_action.tsx
+++ b/components/widgets/menu/menu_items/menu_item_action.tsx
@@ -42,22 +42,7 @@ export const MenuItemActionImpl = ({
         }
         onClick={onClick}
     >
-        {text && (
-            <>
-                <span className='MenuItem__primary-text'>{text}</span>
-                <span
-                    className={classNames([
-                        'MenuItem__right-decorator',
-                        {
-                            'MenuItem__text-color': !isDangerous,
-                        },
-                    ])}
-                >
-                    {rightDecorator}
-                </span>
-            </>
-        )}
-        {extraText && <span className='MenuItem__help-text'>{extraText}</span>}
+        {text && <span className='MenuItem__primary-text'>{text}{rightDecorator}</span>}
     </button>
 );
 


### PR DESCRIPTION
#### Summary
This PR fixes a misalignment issue caused by https://github.com/mattermost/mattermost-webapp/pull/8853. In that PR, I created more problems than necessary with updates to the `menu_item_action` component. In this PR, I create the `rightDecorator` as a component and pass it in to `menuItem`

I would like to merge this PR in to https://github.com/mattermost/mattermost-webapp/pull/10028. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42604

#### Related Pull Requests

#### Screenshots


#### Release Note
```release-note
NONE
```

<details>
<summary>Details</summary>



</details>