### PR TITLE
MM-42390 : Make a minimal GraphQL web client

### DIFF
--- a/packages/mattermost-redux/src/client/client4.test.js
+++ b/packages/mattermost-redux/src/client/client4.test.js
@@ -57,6 +57,15 @@ describe('Client4', () => {
             assert.equal(isMinimumServerVersion(client.serverVersion, 5, 1, 0), true);
         });
     });
+
+    describe('doFetchWithGraphQL', () => {
+        test('Should have correct graphql url', async () => {
+            const client = TestHelper.createClient4();
+            client.setUrl('http://community.mattermost.com');
+
+            assert.equal(client.getGraphQLUrl(), 'http://community.mattermost.com/api/v5/graphql');
+        });
+    });
 });
 
 describe('ClientError', () => {

--- a/packages/mattermost-redux/src/client/client4.test.js
+++ b/packages/mattermost-redux/src/client/client4.test.js
@@ -58,7 +58,7 @@ describe('Client4', () => {
         });
     });
 
-    describe('doFetchWithGraphQL', () => {
+    describe('fetchWithGraphQL', () => {
         test('Should have correct graphql url', async () => {
             const client = TestHelper.createClient4();
             client.setUrl('http://community.mattermost.com');

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -1,12 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
+import FormData from 'form-data';
 
 import {SystemSetting} from 'mattermost-redux/types/general';
-
-import {General} from '../constants';
-
 import {ClusterInfo, AnalyticsRow, SchemaMigration} from 'mattermost-redux/types/admin';
 import type {AppBinding, AppCallRequest, AppCallResponse, AppCallType} from 'mattermost-redux/types/apps';
 import {Audit} from 'mattermost-redux/types/audits';
@@ -40,9 +37,7 @@ import {
 } from 'mattermost-redux/types/config';
 import {CustomEmoji} from 'mattermost-redux/types/emojis';
 import {ServerError} from 'mattermost-redux/types/errors';
-
 import {FileInfo, FileUploadResponse, FileSearchResults} from 'mattermost-redux/types/files';
-
 import {
     Group,
     GroupPatch,
@@ -115,18 +110,17 @@ import {
     GetDataRetentionCustomPoliciesRequest,
 } from 'mattermost-redux/types/data_retention';
 import {CompleteOnboardingRequest} from 'mattermost-redux/types/setup';
-
 import {buildQueryString, isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 import {cleanUrlForLogging} from 'mattermost-redux/utils/sentry';
 import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
-
 import {UserThreadList, UserThread, UserThreadWithPost} from 'mattermost-redux/types/threads';
 
 import Constants from 'utils/constants';
 
+import {General} from '../constants';
+
 import {TelemetryHandler} from './telemetry';
 
-const FormData = require('form-data');
 const HEADER_AUTH = 'Authorization';
 const HEADER_BEARER = 'BEARER';
 const HEADER_CONTENT_TYPE = 'Content-Type';
@@ -139,7 +133,7 @@ const PER_PAGE_DEFAULT = 60;
 const LOGS_PER_PAGE_DEFAULT = 10000;
 export const DEFAULT_LIMIT_BEFORE = 30;
 export const DEFAULT_LIMIT_AFTER = 30;
-/* eslint-disable no-throw-literal */
+const GRAPHQL_ENDPOINT = '/api/v5/graphql';
 
 export default class Client4 {
     logToConsole = false;
@@ -161,7 +155,6 @@ export default class Client4 {
         unknownError: 'We received an unexpected status code from the server.',
     };
     userRoles?: string;
-
     telemetryHandler?: TelemetryHandler;
 
     getUrl() {
@@ -173,6 +166,10 @@ export default class Client4 {
             return baseUrl;
         }
         return this.getUrl() + baseUrl;
+    }
+
+    getGraphQLUrl() {
+        return `${this.url}${GRAPHQL_ENDPOINT}`;
     }
 
     setUrl(url: string) {
@@ -3837,13 +3834,23 @@ export default class Client4 {
 
     // Client Helpers
 
-    doFetch = async <T>(url: string, options: Options): Promise<T> => {
-        const {data} = await this.doFetchWithResponse<T>(url, options);
+    doFetch = async <ClientDataResponse>(url: string, options: Options): Promise<ClientDataResponse> => {
+        const {data} = await this.doFetchWithResponse<ClientDataResponse>(url, options);
 
         return data;
     };
 
-    doFetchWithResponse = async <T>(url: string, options: Options): Promise<ClientResponse<T>> => {
+    /**
+     *
+     * @param query string query of graphQL, pass the json stringified version of the query
+     * eg.  const query = JSON.stringify({query: `{license, config}`});
+     *      client4.doFetchWithResponse(query);
+     */
+    doFetchWithGraphQL = async <DataResponse>(query: string) => {
+        return this.doFetch<DataResponse>(this.getGraphQLUrl(), {method: 'post', body: query});
+    }
+
+    doFetchWithResponse = async <ClientDataResponse>(url: string, options: Options): Promise<ClientResponse<ClientDataResponse>> => {
         const response = await fetch(url, this.getOptions(options));
         const headers = parseAndMergeNestedHeaders(response.headers);
 

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -3841,10 +3841,9 @@ export default class Client4 {
     };
 
     /**
-     *
      * @param query string query of graphQL, pass the json stringified version of the query
      * eg.  const query = JSON.stringify({query: `{license, config}`});
-     *      client4.doFetchWithResponse(query);
+     *      client4.doFetchWithGraphQL(query);
      */
     doFetchWithGraphQL = async <DataResponse>(query: string) => {
         return this.doFetch<DataResponse>(this.getGraphQLUrl(), {method: 'post', body: query});

--- a/packages/mattermost-redux/src/client/client4.ts
+++ b/packages/mattermost-redux/src/client/client4.ts
@@ -3832,6 +3832,15 @@ export default class Client4 {
         );
     }
 
+    /**
+     * @param query string query of graphQL, pass the json stringified version of the query
+     * eg.  const query = JSON.stringify({query: `{license, config}`});
+     *      client4.fetchWithGraphQL(query);
+     */
+    fetchWithGraphQL = async <DataResponse>(query: string) => {
+        return this.doFetch<DataResponse>(this.getGraphQLUrl(), {method: 'post', body: query});
+    }
+
     // Client Helpers
 
     doFetch = async <ClientDataResponse>(url: string, options: Options): Promise<ClientDataResponse> => {
@@ -3839,15 +3848,6 @@ export default class Client4 {
 
         return data;
     };
-
-    /**
-     * @param query string query of graphQL, pass the json stringified version of the query
-     * eg.  const query = JSON.stringify({query: `{license, config}`});
-     *      client4.doFetchWithGraphQL(query);
-     */
-    doFetchWithGraphQL = async <DataResponse>(query: string) => {
-        return this.doFetch<DataResponse>(this.getGraphQLUrl(), {method: 'post', body: query});
-    }
 
     doFetchWithResponse = async <ClientDataResponse>(url: string, options: Options): Promise<ClientResponse<ClientDataResponse>> => {
         const response = await fetch(url, this.getOptions(options));


### PR DESCRIPTION
#### Summary
Add graphql client to existing client4 client. 
Example usage
```typescript
const {data} = await Client4.fetchWithGraphQL<MyDataQueryResponseType>(myDataQuery);
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42390

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
