### PR TITLE
[MM-42636] fix disabled dot menu clicking 

### DIFF
--- a/components/dot_menu/dot_menu.test.tsx
+++ b/components/dot_menu/dot_menu.test.tsx
@@ -10,6 +10,9 @@ import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import {Locations} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
+import * as dotUtils from './utils';
+jest.mock('./utils');
+
 import DotMenu, {DotMenuClass} from './dot_menu';
 
 describe('components/dot_menu/DotMenu', () => {
@@ -157,6 +160,7 @@ describe('components/dot_menu/DotMenu', () => {
             [true, {isFollowingThread: false}],
         ])('should call setThreadFollow with following as %s', (following, caseProps) => {
             const spySetThreadFollow = jest.fn();
+            const spy = jest.spyOn(dotUtils, 'trackDotMenuEvent');
 
             const props = {
                 ...baseProps,
@@ -174,6 +178,7 @@ describe('components/dot_menu/DotMenu', () => {
 
             wrapper.find(`#follow_post_thread_${baseProps.post.id}`).simulate('click');
 
+            expect(spy).toHaveBeenCalled();
             expect(spySetThreadFollow).toHaveBeenCalledWith(
                 'user_id_1',
                 'team_id_1',

--- a/components/dot_menu/utils.tsx
+++ b/components/dot_menu/utils.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {trackEvent} from 'actions/telemetry_actions';
+
+import {EventTypes, TELEMETRY_CATEGORIES} from 'utils/constants';
+
+export type ChangeEvent = KeyboardEvent | MouseEvent;
+
+export const trackDotMenuEvent = (e: ChangeEvent, suffix: string): void => {
+    if (e.type === EventTypes.CLICK) {
+        trackEvent(TELEMETRY_CATEGORIES.POST_INFO_MORE, EventTypes.CLICK + '_' + suffix);
+    } else {
+        trackEvent(TELEMETRY_CATEGORIES.POST_INFO_MORE, EventTypes.SHORTCUT + '_ ' + suffix);
+    }
+};


### PR DESCRIPTION
#### Summary
This PR fixes an issue where the shortcut additions in the post dot menu had disabled the ability to click the menu item with the mouse.

QA should verify that both the shortcut and clicking activate the desired response.

#### Ticket Link

#### Related Pull Requests

#### Screenshots

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
