### PR TITLE
[MM-42778] Fix console warning introduced by Actions Menu

### DIFF
--- a/components/actions_menu/actions_menu_tutorial_tip.tsx
+++ b/components/actions_menu/actions_menu_tutorial_tip.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
-import TourTip, {useMeasurePunchouts} from 'components/widgets/tour_tip';
+import TourTip from 'components/widgets/tour_tip';
 
 const translate = {x: 6, y: -16};
 
@@ -29,17 +29,12 @@ export const ActionsTutorialTip = ({handleOpen, handleDismiss, handleNext, showT
             defaultMessage='Message actions that are provided\nthrough apps, integrations or plugins\nhave moved to this menu item.'
         />
     );
-
-    const overlayPunchOut = useMeasurePunchouts([], []);
-
-    const nextBtn = (): JSX.Element => {
-        return (
-            <FormattedMessage
-                id={'tutorial_tip.got_it'}
-                defaultMessage={'Got it'}
-            />
-        );
-    };
+    const nextBtn = (
+        <FormattedMessage
+            id={'tutorial_tip.got_it'}
+            defaultMessage={'Got it'}
+        />
+    );
 
     return (
         <TourTip
@@ -47,7 +42,7 @@ export const ActionsTutorialTip = ({handleOpen, handleDismiss, handleNext, showT
             onHidden={handleDismiss}
             screen={screen}
             title={title}
-            overlayPunchOut={overlayPunchOut}
+            overlayPunchOut={null}
             placement='top'
             pulsatingDotPlacement='left'
             pulsatingDotTranslate={translate}
@@ -58,7 +53,7 @@ export const ActionsTutorialTip = ({handleOpen, handleDismiss, handleNext, showT
             handleDismiss={handleDismiss}
             handleNext={handleNext}
             handleOpen={handleOpen}
-            nextBtn={nextBtn()}
+            nextBtn={nextBtn}
         />
     );
 };


### PR DESCRIPTION
#### Summary
This PR solves an issue where scrolling up and down the posts in a channel (when the pulsating tooltip is showing) would produce the following error. This is introduced by using the required `overlayPunchOut` prop of the `TourTip` component. 

The solution I chose was to pass `null` into this prop, as suggested inside the tour tip component.

![image](https://user-images.githubusercontent.com/7575921/160186460-bacd2a16-e3da-49a6-a0b4-a30dbc804d48.png)

Testing: 

Before:
scrolling up and down post list would show warning once and only once. To see it again, user must refresh the page.

After: 
scrolling up and down the post list never displays the error in the console.

**None related change: **
convert `nextBtn` from callable function to a const that returns the value of function.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42778

#### Related Pull Requests

#### Screenshots

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
