### PR TITLE
MM-42353 - add more padding bottom if task list is shown

### DIFF
--- a/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
+++ b/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`components/AdminSidebar Plugins should filter plugins 1`] = `
         filter="autolink"
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         >
           <AdminSidebarCategory
             definitionKey="plugins"
@@ -124,7 +124,7 @@ exports[`components/AdminSidebar Plugins should match snapshot 1`] = `
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         >
           <AdminSidebarCategory
             definitionKey="user_management"
@@ -411,7 +411,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         >
           <AdminSidebarCategory
             definitionKey="about"
@@ -1188,7 +1188,7 @@ exports[`components/AdminSidebar should match snapshot with workspace optimizati
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         >
           <AdminSidebarCategory
             definitionKey="about"
@@ -1965,7 +1965,7 @@ exports[`components/AdminSidebar should match snapshot, no access 1`] = `
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         />
       </Highlight>
     </div>
@@ -2020,7 +2020,7 @@ exports[`components/AdminSidebar should match snapshot, not prevent the console 
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         />
       </Highlight>
     </div>
@@ -2075,7 +2075,7 @@ exports[`components/AdminSidebar should match snapshot, render plugins without a
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         />
       </Highlight>
     </div>
@@ -2130,7 +2130,7 @@ exports[`components/AdminSidebar should match snapshot, with license (with all f
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         >
           <AdminSidebarCategory
             definitionKey="about"
@@ -3108,7 +3108,7 @@ exports[`components/AdminSidebar should match snapshot, with license (without an
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked "
+          className="nav nav-pills nav-stacked"
         >
           <AdminSidebarCategory
             definitionKey="user_management"

--- a/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
+++ b/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`components/AdminSidebar Plugins should filter plugins 1`] = `
         filter="autolink"
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         >
           <AdminSidebarCategory
             definitionKey="plugins"
@@ -124,7 +124,7 @@ exports[`components/AdminSidebar Plugins should match snapshot 1`] = `
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         >
           <AdminSidebarCategory
             definitionKey="user_management"
@@ -411,7 +411,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         >
           <AdminSidebarCategory
             definitionKey="about"
@@ -1188,7 +1188,7 @@ exports[`components/AdminSidebar should match snapshot with workspace optimizati
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         >
           <AdminSidebarCategory
             definitionKey="about"
@@ -1965,7 +1965,7 @@ exports[`components/AdminSidebar should match snapshot, no access 1`] = `
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         />
       </Highlight>
     </div>
@@ -2020,7 +2020,7 @@ exports[`components/AdminSidebar should match snapshot, not prevent the console 
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         />
       </Highlight>
     </div>
@@ -2075,7 +2075,7 @@ exports[`components/AdminSidebar should match snapshot, render plugins without a
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         />
       </Highlight>
     </div>
@@ -2130,7 +2130,7 @@ exports[`components/AdminSidebar should match snapshot, with license (with all f
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         >
           <AdminSidebarCategory
             definitionKey="about"
@@ -3108,7 +3108,7 @@ exports[`components/AdminSidebar should match snapshot, with license (without an
         filter=""
       >
         <ul
-          className="nav nav-pills nav-stacked"
+          className="nav nav-pills nav-stacked "
         >
           <AdminSidebarCategory
             definitionKey="user_management"

--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -54,6 +54,7 @@ class AdminSidebar extends React.PureComponent {
         navigationBlocked: PropTypes.bool.isRequired,
         consoleAccess: PropTypes.object,
         intl: intlShape.isRequired,
+        showTaskList: PropTypes.bool,
         actions: PropTypes.shape({
 
             /*
@@ -297,6 +298,7 @@ class AdminSidebar extends React.PureComponent {
     }
 
     render() {
+        const {showTaskList} = this.props;
         return (
             <div className='admin-sidebar'>
                 <AdminSidebarHeader/>
@@ -328,7 +330,7 @@ class AdminSidebar extends React.PureComponent {
                 >
                     <div className='nav-pills__container'>
                         <Highlight filter={this.state.filter}>
-                            <ul className='nav nav-pills nav-stacked'>
+                            <ul className={`nav nav-pills nav-stacked ${showTaskList ? 'task-list-shown' : ''}`}>
                                 {this.renderRootMenu(this.props.adminDefinition)}
                             </ul>
                         </Highlight>

--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -8,6 +8,8 @@ import {FormattedMessage, injectIntl} from 'react-intl';
 import Scrollbars from 'react-custom-scrollbars';
 import isEqual from 'lodash/isEqual';
 
+import classNames from 'classnames';
+
 import * as Utils from 'utils/utils.jsx';
 import {generateIndex} from 'utils/admin_console_index.jsx';
 import {browserHistory} from 'utils/browser_history';
@@ -330,7 +332,7 @@ class AdminSidebar extends React.PureComponent {
                 >
                     <div className='nav-pills__container'>
                         <Highlight filter={this.state.filter}>
-                            <ul className={`nav nav-pills nav-stacked ${showTaskList ? 'task-list-shown' : ''}`}>
+                            <ul className={classNames('nav nav-pills nav-stacked', {'task-list-shown': showTaskList})}>
                                 {this.renderRootMenu(this.props.adminDefinition)}
                             </ul>
                         </Highlight>

--- a/components/admin_console/admin_sidebar/index.js
+++ b/components/admin_console/admin_sidebar/index.js
@@ -6,6 +6,13 @@ import {bindActionCreators} from 'redux';
 
 import {getPlugins} from 'mattermost-redux/actions/admin';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
+
+import {isMobile} from 'utils/utils.jsx';
+
+import {OnboardingTaskCategory, OnboardingTaskList} from 'components/onboarding_tasks';
+
+import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 
 import {getNavigationBlocked} from 'selectors/views/admin';
 import {getAdminDefinition, getConsoleAccess} from 'selectors/admin_console';
@@ -19,6 +26,10 @@ function mapStateToProps(state) {
     const siteName = config.SiteName;
     const adminDefinition = getAdminDefinition(state);
     const consoleAccess = getConsoleAccess(state);
+    const taskListStatus = getBool(state, OnboardingTaskCategory, OnboardingTaskList.ONBOARDING_TASK_LIST_SHOW);
+    const isUserFirstAdmin = isFirstAdmin(state);
+    const isMobileView = isMobile();
+    const showTaskList = isUserFirstAdmin && taskListStatus && !isMobileView;
 
     return {
         license,
@@ -30,6 +41,7 @@ function mapStateToProps(state) {
         adminDefinition,
         consoleAccess,
         cloud: state.entities.cloud,
+        showTaskList,
     };
 }
 

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -641,6 +641,10 @@
         ul {
             padding-bottom: 20px;
             margin-top: 1px;
+
+            &.nav-stacked.task-list-shown {
+                padding-bottom: 60px;
+            }
         }
     }
 

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -643,7 +643,7 @@
             margin-top: 1px;
 
             &.nav-stacked.task-list-shown {
-                padding-bottom: 60px;
+                padding-bottom: 72px;
             }
         }
     }


### PR DESCRIPTION
#### Summary
The task list icon button was covering the bottom items options in the system console. This PR checks if the task list button is shown and if so, it adds a css class which adds more padding to the bottom so the options can be seen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42353

#### Related Pull Requests
n/a

#### Screenshots
Before:
![Icon blocks Bleve](https://user-images.githubusercontent.com/10082627/160245802-e580e5a2-6c09-4195-be00-c2d7de161e03.png)

After:
<img width="1458" alt="Captura de pantalla 2022-03-26 a las 10 28 25" src="https://user-images.githubusercontent.com/10082627/160246368-f456b92d-fb95-4406-a795-5bbafedb2a01.png">

#### Release Note
```release-note
NONe
```
