### PR TITLE
[MM-42603] if mobile view, don't show pulsating dot. Always open the actions menu

### DIFF
--- a/selectors/actions_menu.ts
+++ b/selectors/actions_menu.ts
@@ -4,8 +4,12 @@
 import {GlobalState} from 'types/store';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {Preferences} from 'mattermost-redux/constants';
+import {getIsMobileView} from 'selectors/views/browser';
 
 export function showActionsDropdownPulsatingDot(state: GlobalState): boolean {
+    if (getIsMobileView(state)) {
+        return false;
+    }
     const actionsMenuTutorialState = get(state, Preferences.CATEGORY_ACTIONS_MENU, Preferences.NAME_ACTIONS_MENU_TUTORIAL_STATE, false);
     const modalAlreadyViewed = actionsMenuTutorialState && JSON.parse(actionsMenuTutorialState)[Preferences.ACTIONS_MENU_VIEWED];
     return !modalAlreadyViewed;


### PR DESCRIPTION
#### Summary
When a user is in the mobile view, the actions menu should not wait for the user to view the tooltip.
* do not show pulsating dot on Action menu
* clicking the Actions Menu will always open the menu
* side effect is that they can use the new Actions Menu feature on mobile, but will see the pulsating dot if viewing on web view.

I added the logic to the selector which is used by post_info, rhs_comment, and rhs_root components.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42603

#### Related Pull Requests

#### Screenshots

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/7575921/160440485-5c870b2b-5021-4d47-9604-60c6b657ff5a.png)| <img width="572" alt="image" src="https://user-images.githubusercontent.com/7575921/160441049-0c5b6f42-4d91-40c6-9385-8fb3a733e91d.png"> |

  
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
