### PR TITLE
MM-41607 Don't redeclare redux-batched-actions

### DIFF
--- a/packages/mattermost-redux/src/actions/admin.ts
+++ b/packages/mattermost-redux/src/actions/admin.ts
@@ -1,10 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {AnyAction} from 'redux';
+import {batchActions} from 'redux-batched-actions';
+
 import {AdminTypes} from 'mattermost-redux/action_types';
 import {General} from '../constants';
 import {Client4} from 'mattermost-redux/client';
 
-import {Action, ActionFunc, batchActions, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import {Compliance} from 'mattermost-redux/types/compliance';
 import {GroupSearchOpts} from 'mattermost-redux/types/groups';
 import {
@@ -249,10 +253,8 @@ export function linkLdapGroup(key: string): ActionFunc {
             data = await Client4.linkLdapGroup(key);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: AdminTypes.LINK_LDAP_GROUP_FAILURE, error, data: key},
-                logError(error),
-            ]));
+            dispatch({type: AdminTypes.LINK_LDAP_GROUP_FAILURE, error, data: key});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -281,10 +283,8 @@ export function unlinkLdapGroup(key: string): ActionFunc {
             await Client4.unlinkLdapGroup(key);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: AdminTypes.UNLINK_LDAP_GROUP_FAILURE, error, data: key},
-                logError(error),
-            ]));
+            dispatch({type: AdminTypes.UNLINK_LDAP_GROUP_FAILURE, error, data: key});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -469,14 +469,12 @@ export function getAnalytics(name: string, teamId = ''): ActionFunc {
             data = await Client4.getAnalytics(name, teamId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: AdminTypes.GET_ANALYTICS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: AdminTypes.GET_ANALYTICS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
-        const actions: Action[] = [{type: AdminTypes.GET_ANALYTICS_SUCCESS, data: null}];
+        const actions: AnyAction[] = [{type: AdminTypes.GET_ANALYTICS_SUCCESS, data: null}];
         if (teamId === '') {
             actions.push({type: AdminTypes.RECEIVED_SYSTEM_ANALYTICS, data, name});
         } else {
@@ -518,10 +516,8 @@ export function uploadPlugin(fileData: File, force = false): ActionFunc {
             data = await Client4.uploadPlugin(fileData, force);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: AdminTypes.UPLOAD_PLUGIN_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: AdminTypes.UPLOAD_PLUGIN_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -542,10 +538,8 @@ export function installPluginFromUrl(url: string, force = false): ActionFunc {
             data = await Client4.installPluginFromUrl(url, force);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: AdminTypes.INSTALL_PLUGIN_FROM_URL_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: AdminTypes.INSTALL_PLUGIN_FROM_URL_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -581,10 +575,8 @@ export function removePlugin(pluginId: string): ActionFunc {
             await Client4.removePlugin(pluginId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: AdminTypes.REMOVE_PLUGIN_FAILURE, error, data: pluginId},
-                logError(error),
-            ]));
+            dispatch({type: AdminTypes.REMOVE_PLUGIN_FAILURE, error, data: pluginId});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -607,10 +599,9 @@ export function enablePlugin(pluginId: string): ActionFunc {
             await Client4.enablePlugin(pluginId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: AdminTypes.ENABLE_PLUGIN_FAILURE, error, data: pluginId},
-                logError(error),
-            ]));
+            dispatch(
+                {type: AdminTypes.ENABLE_PLUGIN_FAILURE, error, data: pluginId});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -631,10 +622,9 @@ export function disablePlugin(pluginId: string): ActionFunc {
             await Client4.disablePlugin(pluginId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: AdminTypes.DISABLE_PLUGIN_FAILURE, error, data: pluginId},
-                logError(error),
-            ]));
+            dispatch(
+                {type: AdminTypes.DISABLE_PLUGIN_FAILURE, error, data: pluginId});
+            dispatch(logError(error));
             return {error};
         }
 

--- a/packages/mattermost-redux/src/actions/channel_categories.ts
+++ b/packages/mattermost-redux/src/actions/channel_categories.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {batchActions} from 'redux-batched-actions';
+
 import {ChannelCategoryTypes, ChannelTypes} from 'mattermost-redux/action_types';
 
 import {Client4} from 'mattermost-redux/client';
@@ -22,7 +24,6 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {
     ActionFunc,
-    batchActions,
     DispatchFunc,
     GetStateFunc,
 } from 'mattermost-redux/types/actions';

--- a/packages/mattermost-redux/src/actions/channels.ts
+++ b/packages/mattermost-redux/src/actions/channels.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import * as Redux from 'redux';
+import {AnyAction} from 'redux';
+import {batchActions} from 'redux-batched-actions';
 
 import {ChannelTypes, PreferenceTypes, UserTypes} from 'mattermost-redux/action_types';
 
@@ -22,7 +23,7 @@ import {
 import {getConfig, getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
-import {Action, ActionFunc, batchActions, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {Channel, ChannelNotifyProps, ChannelMembership, ChannelModerationPatch, ChannelsWithTotalCount, ChannelSearchOpts} from 'mattermost-redux/types/channels';
 
@@ -52,13 +53,11 @@ export function createChannel(channel: Channel, userId: string): ActionFunc {
             created = await Client4.createChannel(channel);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {
-                    type: ChannelTypes.CREATE_CHANNEL_FAILURE,
-                    error,
-                },
-                logError(error),
-            ]));
+            dispatch({
+                type: ChannelTypes.CREATE_CHANNEL_FAILURE,
+                error,
+            });
+            dispatch(logError(error));
             return {error};
         }
 
@@ -73,7 +72,7 @@ export function createChannel(channel: Channel, userId: string): ActionFunc {
             last_update_at: created.create_at,
         };
 
-        const actions: Action[] = [];
+        const actions: AnyAction[] = [];
         const {channels, myMembers} = getState().entities.channels;
 
         if (!channels[created.id]) {
@@ -107,10 +106,8 @@ export function createDirectChannel(userId: string, otherUserId: string): Action
             created = await Client4.createDirectChannel([userId, otherUserId]);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.CREATE_CHANNEL_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.CREATE_CHANNEL_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -187,10 +184,8 @@ export function createGroupChannel(userIds: string[]): ActionFunc {
             created = await Client4.createGroupChannel(userIds);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.CREATE_CHANNEL_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.CREATE_CHANNEL_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -265,10 +260,8 @@ export function patchChannel(channelId: string, patch: Partial<Channel>): Action
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
 
-            dispatch(batchActions([
-                {type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
         dispatch(batchActions([
@@ -295,10 +288,8 @@ export function updateChannel(channel: Channel): ActionFunc {
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
 
-            dispatch(batchActions([
-                {type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -326,10 +317,8 @@ export function updateChannelPrivacy(channelId: string, privacy: string): Action
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
 
-            dispatch(batchActions([
-                {type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -386,10 +375,8 @@ export function getChannelByNameAndTeamName(teamName: string, channelName: strin
             data = await Client4.getChannelByNameAndTeamName(teamName, channelName, includeDeleted);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -409,10 +396,8 @@ export function getChannel(channelId: string): ActionFunc {
             data = await Client4.getChannel(channelId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -437,10 +422,8 @@ export function getChannelAndMyMember(channelId: string): ActionFunc {
             member = await memberRequest;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -495,10 +478,8 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
             channelMembers = await memberRequest;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -550,9 +531,7 @@ export function fetchAllMyTeamsChannelsAndChannelMembers(): ActionFunc {
             channelsMembers = await Client4.getAllChannelsMembers(currentUserId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                logError(error),
-            ]));
+            dispatch(logError(error));
             return {error};
         }
 
@@ -805,7 +784,7 @@ export function viewChannel(channelId: string, prevChannelId = ''): ActionFunc {
             return {error};
         }
 
-        const actions: Action[] = [];
+        const actions: AnyAction[] = [];
 
         const {myMembers} = getState().entities.channels;
         const member = myMembers[channelId];
@@ -847,7 +826,7 @@ export function markChannelAsViewed(channelId: string, prevChannelId?: string): 
 }
 
 export function actionsToMarkChannelAsViewed(getState: GetStateFunc, channelId: string, prevChannelId = '') {
-    const actions: Redux.AnyAction[] = [];
+    const actions: AnyAction[] = [];
 
     const state = getState();
     const {myMembers} = state.entities.channels;
@@ -887,10 +866,8 @@ export function getChannels(teamId: string, page = 0, perPage: number = General.
             channels = await Client4.getChannels(teamId, page, perPage);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.GET_CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.GET_CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -938,10 +915,8 @@ export function getAllChannelsWithCount(page = 0, perPage: number = General.CHAN
             payload = await Client4.getAllChannels(page, perPage, notAssociatedToGroup, excludeDefaultChannels, true, includeDeleted, excludePolicyConstrained) as ChannelsWithTotalCount;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.GET_ALL_CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.GET_ALL_CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -972,10 +947,8 @@ export function getAllChannels(page = 0, perPage: number = General.CHANNELS_CHUN
             channels = await Client4.getAllChannels(page, perPage, notAssociatedToGroup, excludeDefaultChannels, false, false, excludePolicyConstrained);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.GET_ALL_CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.GET_ALL_CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -1002,10 +975,8 @@ export function autocompleteChannels(teamId: string, term: string): ActionFunc {
             channels = await Client4.autocompleteChannels(teamId, term);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.GET_CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.GET_CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -1033,10 +1004,8 @@ export function autocompleteChannelsForSearch(teamId: string, term: string): Act
             channels = await Client4.autocompleteChannelsForSearch(teamId, term);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.GET_CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.GET_CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -1068,10 +1037,8 @@ export function searchChannels(teamId: string, term: string, archived?: boolean)
             }
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.GET_CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.GET_CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -1099,10 +1066,8 @@ export function searchAllChannels(term: string, opts: ChannelSearchOpts = {}): A
             response = await Client4.searchAllChannels(term, opts) as ChannelsWithTotalCount;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: ChannelTypes.GET_ALL_CHANNELS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: ChannelTypes.GET_ALL_CHANNELS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -1310,7 +1275,7 @@ export function actionsToMarkChannelAsRead(getState: GetStateFunc, channelId: st
     const channelMember = myMembers[channelId];
     const prevChannelMember = (!prevChanManuallyUnread && prevChannelId) ? myMembers[prevChannelId] : null; // May also be null
 
-    const actions: Redux.AnyAction[] = [];
+    const actions: AnyAction[] = [];
 
     if (channel && channelMember) {
         actions.push({
@@ -1373,7 +1338,7 @@ export function markChannelAsUnread(teamId: string, channelId: string, mentions:
         const {myMembers} = state.entities.channels;
         const {currentUserId} = state.entities.users;
 
-        const actions: Action[] = [{
+        const actions: AnyAction[] = [{
             type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
             data: {
                 teamId,
@@ -1421,7 +1386,7 @@ export function actionsToMarkChannelAsUnread(getState: GetStateFunc, teamId: str
     const {myMembers} = state.entities.channels;
     const {currentUserId} = state.entities.users;
 
-    const actions: Redux.AnyAction[] = [{
+    const actions: AnyAction[] = [{
         type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
         data: {
             teamId,

--- a/packages/mattermost-redux/src/actions/files.ts
+++ b/packages/mattermost-redux/src/actions/files.ts
@@ -1,16 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {batchActions} from 'redux-batched-actions';
+
 import {Client4} from 'mattermost-redux/client';
 import {FileTypes} from 'mattermost-redux/action_types';
 
-import {batchActions, DispatchFunc, GetStateFunc, ActionFunc, Action} from 'mattermost-redux/types/actions';
+import {DispatchFunc, GetStateFunc, ActionFunc} from 'mattermost-redux/types/actions';
 
 import {FileUploadResponse, FileSearchResultItem} from 'mattermost-redux/types/files';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 
-export function receivedFiles(files: Map<string, FileSearchResultItem>): Action {
+export function receivedFiles(files: Map<string, FileSearchResultItem>) {
     return {
         type: FileTypes.RECEIVED_FILES_FOR_SEARCH,
         data: files,
@@ -49,15 +52,14 @@ export function uploadFile(channelId: string, rootId: string, clientIds: string[
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
 
-            const failure = {
+            dispatch({
                 type: FileTypes.UPLOAD_FILES_FAILURE,
                 clientIds,
                 channelId,
                 rootId,
                 error,
-            };
-
-            dispatch(batchActions([failure, logError(error)]));
+            });
+            dispatch(logError(error));
             return {error};
         }
 

--- a/packages/mattermost-redux/src/actions/general.ts
+++ b/packages/mattermost-redux/src/actions/general.ts
@@ -1,5 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {batchActions} from 'redux-batched-actions';
+
 import {Client4} from 'mattermost-redux/client';
 
 import {GeneralTypes} from 'mattermost-redux/action_types';
@@ -8,7 +11,7 @@ import {getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
 import {GeneralState} from 'mattermost-redux/types/general';
 import {LogLevel} from 'mattermost-redux/types/client4';
-import {GetStateFunc, DispatchFunc, ActionFunc, batchActions} from 'mattermost-redux/types/actions';
+import {GetStateFunc, DispatchFunc, ActionFunc} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 import {loadRolesIfNeeded} from './roles';
@@ -61,9 +64,7 @@ export function getClientConfig(): ActionFunc {
         Client4.setEnableLogging(data.EnableDeveloper === 'true');
         Client4.setDiagnosticId(data.DiagnosticId);
 
-        dispatch(batchActions([
-            {type: GeneralTypes.CLIENT_CONFIG_RECEIVED, data},
-        ]));
+        dispatch({type: GeneralTypes.CLIENT_CONFIG_RECEIVED, data});
 
         return {data};
     };
@@ -76,13 +77,11 @@ export function getDataRetentionPolicy(): ActionFunc {
             data = await Client4.getDataRetentionPolicy();
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {
-                    type: GeneralTypes.RECEIVED_DATA_RETENTION_POLICY,
-                    error,
-                },
-                logError(error),
-            ]));
+            dispatch({
+                type: GeneralTypes.RECEIVED_DATA_RETENTION_POLICY,
+                error,
+            });
+            dispatch(logError(error));
             return {error};
         }
 

--- a/packages/mattermost-redux/src/actions/groups.ts
+++ b/packages/mattermost-redux/src/actions/groups.ts
@@ -1,10 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {AnyAction} from 'redux';
+import {batchActions} from 'redux-batched-actions';
+
 import {GroupTypes, UserTypes} from 'mattermost-redux/action_types';
 import {General, Groups} from '../constants';
 import {Client4} from 'mattermost-redux/client';
 
-import {Action, ActionFunc, batchActions, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import {GroupPatch, SyncableType, SyncablePatch, GroupCreateWithUserIds, CustomGroupPatch, GroupSearachParams} from 'mattermost-redux/types/groups';
 
 import Constants from 'utils/constants';
@@ -23,7 +27,7 @@ export function linkGroupSyncable(groupID: string, syncableID: string, syncableT
             return {error};
         }
 
-        const dispatches: Action[] = [];
+        const dispatches: AnyAction[] = [];
         let type = '';
         switch (syncableType) {
         case Groups.SYNCABLE_TYPE_TEAM:
@@ -54,7 +58,7 @@ export function unlinkGroupSyncable(groupID: string, syncableID: string, syncabl
             return {error};
         }
 
-        const dispatches: Action[] = [];
+        const dispatches: AnyAction[] = [];
 
         let type = '';
         const data = {group_id: groupID, syncable_id: syncableID};
@@ -120,7 +124,7 @@ export function patchGroupSyncable(groupID: string, syncableID: string, syncable
             return {error};
         }
 
-        const dispatches: Action[] = [];
+        const dispatches: AnyAction[] = [];
 
         let type = '';
         switch (syncableType) {
@@ -400,7 +404,7 @@ export function searchGroups(params: GroupSearachParams): ActionFunc {
             return {error};
         }
 
-        const dispatches: Action[] = [{type: GroupTypes.RECEIVED_GROUPS, data}];
+        const dispatches: AnyAction[] = [{type: GroupTypes.RECEIVED_GROUPS, data}];
 
         if (params.user_id) {
             dispatches.push({type: GroupTypes.RECEIVED_MY_GROUPS, data});

--- a/packages/mattermost-redux/src/actions/helpers.ts
+++ b/packages/mattermost-redux/src/actions/helpers.ts
@@ -1,10 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import {Client4} from 'mattermost-redux/client';
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {Client4Error} from 'mattermost-redux/types/client4';
-import {batchActions, Action, ActionFunc, GenericAction, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc, GenericAction, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {logError} from './errors';
 type ActionType = string;
@@ -84,11 +85,10 @@ export function bindClientFunc({
             data = await clientFunc(...params);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            const actions: Action[] = [logError(error)];
             if (onFailure) {
-                actions.push(requestFailure(onFailure, error));
+                dispatch(requestFailure(onFailure, error));
             }
-            dispatch(batchActions(actions));
+            dispatch(logError(error));
             return {error};
         }
 

--- a/packages/mattermost-redux/src/actions/integrations.ts
+++ b/packages/mattermost-redux/src/actions/integrations.ts
@@ -1,5 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {batchActions} from 'redux-batched-actions';
+
 import {IntegrationTypes} from 'mattermost-redux/action_types';
 import {General} from '../constants';
 import {Client4} from 'mattermost-redux/client';
@@ -7,7 +10,7 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
-import {batchActions, DispatchFunc, GetStateFunc, ActionFunc} from 'mattermost-redux/types/actions';
+import {DispatchFunc, GetStateFunc, ActionFunc} from 'mattermost-redux/types/actions';
 
 import {Command, CommandArgs, DialogSubmission, IncomingWebhook, OAuthApp, OutgoingWebhook} from 'mattermost-redux/types/integrations';
 

--- a/packages/mattermost-redux/src/actions/search.ts
+++ b/packages/mattermost-redux/src/actions/search.ts
@@ -1,11 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {batchActions} from 'redux-batched-actions';
+
 import {Client4} from 'mattermost-redux/client';
 import {SearchTypes} from 'mattermost-redux/action_types';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {ActionResult, batchActions, DispatchFunc, GetStateFunc, ActionFunc} from 'mattermost-redux/types/actions';
+import {ActionResult, DispatchFunc, GetStateFunc, ActionFunc} from 'mattermost-redux/types/actions';
 
 import {Post} from 'mattermost-redux/types/posts';
 
@@ -211,10 +214,8 @@ export function getFlaggedPosts(): ActionFunc {
             await Promise.all([getProfilesAndStatusesForPosts(posts.posts, dispatch, getState) as any, dispatch(getMissingChannelsFromPosts(posts.posts)) as any]);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: SearchTypes.SEARCH_FLAGGED_POSTS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: SearchTypes.SEARCH_FLAGGED_POSTS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -247,10 +248,7 @@ export function getPinnedPosts(channelId: string): ActionFunc {
             await Promise.all(arr);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: SearchTypes.SEARCH_PINNED_POSTS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: SearchTypes.SEARCH_PINNED_POSTS_FAILURE, error});
             return {error};
         }
 

--- a/packages/mattermost-redux/src/actions/teams.ts
+++ b/packages/mattermost-redux/src/actions/teams.ts
@@ -1,5 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {AnyAction} from 'redux';
+import {batchActions} from 'redux-batched-actions';
+
 import {Client4} from 'mattermost-redux/client';
 import {General} from '../constants';
 import {ChannelTypes, TeamTypes, UserTypes} from 'mattermost-redux/action_types';
@@ -11,7 +15,7 @@ import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {GetStateFunc, DispatchFunc, ActionFunc, ActionResult, batchActions, Action} from 'mattermost-redux/types/actions';
+import {GetStateFunc, DispatchFunc, ActionFunc, ActionResult} from 'mattermost-redux/types/actions';
 
 import {Team, TeamMembership, TeamMemberWithError, GetTeamMembersOpts, TeamsWithCount, TeamSearchOpts} from 'mattermost-redux/types/teams';
 
@@ -146,7 +150,7 @@ export function getTeams(page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, i
             return {error};
         }
 
-        const actions: Action[] = [
+        const actions: AnyAction[] = [
             {
                 type: TeamTypes.RECEIVED_TEAMS_LIST,
                 data: includeTotalCount ? data.teams : data,
@@ -179,10 +183,8 @@ export function searchTeams(term: string, opts: TeamSearchOpts = {}): ActionFunc
             response = await Client4.searchTeams(term, opts);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: TeamTypes.GET_TEAMS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: TeamTypes.GET_TEAMS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -262,7 +264,7 @@ export function deleteTeam(teamId: string): ActionFunc {
         const {
             currentTeamId,
         } = entities.teams;
-        const actions: Action[] = [];
+        const actions: AnyAction[] = [];
         if (teamId === currentTeamId) {
             EventEmitter.emit('leave_team');
             actions.push({type: ChannelTypes.SELECT_CHANNEL, data: ''});
@@ -565,7 +567,7 @@ export function removeUserFromTeam(teamId: string, userId: string): ActionFunc {
             user_id: userId,
         };
 
-        const actions: Action[] = [
+        const actions: AnyAction[] = [
             {
                 type: UserTypes.RECEIVED_PROFILE_NOT_IN_TEAM,
                 data: {id: teamId, user_id: userId},
@@ -710,10 +712,8 @@ export function joinTeam(inviteId: string, teamId: string): ActionFunc {
             }
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: TeamTypes.JOIN_TEAM_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: TeamTypes.JOIN_TEAM_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 

--- a/packages/mattermost-redux/src/actions/threads.ts
+++ b/packages/mattermost-redux/src/actions/threads.ts
@@ -2,13 +2,14 @@
 // See LICENSE.txt for license information.
 
 import {uniq} from 'lodash';
+import {batchActions} from 'redux-batched-actions';
 
 import {ThreadTypes, PostTypes, UserTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
 
 import ThreadConstants from 'mattermost-redux/constants/threads';
 
-import {DispatchFunc, GetStateFunc, batchActions} from 'mattermost-redux/types/actions';
+import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import type {UserThread, UserThreadList} from 'mattermost-redux/types/threads';
 

--- a/packages/mattermost-redux/src/actions/users.ts
+++ b/packages/mattermost-redux/src/actions/users.ts
@@ -1,7 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Action, ActionFunc, ActionResult, batchActions, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {AnyAction} from 'redux';
+import {batchActions} from 'redux-batched-actions';
+
+import {ActionFunc, ActionResult, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import {UserProfile, UserStatus, GetFilteredUsersStatsOpts, UsersStats, UserCustomStatus} from 'mattermost-redux/types/users';
 import {TeamMembership} from 'mattermost-redux/types/teams';
 import {Client4} from 'mattermost-redux/client';
@@ -34,10 +37,8 @@ export function checkMfa(loginId: string): ActionFunc {
             dispatch({type: UserTypes.CHECK_MFA_SUCCESS, data: null});
             return {data: data.mfa_required};
         } catch (error) {
-            dispatch(batchActions([
-                {type: UserTypes.CHECK_MFA_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: UserTypes.CHECK_MFA_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
     };
@@ -85,13 +86,11 @@ export function login(loginId: string, password: string, mfaToken = '', ldapOnly
         try {
             data = await Client4.login(loginId, password, mfaToken, deviceId, ldapOnly);
         } catch (error) {
-            dispatch(batchActions([
-                {
-                    type: UserTypes.LOGIN_FAILURE,
-                    error,
-                },
-                logError(error),
-            ]));
+            dispatch({
+                type: UserTypes.LOGIN_FAILURE,
+                error,
+            });
+            dispatch(logError(error));
             return {error};
         }
 
@@ -109,13 +108,11 @@ export function loginById(id: string, password: string, mfaToken = ''): ActionFu
         try {
             data = await Client4.loginById(id, password, mfaToken, deviceId);
         } catch (error) {
-            dispatch(batchActions([
-                {
-                    type: UserTypes.LOGIN_FAILURE,
-                    error,
-                },
-                logError(error),
-            ]));
+            dispatch({
+                type: UserTypes.LOGIN_FAILURE,
+                error,
+            });
+            dispatch(logError(error));
             return {error};
         }
 
@@ -158,10 +155,8 @@ function completeLogin(data: UserProfile): ActionFunc {
                 }
             }
         } catch (error) {
-            dispatch(batchActions([
-                {type: UserTypes.LOGIN_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: UserTypes.LOGIN_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -177,10 +172,8 @@ function completeLogin(data: UserProfile): ActionFunc {
         try {
             await Promise.all(promises);
         } catch (error) {
-            dispatch(batchActions([
-                {type: UserTypes.LOGIN_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: UserTypes.LOGIN_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -529,7 +522,7 @@ export function getProfilesInGroupChannels(channelsIds: string[]): ActionFunc {
             return {error};
         }
 
-        const actions: Action[] = [];
+        const actions: AnyAction[] = [];
         for (const channelId in channelProfiles) {
             if (channelProfiles.hasOwnProperty(channelId)) {
                 const profiles = channelProfiles[channelId];
@@ -928,10 +921,8 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
             data = await Client4.autocompleteUsers(term, teamId, channelId, options);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(batchActions([
-                {type: UserTypes.AUTOCOMPLETE_USERS_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: UserTypes.AUTOCOMPLETE_USERS_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -940,7 +931,7 @@ export function autocompleteUsers(term: string, teamId = '', channelId = '', opt
             users = [...users, ...data.out_of_channel];
         }
         removeUserFromList(currentUserId, users);
-        const actions: Action[] = [{
+        const actions: AnyAction[] = [{
             type: UserTypes.RECEIVED_PROFILES_LIST,
             data: users,
         }, {
@@ -993,7 +984,7 @@ export function searchProfiles(term: string, options: any = {}): ActionFunc {
             return {error};
         }
 
-        const actions: Action[] = [{type: UserTypes.RECEIVED_PROFILES_LIST, data: removeUserFromList(currentUserId, [...profiles])}];
+        const actions: AnyAction[] = [{type: UserTypes.RECEIVED_PROFILES_LIST, data: removeUserFromList(currentUserId, [...profiles])}];
 
         if (options.in_channel_id) {
             actions.push({
@@ -1096,10 +1087,8 @@ export function updateMe(user: UserProfile): ActionFunc {
         try {
             data = await Client4.patchMe(user);
         } catch (error) {
-            dispatch(batchActions([
-                {type: UserTypes.UPDATE_ME_FAILURE, error},
-                logError(error),
-            ]));
+            dispatch({type: UserTypes.UPDATE_ME_FAILURE, error});
+            dispatch(logError(error));
             return {error};
         }
 
@@ -1333,7 +1322,7 @@ export function createUserAccessToken(userId: string, description: string): Acti
             return {error};
         }
 
-        const actions: Action[] = [{
+        const actions: AnyAction[] = [{
             type: AdminTypes.RECEIVED_USER_ACCESS_TOKEN,
             data: {...data,
                 token: '',
@@ -1367,7 +1356,7 @@ export function getUserAccessToken(tokenId: string): ActionFunc {
             return {error};
         }
 
-        const actions: Action[] = [{
+        const actions: AnyAction[] = [{
             type: AdminTypes.RECEIVED_USER_ACCESS_TOKEN,
             data,
         }];
@@ -1400,14 +1389,10 @@ export function getUserAccessTokens(page = 0, perPage: number = General.PROFILE_
             return {error};
         }
 
-        const actions = [
-            {
-                type: AdminTypes.RECEIVED_USER_ACCESS_TOKENS,
-                data,
-            },
-        ];
-
-        dispatch(batchActions(actions));
+        dispatch({
+            type: AdminTypes.RECEIVED_USER_ACCESS_TOKENS,
+            data,
+        });
 
         return {data};
     };
@@ -1424,7 +1409,7 @@ export function getUserAccessTokensForUser(userId: string, page = 0, perPage: nu
             return {error};
         }
 
-        const actions: Action[] = [{
+        const actions: AnyAction[] = [{
             type: AdminTypes.RECEIVED_USER_ACCESS_TOKENS_FOR_USER,
             data,
             userId,

--- a/packages/mattermost-redux/src/actions/websocket.ts
+++ b/packages/mattermost-redux/src/actions/websocket.ts
@@ -1,11 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {batchActions} from 'redux-batched-actions';
+
 import {UserTypes} from 'mattermost-redux/action_types';
 
 import {getCurrentUserId, getUsers} from 'mattermost-redux/selectors/entities/users';
 
-import {ActionFunc, DispatchFunc, GetStateFunc, batchActions} from 'mattermost-redux/types/actions';
+import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {getKnownUsers} from './users';
 

--- a/packages/mattermost-redux/src/types/actions.ts
+++ b/packages/mattermost-redux/src/types/actions.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {AnyAction} from 'redux';
+import {BatchAction} from 'redux-batched-actions';
 
 import {GlobalState} from './store';
 
@@ -9,13 +10,6 @@ export type GetStateFunc = () => GlobalState;
 export type GenericAction = AnyAction;
 export type Thunk = (b: DispatchFunc, a: GetStateFunc) => Promise<ActionResult> | ActionResult;
 
-type BatchAction = {
-    type: 'BATCHING_REDUCER.BATCH';
-    payload: GenericAction[];
-    meta: {
-        batch: true;
-    };
-};
 export type Action = GenericAction | Thunk | BatchAction | ActionFunc;
 
 export type ActionResult = {
@@ -25,11 +19,3 @@ export type ActionResult = {
 
 export type DispatchFunc = (action: Action, getState?: GetStateFunc | null) => Promise<ActionResult>;
 export type ActionFunc = (dispatch: DispatchFunc, getState: GetStateFunc) => Promise<ActionResult|ActionResult[]> | ActionResult;
-export type PlatformType = 'web' | 'ios' | 'android';
-
-export const BATCH = 'BATCHING_REDUCER.BATCH';
-
-// TODO remove me in favour of just using redux-batched-actions directly
-export function batchActions(actions: Action[], type = BATCH) {
-    return {type, meta: {batch: true}, payload: actions};
-}


### PR DESCRIPTION
We declared our own version of redux-batched-actions when we migrated mattermost-redux to TypeScript. I wasn't sure why we did that originally, but I now think that's because TypeScript threw a bunch of errors, mostly about how we used `logError`. It turns out that redux-batched-actions doesn't work with redux-thunk (https://github.com/tshelburne/redux-batched-actions/issues/3), so that code didn't actually work to begin with.

I don't know if we actually need `logError` at this point, and we could probably implement it in a way that's batching-friendly, but I just went with removing them from batches for the time being.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41607

#### Release Note
```release-note
NONE
```
