### PR TITLE
Fixing edit time limit

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3074,6 +3074,7 @@
   "edit_command.updating": "Updating...",
   "edit_post.editPost": "Edit the post...",
   "edit_post.helper_text": "**{key}ENTER** to Save, **ESC** to Cancel",
+  "edit_post.time_limit.error_text": "You can only edit your posts for {n} seconds after posting",
   "edit_post.time_limit_button.for_n_seconds": "For {n} seconds",
   "edit_post.time_limit_button.no_limit": "Anytime",
   "edit_post.time_limit_modal.description": "Setting a time limit **applies to all users** who have the \"Edit Post\" permissions in any permission scheme.",

--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -630,6 +630,7 @@
         top: 4px;
         display: inline-block;
         margin-bottom: 0;
+        color: var(--error-text);
         font-size: 0.85em;
         font-weight: normal;
         opacity: 0.55;


### PR DESCRIPTION
#### Summary
the inline editing feature did not respect the edit time limit that could have been set through sys-console.

#### Ticket Link
n/a

#### Related Pull Requests
PR that found this bug: #9979 

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
