### PR TITLE
[MM-42884] Guard against malformed error when logging

### DIFF
--- a/packages/mattermost-redux/src/actions/errors.ts
+++ b/packages/mattermost-redux/src/actions/errors.ts
@@ -44,7 +44,11 @@ export function logError(error: ServerError, displayable = false, consoleError =
         const serializedError = serializeError(error);
 
         let sendToServer = true;
-        if (error.stack?.includes('TypeError: Failed to fetch')) {
+
+        const err = error as any;
+        const message = err.stack?.stack || err.stack || '';
+
+        if (message.includes('TypeError: Failed to fetch')) {
             sendToServer = false;
         }
         if (error.server_error_id) {


### PR DESCRIPTION
#### Summary

There's more context in this thread https://community-daily.mattermost.com/core/pl/xirywgxsw3rit815umggaoaz9y, but essentially the [error.stack](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) property is non-standard and can take on different shapes, including a nested structure like the following:

<img width="300px" src="https://user-images.githubusercontent.com/6913320/160655273-ca0a7a2d-4491-4be4-9998-f1d91f4af752.png"/>

This causes an exception on the `.includes` line in the diff of this PR, which makes it so the browser never sends the error to the server.


#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-42884