### PR TITLE
[MM-42608] Actions Menu post merge cleanup

### DIFF
--- a/components/actions_menu/actions_menu.tsx
+++ b/components/actions_menu/actions_menu.tsx
@@ -283,8 +283,6 @@ export class ActionMenuClass extends React.PureComponent<Props, State> {
             return null;
         }
 
-        // const isMobile = this.props.isMobileView TODO;
-
         const pluginItems = this.props.pluginMenuItems?.
             filter((item) => {
                 return item.filter ? item.filter(this.props.post.id) : item;

--- a/components/dot_menu/index.ts
+++ b/components/dot_menu/index.ts
@@ -124,7 +124,6 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         isCollapsedThreadsEnabled: collapsedThreads,
         threadReplyCount,
         isMobileView: getIsMobileView(state),
-        ...ownProps,
     };
 }
 


### PR DESCRIPTION
#### Summary
This PR cleans up 3 small notest that were not addressed in the initial PR for the Actions Menu

1. what to do with `isMobile` prop in `ActionsMenu` component. (See inline code comment)

2. Move to componentDidMount method()

Unfortunately this does not work.  If the event listeners are added/removed when the `...` menu `DidMount` the listeners will track with the hovered post, not the post with the `Dot Menu` open. While this might be a possible desired effect from a UX perspective, it was not designed at this point.  I do think it would make more sense to allow a shortcut to work on a post what is hovered, without having to open that posts `...` menu.

![image](https://user-images.githubusercontent.com/7575921/160858685-d39aae1e-a1ca-4cf7-a819-2b5d2702c475.png)

3. remove … spread operator on OwnProps (See inline code comment)

<img width="686" alt="image" src="https://user-images.githubusercontent.com/7575921/160858733-9c1f768c-e803-479d-860a-1e54fa005d08.png">


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42608

#### Related Pull Requests

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
