### PR TITLE
MM-42654 Improve memoization of makeGetProfilesInChannel

### DIFF
--- a/components/admin_console/team_channel_settings/channel/details/channel_members/index.ts
+++ b/components/admin_console/team_channel_settings/channel/details/channel_members/index.ts
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
+
 import {createSelector} from 'reselect';
 
 import {ServerError} from 'mattermost-redux/types/errors';

--- a/components/admin_console/team_channel_settings/channel/details/channel_members/index.ts
+++ b/components/admin_console/team_channel_settings/channel/details/channel_members/index.ts
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
+import {createSelector} from 'reselect';
 
 import {ServerError} from 'mattermost-redux/types/errors';
 import {UserProfile, UsersStats, GetFilteredUsersStatsOpts} from 'mattermost-redux/types/users';
@@ -56,6 +57,14 @@ function searchUsersToAdd(users: Record<string, UserProfile>, term: string): Rec
     return filteredProfilesMap;
 }
 
+const getUserGridFilters = createSelector(
+    'getUserGridFilters',
+    (state: GlobalState) => state.views.search.userGridSearch.filters,
+    (filters = {}) => {
+        return {...filters, active: true};
+    },
+);
+
 function makeMapStateToProps() {
     const doGetProfilesInChannel = makeGetProfilesInChannel();
     const doSearchProfilesInChannel = makeSearchProfilesInChannel();
@@ -68,10 +77,10 @@ function makeMapStateToProps() {
         const channelMembers = getChannelMembersInChannels(state)[channelId] || {};
         const channel = getChannel(state, channelId) || {channel_id: channelId};
         const searchTerm = state.views.search.userGridSearch?.term || '';
-        const filters = state.views.search.userGridSearch?.filters || {};
+        const filters = getUserGridFilters(state);
 
         let totalCount: number;
-        if (Object.keys(filters).length === 0) {
+        if (Object.keys(filters).length === 1) {
             const stats: ChannelStats = getAllChannelStats(state)[channelId] || {
                 member_count: 0,
                 channel_id: channelId,
@@ -89,10 +98,10 @@ function makeMapStateToProps() {
 
         let users = [];
         if (searchTerm) {
-            users = doSearchProfilesInChannel(state, channelId, searchTerm, false, {...filters, active: true});
+            users = doSearchProfilesInChannel(state, channelId, searchTerm, false, filters);
             usersToAdd = searchUsersToAdd(usersToAdd, searchTerm);
         } else {
-            users = doGetProfilesInChannel(state, channelId, {...filters, active: true});
+            users = doGetProfilesInChannel(state, channelId, filters);
         }
 
         return {

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -69,7 +69,7 @@ function makeMapStateToProps() {
             dmUser = getUser(state, dmUserId);
             customStatus = dmUser && getCustomStatus(state, dmUser.id);
         } else if (channel && channel.type === General.GM_CHANNEL) {
-            gmMembers = doGetProfilesInChannel(state, channel.id, false);
+            gmMembers = doGetProfilesInChannel(state, channel.id);
         }
         const stats = getCurrentChannelStats(state) || EMPTY_CHANNEL_STATS;
 

--- a/components/popover_list_members/index.ts
+++ b/components/popover_list_members/index.ts
@@ -10,7 +10,6 @@ import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUserStatuses, makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
 import {getTeammateNameDisplaySetting, getAddMembersToChannel} from 'mattermost-redux/selectors/entities/preferences';
-import {UserProfile} from 'mattermost-redux/types/users';
 import {Channel} from 'mattermost-redux/types/channels';
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
 
@@ -24,16 +23,6 @@ import {canManageMembers} from 'utils/channel_utils';
 import {sortUsersByStatusAndDisplayName} from 'utils/utils.jsx';
 
 import PopoverListMembers, {Props} from './popover_list_members';
-
-type Filters = {
-    role?: string;
-    inactive?: boolean;
-    active?: boolean;
-    roles?: string[];
-    exclude_roles?: string[];
-    channel_roles?: string[];
-    team_roles?: string[];
-};
 
 const makeSortUsersByStatusAndDisplayName = () => {
     const doGetProfilesInChannel = makeGetProfilesInChannel();

--- a/components/popover_list_members/index.ts
+++ b/components/popover_list_members/index.ts
@@ -35,7 +35,9 @@ type Filters = {
     team_roles?: string[];
 };
 
-const makeSortUsersByStatusAndDisplayName = (doGetProfilesInChannel: (state: GlobalState, channelId: Channel['id'], filters?: Filters) => UserProfile[]) => {
+const makeSortUsersByStatusAndDisplayName = () => {
+    const doGetProfilesInChannel = makeGetProfilesInChannel();
+
     return createSelector(
         'makeSortUsersByStatusAndDisplayName',
         (state: GlobalState, channelId: Channel['id']) => doGetProfilesInChannel(state, channelId),
@@ -46,8 +48,7 @@ const makeSortUsersByStatusAndDisplayName = (doGetProfilesInChannel: (state: Glo
 };
 
 function makeMapStateToProps() {
-    const doGetProfilesInChannel = makeGetProfilesInChannel();
-    const doSortUsersByStatusAndDisplayName = makeSortUsersByStatusAndDisplayName(doGetProfilesInChannel);
+    const doSortUsersByStatusAndDisplayName = makeSortUsersByStatusAndDisplayName();
 
     return function mapStateToProps(state: GlobalState, ownProps: Props) {
         const stats = getAllChannelStats(state)[ownProps.channel.id] || {};

--- a/packages/mattermost-redux/src/selectors/entities/users.test.js
+++ b/packages/mattermost-redux/src/selectors/entities/users.test.js
@@ -503,14 +503,9 @@ describe('Selectors.Users', () => {
     it('makeGetProfilesNotInChannel', () => {
         const getProfilesNotInChannel = Selectors.makeGetProfilesNotInChannel();
 
-        assert.deepEqual(getProfilesNotInChannel(testState, channel1.id, {active: true}), [user3].sort(sortByUsername));
         assert.deepEqual(getProfilesNotInChannel(testState, channel1.id), [user2, user3].sort(sortByUsername));
 
-        assert.deepEqual(getProfilesNotInChannel(testState, channel2.id, {active: true}), [user4, user5].sort(sortByUsername));
         assert.deepEqual(getProfilesNotInChannel(testState, channel2.id), [user4, user5].sort(sortByUsername));
-
-        assert.deepEqual(getProfilesNotInChannel(testState, channel1.id, {role: 'system_guest'}), []);
-        assert.deepEqual(getProfilesNotInChannel(testState, channel2.id, {role: 'system_user'}), [user4, user5].sort(sortByUsername));
 
         assert.deepEqual(getProfilesNotInChannel(testState, 'nonexistentid'), []);
         assert.deepEqual(getProfilesNotInChannel(testState, 'nonexistentid'), []);

--- a/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -556,6 +556,11 @@ export function makeGetProfilesForReactions(): (state: GlobalState, reactions: R
     );
 }
 
+/**
+ * Returns a selector that returns all profiles in a given channel with the given filters applied.
+ *
+ * Note that filters, if provided, must be either a constant or memoized to prevent constant recomputation of the selector.
+ */
 export function makeGetProfilesInChannel(): (state: GlobalState, channelId: Channel['id'], filters?: Filters) => UserProfile[] {
     return createSelector(
         'makeGetProfilesInChannel',
@@ -576,20 +581,20 @@ export function makeGetProfilesInChannel(): (state: GlobalState, channelId: Chan
     );
 }
 
+/**
+ * Returns a selector that returns all profiles not in a given channel.
+ */
 export function makeGetProfilesNotInChannel(): (state: GlobalState, channelId: Channel['id'], filters?: Filters) => UserProfile[] {
     return createSelector(
         'makeGetProfilesNotInChannel',
         getUsers,
         getUserIdsNotInChannels,
         (state: GlobalState, channelId: string) => channelId,
-        (state, channelId, filters) => filters,
-        (users, userIds, channelId, filters = {}) => {
+        (users, userIds, channelId) => {
             const userIdsInChannel = userIds[channelId];
 
             if (!userIdsInChannel) {
                 return [];
-            } else if (filters) {
-                return sortAndInjectProfiles(filterProfiles(users, filters), userIdsInChannel);
             }
 
             return sortAndInjectProfiles(users, userIdsInChannel);


### PR DESCRIPTION
`makeGetProfilesInChannel` takes in an optional `filters` object that does further filtering on the array of users returned, but because of the way we pass it into the result function, it has the potential to cause the selector to recompute constantly if we pass in new object literals each time the selector is called. Usually, I'd get rid of the filters object and pass individual fields to fix that, but since `filters` has 5 or 6 different optional fields, I decided to just memoize `filters` where it was used.

`makeGetProfilesNotInChannel` is also at risk of the same problem, but we never actually passed `filters` to it, so I just removed that option.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42654

#### Release Note
```release-note
NONE
```
