### PR TITLE
[MM-42928]: fixes public links are being generated by the server even if public links are disabled in the config

### DIFF
--- a/components/file_preview_modal/file_preview_modal_main_actions/file_preview_modal_main_actions.test.tsx
+++ b/components/file_preview_modal/file_preview_modal_main_actions/file_preview_modal_main_actions.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import React, {ComponentProps} from 'react';
 
 import OverlayTrigger from 'components/overlay_trigger';
@@ -10,6 +10,7 @@ import {GlobalState} from '../../../types/store';
 
 import {TestHelper} from '../../../utils/test_helper';
 import * as Utils from 'utils/utils';
+import * as fileActions from 'mattermost-redux/actions/files';
 
 import FilePreviewModalMainActions from './file_preview_modal_main_actions';
 
@@ -96,6 +97,22 @@ describe('components/file_preview_modal/file_preview_modal_main_actions/FilePrev
         const overlayWrapper = wrapper.find(OverlayTrigger).first().children('a');
         expect(spy).toHaveBeenCalledTimes(0);
         overlayWrapper.simulate('click');
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not get public api when public links is disabled', async () => {
+        const spy = jest.spyOn(fileActions, 'getFilePublicLink');
+        mount(<FilePreviewModalMainActions {...defaultProps}/>);
+        expect(spy).toHaveBeenCalledTimes(0);
+    });
+
+    test('should get public api when public links is enabled', async () => {
+        const spy = jest.spyOn(fileActions, 'getFilePublicLink');
+        const props = {
+            ...defaultProps,
+            enablePublicLink: true,
+        };
+        mount(<FilePreviewModalMainActions {...props}/>);
         expect(spy).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/file_preview_modal/file_preview_modal_main_actions/file_preview_modal_main_actions.tsx
+++ b/components/file_preview_modal/file_preview_modal_main_actions/file_preview_modal_main_actions.tsx
@@ -45,10 +45,10 @@ const FilePreviewModalMainActions: React.FC<Props> = (props: Props) => {
     const [publicLinkCopied, setPublicLinkCopied] = useState(false);
 
     useEffect(() => {
-        if (isFileInfo(props.fileInfo)) {
+        if (isFileInfo(props.fileInfo) && props.enablePublicLink) {
             dispatch(getFilePublicLink(props.fileInfo.id));
         }
-    }, [props.fileInfo]);
+    }, [props.fileInfo, props.enablePublicLink]);
     const copyPublicLink = () => {
         copyToClipboard(selectedFilePublicLink ?? '');
         setPublicLinkCopied(true);


### PR DESCRIPTION
#### Summary
fixes: public links are being generated by the server even if public links are disabled in the config.
Note: we might need to check the server error log's 

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-42928

#### Related Pull Requests
n/a

#### Screenshots
|  before  |  after  |
|----|----|
| https://user-images.githubusercontent.com/16203333/161056571-0d2c013e-4017-4149-87a8-142e94b6ac2e.mov | https://user-images.githubusercontent.com/16203333/161056763-30f2f04b-9e6f-40f5-854f-bebea56c82e4.mov |




#### Release Note
```release-note
Bug fixes: public link generate API was getting called even if public links are disabled
```
