### PR TITLE
Automated cherry pick of #10084

### DIFF
--- a/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/__snapshots__/permission_system_scheme_settings.test.tsx.snap
+++ b/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/__snapshots__/permission_system_scheme_settings.test.tsx.snap
@@ -279,6 +279,12 @@ exports[`components/admin_console/permission_schemes_settings/permission_system_
         titleId="admin.permissions.systemScheme.playbookAdmin"
       >
         <PermissionsTreePlaybooks
+          license={
+            Object {
+              "CustomPermissionsSchemes": "false",
+              "IsLicensed": "true",
+            }
+          }
           onToggle={[Function]}
           parentRole={
             Object {
@@ -578,6 +584,13 @@ exports[`components/admin_console/permission_schemes_settings/permission_system_
         titleId="admin.permissions.systemScheme.playbookAdmin"
       >
         <PermissionsTreePlaybooks
+          license={
+            Object {
+              "CustomPermissionsSchemes": "true",
+              "GuestAccountsPermissions": "true",
+              "IsLicensed": "true",
+            }
+          }
           onToggle={[Function]}
           parentRole={
             Object {
@@ -877,6 +890,13 @@ exports[`components/admin_console/permission_schemes_settings/permission_system_
         titleId="admin.permissions.systemScheme.playbookAdmin"
       >
         <PermissionsTreePlaybooks
+          license={
+            Object {
+              "CustomPermissionsSchemes": "false",
+              "GuestAccountsPermissions": "false",
+              "IsLicensed": "true",
+            }
+          }
           onToggle={[Function]}
           parentRole={
             Object {
@@ -1176,6 +1196,13 @@ exports[`components/admin_console/permission_schemes_settings/permission_system_
         titleId="admin.permissions.systemScheme.playbookAdmin"
       >
         <PermissionsTreePlaybooks
+          license={
+            Object {
+              "CustomPermissionsSchemes": "false",
+              "GuestAccountsPermissions": "true",
+              "IsLicensed": "true",
+            }
+          }
           onToggle={[Function]}
           parentRole={
             Object {

--- a/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.tsx
+++ b/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.tsx
@@ -453,6 +453,7 @@ export default class PermissionSystemSchemeSettings extends React.PureComponent<
                                 onToggle={this.togglePermission}
                                 selectRow={this.selectRow}
                                 readOnly={this.props.isDisabled || false}
+                                license={this.props.license}
                             />
                         </AdminPanelTogglable>
 

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.tsx.snap
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.tsx.snap
@@ -220,6 +220,13 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
         titleId="admin.permissions.systemScheme.playbookAdmin"
       >
         <PermissionsTreePlaybooks
+          license={
+            Object {
+              "CustomPermissionsSchemes": "true",
+              "GuestAccountsPermissions": "true",
+              "IsLicensed": "true",
+            }
+          }
           onToggle={[Function]}
           parentRole={
             Object {
@@ -564,6 +571,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
         titleId="admin.permissions.systemScheme.playbookAdmin"
       >
         <PermissionsTreePlaybooks
+          license={
+            Object {
+              "IsLicensed": "false",
+            }
+          }
           onToggle={[Function]}
           parentRole={
             Object {
@@ -908,6 +920,13 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
         titleId="admin.permissions.systemScheme.playbookAdmin"
       >
         <PermissionsTreePlaybooks
+          license={
+            Object {
+              "CustomPermissionsSchemes": "true",
+              "GuestAccountsPermissions": "true",
+              "IsLicensed": "true",
+            }
+          }
           onToggle={[Function]}
           parentRole={
             Object {
@@ -1323,6 +1342,13 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
         titleId="admin.permissions.systemScheme.playbookAdmin"
       >
         <PermissionsTreePlaybooks
+          license={
+            Object {
+              "CustomPermissionsSchemes": "true",
+              "GuestAccountsPermissions": "true",
+              "IsLicensed": "true",
+            }
+          }
           onToggle={[Function]}
           parentRole={
             Object {

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
@@ -778,6 +778,7 @@ export default class PermissionTeamSchemeSettings extends React.PureComponent<Pr
                                 onToggle={this.togglePermission}
                                 selectRow={this.selectRow}
                                 readOnly={this.props.isDisabled}
+                                license={this.props.license}
                             />
                         </AdminPanelTogglable>
 

--- a/components/admin_console/permission_schemes_settings/permissions_tree/__snapshots__/permissions_tree.test.tsx.snap
+++ b/components/admin_console/permission_schemes_settings/permissions_tree/__snapshots__/permissions_tree.test.tsx.snap
@@ -102,6 +102,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_public",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_public_create",
               "playbook_public_manage_properties",
@@ -111,6 +112,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_private",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_private_create",
               "playbook_private_manage_properties",
@@ -300,6 +302,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_public",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_public_create",
               "playbook_public_manage_properties",
@@ -309,6 +312,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_private",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_private_create",
               "playbook_private_manage_properties",
@@ -506,20 +510,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_public",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_public_create",
               "playbook_public_manage_properties",
               "playbook_public_manage_members",
-              "playbook_public_make_private",
-            ],
-          },
-          Object {
-            "id": "playbook_private",
-            "permissions": Array [
-              "playbook_private_create",
-              "playbook_private_manage_properties",
-              "playbook_private_manage_members",
-              "playbook_private_make_public",
             ],
           },
           Object {
@@ -712,6 +707,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_public",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_public_create",
               "playbook_public_manage_properties",
@@ -721,6 +717,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_private",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_private_create",
               "playbook_private_manage_properties",
@@ -918,6 +915,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_public",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_public_create",
               "playbook_public_manage_properties",
@@ -927,6 +925,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_private",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_private_create",
               "playbook_private_manage_properties",
@@ -1124,6 +1123,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_public",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_public_create",
               "playbook_public_manage_properties",
@@ -1133,6 +1133,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_private",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_private_create",
               "playbook_private_manage_properties",
@@ -1336,6 +1337,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_public",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_public_create",
               "playbook_public_manage_properties",
@@ -1345,6 +1347,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
           },
           Object {
             "id": "playbook_private",
+            "isVisible": [Function],
             "permissions": Array [
               "playbook_private_create",
               "playbook_private_manage_properties",

--- a/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.test.tsx
+++ b/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.test.tsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
+import {LicenseSkus} from 'mattermost-redux/types/general';
+
 import PermissionsTree from 'components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree';
 
 import PermissionGroup from 'components/admin_console/permission_schemes_settings/permission_group.jsx';
@@ -29,6 +31,7 @@ describe('components/admin_console/permission_schemes_settings/permission_tree',
         license: {
             LDAPGroups: 'true',
             isLicensed: 'true',
+            SkuShortName: LicenseSkus.Enterprise,
         },
         customGroupsEnabled: true,
     };
@@ -131,5 +134,52 @@ describe('components/admin_console/permission_schemes_settings/permission_tree',
         expect(groups[7].id).toStrictEqual('integrations');
         expect(groups[8].id).toStrictEqual('manage_shared_channels');
         expect(groups[9].id).toStrictEqual('custom_groups');
+    });
+
+    describe('should show playbook permissions', () => {
+        describe('for non-enterprise license', () => {
+            ['', LicenseSkus.E10, LicenseSkus.Starter, LicenseSkus.Professional].forEach((licenseSku) => test(licenseSku, () => {
+                const props = {
+                    ...defaultProps,
+                    license: {
+                        isLicensed: licenseSku === '' ? 'false' : 'true',
+                        SkuShortName: licenseSku,
+                    },
+                };
+
+                const wrapper = shallow(
+                    <PermissionsTree
+                        {...props}
+                    />,
+                );
+
+                const groups = wrapper.find(PermissionGroup).first().prop('permissions');
+                expect(groups[3].id).toStrictEqual('playbook_public');
+                expect(groups[4].id).toStrictEqual('runs');
+            }));
+        });
+
+        describe('for enterprise license', () => {
+            [LicenseSkus.E20, LicenseSkus.Enterprise].forEach((licenseSku) => test(licenseSku, () => {
+                const props = {
+                    ...defaultProps,
+                    license: {
+                        isLicensed: 'true',
+                        SkuShortName: licenseSku,
+                    },
+                };
+
+                const wrapper = shallow(
+                    <PermissionsTree
+                        {...props}
+                    />,
+                );
+
+                const groups = wrapper.find(PermissionGroup).first().prop('permissions');
+                expect(groups[3].id).toStrictEqual('playbook_public');
+                expect(groups[4].id).toStrictEqual('playbook_private');
+                expect(groups[5].id).toStrictEqual('runs');
+            }));
+        });
     });
 });

--- a/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.tsx
+++ b/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.tsx
@@ -14,6 +14,8 @@ import PermissionGroup from '../permission_group.jsx';
 import EditPostTimeLimitButton from '../edit_post_time_limit_button';
 import EditPostTimeLimitModal from '../edit_post_time_limit_modal';
 
+import {isEnterpriseLicense, isNonEnterpriseLicense} from 'mattermost-redux/types/general';
+
 import {AdditionalValues, Group} from './types';
 
 type Props = {
@@ -25,7 +27,7 @@ type Props = {
     selected?: string | null;
     selectRow: (id: string) => void;
     readOnly?: boolean;
-    license?: Partial<ClientLicense>;
+    license?: ClientLicense;
     customGroupsEnabled: boolean;
 }
 
@@ -122,8 +124,18 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
                     Permissions.PLAYBOOK_PUBLIC_CREATE,
                     Permissions.PLAYBOOK_PUBLIC_MANAGE_PROPERTIES,
                     Permissions.PLAYBOOK_PUBLIC_MANAGE_MEMBERS,
+                ],
+                isVisible: isNonEnterpriseLicense,
+            },
+            {
+                id: 'playbook_public',
+                permissions: [
+                    Permissions.PLAYBOOK_PUBLIC_CREATE,
+                    Permissions.PLAYBOOK_PUBLIC_MANAGE_PROPERTIES,
+                    Permissions.PLAYBOOK_PUBLIC_MANAGE_MEMBERS,
                     Permissions.PLAYBOOK_PUBLIC_MAKE_PRIVATE,
                 ],
+                isVisible: isEnterpriseLicense,
             },
             {
                 id: 'playbook_private',
@@ -133,6 +145,7 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
                     Permissions.PLAYBOOK_PRIVATE_MANAGE_MEMBERS,
                     Permissions.PLAYBOOK_PRIVATE_MAKE_PUBLIC,
                 ],
+                isVisible: isEnterpriseLicense,
             },
             {
                 id: 'runs',
@@ -199,10 +212,10 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
         const {config, scope, license} = this.props;
 
         const teamsGroup = this.groups[0];
-        const postsGroup = this.groups[6];
-        const integrationsGroup = this.groups[7];
-        const sharedChannelsGroup = this.groups[8];
-        const customGroupsGroup = this.groups[9];
+        const postsGroup = this.groups[7];
+        const integrationsGroup = this.groups[8];
+        const sharedChannelsGroup = this.groups[9];
+        const customGroupsGroup = this.groups[10];
 
         if (config.EnableIncomingWebhooks === 'true' && !integrationsGroup.permissions.includes(Permissions.MANAGE_INCOMING_WEBHOOKS)) {
             integrationsGroup.permissions.push(Permissions.MANAGE_INCOMING_WEBHOOKS);
@@ -243,6 +256,14 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
         if (!this.props.customGroupsEnabled) {
             customGroupsGroup?.permissions.pop();
         }
+
+        this.groups = this.groups.filter((group) => {
+            if (group.isVisible) {
+                return group.isVisible(this.props.license);
+            }
+
+            return true;
+        });
     }
 
     openPostTimeLimitModal = () => {

--- a/components/admin_console/permission_schemes_settings/permissions_tree/types.ts
+++ b/components/admin_console/permission_schemes_settings/permissions_tree/types.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {ClientLicense} from 'mattermost-redux/types/config';
+
 export type Permission = {
     id: string;
     combined?: boolean;
@@ -9,6 +11,7 @@ export type Permission = {
 export type Group = {
     id: string;
     permissions: Array<Permission | string>;
+    isVisible?: (license?: ClientLicense) => boolean;
 }
 
 export type AdditionalValues = {

--- a/components/admin_console/permission_schemes_settings/permissions_tree_playbooks.test.tsx
+++ b/components/admin_console/permission_schemes_settings/permissions_tree_playbooks.test.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {ComponentProps} from 'react';
+
+import {shallow} from 'enzyme';
+
+import {LicenseSkus} from 'mattermost-redux/types/general';
+
+import PermissionsTreePlaybooks from 'components/admin_console/permission_schemes_settings/permissions_tree_playbooks';
+import PermissionGroup from 'components/admin_console/permission_schemes_settings/permission_group.jsx';
+
+describe('components/admin_console/permission_schemes_settings/permissions_tree_playbooks', () => {
+    const defaultProps: ComponentProps<typeof PermissionsTreePlaybooks> = {
+        role: {name: 'role'},
+        parentRole: {},
+        scope: 'scope',
+        selectRow: () => null,
+        readOnly: false,
+        onToggle: () => null,
+        license: {
+        },
+    };
+
+    describe('should show playbook permissions', () => {
+        describe('for non-enterprise license', () => {
+            ['', LicenseSkus.E10, LicenseSkus.Starter, LicenseSkus.Professional].forEach((licenseSku) => test(licenseSku, () => {
+                const props = {
+                    ...defaultProps,
+                    license: {
+                        isLicensed: licenseSku === '' ? 'false' : 'true',
+                        SkuShortName: licenseSku,
+                    },
+                };
+
+                const wrapper = shallow(
+                    <PermissionsTreePlaybooks {...props}/>,
+                );
+
+                const groups = wrapper.find(PermissionGroup).first().prop('permissions');
+                expect(groups).toHaveLength(2);
+                expect(groups[0].id).toStrictEqual('playbook_public');
+                expect(groups[1].id).toStrictEqual('runs');
+            }));
+        });
+
+        describe('for enterprise license', () => {
+            [LicenseSkus.E20, LicenseSkus.Enterprise].forEach((licenseSku) => test(licenseSku, () => {
+                const props = {
+                    ...defaultProps,
+                    license: {
+                        isLicensed: 'true',
+                        SkuShortName: licenseSku,
+                    },
+                };
+
+                const wrapper = shallow(
+                    <PermissionsTreePlaybooks {...props}/>,
+                );
+
+                const groups = wrapper.find(PermissionGroup).first().prop('permissions');
+                expect(groups).toHaveLength(3);
+                expect(groups[0].id).toStrictEqual('playbook_public');
+                expect(groups[1].id).toStrictEqual('playbook_private');
+                expect(groups[2].id).toStrictEqual('runs');
+            }));
+        });
+    });
+});

--- a/components/admin_console/permission_schemes_settings/permissions_tree_playbooks.tsx
+++ b/components/admin_console/permission_schemes_settings/permissions_tree_playbooks.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import Permissions from 'mattermost-redux/constants/permissions';
+import {ClientLicense} from 'mattermost-redux/types/config';
+import {isEnterpriseLicense, isNonEnterpriseLicense} from 'mattermost-redux/types/general';
 
 import {Role} from 'mattermost-redux/types/roles';
 
@@ -17,9 +19,18 @@ interface Props {
     selectRow: any;
     readOnly: boolean;
     onToggle: (a: string, b: string[]) => void;
+    license: ClientLicense;
 }
 
-export const playbooksGroups: any[] = [
+const groups = [
+    {
+        id: 'playbook_public',
+        permissions: [
+            Permissions.PLAYBOOK_PUBLIC_MANAGE_PROPERTIES,
+            Permissions.PLAYBOOK_PUBLIC_MANAGE_MEMBERS,
+        ],
+        isVisible: isNonEnterpriseLicense,
+    },
     {
         id: 'playbook_public',
         permissions: [
@@ -27,6 +38,7 @@ export const playbooksGroups: any[] = [
             Permissions.PLAYBOOK_PUBLIC_MANAGE_MEMBERS,
             Permissions.PLAYBOOK_PUBLIC_MAKE_PRIVATE,
         ],
+        isVisible: isEnterpriseLicense,
     },
     {
         id: 'playbook_private',
@@ -35,6 +47,7 @@ export const playbooksGroups: any[] = [
             Permissions.PLAYBOOK_PRIVATE_MANAGE_MEMBERS,
             Permissions.PLAYBOOK_PRIVATE_MAKE_PUBLIC,
         ],
+        isVisible: isEnterpriseLicense,
     },
     {
         id: 'runs',
@@ -51,6 +64,14 @@ const PermissionsTreePlaybooks = (props: Props) => {
         }
         props.onToggle(props.role?.name || '', ids);
     };
+
+    const filteredGroups = groups.filter((group) => {
+        if (group.isVisible) {
+            return group.isVisible(props.license);
+        }
+
+        return true;
+    });
 
     return (
         <div className='permissions-tree'>
@@ -76,7 +97,7 @@ const PermissionsTreePlaybooks = (props: Props) => {
                     uniqId={props.role?.name}
                     selectRow={props.selectRow}
                     readOnly={props.readOnly}
-                    permissions={playbooksGroups}
+                    permissions={filteredGroups}
                     role={props.role}
                     scope={props.scope}
                     combined={false}

--- a/packages/mattermost-redux/src/types/general.ts
+++ b/packages/mattermost-redux/src/types/general.ts
@@ -28,3 +28,15 @@ export enum LicenseSkus {
     Professional = 'professional',
     Enterprise = 'enterprise',
 }
+
+export const isEnterpriseLicense = (license?: ClientLicense) => {
+    switch (license?.SkuShortName) {
+    case LicenseSkus.Enterprise:
+    case LicenseSkus.E20:
+        return true;
+    }
+
+    return false;
+};
+
+export const isNonEnterpriseLicense = (license?: ClientLicense) => !isEnterpriseLicense(license);


### PR DESCRIPTION
Cherry pick of #10084 on release-6.6.

/cc  @lieut-data

```release-note
NONE
```