### PR TITLE
[MM-48892] fix shortcut key double press to activate action

### DIFF
--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -178,18 +178,15 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
     componentDidUpdate(prevProps: Props): void {
         if (!prevProps.isMenuOpen && this.props.isMenuOpen) {
             window.addEventListener('keydown', this.onShortcutKeyDown);
-            window.addEventListener('keyup', this.onShortcutKeyUp);
         }
 
         if (prevProps.isMenuOpen && !this.props.isMenuOpen) {
             window.removeEventListener('keydown', this.onShortcutKeyDown);
-            window.removeEventListener('keyup', this.onShortcutKeyUp);
         }
     }
 
     componentWillUnmount(): void {
         window.removeEventListener('keydown', this.onShortcutKeyDown);
-        window.removeEventListener('keyup', this.onShortcutKeyUp);
         this.editDisableAction.cancel();
     }
 
@@ -379,10 +376,6 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
             this.props.handleDropdownOpened(false);
             break;
         }
-    }
-
-    onShortcutKeyUp = (e: KeyboardEvent): void => {
-        e.preventDefault();
     }
 
     handleDropdownOpened = (open: boolean) => {

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -129,7 +129,6 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         isReadOnly: false,
         location: Locations.CENTER,
     }
-    private keysHeldDown: string[] = [];
     private editDisableAction: DelayedAction;
     private buttonRef: React.RefObject<HTMLButtonElement>;
 
@@ -384,7 +383,6 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
 
     onShortcutKeyUp = (e: KeyboardEvent): void => {
         e.preventDefault();
-        this.keysHeldDown = this.keysHeldDown.filter((key) => key !== e.key);
     }
 
     handleDropdownOpened = (open: boolean) => {

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -326,11 +326,6 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
             return;
         }
 
-        if (this.keysHeldDown.includes(e.key)) {
-            return;
-        }
-        this.keysHeldDown.push(e.key);
-
         switch (true) {
         case Utils.isKeyPressed(e, Constants.KeyCodes.R):
             this.handleCommentClick(e);


### PR DESCRIPTION
#### Summary
This PR solves an issue where `Save/Unsave` `Pin/Unpin` shortcuts (`S`), (`P`)require pressing twice to execute the action. 

#### Ticket Link
http://localhost:8065/testing-org/pl/od3kp6m1hjbhmxmz61mec6rqec

#### Related Pull Requests

#### Screenshots

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
