### PR TITLE
fix placement of track callback

### DIFF
--- a/components/common/hooks/useCopyText.ts
+++ b/components/common/hooks/useCopyText.ts
@@ -27,11 +27,11 @@ export default function useCopyText(options: CopyOptions): CopyResponse {
         successCopyTimeout = options.successCopyTimeout;
     }
 
-    if (options.trackCallback) {
-        options.trackCallback();
-    }
-
     const onClick = useCallback(() => {
+        if (options.trackCallback) {
+            options.trackCallback();
+        }
+
         if (timerRef.current) {
             clearTimeout(timerRef.current);
             timerRef.current = null;


### PR DESCRIPTION
#### Summary
The track callback was being fired every time the hook fired (bad). We should only trigger it when the copy text element is actually clicked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43003

#### Release Note
```release-note
Fix copy links to not fire track callback until copy link is actually clicked.
```