### PR TITLE
Automated cherry pick of #10118

### DIFF
--- a/components/integrations/__snapshots__/abstract_command.test.jsx.snap
+++ b/components/integrations/__snapshots__/abstract_command.test.jsx.snap
@@ -145,7 +145,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
               values={
                 Object {
                   "link": <a
-                    href="https://docs.mattermost.com/help/messaging/executing-commands.html#built-in-commands"
+                    href="https://developers.mattermost.com/integrate/admin-guide/admin-slash-commands/#built-in-commands"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -615,7 +615,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
               values={
                 Object {
                   "link": <a
-                    href="https://docs.mattermost.com/help/messaging/executing-commands.html#built-in-commands"
+                    href="https://developers.mattermost.com/integrate/admin-guide/admin-slash-commands/#built-in-commands"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/components/integrations/abstract_command.jsx
+++ b/components/integrations/abstract_command.jsx
@@ -436,7 +436,7 @@ export default class AbstractCommand extends React.PureComponent {
                                         values={{
                                             link: (
                                                 <a
-                                                    href='https://docs.mattermost.com/help/messaging/executing-commands.html#built-in-commands'
+                                                    href='https://developers.mattermost.com/integrate/admin-guide/admin-slash-commands/#built-in-commands'
                                                     target='_blank'
                                                     rel='noopener noreferrer'
                                                 >


### PR DESCRIPTION
Cherry pick of #10118 on release-6.6.

/cc  @cwarnermm

```release-note
NONE
```