### PR TITLE
Downgrading Brazilian Portuguese to Beta

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -334,7 +334,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 9,
-                  "text": "Português (Brasil)",
+                  "text": "Português (Brasil) (Beta)",
                   "value": "pt-BR",
                 },
                 Object {
@@ -465,7 +465,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 9,
-                  "text": "Português (Brasil)",
+                  "text": "Português (Brasil) (Beta)",
                   "value": "pt-BR",
                 },
                 Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -85,7 +85,7 @@ const languages = {
     },
     'pt-BR': {
         value: 'pt-BR',
-        name: 'Português (Brasil)',
+        name: 'Português (Brasil) (Beta)',
         order: 9,
         url: ptBR,
     },


### PR DESCRIPTION
#### Summary
Brazilian Portuguese product translations haven't been actively maintained for some months. With this reduction in translation quality, this language is being downgraded to Beta.

#### Release Note
```release-note
Downgraded Brazilian Portuguese language support to Beta.
```
