### PR TITLE
[MM-42998] change dangerous menu hovered color to --button-color

### DIFF
--- a/components/widgets/menu/menu_items/menu_item.scss
+++ b/components/widgets/menu/menu_items/menu_item.scss
@@ -126,10 +126,10 @@
 
                 &:hover {
                     background-color: var(--dnd-indicator) !important;
-                    color: var(--sidebar-text);
+                    color: var(--button-color);
 
                     i {
-                        color: var(--sidebar-text) !important;
+                        color: var(--button-color) !important;
                     }
                 }
             }


### PR DESCRIPTION
#### Summary
This PR changes the color of the text for menu items from `sidebar-text` to `button-color`.  This issue was discovered when viewing the `Quartz` theme.
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42998

#### Related Pull Requests

#### Screenshots
|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/7575921/161814780-4272924f-db12-4d83-b23f-b5937612cd4a.png) | ![image](https://user-images.githubusercontent.com/7575921/161814822-5edc6aa2-38ff-4b5f-bf23-307fc13fffe2.png) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
