### PR TITLE
[MM-42916] Fixes context menu gets in the way when highlighting text

### DIFF
--- a/components/code_block/__snapshots__/code_block.test.jsx.snap
+++ b/components/code_block/__snapshots__/code_block.test.jsx.snap
@@ -91,7 +91,7 @@ exports[`codeBlock should render html code block with proper indentation 1`] = `
     collect={[Function]}
     disable={false}
     disableIfShiftIsPressed={false}
-    holdToDisplay={1000}
+    holdToDisplay={-1}
     id="copy-code-block-context-menu-randompostid"
     mouseButton={2}
     posX={0}
@@ -219,7 +219,7 @@ const myFunction = () => {
     collect={[Function]}
     disable={false}
     disableIfShiftIsPressed={false}
-    holdToDisplay={1000}
+    holdToDisplay={-1}
     id="copy-code-block-context-menu-randompostid"
     mouseButton={2}
     posX={0}
@@ -341,7 +341,7 @@ it shouldn't highlight, it's just garbage
     collect={[Function]}
     disable={false}
     disableIfShiftIsPressed={false}
-    holdToDisplay={1000}
+    holdToDisplay={-1}
     id="copy-code-block-context-menu-randompostid"
     mouseButton={2}
     posX={0}

--- a/components/code_block/code_block.tsx
+++ b/components/code_block/code_block.tsx
@@ -110,7 +110,7 @@ const CodeBlock: React.FC<Props> = ({id, code, language, searchedContent}: Props
             {contextMenu}
             <ContextMenuTrigger
                 id={`copy-code-block-context-menu-${id}`}
-                holdToDisplay={1000}
+                holdToDisplay={-1}
             >
                 <div className='hljs'>
                     {lineNumbers}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Removed the ability to hold on the CodeBlock in order to show the context menu. Now it will only show on right click.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes [MM-42916](https://mattermost.atlassian.net/browse/MM-42916)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixes a bug where the context menu would get in the way when highlighting text
```
