### PR TITLE
Update link to Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _Note: Heroku preview does not include email or persistent storage._
 
 ## Install Mattermost
 
-- [Deploy Guide](https://docs.mattermost.com/guides/deployment.html) - Deploy Mattermost in minutes via Docker, tar, or the Omnibus
+- [Deploy Guide](https://docs.mattermost.com/guides/deployment.html) - Deploy Mattermost in minutes via Docker, Ubuntu, or tar.
 - [Developer Machine Setup](https://developers.mattermost.com/contribute/server/developer-setup) - Follow this guide if you want to write code for Mattermost
 
 Other Install Guides:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ _Note: Heroku preview does not include email or persistent storage._
 - [Developer Machine Setup](https://developers.mattermost.com/contribute/server/developer-setup) - Follow this guide if you want to write code for Mattermost
 
 Other Install Guides:
-- [Docker](https://docs.mattermost.com/install/install-docker.html)
+- [Deploy Mattermost on Docker](https://docs.mattermost.com/install/install-docker.html)
+- [Mattermost Omnibus](https://docs.mattermost.com/install/installing-mattermost-omnibus.html)
+- [Install Mattermost from Tar](https://docs.mattermost.com/install/install-tar.html)
 - [Ubuntu 20.04 LTS](https://docs.mattermost.com/install/installing-ubuntu-2004-LTS.html)
 - [Kubernetes](https://docs.mattermost.com/install/install-kubernetes.html)
 - [Helm](https://docs.mattermost.com/install/install-kubernetes.html#installing-the-operators-via-helm)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ _Note: Heroku preview does not include email or persistent storage._
 - [Developer Machine Setup](https://developers.mattermost.com/contribute/server/developer-setup) - Follow this guide if you want to write code for Mattermost
 
 Other Install Guides:
+- [Docker](https://docs.mattermost.com/install/install-docker.html)
 - [Ubuntu 20.04 LTS](https://docs.mattermost.com/install/installing-ubuntu-2004-LTS.html)
 - [Kubernetes](https://docs.mattermost.com/install/install-kubernetes.html)
 - [Helm](https://docs.mattermost.com/install/install-kubernetes.html#installing-the-operators-via-helm)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ _Note: Heroku preview does not include email or persistent storage._
 
 ## Install Mattermost
 
-- [Quick Install Guide](https://docs.mattermost.com/getting-started/light-install.html) - Deploy in minutes via Mattermost Omnibus on Ubuntu
-- [Docker Deployment](https://docs.mattermost.com/install/install-docker) - Preview Mattermost instantly or deploy via Docker for production use.
+- [Deploy Guide](https://docs.mattermost.com/guides/deployment.html) - Deploy Mattermost in minutes via Docker, tar, or the Omnibus
 - [Developer Machine Setup](https://developers.mattermost.com/contribute/server/developer-setup) - Follow this guide if you want to write code for Mattermost
 
 Other Install Guides:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _Note: Heroku preview does not include email or persistent storage._
 ## Install Mattermost
 
 - [Quick Install Guide](https://docs.mattermost.com/getting-started/light-install.html) - Deploy in minutes via Mattermost Omnibus on Ubuntu
-- [Run Mattermost via Docker](https://docs.mattermost.com/install/setting-up-local-machine-using-docker.html) - Launch a Mattermost server instantly to test functionality and build integrations
+- [Docker Deployment](https://docs.mattermost.com/install/install-docker) - Preview Mattermost instantly or deploy via Docker for production use.
 - [Developer Machine Setup](https://developers.mattermost.com/contribute/server/developer-setup) - Follow this guide if you want to write code for Mattermost
 
 Other Install Guides:


### PR DESCRIPTION
#### Summary
Updated Docker instructions to point to new instructions after [PR#5517](https://github.com/mattermost/docs/pull/5517) is merged.

See also: [PR#19924](https://github.com/mattermost/mattermost-server/pull/19924)

```release-note
NONE
```