### PR TITLE
Automated cherry pick of #10134

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -334,7 +334,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 9,
-                  "text": "Português (Brasil)",
+                  "text": "Português (Brasil) (Beta)",
                   "value": "pt-BR",
                 },
                 Object {
@@ -465,7 +465,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 9,
-                  "text": "Português (Brasil)",
+                  "text": "Português (Brasil) (Beta)",
                   "value": "pt-BR",
                 },
                 Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -85,7 +85,7 @@ const languages = {
     },
     'pt-BR': {
         value: 'pt-BR',
-        name: 'Português (Brasil)',
+        name: 'Português (Brasil) (Beta)',
         order: 9,
         url: ptBR,
     },


### PR DESCRIPTION
Cherry pick of #10134 on release-6.6.

/cc  @cwarnermm

```release-note
NONE
```