### PR TITLE
MM-41791 : Custom emoji "Next" button out of view when banner is present

### DIFF
--- a/sass/routes/_backstage.scss
+++ b/sass/routes/_backstage.scss
@@ -34,7 +34,7 @@
     display: inline-block;
     overflow: auto;
     width: 100%;
-    height: calc(100vh - 41px);
+    height: calc(100vh - #{$announcement-bar-height} - #{$backstage-bar-height});
     background-color: $bg--gray;
 }
 

--- a/sass/routes/_backstage.scss
+++ b/sass/routes/_backstage.scss
@@ -35,9 +35,11 @@
     overflow: auto;
     width: 100%;
     height: calc(100% - #{$announcement-bar-height});
+
     body.announcement-bar--fixed & {
         height: calc(100vh - #{$announcement-bar-height} - #{$backstage-bar-height});
     }
+
     background-color: $bg--gray;
 }
 

--- a/sass/routes/_backstage.scss
+++ b/sass/routes/_backstage.scss
@@ -34,7 +34,10 @@
     display: inline-block;
     overflow: auto;
     width: 100%;
-    height: calc(100vh - #{$announcement-bar-height} - #{$backstage-bar-height});
+    height: calc(100% - #{$announcement-bar-height});
+    body.announcement-bar--fixed & {
+        height: calc(100vh - #{$announcement-bar-height} - #{$backstage-bar-height});
+    }
     background-color: $bg--gray;
 }
 


### PR DESCRIPTION
#### Summary
Adjusts the backstage body element height to accommodate the banner

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41791

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
