### PR TITLE
Automated cherry pick of #10136

### DIFF
--- a/components/code_block/__snapshots__/code_block.test.jsx.snap
+++ b/components/code_block/__snapshots__/code_block.test.jsx.snap
@@ -91,7 +91,7 @@ exports[`codeBlock should render html code block with proper indentation 1`] = `
     collect={[Function]}
     disable={false}
     disableIfShiftIsPressed={false}
-    holdToDisplay={1000}
+    holdToDisplay={-1}
     id="copy-code-block-context-menu-randompostid"
     mouseButton={2}
     posX={0}
@@ -219,7 +219,7 @@ const myFunction = () => {
     collect={[Function]}
     disable={false}
     disableIfShiftIsPressed={false}
-    holdToDisplay={1000}
+    holdToDisplay={-1}
     id="copy-code-block-context-menu-randompostid"
     mouseButton={2}
     posX={0}
@@ -341,7 +341,7 @@ it shouldn't highlight, it's just garbage
     collect={[Function]}
     disable={false}
     disableIfShiftIsPressed={false}
-    holdToDisplay={1000}
+    holdToDisplay={-1}
     id="copy-code-block-context-menu-randompostid"
     mouseButton={2}
     posX={0}

--- a/components/code_block/code_block.tsx
+++ b/components/code_block/code_block.tsx
@@ -110,7 +110,7 @@ const CodeBlock: React.FC<Props> = ({id, code, language, searchedContent}: Props
             {contextMenu}
             <ContextMenuTrigger
                 id={`copy-code-block-context-menu-${id}`}
-                holdToDisplay={1000}
+                holdToDisplay={-1}
             >
                 <div className='hljs'>
                     {lineNumbers}


### PR DESCRIPTION
Cherry pick of #10136 on release-6.6.

/cc  @cleferman

```release-note
NONE
```