### PR TITLE
MM-43228 Fix error occuring before login redirect

### DIFF
--- a/utils/route.tsx
+++ b/utils/route.tsx
@@ -24,7 +24,7 @@ export type ConfigOption = {
 };
 
 export function checkIfMFARequired(
-    user: UserProfile,
+    user: UserProfile | undefined,
     license: ClientLicense,
     config: ConfigOption,
     path: string,
@@ -36,6 +36,7 @@ export function checkIfMFARequired(
         mfaPaths.indexOf(path) === -1
     ) {
         if (
+            user &&
             isGuest(user.roles) &&
             config.GuestAccountsEnforceMultifactorAuthentication !== 'true'
         ) {


### PR DESCRIPTION
Despite the type of `user` and the corresponding `getUserProfile` being typed as non-nullable, those can be undefined when logged out. If you try to visit a route that expects you to get logged in, this code is called with an undefined user which causes an error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43228

#### Release Note
```release-note
Fixed error occuring when a non-logged-in user attempts to view a page that requires being logged in
```
