### PR TITLE
GH 19818 : Reaction toggle behaviour

### DIFF
--- a/components/post_view/post_reaction/index.ts
+++ b/components/post_view/post_reaction/index.ts
@@ -9,11 +9,13 @@ import {GenericAction} from 'mattermost-redux/types/actions';
 import {addReaction} from 'actions/post_actions.jsx';
 
 import PostReaction from './post_reaction';
+import {removeReaction} from 'mattermost-redux/actions/posts';
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             addReaction,
+            removeReaction
         }, dispatch),
     };
 }

--- a/components/post_view/post_reaction/index.ts
+++ b/components/post_view/post_reaction/index.ts
@@ -8,14 +8,15 @@ import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {addReaction} from 'actions/post_actions.jsx';
 
-import PostReaction from './post_reaction';
 import {removeReaction} from 'mattermost-redux/actions/posts';
+
+import PostReaction from './post_reaction';
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             addReaction,
-            removeReaction
+            removeReaction,
         }, dispatch),
     };
 }

--- a/components/post_view/post_reaction/post_reaction.test.tsx
+++ b/components/post_view/post_reaction/post_reaction.test.tsx
@@ -19,6 +19,7 @@ describe('components/post_view/PostReaction', () => {
         toggleEmojiPicker: jest.fn(),
         actions: {
             addReaction: jest.fn(),
+            removeReaction: jest.fn()
         },
     };
 
@@ -31,9 +32,14 @@ describe('components/post_view/PostReaction', () => {
         const wrapper = shallow(<PostReaction {...baseProps}/>);
         const instance = wrapper.instance() as PostReaction;
 
-        instance.handleAddEmoji({name: 'smile'} as Emoji);
+        instance.handleEmoji({name: 'smile'} as Emoji);
         expect(baseProps.actions.addReaction).toHaveBeenCalledTimes(1);
         expect(baseProps.actions.addReaction).toHaveBeenCalledWith('post_id_1', 'smile');
+        expect(baseProps.toggleEmojiPicker).toHaveBeenCalledTimes(1);
+
+        instance.handleEmoji({name: 'smile'} as Emoji);
+        expect(baseProps.actions.removeReaction).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.removeReaction).toHaveBeenCalledWith('post_id_1', 'smile');
         expect(baseProps.toggleEmojiPicker).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/post_view/post_reaction/post_reaction.test.tsx
+++ b/components/post_view/post_reaction/post_reaction.test.tsx
@@ -19,7 +19,7 @@ describe('components/post_view/PostReaction', () => {
         toggleEmojiPicker: jest.fn(),
         actions: {
             addReaction: jest.fn(),
-            removeReaction: jest.fn()
+            removeReaction: jest.fn(),
         },
     };
 
@@ -35,11 +35,6 @@ describe('components/post_view/PostReaction', () => {
         instance.handleEmoji({name: 'smile'} as Emoji);
         expect(baseProps.actions.addReaction).toHaveBeenCalledTimes(1);
         expect(baseProps.actions.addReaction).toHaveBeenCalledWith('post_id_1', 'smile');
-        expect(baseProps.toggleEmojiPicker).toHaveBeenCalledTimes(1);
-
-        instance.handleEmoji({name: 'smile'} as Emoji);
-        expect(baseProps.actions.removeReaction).toHaveBeenCalledTimes(1);
-        expect(baseProps.actions.removeReaction).toHaveBeenCalledWith('post_id_1', 'smile');
         expect(baseProps.toggleEmojiPicker).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/post_view/post_reaction/post_reaction.tsx
+++ b/components/post_view/post_reaction/post_reaction.tsx
@@ -13,18 +13,17 @@ import {Emoji} from 'mattermost-redux/types/emojis';
 
 import {Locations} from 'utils/constants';
 import {localizeMessage} from 'utils/utils.jsx';
+import {makeGetUniqueReactionsToPost} from 'utils/post_utils';
 
 import OverlayTrigger from 'components/overlay_trigger';
 import Tooltip from 'components/tooltip';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
-import store from 'stores/redux_store.jsx';
-import {Post} from 'mattermost-redux/types/posts';
-import {Reaction as ReactionType} from 'mattermost-redux/types/reactions';
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users'
-import { makeGetUniqueReactionsToPost } from 'utils/post_utils';
 
+import store from 'stores/redux_store.jsx';
+
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 const TOP_OFFSET = -7;
 
@@ -58,22 +57,24 @@ export default class PostReaction extends React.PureComponent<Props, State> {
     handleEmoji = (emoji: Emoji): void => {
         this.setState({showEmojiPicker: false});
         const emojiName = 'short_name' in emoji ? emoji.short_name : emoji.name;
-        const state = store.getState()
+        const state = store.getState();
         const getReactionsForPost = makeGetUniqueReactionsToPost();
 
-        let reactions = getReactionsForPost(state, this.props.postId)
-        console.log(reactions)
-        let currentUserReacted = false
-        for (let key in reactions) {
-            let value  = reactions[key];
-            if (value.user_id === getCurrentUserId(state) && value.emoji_name === emojiName) {
-                currentUserReacted = true
-                break
+        const reactions = getReactionsForPost(state, this.props.postId);
+        let currentUserReacted = false;
+
+        for (const key in reactions) {
+            if ({}.hasOwnProperty.call(reactions, key)) {
+                const value = reactions[key];
+                if (value.user_id === getCurrentUserId(state) && value.emoji_name === emojiName) {
+                    currentUserReacted = true;
+                    break;
+                }
             }
         }
 
         if (currentUserReacted) {
-            this.props.actions.removeReaction(this.props.postId, emojiName)
+            this.props.actions.removeReaction(this.props.postId, emojiName);
         } else {
             this.props.actions.addReaction(this.props.postId, emojiName);
         }

--- a/components/post_view/post_recent_reactions/index.ts
+++ b/components/post_view/post_recent_reactions/index.ts
@@ -10,14 +10,21 @@ import {GlobalState} from 'types/store';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {addReaction} from 'actions/post_actions.jsx';
+import {removeReaction} from 'mattermost-redux/actions/posts';
 import {Emoji} from 'mattermost-redux/types/emojis';
 
 import PostReaction from './post_recent_reactions';
+import { Post } from 'mattermost-redux/types/posts';
+
+type Props = {
+    post: Post;
+};
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             addReaction,
+            removeReaction
         }, dispatch),
     };
 }
@@ -27,9 +34,11 @@ function mapStateToProps(state: GlobalState) {
     const emojiMap = getEmojiMap(state);
     const defaultEmojis = [emojiMap.get('thumbsup'), emojiMap.get('grinning'), emojiMap.get('white_check_mark')] as Emoji[];
 
-    return {
-        defaultEmojis,
-        locale,
+    return function mapStateToProps(state: GlobalState, ownProps: Props) {
+        return {
+            defaultEmojis,
+            locale,
+        };
     };
 }
 

--- a/components/post_view/post_recent_reactions/index.ts
+++ b/components/post_view/post_recent_reactions/index.ts
@@ -14,17 +14,12 @@ import {removeReaction} from 'mattermost-redux/actions/posts';
 import {Emoji} from 'mattermost-redux/types/emojis';
 
 import PostReaction from './post_recent_reactions';
-import { Post } from 'mattermost-redux/types/posts';
-
-type Props = {
-    post: Post;
-};
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             addReaction,
-            removeReaction
+            removeReaction,
         }, dispatch),
     };
 }
@@ -34,11 +29,9 @@ function mapStateToProps(state: GlobalState) {
     const emojiMap = getEmojiMap(state);
     const defaultEmojis = [emojiMap.get('thumbsup'), emojiMap.get('grinning'), emojiMap.get('white_check_mark')] as Emoji[];
 
-    return function mapStateToProps(state: GlobalState, ownProps: Props) {
-        return {
-            defaultEmojis,
-            locale,
-        };
+    return {
+        defaultEmojis,
+        locale,
     };
 }
 

--- a/components/post_view/post_recent_reactions/post_recent_reactions.tsx
+++ b/components/post_view/post_recent_reactions/post_recent_reactions.tsx
@@ -5,18 +5,21 @@ import React from 'react';
 import {Dispatch} from 'redux';
 
 import Permissions from 'mattermost-redux/constants/permissions';
+
 import {Emoji} from 'mattermost-redux/types/emojis';
+
 import {Locations} from 'utils/constants';
+import {makeGetUniqueReactionsToPost} from 'utils/post_utils';
+
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 import OverlayTrigger from 'components/overlay_trigger';
 import Tooltip from 'components/tooltip';
-import {Reaction as ReactionType} from 'mattermost-redux/types/reactions';
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users'
+
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
 import store from 'stores/redux_store.jsx';
 
 import EmojiItem from './recent_reactions_emoji_item';
-import {Post} from 'mattermost-redux/types/posts';
-import { makeGetUniqueReactionsToPost } from 'utils/post_utils';
 
 type LocationTypes = 'CENTER' | 'RHS_ROOT' | 'RHS_COMMENT';
 
@@ -48,21 +51,23 @@ export default class PostRecentReactions extends React.PureComponent<Props, Stat
 
     handleEmoji = (emoji: Emoji): void => {
         const emojiName = 'short_name' in emoji ? emoji.short_name : emoji.name;
-        const state = store.getState()
+        const state = store.getState();
         const getReactionsForPost = makeGetUniqueReactionsToPost();
 
-        let reactions = getReactionsForPost(state, this.props.postId)
-        let currentUserReacted = false
-        for (let key in reactions) {
-            let value  = reactions[key];
-            if (value.user_id === getCurrentUserId(state) && value.emoji_name === emojiName) {
-                currentUserReacted = true
-                break
+        const reactions = getReactionsForPost(state, this.props.postId);
+        let currentUserReacted = false;
+        for (const key in reactions) {
+            if ({}.hasOwnProperty.call(reactions, key)) {
+                const value = reactions[key];
+                if (value.user_id === getCurrentUserId(state) && value.emoji_name === emojiName) {
+                    currentUserReacted = true;
+                    break;
+                }
             }
         }
 
         if (currentUserReacted) {
-            this.props.actions.removeReaction(this.props.postId, emojiName)
+            this.props.actions.removeReaction(this.props.postId, emojiName);
         } else {
             this.props.actions.addReaction(this.props.postId, emojiName);
         }

--- a/components/post_view/reaction_list/index.ts
+++ b/components/post_view/reaction_list/index.ts
@@ -48,7 +48,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             addReaction,
-            removeReaction
+            removeReaction,
         }, dispatch),
     };
 }

--- a/components/post_view/reaction_list/index.ts
+++ b/components/post_view/reaction_list/index.ts
@@ -14,6 +14,7 @@ import {Reaction} from 'mattermost-redux/types/reactions';
 import {GlobalState} from 'types/store';
 
 import {addReaction} from 'actions/post_actions.jsx';
+import {removeReaction} from 'mattermost-redux/actions/posts';
 
 import {makeGetUniqueReactionsToPost} from 'utils/post_utils';
 
@@ -47,6 +48,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             addReaction,
+            removeReaction
         }, dispatch),
     };
 }

--- a/components/post_view/reaction_list/reaction_list.tsx
+++ b/components/post_view/reaction_list/reaction_list.tsx
@@ -21,7 +21,7 @@ import ChannelPermissionGate from 'components/permissions_gates/channel_permissi
 import {localizeMessage} from 'utils/utils.jsx';
 
 import store from 'stores/redux_store.jsx';
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users'
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 const DEFAULT_EMOJI_PICKER_RIGHT_OFFSET = 15;
 const EMOJI_PICKER_WIDTH_OFFSET = 260;
@@ -81,20 +81,22 @@ export default class ReactionList extends React.PureComponent<Props, State> {
     handleEmojiClick = (emoji: Emoji): void => {
         this.setState({showEmojiPicker: false});
         const emojiName = isSystemEmoji(emoji) ? emoji.short_names[0] : emoji.name;
-        const state = store.getState()
+        const state = store.getState();
 
-        let {reactions} = this.props
-        let currentUserReacted = false
-        for (let key in reactions) {
-            let value  = reactions[key];
-            if (value.user_id === getCurrentUserId(state) && value.emoji_name === emojiName) {
-                currentUserReacted = true
-                break
+        const {reactions} = this.props;
+        let currentUserReacted = false;
+        for (const key in reactions) {
+            if ({}.hasOwnProperty.call(reactions, key)) {
+                const value = reactions[key];
+                if (value.user_id === getCurrentUserId(state) && value.emoji_name === emojiName) {
+                    currentUserReacted = true;
+                    break;
+                }
             }
         }
 
         if (currentUserReacted) {
-            this.props.actions.removeReaction(this.props.post.id, emojiName)
+            this.props.actions.removeReaction(this.props.post.id, emojiName);
         } else {
             this.props.actions.addReaction(this.props.post.id, emojiName);
         }


### PR DESCRIPTION
…moji selector, and reaction_list emoji selector. Additonally, added a test in post_reaction.test.tsx for removeReaction, WebApp only

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
Fixed bug where we couldn't remove emojis through emoji recent tab, toggle tab, and reaction list tab. 
-->

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/19818
https://mattermost.atlassian.net/browse/MM-42586

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added a new feature where emojis can be removed by pressing them in the emoji picker menu through the toggle or reaction list or through the recent emoji tab.
```
