### PR TITLE
Added minimum node and npm version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   },
   "version": "5.36.0-0",
   "private": true,
+  "engines" : { 
+    "npm" : ">=7.0.0",
+    "node" : ">=16.0.0"
+  },
   "dependencies": {
     "@mattermost/compass-components": "^0.2.12",
     "@mattermost/compass-icons": "0.1.22",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "engines" : { 
     "npm" : ">=7.0.0",
-    "node" : ">=16.0.0"
+    "node" : ">=16.4.0"
   },
   "dependencies": {
     "@mattermost/compass-components": "^0.2.12",


### PR DESCRIPTION
#### Summary
Implicitly we assume developers have node 16 to build mattermost, but this is not enforced. Adding this to `package.json` will issue a warning.

See [this discussion on community](https://community.mattermost.com/core/pl/gwp64h5yhtf48g3sojoin91e9o)

#### Release Note
```release-note
NONE
```
