### PR TITLE
[MM-43317] Fix channel members RHS colors

### DIFF
--- a/components/channel_members_rhs/member.tsx
+++ b/components/channel_members_rhs/member.tsx
@@ -35,14 +35,14 @@ const DisplayName = styled.span`
     margin-left: 8px;
     font-size: 14px;
     line-height: 20px;
-    color: var(--center-channel-text);
+    color: var(--center-channel-color);
 `;
 
 const Username = styled.span`
     margin-left: 8px;
     font-size: 12px;
     line-height: 18px;
-    color: rgba(var(--center-channel-text-rgb), 0.56);
+    color: rgba(var(--center-channel-color-rgb), 0.56);
 `;
 
 const SendMessage = styled.button`
@@ -54,11 +54,11 @@ const SendMessage = styled.button`
     height: 24px;
     border-radius: 4px;
     &:hover {
-        background-color: rgba(var(--center-channel-text-rgb), 0.12);
+        background-color: rgba(var(--center-channel-color-rgb), 0.12);
     }
     .icon {
         font-size: 14.4px;
-        color: rgba(var(--center-channel-text-rgb), 0.56);
+        color: rgba(var(--center-channel-color-rgb), 0.56);
     };
 `;
 


### PR DESCRIPTION
#### Summary
In the new channel members RHS, the wrong color is used for the member list making it hard to see while using a dark themes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43317

#### Related Pull Requests
N/A

#### Screenshots
|  before  |  after  |
|----|----|
| ![2022-04-12-075532_485x944_scrot](https://user-images.githubusercontent.com/785518/162991589-21dc8f2b-4689-4b19-9efd-c6aa88ce3f04.png) | ![2022-04-12-075542_495x944_scrot](https://user-images.githubusercontent.com/785518/162991644-daf0776f-468d-49c0-8d5c-1e1f6bf2c5f2.png) |

#### Release Note
```release-note
NONE
```
