### PR TITLE
fix channel intro components with app filter on

### DIFF
--- a/selectors/plugins.ts
+++ b/selectors/plugins.ts
@@ -43,17 +43,9 @@ export const getChannelHeaderPluginComponents = createSelector(
 
 export const getChannelIntroPluginComponents = createSelector(
     'getChannelIntroPluginComponents',
-    (state: GlobalState) => appBarEnabled(state),
     (state: GlobalState) => state.plugins.components.ChannelIntroButton,
-    (state: GlobalState) => state.plugins.components.AppBar,
-    (enabled, channelIntroComponents = [], appBarComponents = []) => {
-        if (!enabled || !appBarComponents.length) {
-            return channelIntroComponents as unknown as PluginComponent[];
-        }
-
-        // Remove channel header icons for plugins that have also registered an app bar component
-        const appBarPluginIds = appBarComponents.map((appBarComponent) => appBarComponent.pluginId);
-        return channelIntroComponents.filter((channelIntroComponents) => !appBarPluginIds.includes(channelIntroComponents.pluginId));
+    (components = []) => {
+        return components;
     },
 );
 


### PR DESCRIPTION
#### Summary
The focalboard link on the channel intro does not appear if the AppBarEnabled feature flag is turned on. 
The intro link shouldn't work differently for this. 

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2709

#### Related Pull Requests

- focalboard changes - https://github.com/mattermost/focalboard/pull/2766

#### Screenshots

<img width="569" alt="Screen Shot 2022-04-12 at 10 58 38 AM" src="https://user-images.githubusercontent.com/12704875/163015291-3d424cc3-0c82-4c49-b31c-85e34fa489b4.png">

#### Release Note
```release-note
NONE
```
