### PR TITLE
For first admin onboarding, trigger page views when they are shown in…

### DIFF
--- a/components/preparing_workspace/channel.tsx
+++ b/components/preparing_workspace/channel.tsx
@@ -34,7 +34,11 @@ const Channel = (props: Props) => {
     const [triedNext, setTriedNext] = useState(false);
     const validation = channelNameToUrl(props.name);
     const intl = useIntl();
-    useEffect(props.onPageView, []);
+    useEffect(() => {
+        if (props.show) {
+            props.onPageView();
+        }
+    }, [props.show]);
 
     let className = 'Channel-body';
     if (props.className) {

--- a/components/preparing_workspace/invite_members.tsx
+++ b/components/preparing_workspace/invite_members.tsx
@@ -43,7 +43,11 @@ const InviteMembers = (props: Props) => {
         className += ' ' + props.className;
     }
 
-    useEffect(props.onPageView, []);
+    useEffect(() => {
+        if (props.show) {
+            props.onPageView();
+        }
+    }, [props.show]);
 
     const placeholder = formatMessage({
         id: 'onboarding_wizard.invite_members.placeholder',

--- a/components/preparing_workspace/launching_workspace.tsx
+++ b/components/preparing_workspace/launching_workspace.tsx
@@ -34,7 +34,14 @@ export const LAUNCHING_WORKSPACE_FULLSCREEN_Z_INDEX = 1001;
 function LaunchingWorkspace(props: Props) {
     const [hasEntered, setHasEntered] = useState(false);
     const dispatch = useDispatch();
-    useEffect(props.onPageView, []);
+    useEffect(() => {
+        // This component is showed in both the preparing workspace route as an outro (!fullscreen)
+        // and in the main webapp as an intro (fullscreen)
+        // We only want to track the page view once
+        if (!props.fullscreen && props.show) {
+            props.onPageView();
+        }
+    }, [props.show, props.fullscreen]);
 
     useEffect(() => {
         if (hasEntered) {

--- a/components/preparing_workspace/organization.tsx
+++ b/components/preparing_workspace/organization.tsx
@@ -44,8 +44,13 @@ const Organization = (props: Props) => {
 
     useEffect(() => {
         teamValidator.validate(props.organization || '');
-        props.onPageView();
     }, []);
+
+    useEffect(() => {
+        if (props.show) {
+            props.onPageView();
+        }
+    }, [props.show]);
 
     const onNext = (e?: React.KeyboardEvent | React.MouseEvent) => {
         if (e && (e as React.KeyboardEvent).key) {

--- a/components/preparing_workspace/plugins.tsx
+++ b/components/preparing_workspace/plugins.tsx
@@ -33,7 +33,11 @@ const Plugins = (props: Props) => {
     const {formatMessage} = useIntl();
     let className = 'Plugins-body';
 
-    useEffect(props.onPageView, []);
+    useEffect(() => {
+        if (props.show) {
+            props.onPageView();
+        }
+    }, [props.show]);
 
     if (props.className) {
         className += ' ' + props.className;

--- a/components/preparing_workspace/url.tsx
+++ b/components/preparing_workspace/url.tsx
@@ -46,8 +46,12 @@ const Url = (props: Props) => {
 
     useEffect(() => {
         urlValidator.validate(props.url);
-        props.onPageView();
     }, []);
+    useEffect(() => {
+        if (props.show) {
+            props.onPageView();
+        }
+    }, [props.show]);
 
     useEffect(() => {
         reportValidationError(props.url, urlValidator.result.valid);

--- a/components/preparing_workspace/use_case.tsx
+++ b/components/preparing_workspace/use_case.tsx
@@ -43,7 +43,12 @@ const UseCase = (props: Props) => {
         className += ' ' + props.className;
     }
 
-    useEffect(props.onPageView, []);
+    useEffect(() => {
+        if (props.show) {
+            props.onPageView();
+        }
+    }, [props.show]);
+
     return (
         <CSSTransition
             in={props.show}


### PR DESCRIPTION
For first admin onboarding, trigger page views when they are shown instead of when they are mounted

#### Summary
The pages are mounted right away because they need to already be mounted for animations to work. So instead of doing page view on mount, we trigger it when the page starts being shown.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43136

#### Screenshots
TBD

#### Release Note

```release-note
Fix admin onboarding page view events
```