### PR TITLE
[MM-43328] Fix Channel admin not listed in their groups

### DIFF
--- a/actions/views/rhs.test.ts
+++ b/actions/views/rhs.test.ts
@@ -412,52 +412,6 @@ describe('rhs view actions', () => {
                 },
             ]);
         });
-
-        test('it dispatches the right actions for a specific channel', async () => {
-            const channelId = 'channel1';
-
-            (SearchActions.getPinnedPosts as jest.Mock).mockReturnValue((dispatch: DispatchFunc) => {
-                dispatch({type: 'MOCK_GET_PINNED_POSTS'});
-
-                return {data: 'data'};
-            });
-
-            await store.dispatch(showPinnedPosts(channelId));
-
-            expect(SearchActions.getPinnedPosts).toHaveBeenCalledWith(channelId);
-
-            expect(store.getActions()).toEqual([
-                {
-                    type: ActionTypes.UPDATE_RHS_STATE,
-                    channelId,
-                    state: RHSStates.PIN,
-                    previousRhsState: null,
-                },
-                {
-                    type: 'MOCK_GET_PINNED_POSTS',
-                },
-                {
-                    type: 'BATCHING_REDUCER.BATCH',
-                    meta: {
-                        batch: true,
-                    },
-                    payload: [
-                        {
-                            type: SearchTypes.RECEIVED_SEARCH_POSTS,
-                            data: 'data',
-                        },
-                        {
-                            type: SearchTypes.RECEIVED_SEARCH_TERM,
-                            data: {
-                                teamId: currentTeamId,
-                                terms: null,
-                                isOrSearch: false,
-                            },
-                        },
-                    ],
-                },
-            ]);
-        });
     });
 
     describe('showMentions', () => {

--- a/actions/views/rhs.ts
+++ b/actions/views/rhs.ts
@@ -33,6 +33,7 @@ import {GlobalState} from 'types/store';
 import {getPostsByIds} from 'mattermost-redux/actions/posts';
 import {unsetEditingPost} from '../post_actions';
 import {loadProfilesAndReloadChannelMembers} from '../user_actions';
+import {loadMyChannelMemberAndRole} from 'mattermost-redux/actions/channels';
 
 function selectPostFromRightHandSideSearchWithPreviousState(post: Post, previousRhsState?: RhsState) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -209,6 +210,7 @@ export function showChannelMembers(channelId: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState() as GlobalState;
 
+        dispatch(loadMyChannelMemberAndRole(channelId));
         dispatch(loadProfilesAndReloadChannelMembers(channelId));
 
         let previousRhsState = getRhsState(state);

--- a/components/channel_members_rhs/channel_members_rhs.tsx
+++ b/components/channel_members_rhs/channel_members_rhs.tsx
@@ -53,10 +53,6 @@ export interface Props {
 }
 
 export default function ChannelMembersRHS({channel, searchTerms, membersCount, canGoBack, teamUrl, channelAdmins, channelMembers, canManageMembers, actions}: Props) {
-    if (!channel) {
-        return null;
-    }
-
     const [editing, setEditing] = useState(false);
 
     const searching = searchTerms !== '';

--- a/components/channel_members_rhs/channel_members_rhs.tsx
+++ b/components/channel_members_rhs/channel_members_rhs.tsx
@@ -48,10 +48,15 @@ export interface Props {
         goBack: () => void;
         setChannelMembersRhsSearchTerm: (terms: string) => void;
         loadProfilesAndReloadChannelMembers: (channelId: string) => void;
+        loadMyChannelMemberAndRole: (channelId: string) => void;
     };
 }
 
 export default function ChannelMembersRHS({channel, searchTerms, membersCount, canGoBack, teamUrl, channelAdmins, channelMembers, canManageMembers, actions}: Props) {
+    if (!channel) {
+        return null;
+    }
+
     const [editing, setEditing] = useState(false);
 
     const searching = searchTerms !== '';
@@ -88,6 +93,7 @@ export default function ChannelMembersRHS({channel, searchTerms, membersCount, c
         actions.setChannelMembersRhsSearchTerm('');
         setEditing(false);
         actions.loadProfilesAndReloadChannelMembers(channel.id);
+        actions.loadMyChannelMemberAndRole(channel.id);
     }, [channel.id, channel.type]);
 
     const doSearch = async (terms: string) => {

--- a/components/channel_members_rhs/index.ts
+++ b/components/channel_members_rhs/index.ts
@@ -39,12 +39,21 @@ function isChannelAdmin(channelMember: ChannelMembership) {
 
 function mapStateToProps(state: GlobalState) {
     const channel = getCurrentChannel(state);
-    if (!channel) {
-        return {};
-    }
-
     const currentTeam = getCurrentTeam(state);
     const {member_count: membersCount} = getCurrentChannelStats(state) || {member_count: 0};
+
+    if (!channel) {
+        return {
+            channel: {} as Channel,
+            channelMembers: [],
+            channelAdmins: [],
+            searchTerms: '',
+            membersCount,
+            canManageMembers: false,
+            canGoBack: false,
+            teamUrl: '',
+        } as unknown as Props;
+    }
 
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
     const canManageMembers = haveIChannelPermission(state, currentTeam.id, channel.id, isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS : Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS);

--- a/packages/mattermost-redux/src/actions/channels.ts
+++ b/packages/mattermost-redux/src/actions/channels.ts
@@ -23,7 +23,7 @@ import {
 import {getConfig, getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
-import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc, ActionResult, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {Channel, ChannelNotifyProps, ChannelMembership, ChannelModerationPatch, ChannelsWithTotalCount, ChannelSearchOpts} from 'mattermost-redux/types/channels';
 
@@ -1456,6 +1456,17 @@ export function getMyChannelMember(channelId: string) {
             channelId,
         ],
     });
+}
+
+export function loadMyChannelMemberAndRole(channelId: string) {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const result = await getMyChannelMember(channelId)(dispatch, getState) as ActionResult;
+        const roles = result.data?.roles.split(' ');
+        if (roles && roles.length > 0) {
+            dispatch(loadRolesIfNeeded(roles));
+        }
+        return {data: true};
+    };
 }
 
 // favoriteChannel moves the provided channel into the current team's Favorites category.


### PR DESCRIPTION
#### Summary
I was looking at the `channel_admin` role on the membership to determine if a user was a channel admin, turns out this was not working on the community server because it has a Team Override Schemes.

If you want to reproduce the bug (fixed in the spinwick):
- Create a new team.
- Create a Team Override Schemes (add a name, description and add your team)
- Make someone a channel admin
- Go back to the channel member RHS

Without the fix: the user is not listed as a channel admin
With the fix: the user is listed as a channel admin

Also:
- The Channel member RHS would crash when coming back from the Admin console because the channel was not loaded.
- Sometimes the member (as in user of the channel) role was not loaded despite the fact that the member was. I now load the member role.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43328

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
