### PR TITLE
[MM-42585] Add e2e Tests for DotMenu shortcuts

### DIFF
--- a/e2e/cypress/tests/integration/keyboard_shortcuts/dot_menu_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/dot_menu_spec.js
@@ -90,5 +90,24 @@ describe('Keyboard Shortcuts', () => {
             // * Verify message was deleted
             cy.findByText('message to delete').should('not.exist');
         });
+
+        cy.getLastPostId().then((postId) => {
+            // * verify Save not shown in webview
+            cy.findByText('Save').should('not.exist');
+
+            cy.viewport('iphone-6');
+
+            // # Save Post
+            cy.uiPostDropdownMenuShortcut(postId, 'Save', 'S');
+
+            // * Verify post is Saved
+            cy.get(`#post_${postId}`).find('.post-pre-header').should('be.visible').and('have.text', 'Saved');
+
+            // # Unsave Post
+            cy.uiPostDropdownMenuShortcut(postId, 'Remove from Saved', 'S');
+
+            // * Verify post is unsaved
+            cy.get(`#post_${postId}`).and('not.have.text', 'Saved');
+        });
     });
 });

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/dot_menu_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/dot_menu_spec.js
@@ -1,0 +1,94 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @keyboard_shortcuts
+import {beUnread} from '../../support/assertions';
+import {stubClipboard} from '../../utils';
+
+describe('Keyboard Shortcuts', () => {
+    let testTeam;
+    let testChannel;
+    const postMessage = 'test for saved post';
+    const postEditMessage = ' POST EDITED';
+    before(() => {
+        // # Login as test user and visit off-topic channel
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            testTeam = team;
+            testChannel = channel;
+            cy.visit(`/${team.name}/channels/off-topic`);
+        });
+        cy.postMessage(postMessage);
+    });
+
+    it('MM-42585 Dot Menu Shorcuts', () => {
+        cy.getLastPostId().then((postId) => {
+            stubClipboard().as('clipboard');
+            const permalink = `${Cypress.config('baseUrl')}/${testTeam.name}/pl/${postId}`;
+
+            // # Reply
+            cy.uiPostDropdownMenuShortcut(postId, 'Reply', 'R');
+
+            // * Verify reply text box is focused
+            cy.get('#reply_textbox').should('be.focused');
+
+            // # Mark as unread
+            cy.uiPostDropdownMenuShortcut(postId, 'Mark as Unread', 'U');
+
+            // * Verify the channel is unread in LHS
+            cy.get(`#sidebarItem_${testChannel.name}`).should(beUnread);
+
+            // # Pin Post
+            cy.uiPostDropdownMenuShortcut(postId, 'Pin to Channel', 'P');
+
+            // * Verify post is pinned
+            cy.get(`#post_${postId}`).find('.post-pre-header').should('be.visible').and('have.text', 'Pinned');
+
+            // # Unpin Post
+            cy.uiPostDropdownMenuShortcut(postId, 'Unpin from Channel', 'P');
+
+            // * Verify post is unpinned
+            cy.get(`#post_${postId}`).and('not.have.text', 'Pinned');
+
+            // # Copy Link
+            cy.uiPostDropdownMenuShortcut(postId, 'Copy Link', 'K');
+
+            // * Verify link is copied to the clipboard
+            cy.get('@clipboard').its('contents').should('eq', permalink);
+
+            // # Edit
+            cy.uiPostDropdownMenuShortcut(postId, 'Edit', 'E');
+
+            // # add test to the message
+            cy.get('body').type(postEditMessage);
+            cy.get('body').type('{enter}');
+
+            // * Verify edited message
+            cy.uiWaitUntilMessagePostedIncludes(postMessage + postEditMessage);
+            cy.get(`#postMessageText_${postId}`).
+                and('have.text', postMessage + postEditMessage + ' Edited');
+
+            // # Copy Text
+            cy.uiPostDropdownMenuShortcut(postId, 'Copy Text', 'C');
+
+            // * Verify message is copied to the clipboard
+            cy.get('@clipboard').its('contents').should('eq', postMessage + postEditMessage);
+        });
+
+        cy.postMessage('message to delete');
+        cy.getLastPostId().then((postId) => {
+            // # Delete
+            cy.uiPostDropdownMenuShortcut(postId, 'Delete', '{del}');
+            cy.findByText('Delete').click();
+
+            // * Verify message was deleted
+            cy.findByText('message to delete').should('not.exist');
+        });
+    });
+});

--- a/e2e/cypress/tests/support/ui/post_dropdown_menu.js
+++ b/e2e/cypress/tests/support/ui/post_dropdown_menu.js
@@ -24,3 +24,9 @@ Cypress.Commands.add('uiClickPostDropdownMenu', (postId, menuItem, location = 'C
     cy.findAllByTestId(`post-menu-${postId}`).eq(0).should('be.visible');
     cy.findByText(menuItem).scrollIntoView().should('be.visible').click({force: true});
 });
+
+Cypress.Commands.add('uiPostDropdownMenuShortcut', (postId, menuText, shortcutKey, location = 'CENTER') => {
+    cy.clickPostDotMenu(postId, location);
+    cy.findByText(menuText).scrollIntoView().should('be.visible');
+    cy.get('body').type(shortcutKey);
+});


### PR DESCRIPTION
#### Summary
This PR adds e2e test for the shortcuts added to the dotmenu

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42585

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
