### PR TITLE
add more unit tests for sysadmin vs end user

### DIFF
--- a/components/actions_menu/__snapshots__/actions_menu.test.tsx.snap
+++ b/components/actions_menu/__snapshots__/actions_menu.test.tsx.snap
@@ -1,0 +1,252 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/actions_menu/ActionsMenu has actions - end user - should not show actions and app marketplace 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className=""
+  onToggle={[Function]}
+  open={true}
+>
+  <OverlayTrigger
+    className="hidden-xs"
+    defaultOverlayShown={false}
+    delayShow={500}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        className="hidden-xs"
+        id="actions-menu-icon-tooltip"
+        placement="right"
+      >
+        <Memo(MemoizedFormattedMessage)
+          defaultMessage="Actions"
+          id="post_info.tooltip.actions"
+        />
+      </Tooltip>
+    }
+    placement="top"
+    rootClose={true}
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <button
+      aria-expanded="false"
+      aria-label="actions"
+      className="post-menu__item post-menu__item--active"
+      id="center_actions_button_post_id_1"
+      key="more-actions-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <i
+        className="icon icon-apps"
+      />
+    </button>
+  </OverlayTrigger>
+  <Menu
+    ariaLabel="Post extra options"
+    id="center_actions_dropdown_post_id_1"
+    key="center_actions_dropdown_post_id_1"
+    openLeft={true}
+    openUp={false}
+  >
+    <MenuItemAction
+      key="the_component_id_pluginmenuitem"
+      onClick={[Function]}
+      show={true}
+    />
+    <Connect(Pluggable)
+      key="post_id_1pluggable"
+      pluggableName="PostDropdownMenuItem"
+      postId="post_id_1"
+    />
+  </Menu>
+</MenuWrapper>
+`;
+
+exports[`components/actions_menu/ActionsMenu has actions - sysadmin - should show actions and app marketplace 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className=""
+  onToggle={[Function]}
+  open={true}
+>
+  <OverlayTrigger
+    className="hidden-xs"
+    defaultOverlayShown={false}
+    delayShow={500}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        className="hidden-xs"
+        id="actions-menu-icon-tooltip"
+        placement="right"
+      >
+        <Memo(MemoizedFormattedMessage)
+          defaultMessage="Actions"
+          id="post_info.tooltip.actions"
+        />
+      </Tooltip>
+    }
+    placement="top"
+    rootClose={true}
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <button
+      aria-expanded="false"
+      aria-label="actions"
+      className="post-menu__item post-menu__item--active"
+      id="center_actions_button_post_id_1"
+      key="more-actions-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <i
+        className="icon icon-apps"
+      />
+    </button>
+  </OverlayTrigger>
+  <Menu
+    ariaLabel="Post extra options"
+    id="center_actions_dropdown_post_id_1"
+    key="center_actions_dropdown_post_id_1"
+    openLeft={true}
+    openUp={false}
+  >
+    <MenuItemAction
+      key="the_component_id_pluginmenuitem"
+      onClick={[Function]}
+      show={true}
+    />
+    <Connect(Pluggable)
+      key="post_id_1pluggable"
+      pluggableName="PostDropdownMenuItem"
+      postId="post_id_1"
+    />
+    <li
+      className="MenuItem__divider"
+      id="divider_post_post_id_1_marketplace"
+      role="menuitem"
+    />
+    <MenuItemAction
+      icon={
+        <span
+          className="icon-view-grid-plus-outline MenuItem__compass-icon"
+        />
+      }
+      id="marketplace_icon_post_id_1"
+      key="marketplace_post_id_1"
+      onClick={[Function]}
+      show={true}
+      text="App Marketplace"
+    />
+  </Menu>
+</MenuWrapper>
+`;
+
+exports[`components/actions_menu/ActionsMenu no actions - end user - menu should not be visible to end user 1`] = `""`;
+
+exports[`components/actions_menu/ActionsMenu no actions - sysadmin - menu should show visit marketplace 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className=""
+  onToggle={[Function]}
+  open={true}
+>
+  <OverlayTrigger
+    className="hidden-xs"
+    defaultOverlayShown={false}
+    delayShow={500}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        className="hidden-xs"
+        id="actions-menu-icon-tooltip"
+        placement="right"
+      >
+        <Memo(MemoizedFormattedMessage)
+          defaultMessage="Actions"
+          id="post_info.tooltip.actions"
+        />
+      </Tooltip>
+    }
+    placement="top"
+    rootClose={true}
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <button
+      aria-expanded="false"
+      aria-label="actions"
+      className="post-menu__item post-menu__item--active"
+      id="center_actions_button_post_id_1"
+      key="more-actions-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <i
+        className="icon icon-apps"
+      />
+    </button>
+  </OverlayTrigger>
+  <Menu
+    ariaLabel="Post extra options"
+    id="center_actions_dropdown_post_id_1"
+    key="center_actions_dropdown_post_id_1"
+    openLeft={true}
+    openUp={false}
+  >
+    <Connect(SystemPermissionGate)
+      key="visit-marketplace-permissions"
+      permissions={
+        Array [
+          "manage_system",
+        ]
+      }
+    >
+      <div
+        className="visit-marketplace-text"
+      >
+        <injectIntl(FormattedMarkdownMessage)
+          defaultMessage="No Actions currently\\\\nconfigured for this server"
+          id="post_info.actions.noActions"
+        />
+      </div>
+      <div
+        className="visit-marketplace"
+      >
+        <button
+          className="btn btn-primary visit-marketplace-button"
+          id="marketPlaceButton"
+          onClick={[Function]}
+        >
+          <span
+            className="icon-view-grid-plus-outline visit-marketplace-button-icon MenuItem__compass-icon"
+          />
+          <span
+            className="visit-marketplace-button-text"
+          >
+            <injectIntl(FormattedMarkdownMessage)
+              defaultMessage="Visit the Marketplace"
+              id="post_info.actions.visitMarketplace"
+            />
+          </span>
+        </button>
+      </div>
+    </Connect(SystemPermissionGate)>
+  </Menu>
+</MenuWrapper>
+`;

--- a/components/actions_menu/actions_menu.test.tsx
+++ b/components/actions_menu/actions_menu.test.tsx
@@ -55,7 +55,7 @@ describe('components/actions_menu/ActionsMenu', () => {
         },
     };
 
-    test('should have divider when plugin menu item exists', () => {
+    test('sysadmin - should have divider when plugin menu item exists', () => {
         const wrapper = shallowWithIntl(
             <ActionsMenu {...baseProps}/>,
         );
@@ -67,24 +67,47 @@ describe('components/actions_menu/ActionsMenu', () => {
         expect(wrapper.find('#divider_post_post_id_1_marketplace').exists()).toBe(true);
     });
 
-    test('no actions - menu should be visible to sysadmin', () => {
+    test('has actions - sysadmin - should show actions and app marketplace', () => {
         const wrapper = shallowWithIntl(
             <ActionsMenu {...baseProps}/>,
         );
-        expect(wrapper.find('#marketPlaceButton').exists()).toBe(true);
+        wrapper.setProps({
+            pluginMenuItems: dropdownComponents,
+        });
+        expect(wrapper).toMatchSnapshot();
     });
 
-    test('no actions - menu should not be visible to end user', () => {
+    test('has actions - end user - should not show actions and app marketplace', () => {
+        const wrapper = shallowWithIntl(
+            <ActionsMenu {...baseProps}/>,
+        );
+        wrapper.setProps({
+            pluginMenuItems: dropdownComponents,
+            isSysAdmin: false,
+        });
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('no actions - sysadmin - menu should show visit marketplace', () => {
+        const wrapper = shallowWithIntl(
+            <ActionsMenu {...baseProps}/>,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('no actions - end user - menu should not be visible to end user', () => {
         const wrapper = shallowWithIntl(
             <ActionsMenu {...baseProps}/>,
         );
         wrapper.setProps({
             isSysAdmin: false,
         });
-        expect(wrapper.find('#marketPlaceButton').exists()).toBe(false);
+
+        // menu should be empty
+        expect(wrapper.debug()).toMatchSnapshot();
     });
 
-    test('should have divider when pluggable menu item exists', () => {
+    test('sysadmin - should have divider when pluggable menu item exists', () => {
         const wrapper = shallowWithIntl(
             <ActionsMenu {...baseProps}/>,
         );
@@ -96,5 +119,22 @@ describe('components/actions_menu/ActionsMenu', () => {
             },
         });
         expect(wrapper.find('#divider_post_post_id_1_marketplace').exists()).toBe(true);
+    });
+
+    test('end user - should not have divider when pluggable menu item exists', () => {
+        const wrapper = shallowWithIntl(
+            <ActionsMenu {...baseProps}/>,
+        );
+        wrapper.setProps({
+            isSysAdmin: false,
+        });
+        expect(wrapper.find('#divider_post_post_id_1_marketplace').exists()).toBe(false);
+
+        wrapper.setProps({
+            components: {
+                [PLUGGABLE_COMPONENT]: dropdownComponents,
+            },
+        });
+        expect(wrapper.find('#divider_post_post_id_1_marketplace').exists()).toBe(false);
     });
 });


### PR DESCRIPTION
#### Summary
This PR adds more unit tests for the actions menu

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43345

#### Related Pull Requests

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
