### PR TITLE
GH 19818: Reaction toggle behaviour

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -144,16 +144,13 @@ export function toggleReaction(postId, emojiName) {
         const currentUserId = getState().entities.users.currentUserId;
 
         const getReactionsForPost = makeGetUniqueReactionsToPost();
-        const reactions = getReactionsForPost(getState(), postId);
+        const reactions = getReactionsForPost(getState(), postId) ?? {};
 
         let currentUserReacted = false;
-        for (const key in reactions) {
-            if ({}.hasOwnProperty.call(reactions, key)) {
-                const value = reactions[key];
-                if (value.user_id === currentUserId && value.emoji_name === emojiName) {
-                    currentUserReacted = true;
-                    break;
-                }
+        for (const value of Object.values(reactions)) {
+            if (value.user_id === currentUserId && value.emoji_name === emojiName) {
+                currentUserReacted = true;
+                break;
             }
         }
 

--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -27,6 +27,7 @@ import {
 } from 'utils/constants';
 import {matchEmoticons} from 'utils/emoticons';
 import * as UserAgent from 'utils/user_agent';
+import {makeGetUniqueReactionsToPost} from 'utils/post_utils';
 
 import {completePostReceive} from './new_post';
 
@@ -135,6 +136,31 @@ export function addReaction(postId, emojiName) {
         dispatch(PostActions.addReaction(postId, emojiName));
         dispatch(addRecentEmoji(emojiName));
         return {data: true};
+    };
+}
+
+export function toggleReaction(postId, emojiName) {
+    return async (dispatch, getState) => {
+        const currentUserId = getState().entities.users.currentUserId;
+
+        const getReactionsForPost = makeGetUniqueReactionsToPost();
+        const reactions = getReactionsForPost(getState(), postId);
+
+        let currentUserReacted = false;
+        for (const key in reactions) {
+            if ({}.hasOwnProperty.call(reactions, key)) {
+                const value = reactions[key];
+                if (value.user_id === currentUserId && value.emoji_name === emojiName) {
+                    currentUserReacted = true;
+                    break;
+                }
+            }
+        }
+
+        if (currentUserReacted) {
+            return dispatch(PostActions.removeReaction(postId, emojiName));
+        }
+        return dispatch(addReaction(postId, emojiName));
     };
 }
 

--- a/components/post_view/post_reaction/index.ts
+++ b/components/post_view/post_reaction/index.ts
@@ -6,14 +6,14 @@ import {bindActionCreators, Dispatch} from 'redux';
 
 import {GenericAction} from 'mattermost-redux/types/actions';
 
-import {addReaction} from 'actions/post_actions.jsx';
+import {toggleReaction} from 'actions/post_actions.jsx';
 
 import PostReaction from './post_reaction';
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
-            addReaction,
+            toggleReaction,
         }, dispatch),
     };
 }

--- a/components/post_view/post_reaction/post_reaction.test.tsx
+++ b/components/post_view/post_reaction/post_reaction.test.tsx
@@ -18,7 +18,7 @@ describe('components/post_view/PostReaction', () => {
         showEmojiPicker: false,
         toggleEmojiPicker: jest.fn(),
         actions: {
-            addReaction: jest.fn(),
+            toggleReaction: jest.fn(),
         },
     };
 
@@ -31,9 +31,9 @@ describe('components/post_view/PostReaction', () => {
         const wrapper = shallow(<PostReaction {...baseProps}/>);
         const instance = wrapper.instance() as PostReaction;
 
-        instance.handleAddEmoji({name: 'smile'} as Emoji);
-        expect(baseProps.actions.addReaction).toHaveBeenCalledTimes(1);
-        expect(baseProps.actions.addReaction).toHaveBeenCalledWith('post_id_1', 'smile');
+        instance.handleEmoji({name: 'smile'} as Emoji);
+        expect(baseProps.actions.toggleReaction).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.toggleReaction).toHaveBeenCalledWith('post_id_1', 'smile');
         expect(baseProps.toggleEmojiPicker).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/post_view/post_reaction/post_reaction.tsx
+++ b/components/post_view/post_reaction/post_reaction.tsx
@@ -33,7 +33,7 @@ type Props = {
     showEmojiPicker: boolean;
     toggleEmojiPicker: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     actions: {
-        addReaction: (postId: string, emojiName: string) => (dispatch: Dispatch) => void;
+        toggleReaction: (postId: string, emojiName: string) => (dispatch: Dispatch) => void;
     };
 }
 
@@ -48,10 +48,10 @@ export default class PostReaction extends React.PureComponent<Props, State> {
         showEmojiPicker: false,
     };
 
-    handleAddEmoji = (emoji: Emoji): void => {
+    handleEmoji = (emoji: Emoji): void => {
         this.setState({showEmojiPicker: false});
         const emojiName = 'short_name' in emoji ? emoji.short_name : emoji.name;
-        this.props.actions.addReaction(this.props.postId, emojiName);
+        this.props.actions.toggleReaction(this.props.postId, emojiName);
         this.props.toggleEmojiPicker();
     };
 
@@ -83,7 +83,7 @@ export default class PostReaction extends React.PureComponent<Props, State> {
                         target={this.props.getDotMenuRef}
                         onHide={this.props.toggleEmojiPicker}
                         onEmojiClose={this.props.toggleEmojiPicker}
-                        onEmojiClick={this.handleAddEmoji}
+                        onEmojiClick={this.handleEmoji}
                         topOffset={TOP_OFFSET}
                         spaceRequiredAbove={spaceRequiredAbove}
                         spaceRequiredBelow={spaceRequiredBelow}

--- a/components/post_view/post_recent_reactions/index.ts
+++ b/components/post_view/post_recent_reactions/index.ts
@@ -9,7 +9,7 @@ import {getCurrentLocale} from 'selectors/i18n';
 import {GlobalState} from 'types/store';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
-import {addReaction} from 'actions/post_actions.jsx';
+import {toggleReaction} from 'actions/post_actions.jsx';
 import {Emoji} from 'mattermost-redux/types/emojis';
 
 import PostReaction from './post_recent_reactions';
@@ -17,7 +17,7 @@ import PostReaction from './post_recent_reactions';
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
-            addReaction,
+            toggleReaction,
         }, dispatch),
     };
 }

--- a/components/post_view/post_recent_reactions/post_recent_reactions.tsx
+++ b/components/post_view/post_recent_reactions/post_recent_reactions.tsx
@@ -40,7 +40,7 @@ export default class PostRecentReactions extends React.PureComponent<Props, Stat
         size: 3,
     };
 
-    handleAddEmoji = (emoji: Emoji): void => {
+    handleEmoji = (emoji: Emoji): void => {
         const emojiName = 'short_name' in emoji ? emoji.short_name : emoji.name;
         this.props.actions.toggleReaction(this.props.postId, emojiName);
     };
@@ -108,7 +108,7 @@ export default class PostRecentReactions extends React.PureComponent<Props, Stat
                             <EmojiItem
                                 // eslint-disable-next-line react/no-array-index-key
                                 emoji={emoji}
-                                onItemClick={this.handleAddEmoji}
+                                onItemClick={this.handleEmoji}
                                 order={n}
                             />
                         </React.Fragment>

--- a/components/post_view/post_recent_reactions/post_recent_reactions.tsx
+++ b/components/post_view/post_recent_reactions/post_recent_reactions.tsx
@@ -26,7 +26,7 @@ type Props = {
     size: number;
     defaultEmojis: Emoji[];
     actions: {
-        addReaction: (postId: string, emojiName: string) => (dispatch: Dispatch) => void;
+        toggleReaction: (postId: string, emojiName: string) => (dispatch: Dispatch) => void;
     };
 }
 
@@ -42,7 +42,7 @@ export default class PostRecentReactions extends React.PureComponent<Props, Stat
 
     handleAddEmoji = (emoji: Emoji): void => {
         const emojiName = 'short_name' in emoji ? emoji.short_name : emoji.name;
-        this.props.actions.addReaction(this.props.postId, emojiName);
+        this.props.actions.toggleReaction(this.props.postId, emojiName);
     };
 
     complementEmojis = (emojis: Emoji[]): (Emoji[]) => {

--- a/components/post_view/reaction_list/index.ts
+++ b/components/post_view/reaction_list/index.ts
@@ -13,7 +13,7 @@ import {Reaction} from 'mattermost-redux/types/reactions';
 
 import {GlobalState} from 'types/store';
 
-import {addReaction} from 'actions/post_actions.jsx';
+import {toggleReaction} from 'actions/post_actions.jsx';
 
 import {makeGetUniqueReactionsToPost} from 'utils/post_utils';
 
@@ -46,7 +46,7 @@ function makeMapStateToProps() {
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
-            addReaction,
+            toggleReaction,
         }, dispatch),
     };
 }

--- a/components/post_view/reaction_list/reaction_list.tsx
+++ b/components/post_view/reaction_list/reaction_list.tsx
@@ -50,7 +50,7 @@ type Props = {
         /**
          * Function to add a reaction to the post
          */
-        addReaction: (postId: string, emojiName: string) => void;
+        toggleReaction: (postId: string, emojiName: string) => void;
     };
 };
 
@@ -76,7 +76,7 @@ export default class ReactionList extends React.PureComponent<Props, State> {
     handleEmojiClick = (emoji: Emoji): void => {
         this.setState({showEmojiPicker: false});
         const emojiName = isSystemEmoji(emoji) ? emoji.short_names[0] : emoji.name;
-        this.props.actions.addReaction(this.props.post.id, emojiName);
+        this.props.actions.toggleReaction(this.props.post.id, emojiName);
     }
 
     hideEmojiPicker = (): void => {

--- a/components/post_view/reaction_list/reactions_list.test.tsx
+++ b/components/post_view/reaction_list/reactions_list.test.tsx
@@ -25,7 +25,7 @@ describe('components/ReactionList', () => {
     const teamId = 'teamId';
 
     const actions = {
-        addReaction: jest.fn(),
+        toggleReaction: jest.fn(),
     };
 
     const baseProps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "redux-batched-actions": "0.5.0",
         "redux-persist": "6.0.0",
         "redux-thunk": "2.3.0",
-        "regenerator-runtime": "0.13.9",
+        "regenerator-runtime": "0.13.7",
         "rudder-sdk-js": "1.0.16",
         "sass": "1.35.1",
         "semver": "7.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "redux-batched-actions": "0.5.0",
         "redux-persist": "6.0.0",
         "redux-thunk": "2.3.0",
-        "regenerator-runtime": "0.13.7",
+        "regenerator-runtime": "0.13.9",
         "rudder-sdk-js": "1.0.16",
         "sass": "1.35.1",
         "semver": "7.3.5",
@@ -112,7 +112,7 @@
         "@types/bootstrap": "4.5.0",
         "@types/chart.js": "2.9.34",
         "@types/country-list": "2.1.0",
-        "@types/enzyme": "3.10.10",
+        "@types/enzyme": "3.10.11",
         "@types/highlight.js": "10.1.0",
         "@types/jest": "26.0.24",
         "@types/katex": "0.11.0",
@@ -10912,9 +10912,9 @@
       "dev": true
     },
     "node_modules/@types/enzyme": {
-      "version": "3.10.10",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.10.tgz",
-      "integrity": "sha512-/D4wFhiEjUDfPu+j5FVK0g/jf7rqeEIpNfAI+kyxzLpw5CKO0drnW3W5NC38alIjsWgnyQ8pbuPF5+UD+vhVyg==",
+      "version": "3.10.11",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.11.tgz",
+      "integrity": "sha512-LEtC7zXsQlbGXWGcnnmOI7rTyP+i1QzQv4Va91RKXDEukLDaNyxu0rXlfMiGEhJwfgTPCTb0R+Pnlj//oM9e/w==",
       "dev": true,
       "dependencies": {
         "@types/cheerio": "*",
@@ -33783,9 +33783,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -48530,9 +48530,9 @@
       "dev": true
     },
     "@types/enzyme": {
-      "version": "3.10.10",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.10.tgz",
-      "integrity": "sha512-/D4wFhiEjUDfPu+j5FVK0g/jf7rqeEIpNfAI+kyxzLpw5CKO0drnW3W5NC38alIjsWgnyQ8pbuPF5+UD+vhVyg==",
+      "version": "3.10.11",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.11.tgz",
+      "integrity": "sha512-LEtC7zXsQlbGXWGcnnmOI7rTyP+i1QzQv4Va91RKXDEukLDaNyxu0rXlfMiGEhJwfgTPCTb0R+Pnlj//oM9e/w==",
       "dev": true,
       "requires": {
         "@types/cheerio": "*",
@@ -67186,9 +67186,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",


### PR DESCRIPTION
…call to the function in the necessary components. Additionally added unit tests for the new function

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--

-->This pull addresses the emoji reaction toggle behavior for the WebApp. A toggleReaction function has been added to the post_actions.jsx file to handle the proper toggle behaviour.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

Otherwise, link the JIRA ticket.
-->https://github.com/mattermost/mattermost-server/issues/19818

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added reaction toggle behavior for emojis in post_recent_reactions, post menu emoji picker, and reaction_list emoji picker
```
