### PR TITLE
MM-41565: fixes total thread count

### DIFF
--- a/components/threading/global_threads/global_threads.tsx
+++ b/components/threading/global_threads/global_threads.tsx
@@ -15,7 +15,7 @@ import {
     getThread,
 } from 'mattermost-redux/selectors/entities/threads';
 
-import {getThreads} from 'mattermost-redux/actions/threads';
+import {getThreadCounts, getThreads} from 'mattermost-redux/actions/threads';
 import {selectChannel} from 'mattermost-redux/actions/channels';
 
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
@@ -86,6 +86,10 @@ const GlobalThreads = () => {
             dispatch(unsuppressRHS);
         };
     }, []);
+
+    useEffect(() => {
+        dispatch(getThreadCounts(currentUserId, currentTeamId));
+    }, [currentTeamId, currentUserId]);
 
     useEffect(() => {
         if (!selectedThreadId || selectedThreadId !== threadIdentifier) {


### PR DESCRIPTION
#### Summary

Since we don't have a ThreadCreated WS event, we can't know the total
number of threads currently in global threads with certainty.
So when you follow new threads by replying you won't see the end of the
list component in the global threads, since the total count you have is
less than the actual count, also you might miss some threads in the end
of the list when paginating.

This commit fixes this issue by fetching thread counts once, each time you
enter global threads.

#### Ticket Link


#### Related Pull Requests


```release-note
NONE
```
