### PR TITLE
Skip integrity check for mattermost/marked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28239,7 +28239,6 @@
     "node_modules/marked": {
       "version": "0.3.6",
       "resolved": "git+ssh://git@github.com/mattermost/marked.git#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008",
-      "integrity": "sha512-Gb+xARiFJgNrEs5DVP5+YAea5SJ3MTwzQsftb2LccYDAM+MOUFHSCN1+dgmdru29bhq49sDZnes9aJsK2tgAAw==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked"
@@ -62644,7 +62643,6 @@
     },
     "marked": {
       "version": "git+ssh://git@github.com/mattermost/marked.git#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008",
-      "integrity": "sha512-Gb+xARiFJgNrEs5DVP5+YAea5SJ3MTwzQsftb2LccYDAM+MOUFHSCN1+dgmdru29bhq49sDZnes9aJsK2tgAAw==",
       "from": "marked@github:mattermost/marked#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008"
     },
     "match-stream": {

--- a/skip_integrity_check.js
+++ b/skip_integrity_check.js
@@ -8,5 +8,7 @@ const content = JSON.parse(fs.readFileSync('package-lock.json', 'utf-8'));
 // @see https://github.com/npm/cli/issues/2846
 delete content.dependencies.mmjstool.integrity;
 delete content.packages['node_modules/mmjstool'].integrity;
+delete content.dependencies.marked.integrity;
+delete content.packages['node_modules/marked'].integrity;
 
 fs.writeFileSync('package-lock.json', JSON.stringify(content, null, 2) + '\n');


### PR DESCRIPTION
#### Summary
Checksum for `mattermost/marked` was failing in the same way as `mmjstool` was, so I've removed the integrity check for it as well.

```release-note
NONE
```
