### PR TITLE
Made unread msg badge in team sidebar hidden in products

### DIFF
--- a/components/team_sidebar/components/team_button.tsx
+++ b/components/team_sidebar/components/team_button.tsx
@@ -38,6 +38,7 @@ interface Props {
     isDraggable?: boolean;
     teamIndex?: number;
     teamId?: string;
+    isInProduct?: boolean;
 }
 
 // eslint-disable-next-line react/require-optimization
@@ -154,7 +155,7 @@ class TeamButton extends React.PureComponent<Props> {
                 }
             >
                 <div className={'team-btn ' + btnClass}>
-                    {badge}
+                    {!this.props.isInProduct && badge}
                     {content}
                 </div>
             </OverlayTrigger>

--- a/components/team_sidebar/team_sidebar.tsx
+++ b/components/team_sidebar/team_sidebar.tsx
@@ -252,6 +252,7 @@ export default class TeamSidebar extends React.PureComponent<Props, State> {
                     isDraggable={true}
                     teamId={team.id}
                     teamIndex={index}
+                    isInProduct={Boolean(currentProduct)}
                 />
             );
         });


### PR DESCRIPTION
#### Summary
The team sidebar in products shows channel's, unread message count. This is incorrect. This PR adds the feature of hiding the unread msg count badge when being rendered in a product.

#### Ticket Link
https://github.com/mattermost/focalboard/issues/2802

#### Release Note
```release-note
none
```
