### PR TITLE
Automated cherry pick of #10176

### DIFF
--- a/actions/views/rhs.test.ts
+++ b/actions/views/rhs.test.ts
@@ -412,52 +412,6 @@ describe('rhs view actions', () => {
                 },
             ]);
         });
-
-        test('it dispatches the right actions for a specific channel', async () => {
-            const channelId = 'channel1';
-
-            (SearchActions.getPinnedPosts as jest.Mock).mockReturnValue((dispatch: DispatchFunc) => {
-                dispatch({type: 'MOCK_GET_PINNED_POSTS'});
-
-                return {data: 'data'};
-            });
-
-            await store.dispatch(showPinnedPosts(channelId));
-
-            expect(SearchActions.getPinnedPosts).toHaveBeenCalledWith(channelId);
-
-            expect(store.getActions()).toEqual([
-                {
-                    type: ActionTypes.UPDATE_RHS_STATE,
-                    channelId,
-                    state: RHSStates.PIN,
-                    previousRhsState: null,
-                },
-                {
-                    type: 'MOCK_GET_PINNED_POSTS',
-                },
-                {
-                    type: 'BATCHING_REDUCER.BATCH',
-                    meta: {
-                        batch: true,
-                    },
-                    payload: [
-                        {
-                            type: SearchTypes.RECEIVED_SEARCH_POSTS,
-                            data: 'data',
-                        },
-                        {
-                            type: SearchTypes.RECEIVED_SEARCH_TERM,
-                            data: {
-                                teamId: currentTeamId,
-                                terms: null,
-                                isOrSearch: false,
-                            },
-                        },
-                    ],
-                },
-            ]);
-        });
     });
 
     describe('showMentions', () => {

--- a/actions/views/rhs.ts
+++ b/actions/views/rhs.ts
@@ -33,6 +33,7 @@ import {GlobalState} from 'types/store';
 import {getPostsByIds} from 'mattermost-redux/actions/posts';
 import {unsetEditingPost} from '../post_actions';
 import {loadProfilesAndReloadChannelMembers} from '../user_actions';
+import {loadMyChannelMemberAndRole} from 'mattermost-redux/actions/channels';
 
 function selectPostFromRightHandSideSearchWithPreviousState(post: Post, previousRhsState?: RhsState) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -209,6 +210,7 @@ export function showChannelMembers(channelId: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState() as GlobalState;
 
+        dispatch(loadMyChannelMemberAndRole(channelId));
         dispatch(loadProfilesAndReloadChannelMembers(channelId));
 
         let previousRhsState = getRhsState(state);

--- a/components/channel_members_rhs/channel_members_rhs.tsx
+++ b/components/channel_members_rhs/channel_members_rhs.tsx
@@ -48,6 +48,7 @@ export interface Props {
         goBack: () => void;
         setChannelMembersRhsSearchTerm: (terms: string) => void;
         loadProfilesAndReloadChannelMembers: (channelId: string) => void;
+        loadMyChannelMemberAndRole: (channelId: string) => void;
     };
 }
 
@@ -88,6 +89,7 @@ export default function ChannelMembersRHS({channel, searchTerms, membersCount, c
         actions.setChannelMembersRhsSearchTerm('');
         setEditing(false);
         actions.loadProfilesAndReloadChannelMembers(channel.id);
+        actions.loadMyChannelMemberAndRole(channel.id);
     }, [channel.id, channel.type]);
 
     const doSearch = async (terms: string) => {

--- a/components/channel_members_rhs/index.ts
+++ b/components/channel_members_rhs/index.ts
@@ -19,7 +19,6 @@ import {
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
-import {isInRole} from 'utils/utils';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 import {openDirectChannelToUserId} from 'actions/channel_actions';
 import {openModal} from 'actions/views/modals';
@@ -28,13 +27,33 @@ import {getPreviousRhsState} from 'selectors/rhs';
 import {UserProfile} from 'mattermost-redux/types/users';
 import {setChannelMembersRhsSearchTerm} from 'actions/views/search';
 import {loadProfilesAndReloadChannelMembers} from 'actions/user_actions';
+import {Channel, ChannelMembership} from 'mattermost-redux/types/channels';
+import * as UserUtils from 'mattermost-redux/utils/user_utils';
+import {loadMyChannelMemberAndRole} from 'mattermost-redux/actions/channels';
 
 import RHS, {Props, ChannelMember} from './channel_members_rhs';
+
+function isChannelAdmin(channelMember: ChannelMembership) {
+    return UserUtils.isChannelAdmin(channelMember.roles) || channelMember.scheme_admin;
+}
 
 function mapStateToProps(state: GlobalState) {
     const channel = getCurrentChannel(state);
     const currentTeam = getCurrentTeam(state);
     const {member_count: membersCount} = getCurrentChannelStats(state) || {member_count: 0};
+
+    if (!channel) {
+        return {
+            channel: {} as Channel,
+            channelMembers: [],
+            channelAdmins: [],
+            searchTerms: '',
+            membersCount,
+            canManageMembers: false,
+            canGoBack: false,
+            teamUrl: '',
+        } as unknown as Props;
+    }
 
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
     const canManageMembers = haveIChannelPermission(state, currentTeam.id, channel.id, isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS : Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS);
@@ -64,7 +83,7 @@ function mapStateToProps(state: GlobalState) {
 
         if (member.membership) {
             // group by role unless we are doing a search
-            if (isInRole(member.membership.roles, Constants.PERMISSIONS_CHANNEL_ADMIN) && searchTerms === '') {
+            if (isChannelAdmin(member.membership) && searchTerms === '') {
                 channelAdmins.push(member);
                 return;
             }
@@ -97,6 +116,7 @@ function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
             goBack,
             setChannelMembersRhsSearchTerm,
             loadProfilesAndReloadChannelMembers,
+            loadMyChannelMemberAndRole,
         }, dispatch),
     };
 }

--- a/packages/mattermost-redux/src/actions/channels.ts
+++ b/packages/mattermost-redux/src/actions/channels.ts
@@ -23,7 +23,7 @@ import {
 import {getConfig, getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
-import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc, ActionResult, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {Channel, ChannelNotifyProps, ChannelMembership, ChannelModerationPatch, ChannelsWithTotalCount, ChannelSearchOpts} from 'mattermost-redux/types/channels';
 
@@ -1456,6 +1456,17 @@ export function getMyChannelMember(channelId: string) {
             channelId,
         ],
     });
+}
+
+export function loadMyChannelMemberAndRole(channelId: string) {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const result = await getMyChannelMember(channelId)(dispatch, getState) as ActionResult;
+        const roles = result.data?.roles.split(' ');
+        if (roles && roles.length > 0) {
+            dispatch(loadRolesIfNeeded(roles));
+        }
+        return {data: true};
+    };
 }
 
 // favoriteChannel moves the provided channel into the current team's Favorites category.


### PR DESCRIPTION
Cherry pick of #10176 on cloud.

/cc  @JulienTant

```release-note
NONE
```