### PR TITLE
Bugfix/[MM-42361] Reactions change order when original is removed

### DIFF
--- a/components/post_view/reaction_list/reaction_list.tsx
+++ b/components/post_view/reaction_list/reaction_list.tsx
@@ -55,6 +55,8 @@ type Props = {
 };
 
 type State = {
+    emojiNames: string[];
+    reactionsByName: Map<string, ReactionType[]>;
     showEmojiPicker: boolean;
 };
 
@@ -65,8 +67,31 @@ export default class ReactionList extends React.PureComponent<Props, State> {
         super(props);
 
         this.state = {
+            emojiNames: [],
+            reactionsByName: new Map(),
             showEmojiPicker: false,
         };
+    }
+
+    static getDerivedStateFromProps(props: Props, state: State): Partial<State> {
+        const reactionsByName = new Map();
+        let emojiNames = [...state.emojiNames];
+
+        for (const reaction of Object.values(props.reactions ?? {})) {
+            const emojiName = reaction.emoji_name;
+
+            if (reactionsByName.has(emojiName)) {
+                reactionsByName.get(emojiName).push(reaction);
+            } else {
+                if (!emojiNames.includes(emojiName)) {
+                    emojiNames.push(emojiName);
+                }
+                reactionsByName.set(emojiName, [reaction]);
+            }
+        }
+        emojiNames = emojiNames.filter((name) => reactionsByName.has(name));
+
+        return {reactionsByName, emojiNames};
     }
 
     getTarget = (): HTMLButtonElement | null => {
@@ -88,21 +113,7 @@ export default class ReactionList extends React.PureComponent<Props, State> {
     }
 
     render(): React.ReactNode {
-        const reactionsByName = new Map();
-        const emojiNames = [];
-
-        if (this.props.reactions) {
-            for (const reaction of Object.values(this.props.reactions)) {
-                const emojiName = reaction.emoji_name;
-
-                if (reactionsByName.has(emojiName)) {
-                    reactionsByName.get(emojiName).push(reaction);
-                } else {
-                    emojiNames.push(emojiName);
-                    reactionsByName.set(emojiName, [reaction]);
-                }
-            }
-        }
+        const {reactionsByName, emojiNames} = this.state;
 
         if (reactionsByName.size === 0) {
             return null;

--- a/components/post_view/reaction_list/reactions_list.test.tsx
+++ b/components/post_view/reaction_list/reactions_list.test.tsx
@@ -6,6 +6,8 @@ import {shallow} from 'enzyme';
 
 import {TestHelper} from 'utils/test_helper';
 
+import Reaction from 'components/post_view/reaction';
+
 import ReactionList from './reaction_list';
 
 describe('components/ReactionList', () => {
@@ -55,5 +57,50 @@ describe('components/ReactionList', () => {
         );
 
         expect(wrapper).toMatchSnapshot();
+    });
+
+    /*
+    This test uses 3 different reactions from 2 users. Reactions A and B are done by the first user.
+    React C is an additional reaction with the same emoji as the first by a second user.
+
+    When the first user removes Reaction A, the ordering should not change.
+
+    First Render : Reactions A, B and C
+    Second Render : Reactions B, C
+
+    In both cases, the emoji order should be the same
+    */
+    test('should render consistently when reactions from state are not in the same order', () => {
+        const reactionA = reaction;
+        const reactionB = {...reaction, emoji_name: '+1', create_at: reaction.create_at + 100};
+        const reactionC = {...reaction, user_id: 'x8pb0', create_at: reaction.create_at + 200};
+
+        const propsA = {
+            ...baseProps,
+            reactions: {
+                [reactionA.user_id + '-' + reactionA.emoji_name]: reactionA,
+                [reactionB.user_id + '-' + reactionB.emoji_name]: reactionB,
+                [reactionC.user_id + '-' + reactionC.emoji_name]: reactionC,
+            },
+        };
+        const propsB = {
+            ...baseProps,
+            reactions: {
+                [reactionB.user_id + '-' + reactionB.emoji_name]: reactionB,
+                [reactionC.user_id + '-' + reactionC.emoji_name]: reactionC,
+            },
+        };
+
+        const wrapper = shallow<ReactionList>(
+            <ReactionList {...propsA}/>,
+        );
+        const firstRender = wrapper.find(Reaction).map((node) => node.key);
+
+        wrapper.setProps(propsB);
+
+        const secondRender = wrapper.find(Reaction).map((node) => node.key);
+
+        expect(firstRender.length).toBe(2);
+        expect(firstRender).toEqual(secondRender);
     });
 });


### PR DESCRIPTION
#### Summary
Ensures that Reaction emojis never reorder themselves, even when removing original, by storing `emojiNames` and `reactionsByName` variables as states instead of recreating them in each render. This works for the user who removes the emoji and also for other users who receive the live update.

- Set `emojiNames` and `reactionsByName` as states
- Create test for Reactions ordering

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/19859
https://mattermost.atlassian.net/browse/MM-42361

#### Release Note
```
NONE
```
