### PR TITLE
GH-19991: fix styling for channel-archived-warning

### DIFF
--- a/components/threading/thread_viewer/thread_viewer.scss
+++ b/components/threading/thread_viewer/thread_viewer.scss
@@ -34,4 +34,13 @@
     > div {
         flex: 1 1 auto;
     }
+
+    .channel-archived-warning__container {
+        padding-top: 16px;
+    }
+
+    .channel-archived-warning__content {
+        padding: 24px;
+        text-align: center;
+    }
 }

--- a/components/threading/virtualized_thread_viewer/create_comment.tsx
+++ b/components/threading/virtualized_thread_viewer/create_comment.tsx
@@ -14,6 +14,7 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import Constants from 'utils/constants';
 import {Posts} from 'mattermost-redux/constants';
 import {GlobalState} from 'types/store';
+import BasicSeparator from 'components/widgets/separator/basic-separator';
 
 type Props = {
     focusOnMount: boolean;
@@ -60,11 +61,14 @@ const CreateComment = forwardRef<HTMLDivElement, Props>(({
 
     if (channelIsArchived) {
         return (
-            <div className='channel-archived-warning'>
-                <FormattedMarkdownMessage
-                    id='archivedChannelMessage'
-                    defaultMessage='You are viewing an **archived channel**. New messages cannot be posted.'
-                />
+            <div className='channel-archived-warning__container'>
+                <BasicSeparator/>
+                <div className='channel-archived-warning__content'>
+                    <FormattedMarkdownMessage
+                        id='archivedChannelMessage'
+                        defaultMessage='You are viewing an **archived channel**. New messages cannot be posted.'
+                    />
+                </div>
             </div>
         );
     }

--- a/sass/layout/_sidebar-right.scss
+++ b/sass/layout/_sidebar-right.scss
@@ -65,10 +65,6 @@
         }
     }
 
-    .channel-archived-warning {
-        padding: 20px;
-    }
-
     .sidebar--right__content {
         display: flex;
         height: 100%;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Fixed spacing and Added a divider.
`css` for `.channel-archived-warning` was included  in `.sidebar--right`.
I moved it to `.ThreadViewer`, so styling can be applied to global thread view.



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#19991

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> |  |

-->

|  before  |  after  |
|----|----|
| <img width="400" alt="스크린샷 2022-04-23 오전 4 27 11" src="https://user-images.githubusercontent.com/59413880/164781348-8662b001-653c-4234-bf22-69fe0d9d1f3e.png">|<img width="400" alt="스크린샷 2022-04-23 오전 3 55 53" src="https://user-images.githubusercontent.com/59413880/164780950-30aa9d2e-59d6-4895-b7f2-50989f79c269.png">|


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
