### PR TITLE
MM-43661 - fix add members to channel from system console

### DIFF
--- a/components/channel_invite_modal/index.ts
+++ b/components/channel_invite_modal/index.ts
@@ -11,7 +11,7 @@ import {Action, ActionResult} from 'mattermost-redux/types/actions';
 import {UserProfile} from 'mattermost-redux/types/users';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
-import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentTeam, getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {Permissions} from 'mattermost-redux/constants';
 
 import {Value} from 'components/multiselect/multiselect';
@@ -48,7 +48,8 @@ function makeMapStateToProps() {
 
         const config = getConfig(state);
         const license = getLicense(state);
-        const currentTeam = getCurrentTeam(state);
+
+        const currentTeam = props.teamId ? getTeam(state, props.teamId) : getCurrentTeam(state);
 
         const guestAccountsEnabled = config.EnableGuestAccounts === 'true';
         const emailInvitationsEnabled = config.EnableEmailInvitations === 'true';

--- a/components/invitation_modal/index.test.tsx
+++ b/components/invitation_modal/index.test.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Permissions} from 'mattermost-redux/constants';
+import {Channel} from 'mattermost-redux/types/channels';
 
 import {GlobalState} from 'types/store';
 
@@ -88,7 +89,7 @@ describe('mapStateToProps', () => {
             },
         } as unknown as GlobalState;
 
-        const props = mapStateToProps(testState);
+        const props = mapStateToProps(testState, {});
         expect(props.canInviteGuests).toBe(false);
     });
 
@@ -112,7 +113,39 @@ describe('mapStateToProps', () => {
             },
         } as unknown as GlobalState;
 
-        const props = mapStateToProps(testState);
+        const props = mapStateToProps(testState, {});
         expect(props.canInviteGuests).toBe(true);
+    });
+
+    test('grabs the team info based on the ownProps channelToInvite value', () => {
+        const testState = {
+            ...initialState,
+            entities: {
+                ...initialState.entities,
+                teams: {
+                    ...initialState.entities.teams,
+                    myMembers: {
+                        ...initialState.entities.teams.myMembers,
+                    },
+                    teams: {
+                        [currentTeamId]: {
+                            id: currentTeamId,
+                            group_constrained: false,
+                        },
+                        currentTeamId: '',
+                    },
+                },
+            },
+        } as unknown as GlobalState;
+
+        const testChannel = {
+            display_name: 'team1',
+            channel_id: currentChannelId,
+            team_id: currentTeamId,
+        } as unknown as Channel;
+
+        const props = mapStateToProps(testState, {channelToInvite: testChannel});
+
+        expect(props.currentTeam.id).toBe(testChannel.team_id);
     });
 });

--- a/components/invitation_modal/index.tsx
+++ b/components/invitation_modal/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
-import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentTeam, getCurrentTeamId, getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannel, getChannelsInCurrentTeam, getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
 import {haveIChannelPermission, haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
@@ -45,14 +45,19 @@ const searchChannels = (teamId: string, term: string) => {
     return reduxSearchChannels(teamId, term);
 };
 
-export function mapStateToProps(state: GlobalState) {
+type OwnProps = {
+    channelToInvite?: Channel;
+}
+
+export function mapStateToProps(state: GlobalState, props: OwnProps) {
     const config = getConfig(state);
     const license = getLicense(state);
     const channels = getChannelsInCurrentTeam(state);
     const channelsByName = getChannelsNameMapInCurrentTeam(state);
     const townSquareDisplayName = channelsByName[Constants.DEFAULT_CHANNEL]?.display_name || Constants.DEFAULT_CHANNEL_UI_NAME;
 
-    const currentTeam = getCurrentTeam(state);
+    const currentTeamId = getCurrentTeamId(state);
+    const currentTeam = currentTeamId === '' && props.channelToInvite ? getTeam(state, props.channelToInvite.team_id) : getCurrentTeam(state);
     const currentChannel = getCurrentChannel(state);
     const invitableChannels = channels.filter((channel) => {
         if (channel.type === Constants.DM_CHANNEL || channel.type === Constants.GM_CHANNEL) {


### PR DESCRIPTION
#### Summary
This PR makes sure that the invite modal and channel invitation modal load the team information, either from the global state or from a prop sent, so when the add members button is clicked, it will work fine from the workspace team and from the system console.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43661

#### Related Pull Requests


#### Screenshots
Before:

https://user-images.githubusercontent.com/10082627/165024447-c1fc418c-dfbc-4dfd-b757-af0fdb41249d.mp4


After:

https://user-images.githubusercontent.com/10082627/165024103-af629951-641a-4f04-94d9-5b470f4c928b.mp4


https://user-images.githubusercontent.com/10082627/165024282-8fc381e6-95c5-4dba-ac31-70fdddbccd5d.mp4


#### Release Note
```release-note
NONE
```
