### PR TITLE
MM-43302 Check if performance metrics are enabled closer to when we send selector metrics

### DIFF
--- a/actions/telemetry_actions.jsx
+++ b/actions/telemetry_actions.jsx
@@ -196,11 +196,11 @@ export function trackPluginInitialization(plugins) {
 }
 
 export function trackSelectorMetrics() {
-    if (!shouldTrackPerformance()) {
-        return;
-    }
-
     setTimeout(() => {
+        if (!shouldTrackPerformance()) {
+            return;
+        }
+
         const selectors = getSortedTrackedSelectors();
 
         trackEvent('performance', 'least_effective_selectors', {


### PR DESCRIPTION
I think these metrics aren't being sent because we're checking if performance metrics are enabled before we have that config setting loaded

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43302

#### Release Note
```release-note
Fix timing of selector performance metrics
```
