### PR TITLE
MM-42755: consistently run playbook

### DIFF
--- a/components/channel_layout/playbook_runner.tsx
+++ b/components/channel_layout/playbook_runner.tsx
@@ -6,7 +6,7 @@ import {AnyAction, Dispatch} from 'redux';
 import {useDispatch, useSelector} from 'react-redux';
 import {useRouteMatch} from 'react-router-dom';
 
-import {getChannelByName} from 'mattermost-redux/selectors/entities/channels';
+import {getChannelByTeamIdAndChannelName} from 'mattermost-redux/selectors/entities/channels';
 import {Client4} from 'mattermost-redux/client';
 import {IntegrationTypes} from 'mattermost-redux/action_types';
 import {Channel} from 'mattermost-redux/types/channels';
@@ -32,7 +32,7 @@ const PlaybookRunner = () => {
     const team = useSelector((state: GlobalState) => getTeamByName(state, teamName));
 
     const lastViewedChannelName = useSelector((state: GlobalState) => getLastViewedChannelNameByTeamName(state, teamName));
-    const lastViewedChannel = useSelector((state: GlobalState) => getChannelByName(state, lastViewedChannelName));
+    const lastViewedChannel = useSelector((state: GlobalState) => getChannelByTeamIdAndChannelName(state, team?.id || '', lastViewedChannelName));
 
     useEffect(() => {
         const switchToChannelAndStartRun = async () => {

--- a/packages/mattermost-redux/src/selectors/entities/channels.test.js
+++ b/packages/mattermost-redux/src/selectors/entities/channels.test.js
@@ -544,6 +544,59 @@ describe('Selectors.Channels.getChannelByName', () => {
     });
 });
 
+describe('Selectors.Channels.getChannelByTeamIdAndChannelName', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+    const team2 = TestHelper.fakeTeamWithId();
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: 'ch1',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        name: 'ch2',
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: 'ch3',
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            channels: {
+                channels,
+            },
+        },
+    });
+
+    it('get channel1 matching team id and name', () => {
+        assert.deepEqual(Selectors.getChannelByTeamIdAndChannelName(testState, team1.id, channel1.name), channel1);
+    });
+
+    it('get channel2 matching team id and name', () => {
+        assert.deepEqual(Selectors.getChannelByTeamIdAndChannelName(testState, team2.id, channel2.name), channel2);
+    });
+
+    it('get channel3 matching team id and name', () => {
+        assert.deepEqual(Selectors.getChannelByTeamIdAndChannelName(testState, team1.id, channel3.name), channel3);
+    });
+
+    it('return null if no channel matches team id and name', () => {
+        assert.deepEqual(Selectors.getChannelByTeamIdAndChannelName(testState, team1.id, channel2.name), null);
+    });
+
+    it('return null on empty team id', () => {
+        assert.deepEqual(Selectors.getChannelByTeamIdAndChannelName(testState, '', channel1.name), null);
+    });
+
+});
+
 describe('Selectors.Channels.getChannelsNameMapInCurrentTeam', () => {
     const team1 = TestHelper.fakeTeamWithId();
     const team2 = TestHelper.fakeTeamWithId();

--- a/packages/mattermost-redux/src/selectors/entities/channels.test.js
+++ b/packages/mattermost-redux/src/selectors/entities/channels.test.js
@@ -594,7 +594,6 @@ describe('Selectors.Channels.getChannelByTeamIdAndChannelName', () => {
     it('return null on empty team id', () => {
         assert.deepEqual(Selectors.getChannelByTeamIdAndChannelName(testState, '', channel1.name), null);
     });
-
 });
 
 describe('Selectors.Channels.getChannelsNameMapInCurrentTeam', () => {

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -353,6 +353,12 @@ export function getChannelByName(state: GlobalState, channelName: string): Chann
     return getChannelByNameHelper(getAllChannels(state), channelName);
 }
 
+export function getChannelByTeamIdAndChannelName(state: GlobalState, teamId: string, channelName: string): Channel | undefined | null {
+    return Object.values(getAllChannels(state)).find((channel) =>
+        channel.team_id === teamId && channel.name === channelName,
+    );
+}
+
 export const getChannelSetInCurrentTeam: (state: GlobalState) => string[] = createSelector(
     'getChannelSetInCurrentTeam',
     getCurrentTeamId,


### PR DESCRIPTION
#### Summary
The route handler for `:team/_playbooks/:playbookId/run` was incorrectly sensitive to the currently selected team, and would inadvertently switch teams if it found a channel matching the "current channel name" (i.e. the commonly shared, `town-square`), preventing the handler from ultimately finding the playbook since it wasn't on that team.

Introduce a new Redux selector and use it to constrain the search for channels by name in the given team. In addition to the unit tests in this PR, see linked PR for E2E tests in Playbooks itself.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-42755

#### Related Pull Requests
- https://github.com/mattermost/mattermost-plugin-playbooks/pull/1146

#### Release Note
```release-note
NONE
```
