### PR TITLE
Cypress/E2E: Fix message with gif spec

### DIFF
--- a/e2e/cypress/tests/integration/messaging/message_with_gif_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_with_gif_spec.js
@@ -36,11 +36,11 @@ describe('Show GIF images properly', () => {
         cy.url().should('include', offtopiclink);
 
         // # Post tenor GIF
-        cy.postMessage('https://media1.tenor.com/images/4627c6507cdc899d211319081ba5740b/tenor.gif');
+        cy.postMessage('https://c.tenor.com/Ztva2YFROSkAAAAi/duck-searching.gif');
 
         cy.getLastPostId().as('postId').then((postId) => {
             // * Validate image size
-            cy.get(`#post_${postId}`).find('.attachment__image').should('have.css', 'width', '320px');
+            cy.get(`#post_${postId}`).find('.attachment__image').should('have.css', 'width', '137px');
         });
 
         // # Post giphy GIF


### PR DESCRIPTION
#### Summary
- Replaced tenor gif url and width to fix message with gif spec

#### Ticket Link
NA

#### Screenshots
![Screen Shot 2022-04-25 at 4 09 57 PM](https://user-images.githubusercontent.com/487991/165189065-7bd2e4c5-78c1-4d4d-ace7-5aa42c3eebae.png)

#### Release Note
```release-note
NONE
```