### PR TITLE
set plugin stat title type to reactnode to enable translations

### DIFF
--- a/packages/types/src/admin.ts
+++ b/packages/types/src/admin.ts
@@ -58,7 +58,7 @@ export type IndexedPluginAnalyticsRow = {
 
 export type PluginAnalyticsRow = {
     id: string;
-    name: string;
+    name: React.ReactNode;
     icon: string;
     value: number;
 };


### PR DESCRIPTION
#### Summary
PluginAnalytics name type changed to React.ReactNode. 
This is needed to match the type that will be used from the plugins which are using `<FormattedMessage.../>` to translate the names of the stats. [Example at playbooks](https://github.com/mattermost/mattermost-plugin-playbooks/pull/1128/files#diff-47ddfada7835e6c591120fc4ca2bde4e83ba9834df8550cddb48349d7040b36eR140)

This type did not fail before because pluginRegistry is not typed yet.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42971

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/10180
https://github.com/mattermost/mattermost-plugin-playbooks/pull/1128

#### Release Note
```
NONE
```
