### PR TITLE
MM-28269 Allow clicking through mobile web view timestamp

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -311,6 +311,7 @@
     display: none;
     width: 100%;
     opacity: 0;
+    pointer-events: none;
     text-align: center;
     transform: translateY(-45px);
     transition: all 0.6s ease;


### PR DESCRIPTION
This is a fix for a long running, but easy to fix bug where the "New Messages Below" banner in the mobile web view wasn't able to be clicked on because it was covered by the invisible div that holds the floating timestamp.

![Screen Shot 2022-04-28 at 11 26 35 AM](https://user-images.githubusercontent.com/3277310/165788254-fde07bec-7873-424f-902e-9cb3cd954f6b.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28269

#### Release Note
```release-note
Fixed the New Messages toast in mobile web view not being fully clickable
```
