### PR TITLE
MM-29798 Log in background tabs on focus

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -394,7 +394,7 @@ export default class Root extends React.PureComponent {
             function reloadOnFocus() {
                 location.reload();
             }
-            document.addEventListener('focus', reloadOnFocus, false);
+            window.addEventListener('focus', reloadOnFocus);
         }
     }
 

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -391,10 +391,10 @@ export default class Root extends React.PureComponent {
             }
 
             // detected login from a different tab
-            function onVisibilityChange() {
+            function reloadOnFocus() {
                 location.reload();
             }
-            document.addEventListener('visibilitychange', onVisibilityChange, false);
+            document.addEventListener('focus', reloadOnFocus, false);
         }
     }
 

--- a/components/root/root.test.jsx
+++ b/components/root/root.test.jsx
@@ -169,7 +169,7 @@ describe('components/Root', () => {
         });
 
         window.dispatchEvent(loginSignal);
-        document.dispatchEvent(new Event('focus'));
+        window.dispatchEvent(new Event('focus'));
         expect(window.location.reload).toBeCalledTimes(1);
         wrapper.unmount();
     });

--- a/components/root/root.test.jsx
+++ b/components/root/root.test.jsx
@@ -169,7 +169,7 @@ describe('components/Root', () => {
         });
 
         window.dispatchEvent(loginSignal);
-        document.dispatchEvent(new Event('visibilitychange'));
+        document.dispatchEvent(new Event('focus'));
         expect(window.location.reload).toBeCalledTimes(1);
         wrapper.unmount();
     });


### PR DESCRIPTION
So we've had a feature for a while that logs a user in and out on multiple tabs if they have multiple tabs open at once. That was broken for a while, and then it was re-added in https://github.com/mattermost/mattermost-webapp/pull/6319, but when it was re-added, it was changed to only actually log the user in when the window became visible. I thought this was broken a while back, but it turns out that it just didn't work if the tab was already visible because you had multiple windows open at once instead of two tabs in a single window.

This changes it so that the login reload is triggered when the window gains focus to allow it to work when you have two tabs in separate windows open.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29798

#### Release Note
```release-note
NONE
```
