### PR TITLE
Fixes: invalid CRT preference state

### DIFF
--- a/packages/mattermost-redux/src/actions/users.ts
+++ b/packages/mattermost-redux/src/actions/users.ts
@@ -138,8 +138,6 @@ export function loadMe(): ActionFunc {
         const serverVersion = Client4.getServerVersion() || getState().entities.general.serverVersion;
         dispatch(setServerVersion(serverVersion));
 
-        const isCollapsedThreads = isCollapsedThreadsEnabled(getState());
-
         try {
             await Promise.all([
                 dispatch(getClientConfig()),
@@ -150,6 +148,7 @@ export function loadMe(): ActionFunc {
                 dispatch(getMyTeamMembers()),
             ]);
 
+            const isCollapsedThreads = isCollapsedThreadsEnabled(getState());
             await dispatch(getMyTeamUnreads(isCollapsedThreads));
         } catch (error) {
             dispatch(logError(error));


### PR DESCRIPTION
#### Summary

We are asking for CRT preference state in redux before we actually fetch
the user's preferences, resulting in always being false.

This commit fixes that by moving the selector after the dispatches have
finished and the state has been updated.

#### Release Note

```release-note
NONE
```
