### PR TITLE
[MM-43905] Hide deactivated users from Channel Member RHS

### DIFF
--- a/components/channel_members_rhs/index.ts
+++ b/components/channel_members_rhs/index.ts
@@ -15,8 +15,8 @@ import {GlobalState} from 'types/store';
 import {Constants} from 'utils/constants';
 import {getCurrentRelativeTeamUrl, getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {
-    getProfilesInCurrentChannel,
-    getUserStatuses, searchProfilesInCurrentChannel,
+    getActiveProfilesInCurrentChannel,
+    getUserStatuses, searchActiveProfilesInCurrentChannel,
 } from 'mattermost-redux/selectors/entities/users';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
@@ -36,7 +36,7 @@ import RHS, {Props, ChannelMember} from './channel_members_rhs';
 
 const getProfiles = createSelector(
     'getProfiles',
-    getProfilesInCurrentChannel,
+    getActiveProfilesInCurrentChannel,
     getUserStatuses,
     getTeammateNameDisplaySetting,
     getMembersInCurrentChannel,
@@ -67,7 +67,7 @@ const getProfiles = createSelector(
 
 const searchProfiles = createSelector(
     'searchProfiles',
-    (state: GlobalState, search: string) => searchProfilesInCurrentChannel(state, search, false),
+    (state: GlobalState, search: string) => searchActiveProfilesInCurrentChannel(state, search, false),
     getUserStatuses,
     getTeammateNameDisplaySetting,
     getMembersInCurrentChannel,

--- a/e2e/cypress/tests/integration/channel/channel_members_rhs_spec.js
+++ b/e2e/cypress/tests/integration/channel/channel_members_rhs_spec.js
@@ -154,6 +154,31 @@ describe('Channel members RHS', () => {
         });
     });
 
+    it('should hide deactivated members', () => {
+        cy.apiCreateChannel(testTeam.id, 'hide-test-channel', 'Hide Test Channel', 'O').then(({channel}) => {
+            let testUser = null;
+            cy.apiCreateUser().then(({user: newUser}) => {
+                cy.apiAddUserToTeam(testTeam.id, newUser.id).then(() => {
+                    cy.apiAddUserToChannel(channel.id, newUser.id).then(() => {
+                        testUser = newUser;
+
+                        // # Open the Channel Members RHS
+                        openChannelMembersRhs(testTeam, channel);
+
+                        // * Ensure the member is visible
+                        cy.uiGetRHS().findByText(`@${testUser.username}`).should('be.visible');
+
+                        // # Deactivate the user
+                        cy.apiDeactivateUser(testUser.id);
+
+                        // * Ensure the user is not visible anymore
+                        cy.uiGetRHS().findByText(`@${testUser.username}`).should('not.exist');
+                    });
+                });
+            });
+        });
+    });
+
     describe('as an admin', () => {
         it('should be able to invite new members', () => {
             // # Open the Channel Members RHS

--- a/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -176,7 +176,7 @@ export const getCurrentUserRoles: (a: GlobalState) => UserProfile['roles'] = cre
     },
 );
 
-export type UserMentionKey= {
+export type UserMentionKey = {
     key: string;
     caseSensitive?: boolean;
 }
@@ -319,6 +319,15 @@ export const getProfilesInCurrentChannel: (state: GlobalState) => UserProfile[] 
     },
 );
 
+export const getActiveProfilesInCurrentChannel: (state: GlobalState) => UserProfile[] = createSelector(
+    'getProfilesInCurrentChannel',
+    getUsers,
+    getProfileSetInCurrentChannel,
+    (profiles, currentChannelProfileSet) => {
+        return sortAndInjectProfiles(profiles, currentChannelProfileSet).filter((user) => user.delete_at === 0);
+    },
+);
+
 export const getProfilesNotInCurrentChannel: (state: GlobalState) => UserProfile[] = createSelector(
     'getProfilesNotInCurrentChannel',
     getUsers,
@@ -453,6 +462,10 @@ export function searchProfilesInCurrentChannel(state: GlobalState, term: string,
     }
 
     return profiles;
+}
+
+export function searchActiveProfilesInCurrentChannel(state: GlobalState, term: string, skipCurrent = false): UserProfile[] {
+    return searchProfilesInCurrentChannel(state, term, skipCurrent).filter((user) => user.delete_at === 0);
 }
 
 export function searchProfilesNotInCurrentChannel(state: GlobalState, term: string, skipCurrent = false): UserProfile[] {


### PR DESCRIPTION
#### Summary
The channel members RHS was showing deactivated users. This is now fixed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43905

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
