### PR TITLE
Fix plugin link tooltip flickering

### DIFF
--- a/components/link_tooltip/__snapshots__/link_tooltip.test.tsx.snap
+++ b/components/link_tooltip/__snapshots__/link_tooltip.test.tsx.snap
@@ -2,6 +2,26 @@
 
 exports[`components/link_tooltip/link_tooltip should match snapshot 1`] = `
 <Fragment>
+  <div
+    className="tooltip-container"
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexDirection": "column",
+        "left": -1000,
+        "position": "absolute",
+        "top": -1000,
+        "zIndex": 1070,
+      }
+    }
+  >
+    <Connect(Pluggable)
+      href="www.test.com"
+      pluggableName="LinkTooltip"
+      show={false}
+    />
+  </div>
   <span
     data-channel-mention="somechannel"
     data-hashtag="#somehashtag"
@@ -16,6 +36,26 @@ exports[`components/link_tooltip/link_tooltip should match snapshot 1`] = `
 
 exports[`components/link_tooltip/link_tooltip should match snapshot with uncommon link structure 1`] = `
 <Fragment>
+  <div
+    className="tooltip-container"
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexDirection": "column",
+        "left": -1000,
+        "position": "absolute",
+        "top": -1000,
+        "zIndex": 1070,
+      }
+    }
+  >
+    <Connect(Pluggable)
+      href="https://www.google.com"
+      pluggableName="LinkTooltip"
+      show={false}
+    />
+  </div>
   <span
     onMouseLeave={[Function]}
     onMouseOver={[Function]}

--- a/components/link_tooltip/link_tooltip.scss
+++ b/components/link_tooltip/link_tooltip.scss
@@ -1,5 +1,12 @@
 @import 'sass/utils/variables';
 
 .tooltip-container {
+    opacity: 0;
     transition: opacity $transition-quick ease-in;
+    visibility: hidden;
+
+    &.visible {
+        opacity: 1;
+        visibility: visible;
+    }
 }

--- a/e2e/cypress/tests/integration/plugins/link_tooltip_spec.js
+++ b/e2e/cypress/tests/integration/plugins/link_tooltip_spec.js
@@ -24,23 +24,23 @@ describe('Link tooltips', () => {
         cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             cy.visit(`/${team.name}/channels/${channel.name}`);
         });
+        cy.postMessage('www.test.com');
     });
 
     it('MM-T3422 fade in and out with an animation', () => {
-        cy.postMessage('www.test.com');
         cy.get('a[href*="www.test.com"] span').as('link');
+        cy.contains('This is a custom tooltip from the Demo Plugin').parents('.tooltip-container').as('tooltip-container');
 
         // # Mouse over the link
         cy.get('@link').trigger('mouseover');
 
         // * Check tooltip has appeared
-        cy.contains('This is a custom tooltip from the Demo Plugin').parents('.tooltip-container').as('tooltip-container');
-        cy.get('@tooltip-container').should('exist');
+        cy.get('@tooltip-container').should('have.class', 'visible');
 
         // # Mouse out the link
         cy.get('@link').trigger('mouseout');
 
         // * Check tooltip has disappeared
-        cy.get('.tooltip-container').should('not.exist');
+        cy.get('@tooltip-container').should('not.have.class', 'visible');
     });
 });


### PR DESCRIPTION
#### Summary

The PR #10004 for "Eliminate unnecessary tooltip divs added for links" introduced a few issues when hovering over a  plugin `LinkTooltip` link:

- In certain mouse and screen positions, the tooltip be placed right at the pointer of the mouse, causing sporadic `mouseon` and `mouseleave` events to fire. This makes the tooltip flicker continuously.
- The protocol for this plugin feature has changed. Before the PR, the `LinkTooltip` component was mounted on initial render of the post containing the link. The component receives a `show` prop when it needs to react to being hovered. After the PR, the component is mounted on hover, making it so the component cannot do any local state caching.
- The popover does not fade into appearance anymore. It just instantly shows instead.

The first two bullets together is causing a spam of requests to fetch data for the plugin's component.

The changes in the linked PR are a little complicated, and I'm not sure which pieces are causing which issues, so I've decided to revert the PR.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-43906

#### Related Pull Requests

#10004

#### Release Note

```release-note
Fix plugin link tooltip flickering issue
```
