### PR TITLE
Automated cherry pick of #10261

### DIFF
--- a/components/keyboard_shortcuts/keyboard_shortcuts_modal/__snapshots__/keyboard_shortcuts_modal.test.tsx.snap
+++ b/components/keyboard_shortcuts/keyboard_shortcuts_modal/__snapshots__/keyboard_shortcuts_modal.test.tsx.snap
@@ -286,7 +286,7 @@ exports[`components/KeyboardShortcutsModal should match snapshot modal 1`] = `
                       "id": "shortcuts.nav.open_channel_info",
                     },
                     "mac": Object {
-                      "defaultMessage": "View channel info:	⌘|Alt|I",
+                      "defaultMessage": "View channel info:	⌘|Shift|I",
                       "id": "shortcuts.nav.open_channel_info.mac",
                     },
                   }

--- a/components/keyboard_shortcuts/keyboard_shortcuts_sequence/keyboard_shortcuts.ts
+++ b/components/keyboard_shortcuts/keyboard_shortcuts_sequence/keyboard_shortcuts.ts
@@ -179,7 +179,7 @@ export const KEYBOARD_SHORTCUTS = {
         },
         mac: {
             id: t('shortcuts.nav.open_channel_info.mac'),
-            defaultMessage: 'View channel info:\t⌘|Alt|I',
+            defaultMessage: 'View channel info:\t⌘|Shift|I',
         },
     },
     msgEdit: {

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -74,6 +74,9 @@ export default class SidebarRight extends React.PureComponent {
     }
 
     handleShortcut = (e) => {
+        const channelInfoShortcutMac = Utils.isMac() && e.shiftKey;
+        const channelInfoShortcut = !Utils.isMac() && e.altKey;
+
         if (Utils.cmdOrCtrlPressed(e, true)) {
             if (e.shiftKey && Utils.isKeyPressed(e, Constants.KeyCodes.PERIOD)) {
                 e.preventDefault();
@@ -93,7 +96,7 @@ export default class SidebarRight extends React.PureComponent {
                 } else {
                     this.props.actions.openAtPrevious(this.previous);
                 }
-            } else if (e.altKey && Utils.isKeyPressed(e, Constants.KeyCodes.I)) {
+            } else if (Utils.isKeyPressed(e, Constants.KeyCodes.I) && (channelInfoShortcutMac || channelInfoShortcut)) {
                 e.preventDefault();
                 if (this.props.isOpen && this.props.isChannelInfo) {
                     this.props.actions.closeRightHandSide();


### PR DESCRIPTION
Cherry pick of #10261 on cloud.

/cc  @JulienTant

```release-note
NONE
```