### PR TITLE
Automated cherry pick of #10264

### DIFF
--- a/components/new_channel_modal/new_channel_modal.tsx
+++ b/components/new_channel_modal/new_channel_modal.tsx
@@ -171,6 +171,7 @@ const NewChannelModal = () => {
 
         if (!urlModified) {
             setURL(cleanUpUrlable(displayName));
+            setURLError('');
         }
     };
 

--- a/e2e/cypress/tests/integration/multi_team_and_dm/existing_channel_name_spec.js
+++ b/e2e/cypress/tests/integration/multi_team_and_dm/existing_channel_name_spec.js
@@ -44,6 +44,30 @@ describe('Channel', () => {
             verifyChannel(channel);
         });
     });
+
+    it('MM-43881 Channel name already taken for public channel and changed allows to create', () => {
+        // # Create a new public channel
+        createNewChannel('other-public', false, testTeamId).as('channel');
+        cy.reload();
+
+        cy.get('@channel').then((channel) => {
+            // * Verify new public channel cannot be created with existing public channel name
+            verifyExistingChannelError(channel.name);
+
+            // Update channel name in the input field for new channel
+            cy.get('#input_new-channel-modal-name').should('be.visible').click().type(`${channel.name}1`);
+            cy.wait(TIMEOUTS.HALF_SEC);
+
+            // * Error message saying "A channel with that name already exists" should be removed
+            cy.get('.url-input-error').should('not.exist');
+
+            // * 'Create Channel' button should be enabled
+            cy.findByText('Create channel').should('not.have.class', 'disabled');
+
+            // # Click on Cancel button to move out of New Channel Modal
+            cy.findByText('Cancel').click();
+        });
+    });
 });
 
 /**


### PR DESCRIPTION
Cherry pick of #10264 on release-6.7.

/cc  @julmondragon

```release-note
NONE
```