### PR TITLE
MM-36708 Ensure that date is in yyyy-MM-dd format

### DIFF
--- a/components/custom_status/date_time_input.tsx
+++ b/components/custom_status/date_time_input.tsx
@@ -143,7 +143,7 @@ const DateTimeInputContainer: React.FC<Props> = (props: Props) => {
                     <i className='icon-calendar-outline'/>
                 </span>
                 <DayPickerInput
-                    value={time.toDate()}
+                    value={time.toDate().toLocaleDateString("fr-CA")}
                     onDayChange={handleDayChange}
                     inputProps={{
                         readOnly: true,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Changing date format from yyyy-M-dd to yyyy-MM-dd when trying to set status till a custom time

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-36708


#### Screenshots
| Before | After |
| ------- | ----- |
| ![Before](https://user-images.githubusercontent.com/40962760/167248661-c1115e2d-2ae3-4141-be84-a1420f1c527e.png) | ![After](https://user-images.githubusercontent.com/40962760/167248689-55d5614b-b54f-4a11-acfc-d56bc91632b4.png) |


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-notes
Changed date's format to fr-CA in order to make the formatting yyyy-MM-dd
```
