### PR TITLE
MM-43889 Reduce unnecessary calls to viewChannel API

### DIFF
--- a/actions/team_actions.jsx
+++ b/actions/team_actions.jsx
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 import {TeamTypes} from 'mattermost-redux/action_types';
-import {viewChannel, getChannelStats} from 'mattermost-redux/actions/channels';
+import {getChannelStats} from 'mattermost-redux/actions/channels';
 import * as TeamActions from 'mattermost-redux/actions/teams';
-import {getCurrentChannelId, isManuallyUnread} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getUser} from 'mattermost-redux/actions/users';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
@@ -81,16 +81,15 @@ export function addUsersToTeam(teamId, userIds) {
     };
 }
 
-export function switchTeam(url, setTeam = undefined) {
-    return (dispatch, getState) => {
-        const state = getState();
-        const currentChannelId = getCurrentChannelId(state);
-        if (!isManuallyUnread(state, currentChannelId)) {
-            dispatch(viewChannel(currentChannelId));
-        }
-
-        if (setTeam) {
-            dispatch(selectTeam(setTeam));
+export function switchTeam(url, team) {
+    return (dispatch) => {
+        // In Channels, the team argument is undefined, and team switching is done by pushing a URL onto history.
+        // In other products, a team is passed instead of a URL because the current team isn't tied to the page URL.
+        //
+        // Note that url may also be a non-team URL since this is called when switching to the Create Team page
+        // from the team sidebar as well.
+        if (team) {
+            dispatch(selectTeam(team));
         } else {
             browserHistory.push(url);
         }

--- a/components/post_view/post_list/index.js
+++ b/components/post_view/post_list/index.js
@@ -6,7 +6,6 @@ import {bindActionCreators} from 'redux';
 import {withRouter} from 'react-router-dom';
 
 import {getRecentPostsChunkInChannel, makeGetPostsChunkAroundPost, getUnreadPostsChunk, getPost} from 'mattermost-redux/selectors/entities/posts';
-import {isManuallyUnread} from 'mattermost-redux/selectors/entities/channels';
 import {memoizeResult} from 'mattermost-redux/utils/helpers';
 import {markChannelAsRead, markChannelAsViewed} from 'mattermost-redux/actions/channels';
 import {makePreparePostIdsForPostList} from 'mattermost-redux/utils/post_list';
@@ -48,7 +47,6 @@ function makeMapStateToProps() {
         const channelViewState = state.views.channel;
         const lastViewedAt = channelViewState.lastChannelViewTime[channelId];
         const isPrefetchingInProcess = channelViewState.channelPrefetchStatus[channelId] === RequestStatus.STARTED;
-        const channelManuallyUnread = isManuallyUnread(state, channelId);
 
         if (focusedPostId && unreadChunkTimeStamp !== '') {
             chunk = getPostsChunkAroundPost(state, focusedPostId, channelId);
@@ -82,7 +80,6 @@ function makeMapStateToProps() {
             latestPostTimeStamp,
             postListIds: postIds,
             isPrefetchingInProcess,
-            channelManuallyUnread,
             isMobileView: getIsMobileView(state),
         };
     };

--- a/components/post_view/post_list/post_list.jsx
+++ b/components/post_view/post_list/post_list.jsx
@@ -82,11 +82,6 @@ export default class PostList extends React.PureComponent {
          */
         latestPostTimeStamp: PropTypes.number,
 
-        /*
-         * Used for handling the read logic when unmounting the component
-         */
-        channelManuallyUnread: PropTypes.bool.isRequired,
-
         /**
          * Lastest post id of the current post list, this doesnt include timestamps etc, just actual posts
          */
@@ -184,10 +179,6 @@ export default class PostList extends React.PureComponent {
     }
 
     componentWillUnmount() {
-        if (!this.props.channelManuallyUnread) {
-            this.markChannelAsReadAndViewed(this.props.channelId);
-        }
-
         this.mounted = false;
     }
 

--- a/components/post_view/post_list/post_list.test.jsx
+++ b/components/post_view/post_list/post_list.test.jsx
@@ -43,7 +43,6 @@ const baseProps = {
     isFirstLoad: true,
     atLatestPost: false,
     formattedPostIds: [],
-    channelManuallyUnread: false,
     isPrefetchingInProcess: false,
     isMobileView: false,
 };

--- a/packages/mattermost-redux/src/actions/teams.test.js
+++ b/packages/mattermost-redux/src/actions/teams.test.js
@@ -40,7 +40,7 @@ describe('Actions.Teams', () => {
     });
 
     it('selectTeam', async () => {
-        await Actions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
+        await store.dispatch(Actions.selectTeam(TestHelper.basicTeam));
         await TestHelper.wait(100);
         const {currentTeamId} = store.getState().entities.teams;
 

--- a/packages/mattermost-redux/src/actions/teams.ts
+++ b/packages/mattermost-redux/src/actions/teams.ts
@@ -59,15 +59,11 @@ async function getProfilesAndStatusesForMembers(userIds: string[], dispatch: Dis
     await Promise.all(requests);
 }
 
-export function selectTeam(team: Team | string): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
-        const teamId = (typeof team === 'string') ? team : team.id;
-        dispatch({
-            type: TeamTypes.SELECT_TEAM,
-            data: teamId,
-        });
-
-        return {data: true};
+export function selectTeam(team: Team | string) {
+    const teamId = (typeof team === 'string') ? team : team.id;
+    return {
+        type: TeamTypes.SELECT_TEAM,
+        data: teamId,
     };
 }
 


### PR DESCRIPTION
TL;DR:
- I got rid of the call to viewChannel when unmounting PostList and switching away from a channel
- I got rid of the extra call to viewChannel when switching teams

---

The viewChannel API is called to update the lastViewedAt for a channel as well as keeping track of the channel that the user is active in. This is currently called:
1. When the PostList is mounted, the current channel changes in it, or it's unmounted. This works out to:
    - (mount) When opening the app or switching to a channel
    - (channel change) This doesn't actually occur since we remount the component when this happens
    - (unmount) When switching away from a channel or away from Channels in general
2. When switching teams from the TeamSidebar
3. When focusing the window
4. When blurring the window
    - This is called with an empty channel ID to indicate that you're not active in any channel
6. When receiving a new post while viewing the app
7. When a post is edited in the channel you're viewing
    - I'm honestly not sure why this case is there, but I think it might be something to do with how we sometimes get posts by the lastPostAt when reloading the channel
9. Before the window is unloaded

Most of these use cases have some purpose, but if you're looking closely, you'll notice two problem cases:
1. We make two calls to the API when switching channels (one for the new channel on PostList mount and one for the previous one on PostList unmount)
2. We make those two calls plus a third when switching teams

We used to need to mark the previous channel as read when switching away because we didn't trust that the websocket was reliable. Both used to be done with a single API call, but that caused other issues, so we're not going back to that. Instead, I just removed the call on unmount. Since we mark the channel as read when you view it, when you receive a new message while viewing it, and when you click back onto the window, this should keep it read without the extra call. This is also how mobile works.

For team switching, I just removed the extra call.

The only other case I was looking at removing was the case where you're editing a post. I didn't get to this in the time I had assigned to it, and I think it's a relatively infrequent case that has less performance impact, so I left it as-is.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43889

#### Release Note
```release-note
Reduce number of calls made to viewChannel API during regular usage
```
