### PR TITLE
[MM-44172] Fix hotkey for channel info shows alt instead of shift in the shortcut [mac only]

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4334,7 +4334,7 @@
   "shortcuts.nav.next": "Next channel:\tAlt|Down",
   "shortcuts.nav.next.mac": "Next channel:\t⌥|Down",
   "shortcuts.nav.open_channel_info": "View channel info:\tCtrl|Alt|I",
-  "shortcuts.nav.open_channel_info.mac": "View channel info:\t⌘|Alt|I",
+  "shortcuts.nav.open_channel_info.mac": "View channel info:\t⌘|Shift|I",
   "shortcuts.nav.open_close_sidebar": "Open or close the right sidebar\tCtrl|.",
   "shortcuts.nav.open_close_sidebar.mac": "Open or close the right sidebar\t⌘|.",
   "shortcuts.nav.prev": "Previous channel:\tAlt|Up",


### PR DESCRIPTION
#### Summary
This PR fixes the shortcut info modal which was showing the wrong shortcut for the show channel info on mac.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44172

#### Related Pull Requests
N/A

#### Screenshots
![image](https://user-images.githubusercontent.com/785518/168327869-27930642-c092-44c2-a8be-a849dc46e024.png)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
