### PR TITLE
MM-44334: export styled components

### DIFF
--- a/plugins/export.js
+++ b/plugins/export.js
@@ -31,6 +31,7 @@ window.ReactBootstrap = require('react-bootstrap');
 window.ReactRouterDom = require('react-router-dom');
 window.PropTypes = require('prop-types');
 window.Luxon = require('luxon');
+window.StyledComponents = require('styled-components');
 
 // Functions exposed on window for plugins to use.
 window.PostUtils = {formatText, messageHtmlToComponent};


### PR DESCRIPTION
#### Summary
Plugins shouldn't have to import a duplicate copy of the styled components library. This will help avoid this warning:

<img width="674" alt="CleanShot 2022-05-17 at 15 15 21@2x" src="https://user-images.githubusercontent.com/1023171/168882609-8aea1163-7b90-4482-9678-fc5ea1b09d32.png">

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-44334

#### Release Note
```release-note
NONE
```
