### PR TITLE
[MM-44228]: fixed post hover-state on compact message display

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -673,11 +673,7 @@
     word-wrap: break-word;
 
     &:not(.post--editing):not(.post--editing):hover {
-        background-color: rgba(v(center-channel-color-rgb), 0.04);
-
-        .post__header {
-            padding: 0 55px 0 0;
-        }
+        background-color: rgba(var(--center-channel-color-rgb), 0.04);
     }
 
     .hide-element {


### PR DESCRIPTION
#### Summary
Post hover state was adding incorrect padding to the post-header for the compact message display.

#### Ticket Link
[MM-44228](https://mattermost.atlassian.net/browse/MM-44228)

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
