### PR TITLE
[MM-44159] Members RHS: fix search + allow to load more users

### DIFF
--- a/components/channel_members_rhs/channel_members_rhs.tsx
+++ b/components/channel_members_rhs/channel_members_rhs.tsx
@@ -93,7 +93,7 @@ export default function ChannelMembersRHS({channel, searchTerms, membersCount, c
             actions.setChannelMembersRhsSearchTerm('');
         };
     }, []);
-   
+
     useEffect(() => {
         if (channel.type === Constants.DM_CHANNEL) {
             let rhsAction = actions.closeRightHandSide;

--- a/components/channel_members_rhs/index.ts
+++ b/components/channel_members_rhs/index.ts
@@ -27,7 +27,7 @@ import {openModal} from 'actions/views/modals';
 import {closeRightHandSide, goBack} from 'actions/views/rhs';
 import {getPreviousRhsState} from 'selectors/rhs';
 import {setChannelMembersRhsSearchTerm} from 'actions/views/search';
-import {loadProfilesAndReloadChannelMembers} from 'actions/user_actions';
+import {loadProfilesAndReloadChannelMembers, searchProfilesAndChannelMembers} from 'actions/user_actions';
 import {Channel, ChannelMembership} from 'mattermost-redux/types/channels';
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
 import {loadMyChannelMemberAndRole} from 'mattermost-redux/actions/channels';
@@ -74,12 +74,14 @@ const searchProfiles = createSelector(
     (profilesInCurrentChannel, userStatuses, teammateNameDisplaySetting, membersInCurrentChannel) => {
         const channelMembers: ChannelMember[] = [];
         profilesInCurrentChannel.forEach((profile) => {
-            channelMembers.push({
-                user: profile,
-                membership: membersInCurrentChannel[profile.id],
-                status: userStatuses[profile.id],
-                displayName: displayUsername(profile, teammateNameDisplaySetting),
-            });
+            if (membersInCurrentChannel[profile.id]) {
+                channelMembers.push({
+                    user: profile,
+                    membership: membersInCurrentChannel[profile.id],
+                    status: userStatuses[profile.id],
+                    displayName: displayUsername(profile, teammateNameDisplaySetting),
+                });
+            }
         });
         return [[] as ChannelMember[], channelMembers];
     },
@@ -145,6 +147,7 @@ function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
             setChannelMembersRhsSearchTerm,
             loadProfilesAndReloadChannelMembers,
             loadMyChannelMemberAndRole,
+            searchProfilesAndChannelMembers,
         }, dispatch),
     };
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2808,6 +2808,8 @@
   "channel_members_rhs.header.title": "Members",
   "channel_members_rhs.list.channel_admin_title": "CHANNEL ADMINS",
   "channel_members_rhs.list.channel_members_title": "MEMBERS",
+  "channel_members_rhs.list.load-more": "Load More",
+  "channel_members_rhs.list.loading": "Loading",
   "channel_members_rhs.member.select_role_channel_admin": "Admin",
   "channel_members_rhs.member.select_role_channel_member": "Member",
   "channel_members_rhs.member.select_role_guest": "Guest",


### PR DESCRIPTION
#### Summary
This PR fixes the search two issues:

- Be able to load more than 100 users at a time using infinite scrolling + a backup button.
- Searching was not working on not loaded users.

```diff
- IMPORTANT NOTICE:
```

This is a 'poor-man' solution as it does not take into consideration the performance issue a user would face if they decide to load thousands of users in the list. It is difficult to use a virtualized list to solve the issue because the scrollable zone is composed of two lists:

![image](https://user-images.githubusercontent.com/785518/169121938-8535f09f-f26a-450d-bd9a-ba510d80e911.png)

As a solution we could:
- Add simple pagination instead of infinite scrolling on the members list.
- Making only the "Members" area scrollable, but we could end up with weird-looking pages if the channel admin section is pretty height.

In both scenarios, it will also require being able to load 'Channel admin' and 'Members' separately instead of all together followed by a sorting process.

If there's a better solution I'm happy to hear it.

I decided to submit this PR anyway to propose a 'quick solution' to the problem, if we would rather not offer this solution I'm fine closing this PR and delaying it until we have a better solution - and more time on my side to work on it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44159

#### Related Pull Requests
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots


https://user-images.githubusercontent.com/785518/169131868-d933c44d-53ba-4cc9-9847-ff710a4ad908.mp4


#### Release Note
```release-note
NONE
```
