### PR TITLE
[MM-41296] : Add a condition to hide legacy Enable post formatting setting if Advanced Text editor is enabled

### DIFF
--- a/components/channel_view/index.ts
+++ b/components/channel_view/index.ts
@@ -12,7 +12,7 @@ import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general
 
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
-import {getIsAdvancesTextEditorEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {getIsAdvancedTextEditorEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 
 import {goToLastViewedChannel} from 'actions/views/channel';
@@ -65,7 +65,7 @@ function mapStateToProps(state: GlobalState) {
         isCloud: getLicense(state).Cloud === 'true',
         teamUrl: getCurrentRelativeTeamUrl(state),
         isFirstAdmin: isFirstAdmin(state),
-        isAdvancedTextEditorEnabled: getIsAdvancesTextEditorEnabled(state),
+        isAdvancedTextEditorEnabled: getIsAdvancedTextEditorEnabled(state),
     };
 }
 

--- a/components/threading/virtualized_thread_viewer/create_comment.tsx
+++ b/components/threading/virtualized_thread_viewer/create_comment.tsx
@@ -4,7 +4,7 @@
 import React, {memo, forwardRef, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
-import {getIsAdvancesTextEditorEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {getIsAdvancedTextEditorEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
 import {makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
@@ -38,7 +38,7 @@ const CreateComment = forwardRef<HTMLDivElement, Props>(({
 }: Props, ref) => {
     const getChannel = useMemo(makeGetChannel, []);
     const rootPost = useSelector((state: GlobalState) => getPost(state, threadId));
-    const isAdvancedTextEditorEnabled = useSelector(getIsAdvancesTextEditorEnabled);
+    const isAdvancedTextEditorEnabled = useSelector(getIsAdvancedTextEditorEnabled);
     const channel = useSelector((state: GlobalState) => getChannel(state, {id: rootPost.channel_id}));
     const rootDeleted = (rootPost as Post).state === Posts.POST_DELETED;
     const isFakeDeletedPost = rootPost.type === Constants.PostTypes.FAKE_PARENT_DELETED;

--- a/components/user_settings/advanced/index.js
+++ b/components/user_settings/advanced/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import {get, makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
+import {get, getIsAdvancedTextEditorEnabled, makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {updateUserActive, revokeAllSessionsForUser} from 'mattermost-redux/actions/users';
 
@@ -25,6 +25,7 @@ function makeMapStateToProps() {
 
         return {
             advancedSettingsCategory: getAdvancedSettingsCategory(state, Preferences.CATEGORY_ADVANCED_SETTINGS),
+            isAdvancedTextEditorEnabled: getIsAdvancedTextEditorEnabled(state),
             sendOnCtrlEnter: get(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter', 'false'),
             codeBlockOnCtrlEnter: get(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'code_block_ctrl_enter', 'true'),
             formatting: get(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', 'true'),

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -24,6 +24,7 @@ export default class AdvancedSettingsDisplay extends React.PureComponent {
     static propTypes = {
         currentUser: PropTypes.object.isRequired,
         advancedSettingsCategory: PropTypes.array.isRequired,
+        isAdvancedTextEditorEnabled: PropTypes.bool,
         sendOnCtrlEnter: PropTypes.string.isRequired,
         codeBlockOnCtrlEnter: PropTypes.bool,
         formatting: PropTypes.string.isRequired,
@@ -459,7 +460,7 @@ export default class AdvancedSettingsDisplay extends React.PureComponent {
             );
         }
 
-        const formattingSection = this.renderFormattingSection();
+        const formattingSection = this.props.isAdvancedTextEditorEnabled ? null : this.renderFormattingSection();
         let formattingSectionDivider = null;
         if (formattingSection) {
             formattingSectionDivider = <div className='divider-light'/>;

--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -219,6 +219,6 @@ export function cloudFreeEnabled(state: GlobalState): boolean {
     return getFeatureFlagValue(state, 'CloudFree') === 'true';
 }
 
-export function getIsAdvancesTextEditorEnabled(state: GlobalState): boolean {
+export function getIsAdvancedTextEditorEnabled(state: GlobalState): boolean {
     return getFeatureFlagValue(state, 'AdvancedTextEditor') === 'true';
 }


### PR DESCRIPTION
#### Summary
 Add a condition to hide legacy Enable post formatting setting if Advanced Text editor is enabled

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-41296
  Epic: https://mattermost.atlassian.net/browse/MM-41347

#### Related Pull Requests
NONE

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="851" alt="Screenshot 2022-05-20 at 3 34 31 PM" src="https://user-images.githubusercontent.com/16203333/169505460-be9ab26e-afb4-4305-af6b-6b8b92727088.png"> | <img width="856" alt="Screenshot 2022-05-20 at 3 32 27 PM" src="https://user-images.githubusercontent.com/16203333/169505482-c4a2e08e-a818-4b5a-98bf-3074506d5293.png"> |

#### Release Note

```release-note
* Add a condition to hide legacy Enable post formatting setting if Advanced Text editor is enabled
```
