### PR TITLE
[MM-44389] : fix show preview tooltip text for windows/linux

### DIFF
--- a/components/keyboard_shortcuts/keyboard_shortcuts_sequence/keyboard_shortcuts.ts
+++ b/components/keyboard_shortcuts/keyboard_shortcuts_sequence/keyboard_shortcuts.ts
@@ -329,7 +329,7 @@ export const KEYBOARD_SHORTCUTS = {
     msgMarkdownPreview: {
         default: {
             id: t('shortcuts.msgs.markdown.preview'),
-            defaultMessage: 'Emoji / Gif picker:\tCtrl|Shift|P',
+            defaultMessage: 'Show/Hide Preview:\tCtrl|Shift|P',
         },
         mac: {
             id: t('shortcuts.msgs.markdown.preview.mac'),

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4282,7 +4282,7 @@
   "shortcuts.msgs.markdown.link.mac": "Link:\t⌘|Alt|K",
   "shortcuts.msgs.markdown.ordered": "Numbered List:\tCtrl|Shift|7",
   "shortcuts.msgs.markdown.ordered.mac": "Numbered List:\t⌘|Shift|7",
-  "shortcuts.msgs.markdown.preview": "Emoji / Gif picker:\tCtrl|Shift|P",
+  "shortcuts.msgs.markdown.preview": "Show/Hide Preview:\tCtrl|Shift|P",
   "shortcuts.msgs.markdown.preview.mac": "Show/Hide Preview:\t⌘|Shift|P",
   "shortcuts.msgs.markdown.quote": "Quote:\tCtrl|Shift|9",
   "shortcuts.msgs.markdown.quote.mac": "Quote:\t⌘|Shift|9",


### PR DESCRIPTION
#### Summary
Advanced Text Editor: fix show preview tooltip text for windows/linux

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-44389
  Epic: https://mattermost.atlassian.net/browse/MM-41347

#### Related Pull Requests
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Advanced Text Editor: fix show preview tooltip text for windows/linux
```
