### PR TITLE
[MM-44437]: Advanced text editor: alignment to center when channel display is set to fixed width

### DIFF
--- a/components/advanced_text_editor/advanced_text_editor.scss
+++ b/components/advanced_text_editor/advanced_text_editor.scss
@@ -2,7 +2,6 @@
     &__ctr {
         form {
             padding: unset;
-            margin: unset;
         }
     }
 


### PR DESCRIPTION
#### Summary
Advanced text editor: alignment to centre when channel display is set to fixed width

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-44437
  EPIC https://mattermost.atlassian.net/browse/MM-44437

#### Related Pull Requests
NONE

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="2032" alt="image-20220519-194747" src="https://user-images.githubusercontent.com/16203333/169540135-ce43b183-d9f5-4c40-95d1-781b7148627b.png"> | <img width="1462" alt="Screenshot 2022-05-20 at 7 07 49 PM" src="https://user-images.githubusercontent.com/16203333/169540192-44ddede3-279c-4a8b-a393-1301450c9815.png"> |

#### Release Note
```release-note
Advanced text editor: alignment to centre when channel display is set to fixed width
```
