### PR TITLE
MM-44460 - hide trial disclosure after start

### DIFF
--- a/components/admin_console/feature_discovery/feature_discovery.tsx
+++ b/components/admin_console/feature_discovery/feature_discovery.tsx
@@ -92,10 +92,12 @@ export default class FeatureDiscovery extends React.PureComponent<Props, State> 
                 this.setState({gettingTrialError: error, gettingTrialResponseCode: data.status});
             }
         }
+        this.handleAfterTrialRequest();
+    }
+    handleAfterTrialRequest = () => {
         this.setState({gettingTrial: false});
         this.props.actions.getLicenseConfig();
     }
-
     openUpgradeModal = (e: React.MouseEvent) => {
         e.preventDefault();
 
@@ -139,6 +141,7 @@ export default class FeatureDiscovery extends React.PureComponent<Props, State> 
                 message={Utils.localizeMessage('admin.ldap_feature_discovery.call_to_action.primary', 'Start trial')}
                 telemetryId={'start_cloud_trial_feature_discovery'}
                 extraClass='btn btn-primary'
+                afterTrialRequest={this.handleAfterTrialRequest}
             />
         ) : (
             <button

--- a/components/admin_console/feature_discovery/feature_discovery.tsx
+++ b/components/admin_console/feature_discovery/feature_discovery.tsx
@@ -92,13 +92,10 @@ export default class FeatureDiscovery extends React.PureComponent<Props, State> 
                 this.setState({gettingTrialError: error, gettingTrialResponseCode: data.status});
             }
         }
-        this.handleAfterTrialRequest();
-    }
-
-    handleAfterTrialRequest = () => {
         this.setState({gettingTrial: false});
         this.props.actions.getLicenseConfig();
     }
+
     openUpgradeModal = (e: React.MouseEvent) => {
         e.preventDefault();
 
@@ -142,7 +139,6 @@ export default class FeatureDiscovery extends React.PureComponent<Props, State> 
                 message={Utils.localizeMessage('admin.ldap_feature_discovery.call_to_action.primary', 'Start trial')}
                 telemetryId={'start_cloud_trial_feature_discovery'}
                 extraClass='btn btn-primary'
-                afterTrialRequest={this.handleAfterTrialRequest}
             />
         ) : (
             <button

--- a/components/admin_console/feature_discovery/feature_discovery.tsx
+++ b/components/admin_console/feature_discovery/feature_discovery.tsx
@@ -94,6 +94,7 @@ export default class FeatureDiscovery extends React.PureComponent<Props, State> 
         }
         this.handleAfterTrialRequest();
     }
+
     handleAfterTrialRequest = () => {
         this.setState({gettingTrial: false});
         this.props.actions.getLicenseConfig();

--- a/components/cloud_start_trial/cloud_start_trial_btn.tsx
+++ b/components/cloud_start_trial/cloud_start_trial_btn.tsx
@@ -23,6 +23,7 @@ export type CloudStartTrialBtnProps = {
     telemetryId: string;
     onClick?: () => void;
     extraClass?: string;
+    afterTrialRequest?: () => void;
 };
 
 enum TrialLoadStatus {
@@ -38,6 +39,7 @@ const CloudStartTrialButton = ({
     telemetryId,
     extraClass,
     onClick,
+    afterTrialRequest,
 }: CloudStartTrialBtnProps) => {
     const {formatMessage} = useIntl();
     const dispatch = useDispatch<DispatchFunc>();
@@ -52,6 +54,9 @@ const CloudStartTrialButton = ({
             return TrialLoadStatus.Failed;
         }
         await dispatch(getLicenseConfig());
+        if (afterTrialRequest) {
+            afterTrialRequest();
+        }
         setLoadStatus(TrialLoadStatus.Success);
         return TrialLoadStatus.Success;
     };

--- a/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import {FormattedMessage, useIntl} from 'react-intl';
 
-import {useSelector, useDispatch} from 'react-redux';
+import {useSelector, useDispatch, shallowEqual} from 'react-redux';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
@@ -125,7 +125,7 @@ const Completed = (props: Props): JSX.Element => {
     const isCurrentLicensed = license?.IsLicensed;
 
     // Cloud conditions
-    const subscription = useSelector((state: GlobalState) => state.entities.cloud.subscription);
+    const subscription = useSelector((state: GlobalState) => state.entities.cloud.subscription, shallowEqual);
     const isCloud = license?.Cloud === 'true';
     const isFreeTrial = subscription?.is_free_trial === 'true';
     const hadPrevCloudTrial = subscription?.is_free_trial === 'false' && subscription?.trial_end_at > 0;

--- a/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import {FormattedMessage, useIntl} from 'react-intl';
 
-import {useSelector, useDispatch, shallowEqual} from 'react-redux';
+import {useSelector, useDispatch} from 'react-redux';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
@@ -125,7 +125,7 @@ const Completed = (props: Props): JSX.Element => {
     const isCurrentLicensed = license?.IsLicensed;
 
     // Cloud conditions
-    const subscription = useSelector((state: GlobalState) => state.entities.cloud.subscription, shallowEqual);
+    const subscription = useSelector((state: GlobalState) => state.entities.cloud.subscription);
     const isCloud = license?.Cloud === 'true';
     const isFreeTrial = subscription?.is_free_trial === 'true';
     const hadPrevCloudTrial = subscription?.is_free_trial === 'false' && subscription?.trial_end_at > 0;
@@ -186,6 +186,7 @@ const Completed = (props: Props): JSX.Element => {
                                     message={formatMessage({id: 'menu.cloudFree.tryFreeFor30Days', defaultMessage: 'Try free for 30 days'})}
                                     telemetryId={'start_cloud_trial_after_completing_steps'}
                                     extraClass={'btn btn-primary'}
+                                    afterTrialRequest={dismissAction}
                                 />
                             ) : (
                                 <StartTrialBtn

--- a/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
@@ -212,14 +212,14 @@ const Completed = (props: Props): JSX.Element => {
                             />
                         </span>
                     </div>
-                    <div className='disclaimer'>
+                    {showStartTrialBtn && <div className='disclaimer'>
                         <span>
                             <FormattedMarkdownMessage
                                 id='onboardingTask.checklist.disclaimer'
                                 defaultMessage='By clicking “Start trial”, I agree to the [Mattermost Software Evaluation Agreement,](!https://mattermost.com/software-evaluation-agreement) [privacy policy,](!https://mattermost.com/privacy-policy/) and receiving product emails.'
                             />
                         </span>
-                    </div>
+                    </div>}
                 </CompletedWrapper>
             </CSSTransition>
         </>


### PR DESCRIPTION
#### Summary
This PR adds code to ensure that  the disclaimer is only shown when the trial button is available.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44460

#### Related Pull Requests
n/a

#### Screenshots
For end users will look like this. For Admins must close the onboarding task list.

<img width="1356" alt="Captura de pantalla 2022-05-20 a las 11 33 31" src="https://user-images.githubusercontent.com/10082627/169557302-5bb9c727-b1ff-4834-8a8c-1c26e0617993.png">


#### Release Note
```release-note
NONE
```
