### PR TITLE
Cypress/E2E: Hide trial modal for first admin

### DIFF
--- a/e2e/cypress/tests/integration/accessibility/accessibility_sidebar_spec.js
+++ b/e2e/cypress/tests/integration/accessibility/accessibility_sidebar_spec.js
@@ -10,11 +10,9 @@
 // Stage: @prod
 // Group: @accessibility @smoke
 
-import {getAdminAccount} from '../../support/env';
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('Verify Accessibility Support in Channel Sidebar Navigation', () => {
-    const sysadmin = getAdminAccount();
     let testUser;
     let testTeam;
     let testChannel;
@@ -24,12 +22,11 @@ describe('Verify Accessibility Support in Channel Sidebar Navigation', () => {
         let otherUser;
         let otherChannel;
 
-        cy.apiInitSetup().then(({team, channel, user, offTopicUrl: url}) => {
+        cy.apiInitSetup({promoteNewUserAsAdmin: true}).then(({team, channel, user, offTopicUrl: url}) => {
             testUser = user;
             testTeam = team;
             testChannel = channel;
             offTopicUrl = url;
-            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
             return cy.apiCreateChannel(testTeam.id, 'test', 'Test');
         }).then(({channel}) => {
             otherChannel = channel;

--- a/e2e/cypress/tests/integration/channel_sidebar/dm_category_spec.js
+++ b/e2e/cypress/tests/integration/channel_sidebar/dm_category_spec.js
@@ -10,25 +10,20 @@
 // Stage: @prod
 // Group: @dm_category
 
-import {getAdminAccount} from '../../support/env';
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
 const SpaceKeyCode = 32;
 const DownArrowKeyCode = 40;
 
 describe('MM-T3156 DM category', () => {
-    const sysadmin = getAdminAccount();
     let testUser;
     const usernames = [];
 
     before(() => {
         // # Login as test user and visit town-square
-        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
+        cy.apiInitSetup({loginAfter: true, promoteNewUserAsAdmin: true}).then(({team, user}) => {
             testUser = user;
             cy.visit(`/${team.name}/channels/town-square`);
-
-            // # upgrade user to sys admin role
-            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
         });
     });
 

--- a/e2e/cypress/tests/integration/channel_sidebar/dm_gm_behaviour_spec.js
+++ b/e2e/cypress/tests/integration/channel_sidebar/dm_gm_behaviour_spec.js
@@ -10,20 +10,16 @@
 // Stage: @prod
 // Group: @dm_category
 
-import {getAdminAccount} from '../../support/env';
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('DM category', () => {
-    const sysadmin = getAdminAccount();
     let testUser;
+
     before(() => {
         // # Login as test user and visit town-square
-        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
+        cy.apiInitSetup({loginAfter: true, promoteNewUserAsAdmin: true}).then(({team, user}) => {
             testUser = user;
             cy.visit(`/${team.name}/channels/town-square`);
-
-            // # upgrade user to sys admin role
-            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
         });
     });
 

--- a/e2e/cypress/tests/integration/channel_sidebar/dm_gm_filtering_sorting_spec.js
+++ b/e2e/cypress/tests/integration/channel_sidebar/dm_gm_filtering_sorting_spec.js
@@ -11,19 +11,15 @@
 // Group: @dm_category
 
 import * as MESSAGES from '../../fixtures/messages';
-import {getAdminAccount} from '../../support/env';
 
 describe('DM/GM filtering and sorting', () => {
-    const sysadmin = getAdminAccount();
     let testUser;
+
     before(() => {
         // # Login as test user and visit town-square
-        cy.apiInitSetup({loginAfter: true}).then(({user, townSquareUrl}) => {
+        cy.apiInitSetup({loginAfter: true, promoteNewUserAsAdmin: true}).then(({user, townSquareUrl}) => {
             testUser = user;
             cy.visit(townSquareUrl);
-
-            // # upgrade user to sys admin role
-            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
         });
     });
 

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/channel_notifications_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/channel_notifications_spec.js
@@ -45,7 +45,6 @@ describe('CRT Desktop notifications', () => {
 
             // # Login as receiver
             cy.apiLogin(receiver);
-            cy.apiSaveShowStartTrialModal(receiver.id, 'true');
         });
     });
 

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/crt_tour_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/crt_tour_spec.js
@@ -12,7 +12,6 @@
 
 describe('Collapsed Reply Threads', () => {
     let testTeam;
-    let testUser;
     let otherUser;
     let testChannel;
     let rootPost;
@@ -26,12 +25,10 @@ describe('Collapsed Reply Threads', () => {
         });
 
         // # Log in as user that hasn't had CRT enabled before
-        cy.apiInitSetup({loginAfter: true, promoteNewUserAsAdmin: true, userPrefix: 'tipbutton'}).then(({team, channel, user}) => {
+        cy.apiInitSetup({loginAfter: true, promoteNewUserAsAdmin: true, userPrefix: 'tipbutton'}).then(({team, channel}) => {
             testTeam = team;
-            testUser = user;
             testChannel = channel;
 
-            cy.apiSaveShowStartTrialModal(testUser.id, 'true');
             cy.apiCreateUser({prefix: 'other'}).then(({user: user1}) => {
                 otherUser = user1;
 

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/files_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/files_spec.js
@@ -82,7 +82,6 @@ describe('Collapsed Reply Threads', () => {
             testChannel = channel;
 
             cy.apiSaveCRTPreference(user1.id, 'on');
-            cy.apiSaveShowStartTrialModal(user1.id, 'true');
         });
     });
 

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/following_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/following_spec.js
@@ -30,7 +30,6 @@ describe('Collapsed Reply Threads', () => {
             testUser = user;
             testChannel = channel;
 
-            cy.apiSaveShowStartTrialModal(testUser.id, 'true');
             cy.apiSaveCRTPreference(testUser.id, 'on');
             cy.apiCreateUser({prefix: 'other'}).then(({user: user1}) => {
                 otherUser = user1;

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/global_threads_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/global_threads_spec.js
@@ -40,7 +40,6 @@ describe('Collapsed Reply Threads', () => {
             user1 = user;
             testChannel = channel;
 
-            cy.apiSaveShowStartTrialModal(user1.id, 'true');
             cy.apiSaveCRTPreference(user1.id, 'on');
             cy.apiCreateUser({prefix: 'user2'}).then(({user: newUser}) => {
                 user2 = newUser;

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/replies_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/replies_spec.js
@@ -32,7 +32,6 @@ describe('Collapsed Reply Threads', () => {
             testUser = user;
             testChannel = channel;
 
-            cy.apiSaveShowStartTrialModal(testUser.id, 'true');
             cy.apiSaveCRTPreference(testUser.id, 'on');
             cy.apiCreateUser({prefix: 'other'}).then(({user: user1}) => {
                 otherUser = user1;

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/unread_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/unread_spec.js
@@ -31,7 +31,6 @@ describe('Collapsed Reply Threads', () => {
             testChannel = channel;
 
             cy.apiSaveCRTPreference(testUser.id, 'on');
-            cy.apiSaveShowStartTrialModal(testUser.id, 'true');
 
             cy.apiCreateUser({prefix: 'other'}).then(({user: user1}) => {
                 otherUser = user1;

--- a/e2e/cypress/tests/support/api/preference.d.ts
+++ b/e2e/cypress/tests/support/api/preference.d.ts
@@ -129,8 +129,8 @@ declare namespace Cypress {
          * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
          *
          * @example
-         *   cy.apiSaveShowStartTrialModal('user-id', 'true');
+         *   cy.apiSaveStartTrialModal('user-id', 'true');
          */
-        apiSaveShowStartTrialModal(userId: string, value: string): Chainable<Response>;
+        apiSaveStartTrialModal(userId: string, value: string): Chainable<Response>;
     }
 }

--- a/e2e/cypress/tests/support/api/preference.js
+++ b/e2e/cypress/tests/support/api/preference.js
@@ -263,7 +263,7 @@ Cypress.Commands.add('apiSaveActionsMenuPreference', (userId, value = true) => {
     return cy.apiSaveUserPreference([preference], userId);
 });
 
-Cypress.Commands.add('apiSaveShowStartTrialModal', (userId, value = 'true') => {
+Cypress.Commands.add('apiSaveStartTrialModal', (userId, value = 'true') => {
     const preference = {
         user_id: userId,
         category: 'start_trial_modal',

--- a/e2e/cypress/tests/support/api/setup.d.ts
+++ b/e2e/cypress/tests/support/api/setup.d.ts
@@ -23,6 +23,7 @@ declare namespace Cypress {
          * Requires sysadmin session to initiate this command.
          * @param {boolean} options.loginAfter - false (default) or true if wants to login as the new user after setting up. Note that when true, succeeding API request will be limited to access/permission of a regular system user.
          * @param {boolean} options.promoteNewUserAsAdmin - false (default) or true if wants to promote the newly created user as sysadmin.
+         * @param {boolean} options.hideAdminTrialModal - true (default) or false if wants to hide Start Enterprise Trial modal.
          * @param {string} options.userPrefix - 'user' (default) or any prefix to easily identify a user
          * @param {string} options.teamPrefix - {name: 'team', displayName: 'Team'} (default) or any prefix to easily identify a team
          * @param {string} options.channelPrefix - {name: 'team', displayName: 'Team'} (default) or any prefix to easily identify a channel
@@ -47,6 +48,8 @@ declare namespace Cypress {
         apiInitSetup(
             options: {
                 loginAfter: boolean;
+                promoteNewUserAsAdmin: boolean;
+                hideAdminTrialModal: boolean;
                 userPrefix: string;
                 teamPrefix: string;
                 channelPrefix: string;

--- a/e2e/cypress/tests/support/api/setup.js
+++ b/e2e/cypress/tests/support/api/setup.js
@@ -4,6 +4,7 @@
 Cypress.Commands.add('apiInitSetup', ({
     loginAfter = false,
     promoteNewUserAsAdmin = false,
+    hideAdminTrialModal = true,
     userPrefix,
     teamPrefix = {name: 'team', displayName: 'Team'},
     channelPrefix = {name: 'channel', displayName: 'Channel'},
@@ -14,6 +15,9 @@ Cypress.Commands.add('apiInitSetup', ({
             return cy.apiCreateUser({prefix: userPrefix || (promoteNewUserAsAdmin ? 'admin' : 'user')}).then(({user}) => {
                 if (promoteNewUserAsAdmin) {
                     cy.apiPatchUserRoles(user.id, ['system_admin', 'system_user']);
+
+                    // Only hide start trial modal for admin since it's not applicable to other users
+                    cy.apiSaveStartTrialModal(user.id, hideAdminTrialModal.toString());
                 }
 
                 return cy.apiAddUserToTeam(team.id, user.id).then(() => {

--- a/e2e/cypress/tests/support/api/user.d.ts
+++ b/e2e/cypress/tests/support/api/user.d.ts
@@ -188,10 +188,11 @@ declare namespace Cypress {
          * Create a randomly named admin account
          *
          * @param {boolean} options.loginAfter - false (default) or true if wants to login as the new admin.
+         * @param {boolean} options.hideAdminTrialModal - true (default) or false if wants to hide Start Enterprise Trial modal.
          *
          * @returns {UserProfile} `out.sysadmin` as `UserProfile` object
          */
-        apiCreateCustomAdmin(options: {loginAfter: boolean}): Chainable<{sysadmin: UserProfile}>;
+        apiCreateCustomAdmin(options: {loginAfter: boolean; hideAdminTrialModal: boolean}): Chainable<{sysadmin: UserProfile}>;
 
         /**
          * Create a new user with an options to set name prefix and be able to bypass tutorial steps.

--- a/e2e/cypress/tests/support/api/user.js
+++ b/e2e/cypress/tests/support/api/user.js
@@ -170,12 +170,14 @@ Cypress.Commands.add('apiPatchMe', (data) => {
     });
 });
 
-Cypress.Commands.add('apiCreateCustomAdmin', ({loginAfter = false} = {}) => {
+Cypress.Commands.add('apiCreateCustomAdmin', ({loginAfter = false, hideAdminTrialModal = true} = {}) => {
     const sysadminUser = generateRandomUser('other-admin');
 
     return cy.apiCreateUser({user: sysadminUser}).then(({user}) => {
         return cy.apiPatchUserRoles(user.id, ['system_admin', 'system_user']).then(() => {
             const data = {sysadmin: user};
+
+            cy.apiSaveStartTrialModal(user.id, hideAdminTrialModal.toString());
 
             if (loginAfter) {
                 return cy.apiLogin(user).then(() => {

--- a/e2e/cypress/tests/support/index.js
+++ b/e2e/cypress/tests/support/index.js
@@ -230,4 +230,5 @@ function resetUserPreference(userId) {
     cy.apiSaveCloudTrialBannerPreference(userId, 'trial', '14_days_banner');
     cy.apiSaveActionsMenuPreference(userId);
     cy.apiSaveSkipStepsPreference(userId, 'true');
+    cy.apiSaveStartTrialModal(userId, 'true');
 }


### PR DESCRIPTION
#### Summary
Hide trial modal for first admin, then only enable as required by test.

#### Release Note
```release-note
NONE
```
