### PR TITLE
MM-42490_Rename new footer and header containers' classnames

### DIFF
--- a/components/header_footer_route/footer.scss
+++ b/components/header_footer_route/footer.scss
@@ -3,7 +3,7 @@
 
 @import 'utils/mixins';
 
-.footer {
+.hfroute-footer {
     display: flex;
     width: 100%;
     max-width: 1520px;
@@ -37,7 +37,7 @@
 }
 
 @media screen and (max-width: 699px) {
-    .footer {
+    .hfroute-footer {
         padding: 0 24px;
     }
 }

--- a/components/header_footer_route/footer.tsx
+++ b/components/header_footer_route/footer.tsx
@@ -15,7 +15,7 @@ const Footer = () => {
     const {AboutLink, PrivacyPolicyLink, TermsOfServiceLink, HelpLink} = useSelector(getConfig);
 
     return (
-        <div className='footer'>
+        <div className='hfroute-footer'>
             <span
                 key='footer-copyright'
                 className='footer-copyright'

--- a/components/header_footer_route/header.scss
+++ b/components/header_footer_route/header.scss
@@ -3,7 +3,7 @@
 
 @import 'utils/mixins';
 
-.header {
+.hfroute-header {
     position: relative;
     display: flex;
     width: 100%;
@@ -69,7 +69,7 @@
 }
 
 @media screen and (max-width: 699px) {
-    .header {
+    .hfroute-header {
         padding: 0 24px;
 
         .header-main {

--- a/components/header_footer_route/header.tsx
+++ b/components/header_footer_route/header.tsx
@@ -24,7 +24,7 @@ const Header = ({alternateMessage, alternateLinkPath, alternateLinkLabel, backBu
     const {EnableCustomBrand, SiteName} = useSelector(getConfig);
 
     return (
-        <div className='header'>
+        <div className='hfroute-header'>
             <div className='header-main'>
                 <Link
                     className='header-logo-link'

--- a/e2e/cypress/tests/integration/signin_authentication/login_spec.js
+++ b/e2e/cypress/tests/integration/signin_authentication/login_spec.js
@@ -67,7 +67,7 @@ describe('Login page', () => {
         cy.findByText('Create an account').should('exist').and('be.visible').should('have.attr', 'href', '/signup_user_complete');
 
         // # Move inside of footer section
-        cy.get('.footer').should('exist').and('be.visible').within(() => {
+        cy.get('.hfroute-footer').should('exist').and('be.visible').within(() => {
             const {
                 ABOUT_LINK,
                 HELP_LINK,

--- a/e2e/cypress/tests/integration/signin_authentication/signup_spec.js
+++ b/e2e/cypress/tests/integration/signin_authentication/signup_spec.js
@@ -92,7 +92,7 @@ describe('Signup Email page', () => {
         } = FixedCloudConfig.SupportSettings;
 
         // * Check elements in the footer
-        cy.get('.footer').scrollIntoView().should('be.visible').within(() => {
+        cy.get('.hfroute-footer').scrollIntoView().should('be.visible').within(() => {
             // * Check if about footer link is present
             cy.findByText('About').should('exist').
                 and('have.attr', 'href', config.SupportSettings.AboutLink || ABOUT_LINK);

--- a/e2e/cypress/tests/integration/system_console/site_configuration/link_customization_e20_1_spec.js
+++ b/e2e/cypress/tests/integration/system_console/site_configuration/link_customization_e20_1_spec.js
@@ -84,7 +84,7 @@ describe('SupportSettings', () => {
         cy.url().should('include', '/signup_user_complete');
 
         // * Verify that links are correct at signup page
-        cy.get('.footer').scrollIntoView().should('be.visible').within(() => {
+        cy.get('.hfroute-footer').scrollIntoView().should('be.visible').within(() => {
             guides.forEach((guide) => {
                 cy.findByText(guide.text).
                     should('have.attr', 'href', guide.link);

--- a/e2e/cypress/tests/integration/system_console/site_configuration/link_customization_e20_2_spec.js
+++ b/e2e/cypress/tests/integration/system_console/site_configuration/link_customization_e20_2_spec.js
@@ -101,7 +101,7 @@ describe('SupportSettings', () => {
         cy.findByText('Create an account', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').click();
 
         // * Verify no privacy link
-        cy.get('.footer').scrollIntoView().should('be.visible').within(() => {
+        cy.get('.hfroute-footer').scrollIntoView().should('be.visible').within(() => {
             cy.findByText('Privacy Policy').should('not.exist');
         });
     });


### PR DESCRIPTION
#### Summary
Apply new designs for the Signup screen - Rename new footer and header containers' classnames to avoid affecting other components.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42490

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/10324

#### Screenshots
##### Before
<img width="1791" alt="Screen Shot 2022-05-24 at 1 37 16 PM" src="https://user-images.githubusercontent.com/79058848/170120227-301b24e0-4def-481b-af0a-ece635dbdba5.png">

##### After
<img width="1787" alt="Screen Shot 2022-05-24 at 2 52 17 PM" src="https://user-images.githubusercontent.com/79058848/170120637-c738458d-94be-4fad-a4d1-b19f47a83e2a.png">

##### New login/signup
<img width="1789" alt="Screen Shot 2022-05-24 at 2 54 18 PM" src="https://user-images.githubusercontent.com/79058848/170120933-f103de85-25fc-47c8-8f3e-6170c676a9cd.png">

#### Release Note
```release-note
NONE
```
