### PR TITLE
MM-44545 - show task list open by default

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -40,7 +40,7 @@ import {initializePlugins} from 'plugins';
 import 'plugins/export.js';
 import Pluggable from 'plugins/pluggable';
 import BrowserStore from 'stores/browser_store';
-import Constants, {StoragePrefixes, WindowSizes} from 'utils/constants';
+import Constants, {StoragePrefixes, WindowSizes, RecommendedNextStepsLegacy, Preferences} from 'utils/constants';
 import {EmojiIndicesByAlias} from 'utils/emoji.jsx';
 import * as UserAgent from 'utils/user_agent';
 import * as Utils from 'utils/utils';
@@ -401,6 +401,12 @@ export default class Root extends React.PureComponent {
                 user_id: this.props.userId,
                 category: OnboardingTaskCategory,
                 name: OnboardingTaskList.ONBOARDING_TASK_LIST_OPEN,
+                value: 'true',
+            },
+            {
+                user_id: this.props.userId,
+                category: Preferences.RECOMMENDED_NEXT_STEPS,
+                name: RecommendedNextStepsLegacy.HIDE,
                 value: 'true',
             },
         ]);

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -40,7 +40,7 @@ import {initializePlugins} from 'plugins';
 import 'plugins/export.js';
 import Pluggable from 'plugins/pluggable';
 import BrowserStore from 'stores/browser_store';
-import Constants, {StoragePrefixes, WindowSizes, RecommendedNextStepsLegacy, Preferences} from 'utils/constants';
+import Constants, {StoragePrefixes, WindowSizes} from 'utils/constants';
 import {EmojiIndicesByAlias} from 'utils/emoji.jsx';
 import * as UserAgent from 'utils/user_agent';
 import * as Utils from 'utils/utils';
@@ -361,6 +361,10 @@ export default class Root extends React.PureComponent {
 
         measurePageLoadTelemetry();
         trackSelectorMetrics();
+
+        if (this.props.firstTimeOnboarding) {
+            this.initOnboardingPrefs();
+        }
     }
 
     componentWillUnmount() {
@@ -397,12 +401,6 @@ export default class Root extends React.PureComponent {
                 user_id: this.props.userId,
                 category: OnboardingTaskCategory,
                 name: OnboardingTaskList.ONBOARDING_TASK_LIST_OPEN,
-                value: 'true',
-            },
-            {
-                user_id: this.props.userId,
-                category: Preferences.RECOMMENDED_NEXT_STEPS,
-                name: RecommendedNextStepsLegacy.HIDE,
                 value: 'true',
             },
         ]);


### PR DESCRIPTION
#### Summary
This PR makes sure of starting the initial preferences for always showing the onboarding task list opened.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44545

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/20284

#### Screenshots


#### Release Note
```release-note
NONE
```
