### PR TITLE
[MM-44566] - 501 errors for non-cloud environment getting subscription info

### DIFF
--- a/components/global_header/right_controls/cloud_upgrade_button/cloud_upgrade_button.test.tsx
+++ b/components/global_header/right_controls/cloud_upgrade_button/cloud_upgrade_button.test.tsx
@@ -7,6 +7,7 @@ import * as reactRedux from 'react-redux';
 import configureStore from 'redux-mock-store';
 
 import {CloudProducts} from 'utils/constants';
+import * as cloudActions from 'mattermost-redux/actions/cloud';
 
 import CloudUpgradeButton from './index';
 
@@ -52,6 +53,9 @@ describe('components/global/CloudUpgradeButton', () => {
             ...initialState,
         };
 
+        const cloudSubscriptionSpy = jest.spyOn(cloudActions, 'getCloudSubscription');
+        const cloudProductsSpy = jest.spyOn(cloudActions, 'getCloudProducts');
+
         const mockStore = configureStore();
         const store = mockStore(state);
 
@@ -64,6 +68,8 @@ describe('components/global/CloudUpgradeButton', () => {
             </reactRedux.Provider>,
         );
 
+        expect(cloudSubscriptionSpy).toHaveBeenCalledTimes(1);
+        expect(cloudProductsSpy).toHaveBeenCalledTimes(1);
         expect(wrapper.find('UpgradeButton').exists()).toEqual(true);
     });
 
@@ -191,6 +197,9 @@ describe('components/global/CloudUpgradeButton', () => {
             Cloud: 'false',
         };
 
+        const cloudSubscriptionSpy = jest.spyOn(cloudActions, 'getCloudSubscription');
+        const cloudProductsSpy = jest.spyOn(cloudActions, 'getCloudProducts');
+
         const mockStore = configureStore();
         const store = mockStore(state);
 
@@ -203,6 +212,8 @@ describe('components/global/CloudUpgradeButton', () => {
             </reactRedux.Provider>,
         );
 
+        expect(cloudSubscriptionSpy).toHaveBeenCalledTimes(0); // no calls to cloud endpoints for non cloud
+        expect(cloudProductsSpy).toHaveBeenCalledTimes(0);
         expect(wrapper.find('UpgradeButton').exists()).toEqual(false);
     });
 });

--- a/components/global_header/right_controls/cloud_upgrade_button/index.tsx
+++ b/components/global_header/right_controls/cloud_upgrade_button/index.tsx
@@ -50,7 +50,7 @@ const UpgradeCloudButton = (): JSX.Element | null => {
             dispatch(getCloudSubscription());
             dispatch(getCloudProducts());
         }
-    }, []);
+    }, [isCloud]);
 
     openPricingModal = () => {
         trackEvent('cloud_admin', 'click_open_pricing_modal');

--- a/components/global_header/right_controls/cloud_upgrade_button/index.tsx
+++ b/components/global_header/right_controls/cloud_upgrade_button/index.tsx
@@ -39,9 +39,17 @@ const UpgradeCloudButton = (): JSX.Element | null => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
 
+    const isCloudFreeEnabled = useSelector(cloudFreeEnabled);
+    const isAdmin = useSelector((state: GlobalState) => isCurrentUserSystemAdmin(state));
+    const subscription = useSelector(selectCloudSubscription);
+    const product = useSelector(selectCloudProduct);
+    const isCloud = useSelector(isCurrentLicenseCloud);
+
     useEffect(() => {
-        dispatch(getCloudSubscription());
-        dispatch(getCloudProducts());
+        if (isCloud) {
+            dispatch(getCloudSubscription());
+            dispatch(getCloudProducts());
+        }
     }, []);
 
     openPricingModal = () => {
@@ -51,12 +59,6 @@ const UpgradeCloudButton = (): JSX.Element | null => {
             dialogType: PricingModal,
         }));
     };
-
-    const isCloudFreeEnabled = useSelector(cloudFreeEnabled);
-    const isAdmin = useSelector((state: GlobalState) => isCurrentUserSystemAdmin(state));
-    const subscription = useSelector(selectCloudSubscription);
-    const product = useSelector(selectCloudProduct);
-    const isCloud = useSelector(isCurrentLicenseCloud);
 
     const isEnterpriseTrial = subscription?.is_free_trial === 'true';
     const isStarter = product?.sku === CloudProducts.STARTER;


### PR DESCRIPTION
#### Summary
In the cloud_upgrade_button component, only make calls to the cloud endpoints when on cloud workspaces

#### Ticket Link
[MM-44566](https://mattermost.atlassian.net/browse/MM-44566)

#### Release Note
```release-note
NONE
```
