### PR TITLE
MM-44545 - show onboarding task list opened by default

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -269,6 +269,10 @@ export default class Root extends React.PureComponent {
         }
 
         Utils.applyTheme(this.props.theme);
+
+        if (this.props.firstTimeOnboarding) {
+            this.initOnboardingPrefs();
+        }
     }
 
     componentDidUpdate(prevProps) {

--- a/selectors/onboarding.ts
+++ b/selectors/onboarding.ts
@@ -95,24 +95,6 @@ const getSteps = createSelector(
     },
 );
 
-// show Onboarding task list if they haven't skipped/finished the legacy steps or there are legacy steps unfinished
-export const showOnboardingTaskListToExistingUsers = createSelector(
-    'showOnboardingTaskListToExistingUsers',
-    (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
-    (state: GlobalState) => legacyNextStepsNotFinished(state),
-    (stepPreferences, legacyNextStepsNotFinished) => {
-        if (stepPreferences.some((pref) => (pref.name === RecommendedNextStepsLegacy.SKIP && pref.value === 'true'))) {
-            return false;
-        }
-
-        if (stepPreferences.some((pref) => (pref.name === RecommendedNextStepsLegacy.HIDE && pref.value === 'true'))) {
-            return false;
-        }
-
-        return legacyNextStepsNotFinished;
-    },
-);
-
 // Loop through all Steps. For each step, check that
 export const legacyNextStepsNotFinished = createSelector(
     'legacyNextStepsNotFinished',
@@ -127,30 +109,64 @@ export const legacyNextStepsNotFinished = createSelector(
     },
 );
 
+// Loop through all Steps. For each step, check that
+export const hasLegacyNextStepsPreferences = createSelector(
+    'hasLegacyNextStepsPreferences',
+    (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
+    (state: GlobalState) => getSteps(state),
+    (stepPreferences, mySteps) => {
+        const checkPref = (step: StepType) => stepPreferences.some((pref) => (pref.name === step.id));
+        return mySteps.some(checkPref);
+    },
+);
+
 export const getShowTaskListBool = createSelector(
     'getShowTaskListBool',
     (state: GlobalState) => state,
     (state: GlobalState) => getCategory(state, OnboardingTaskCategory),
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
     (state, onboardingPreferences, legacyStepsPreferences) => {
+        const isMobileView = isMobile();
+
         // conditions to validate scenario where users (initially first_admins) had already set any of the onboarding task list preferences values.
         // We check wether the preference value exists meaning the onboarding tasks list already started no matter what the state of the process is
         const hasUserStartedOnboardingTaskListProcess = onboardingPreferences?.some((pref) =>
             pref.name === OnboardingTaskList.ONBOARDING_TASK_LIST_SHOW || pref.name === OnboardingTaskList.ONBOARDING_TASK_LIST_OPEN);
 
-        // This condition verifies existing users hasn't finished nor skipped legacy next steps or there are still steps not completed
-        const hasLegacyNextStepsPrefs = legacyStepsPreferences?.some((pref) =>
-            pref.name === RecommendedNextStepsLegacy.SKIP || pref.name === RecommendedNextStepsLegacy.HIDE);
-
-        const existingUserHasntFinishedNorSkippedLegacyNextSteps = hasLegacyNextStepsPrefs && showOnboardingTaskListToExistingUsers(state);
-
-        const completelyNewUserForOnboarding = !hasUserStartedOnboardingTaskListProcess && !hasLegacyNextStepsPrefs;
-
-        const firstTimeOnboarding = completelyNewUserForOnboarding || existingUserHasntFinishedNorSkippedLegacyNextSteps;
-
         const taskListStatus = getBool(state, OnboardingTaskCategory, OnboardingTaskList.ONBOARDING_TASK_LIST_SHOW);
-        const isMobileView = isMobile();
-        const showTaskList = (firstTimeOnboarding || taskListStatus) && !isMobileView;
+
+        if (hasUserStartedOnboardingTaskListProcess) {
+            return [(taskListStatus && !isMobileView), false];
+        }
+
+        // validate is a new user that must do the first time onboarding by checking that:
+        // 1. has not preferences related to the new onboarding task list.
+        // 2. has no legacy skip preference
+        // 3. has no legacy steps preferences
+        // 4. has completed legacy next steps (hide value for recommended_next_steps category set to false)
+
+        // This condition verifies existing users hasn't finished nor skipped legacy next steps or there are still steps not completed
+        const hasSkipLegacyStepsPreference = legacyStepsPreferences.some((pref) => (pref.name === RecommendedNextStepsLegacy.SKIP));
+        const hideLegacyStepsSetToFalse = legacyStepsPreferences.some((pref) => (pref.name === RecommendedNextStepsLegacy.HIDE && pref.value === 'false'));
+        const hasAnyOfTheLegacyStepsPreferences = hasLegacyNextStepsPreferences(state);
+        const areFirstUserPrefs = !hasSkipLegacyStepsPreference && hideLegacyStepsSetToFalse && !hasAnyOfTheLegacyStepsPreferences;
+
+        const completelyNewUserForOnboarding = !hasUserStartedOnboardingTaskListProcess && areFirstUserPrefs;
+
+        if (completelyNewUserForOnboarding) {
+            return [(!isMobileView), true];
+        }
+
+        // If none of the previous conditions matched, then it is an existing user with legacy prefs.
+        // To determine if we show the new onboarding task list we need to validate:
+        // has not skipped nor completed the legacy steps
+        const hasSkippedLegacySteps = legacyStepsPreferences.some((pref) => (pref.name === RecommendedNextStepsLegacy.SKIP && pref.value === 'true'));
+        const hasCompletedLegacySteps = legacyStepsPreferences.some((pref) => (pref.name === RecommendedNextStepsLegacy.HIDE && pref.value === 'true'));
+
+        const existingUserHasntFinishedNorSkippedLegacyNextSteps = !hasSkippedLegacySteps && !hasCompletedLegacySteps;
+
+        const showTaskList = existingUserHasntFinishedNorSkippedLegacyNextSteps && !isMobileView;
+        const firstTimeOnboarding = existingUserHasntFinishedNorSkippedLegacyNextSteps;
 
         return [showTaskList, firstTimeOnboarding];
     },


### PR DESCRIPTION
#### Summary
This PR makes sure of starting the initial preferences for always showing the onboarding task list opened.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44545

#### Related Pull Requests
n/a
#### Screenshots


#### Release Note
```release-note
NONE
```
