### PR TITLE
[MM-44587] Drop unnecessary periodic sync functionality

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -266,26 +266,6 @@ function syncThreads(teamId, userId) {
     dispatch(getCountsAndThreadsSince(userId, teamId, newestThread.last_reply_at));
 }
 
-let intervalId = '';
-const SYNC_INTERVAL_MILLISECONDS = 1000 * 60 * 15; // 15 minutes
-
-export function startPeriodicSync() {
-    clearInterval(intervalId);
-
-    intervalId = setInterval(
-        () => {
-            if (getCurrentUser(getState()) != null) {
-                reconnect(false);
-            }
-        },
-        SYNC_INTERVAL_MILLISECONDS,
-    );
-}
-
-export function stopPeriodicSync() {
-    clearInterval(intervalId);
-}
-
 export function registerPluginWebSocketEvent(pluginId, event, action) {
     if (!pluginEventHandlers[pluginId]) {
         pluginEventHandlers[pluginId] = {};

--- a/components/needs_team/needs_team.tsx
+++ b/components/needs_team/needs_team.tsx
@@ -11,7 +11,7 @@ import {Group} from 'mattermost-redux/types/groups';
 import {UserProfile, UserStatus} from 'mattermost-redux/types/users';
 
 import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
-import {startPeriodicSync, stopPeriodicSync, reconnect} from 'actions/websocket_actions.jsx';
+import {reconnect} from 'actions/websocket_actions.jsx';
 import * as GlobalActions from 'actions/global_actions';
 
 import Constants from 'utils/constants';
@@ -139,7 +139,6 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
 
     public componentDidMount() {
         startPeriodicStatusUpdates();
-        startPeriodicSync();
         this.fetchAllTeams();
 
         // Set up tracking for whether the window is active
@@ -169,7 +168,6 @@ export default class NeedsTeam extends React.PureComponent<Props, State> {
     componentWillUnmount() {
         window.isActive = false;
         stopPeriodicStatusUpdates();
-        stopPeriodicSync();
         if (UserAgent.isIosSafari()) {
             iNoBounce.disable();
         }


### PR DESCRIPTION
#### Summary

We have this function to periodically trigger `reconnect()` (every 15 minutes). This has an undesired side effect on plugins making use of the `registerReconnectHandler` hook which is expected to run on an actual reconnect and not just every few minutes. Any needed synchronization should be handled by the actual websocket reconnect functionality we have in place so proposing to drop this as unnecessary and see how it goes. Of course it's a bit hard to test whether this change would have unpredicted side effects so we'll have to rely on the usual dogfooding process through Community.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44587

#### Release Note

```release-note
NONE
```