### PR TITLE
MM-44631 - use the enable onboarding config to show/hide the  onboarding

### DIFF
--- a/components/root/index.js
+++ b/components/root/index.js
@@ -33,8 +33,8 @@ function mapStateToProps(state) {
     let showTaskList = false;
     let firstTimeOnboarding = false;
 
-    // validation to avoid execute logic on first load which has no preferences values on global store
-    if (Object.keys(state.entities.preferences.myPreferences).length > 0) {
+    // validation to avoid execute logic on first load which has no preferences values on global store, also check the enable onboarding config value
+    if (Object.keys(state.entities.preferences.myPreferences).length > 0 && config.EnableOnboardingFlow === 'true') {
         [showTaskList, firstTimeOnboarding] = getShowTaskListBool(state);
     }
 


### PR DESCRIPTION
#### Summary
This PR adds the code to check the EnableOnboardingFlow config option to hide/show the new onboarding tasklist

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44631

#### Related Pull Requests
n/a

#### Screenshots

https://user-images.githubusercontent.com/10082627/170373448-948ad3a6-3ad1-49e0-949d-289bb102496d.mp4

#### Release Note
```release-note
NONE
```
