### PR TITLE
WIP: [MM-25147] Fix screenreader issue for usernames in messages

### DIFF
--- a/components/at_mention/at_mention.tsx
+++ b/components/at_mention/at_mention.tsx
@@ -12,6 +12,7 @@ import {Group} from '@mattermost/types/groups';
 import ProfilePopover from 'components/profile_popover';
 
 import {popOverOverlayPosition} from 'utils/position_utils';
+import {getUserFromMentionName} from 'utils/post_utils';
 
 const spaceRequiredForPopOver = 300;
 
@@ -68,26 +69,6 @@ export default class AtMention extends React.PureComponent<Props, State> {
         this.setState({show: false});
     }
 
-    getUserFromMentionName() {
-        const {usersByUsername, mentionName} = this.props;
-        let mentionNameToLowerCase = mentionName.toLowerCase();
-
-        while (mentionNameToLowerCase.length > 0) {
-            if (usersByUsername.hasOwnProperty(mentionNameToLowerCase)) {
-                return usersByUsername[mentionNameToLowerCase];
-            }
-
-            // Repeatedly trim off trailing punctuation in case this is at the end of a sentence
-            if ((/[._-]$/).test(mentionNameToLowerCase)) {
-                mentionNameToLowerCase = mentionNameToLowerCase.substring(0, mentionNameToLowerCase.length - 1);
-            } else {
-                break;
-            }
-        }
-
-        return '';
-    }
-
     getGroupFromMentionName() {
         const {groupsByName, mentionName} = this.props;
         const mentionNameTrimmed = mentionName.toLowerCase().replace(/[._-]*$/, '');
@@ -95,7 +76,7 @@ export default class AtMention extends React.PureComponent<Props, State> {
     }
 
     render() {
-        const user = this.getUserFromMentionName();
+        const user = getUserFromMentionName(this.props.usersByUsername, this.props.mentionName);
 
         if (!this.props.disableGroupHighlight && !user) {
             const group = this.getGroupFromMentionName();

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1198,6 +1198,7 @@ export const Constants = {
     HERE_MENTION_REGEX: /(?:\B|\b_+)@(here)(?!(\.|-|_)*[^\W_])/gi,
     NOTIFY_ALL_MEMBERS: 5,
     ALL_MEMBERS_MENTIONS_REGEX: /(?:\B|\b_+)@(channel|all)(?!(\.|-|_)*[^\W_])/gi,
+    MENTIONS_WITHOUT_SPECIAL_MENTIONS: /(?:\B|\b_+)(?!@(here|channel|all))@([a-z0-9.\-_]+)/gi,
     DEFAULT_CHARACTER_LIMIT: 4000,
     IMAGE_TYPE_GIF: 'gif',
     TEXT_TYPES: ['txt', 'rtf'],


### PR DESCRIPTION
#### Summary
This will allow screen readers to read preferred names that are mentioned in messages

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25147

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
