### PR TITLE
[MM 44588] fixes: Keyboard focus not put back to post textbox after hitting ctrl+shift+p twice

### DIFF
--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -320,6 +320,11 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         if (prevState.showEmojiPicker && !this.state.showEmojiPicker) {
             this.focusTextbox();
         }
+
+        // Focus on textbox when returned from preview mode
+        if (prevProps.shouldShowPreview && !this.props.shouldShowPreview) {
+            this.focusTextbox();
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
#### Summary
fixes: Keyboard focus not put back to post textbox after hitting ctrl+shift+p twice

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-44588

#### Related Pull Requests
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Bugfix: Keyboard focus not put back to post textbox after hitting ctrl+shift+p twice
```
