### PR TITLE
[MM-44435] Fix crash when coming back from system console with RHS open.

### DIFF
--- a/components/channel_info_rhs/index.ts
+++ b/components/channel_info_rhs/index.ts
@@ -59,6 +59,8 @@ function mapStateToProps(state: GlobalState) {
             canManageMembers: false,
             canManageProperties: false,
             channelStats,
+            isMobile: false,
+            channelMembers: [],
         };
     }
 

--- a/e2e/cypress/tests/integration/channel/channel_info_rhs_spec.js
+++ b/e2e/cypress/tests/integration/channel/channel_info_rhs_spec.js
@@ -89,6 +89,32 @@ describe('Channel Info RHS', () => {
         });
     });
 
+    it('MM-44435 - should be able to open RHS, visit the system console and come back without issues', () => {
+        // # Go to test channel
+        cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+
+        // # Click on the channel info button
+        cy.get('#channel-info-btn').click();
+
+        // * RHS Container shoud exist
+        cy.get('#rhsContainer').then((rhsContainer) => {
+            cy.wrap(rhsContainer).findByText('Info').should('be.visible');
+            cy.wrap(rhsContainer).findByText(testChannel.display_name).should('be.visible');
+        });
+
+        // # visit the system console...
+        cy.uiOpenProductMenu('System Console');
+
+        // # ...and leave it
+        cy.get('.backstage-navbar__back').click();
+
+        // * RHS Container shoud exist again
+        cy.get('#rhsContainer').then((rhsContainer) => {
+            cy.wrap(rhsContainer).findByText('Info').should('be.visible');
+            cy.wrap(rhsContainer).findByText(testChannel.display_name).should('be.visible');
+        });
+    });
+
     describe('regular channel', () => {
         describe('top buttons', () => {
             it('should be able to toggle favorite on a channel', () => {


### PR DESCRIPTION
#### Summary
Fix a bug causing the webapp to blank when a user opens the channel info rhs, goes to the systen console and comes back to the app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44435

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
