### PR TITLE
MM-44429 - open view plans modal

### DIFF
--- a/components/widgets/menu/menu_items/menu_cloud_trial.tsx
+++ b/components/widgets/menu/menu_items/menu_cloud_trial.tsx
@@ -22,6 +22,7 @@ import {TrialPeriodDays, ModalIdentifiers} from 'utils/constants';
 import useGetHighestThresholdCloudLimit from 'components/common/hooks/useGetHighestThresholdCloudLimit';
 import useGetLimits from 'components/common/hooks/useGetLimits';
 import useGetUsage from 'components/common/hooks/useGetUsage';
+import useOpenPricingModal from 'components/common/hooks/useOpenPricingModal';
 
 import './menu_item.scss';
 
@@ -33,6 +34,7 @@ const MenuCloudTrial = ({id}: Props) => {
     const license = useSelector(getLicense);
     const dispatch = useDispatch<DispatchFunc>();
     const {formatMessage} = useIntl();
+    const openPricingModal = useOpenPricingModal();
 
     const isCloud = license?.Cloud === 'true';
     const isFreeTrial = subscription?.is_free_trial === 'true';
@@ -122,11 +124,9 @@ const MenuCloudTrial = ({id}: Props) => {
                 id='menu.cloudFree.tryEnterprise'
                 defaultMessage='Interested in a limitless plan with high-security features?'
             />
-
-            {/* Todo: modify this to open the see plans modal */}
             <a
                 className='open-see-plans-modal style-link'
-                onClick={() => null}
+                onClick={openPricingModal}
             >
                 <FormattedMessage
                     id='menu.cloudFree.seePlans'


### PR DESCRIPTION
#### Summary
This PR adds the logic to open the view plans modal from the See Plans link shown on the main menu. This one is shown once the trial have passed and there is no subscription.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44419

#### Related Pull Requests
n/a

#### Screenshots

https://user-images.githubusercontent.com/10082627/171473554-b9a7d8be-c823-41cb-8527-0f0499c64d84.mp4



#### Release Note
```release-note
NONE
```
