### PR TITLE
default to 0 storage used until real storage data is available

### DIFF
--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -141,9 +141,8 @@ export function getFilesUsage(): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         dispatch({
             type: CloudTypes.RECEIVED_FILES_USAGE,
-
             // TODO: Fill this in with the backing client API method once it is available in the server
-            data: 3 * FileSizes.Gigabyte,
+            data: 0,
         });
         return {data: true};
     };

--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -4,8 +4,6 @@
 import {Stripe} from '@stripe/stripe-js';
 import {getCode} from 'country-list';
 
-import {FileSizes} from 'utils/file_utils';
-
 import {Client4} from 'mattermost-redux/client';
 import {ActionFunc, DispatchFunc} from 'mattermost-redux/types/actions';
 
@@ -141,6 +139,7 @@ export function getFilesUsage(): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         dispatch({
             type: CloudTypes.RECEIVED_FILES_USAGE,
+
             // TODO: Fill this in with the backing client API method once it is available in the server
             data: 0,
         });


### PR DESCRIPTION
#### Summary
Per bug bash, we want to show 0 file storage usage instead of fake file storage until real usage is available.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44742

#### Screenshots
![no-storage](https://user-images.githubusercontent.com/13738432/171475030-dc7036b4-411c-4cbb-a5dd-3df622552119.png)

#### Release Note
```release-note
NONE
```
