### PR TITLE
MM-44650_Turn off Use Case Based Onboarding for Self-Managed while A/B Test runs on Cloud

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -208,7 +208,7 @@ export function isCustomGroupsEnabled(state: GlobalState): boolean {
 }
 
 export function getUseCaseOnboarding(state: GlobalState): boolean {
-    return getFeatureFlagValue(state, 'UseCaseOnboarding') === 'true';
+    return getFeatureFlagValue(state, 'UseCaseOnboarding') === 'true' && getLicense(state)?.Cloud === 'true';
 }
 
 export function insightsAreEnabled(state: GlobalState): boolean {


### PR DESCRIPTION
#### Summary
While the A/B test to hide the Use Case Based Onboarding is running on Cloud the experience should be hidden by default for Self-Managed workspaces.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44650

#### Release Note
```release-note
NONE
```
