### PR TITLE
Fix incorrect message when **Make Team Admin** fails

### DIFF
--- a/components/admin_console/manage_teams_modal/manage_teams_dropdown.tsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_dropdown.tsx
@@ -32,7 +32,7 @@ const ManageTeamsDropdown = (props: Props) => {
             props.onError(
                 <FormattedMessage
                     id='admin.manage_teams.makeAdminError'
-                    defaultMessage='Unable to remove user an admin.'
+                    defaultMessage='Unable to make user a team admin.'
                 />);
         } else {
             props.onMemberChange(props.teamMember.team_id);

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1326,7 +1326,7 @@
   "admin.manage_roles.saveError": "Unable to save roles.",
   "admin.manage_roles.systemAdmin": "System Admin",
   "admin.manage_roles.systemMember": "Member",
-  "admin.manage_teams.makeAdminError": "Unable to remove user an admin.",
+  "admin.manage_teams.makeAdminError": "Unable to make user a team admin.",
   "admin.manage_teams.makeMemberError": "Unable to make user a member.",
   "admin.manage_teams.removeError": "Unable to remove user from team.",
   "admin.manage_tokens.manageTokensTitle": "Manage Personal Access Tokens",


### PR DESCRIPTION
#### Summary
The message displayed when  **Make Team Admin** fails is not an appropriate description of the error.

https://user-images.githubusercontent.com/1453749/171641388-801edc65-1143-47c8-a14b-96e98b4a5489.mp4

This PR fixes the message.

#### Ticket Link

N/A

(This issue is discussed in [i18 - Localization channel](https://community-daily.mattermost.com/core/pl/mpr7ugyj3fdn9nsonhypibzzto) of community chat)

#### Related Pull Requests

N/A

#### Screenshots

N/A

#### Release Note
N/A