### PR TITLE
MM-44685: Render app bar icons on top of RHS background

### DIFF
--- a/components/app_bar/app_bar.scss
+++ b/components/app_bar/app_bar.scss
@@ -36,6 +36,9 @@ $channel-view-padding: 63px;
 
     .app-bar__icon {
         position: relative;
+        // Render App Bar icons on top of the RHS background div
+        //(see `@media screen and (min-width: 769px) > #sidebar-right` in sass/layout/_sidebar-right.scss)
+        z-index: 21;
         width: 100%;
         border-left: none;
         margin-bottom: 16px;

--- a/sass/layout/_sidebar-right.scss
+++ b/sass/layout/_sidebar-right.scss
@@ -322,6 +322,8 @@
 @media screen and (min-width: 769px) {
     // adjust RHS position and height
     #sidebar-right {
+        // If this is changed, the interaction with the App Bar icons must be tested
+        //(see .app-bar__icon in components/app_bar/app_bar.scss)
         z-index: 20;
         top: 0;
 


### PR DESCRIPTION
#### Summary
When the RHS is open and expanded, it renders a `position: absolute` div that covers the whole screen. This div handles any click on it to collapse the RHS again. The end result is that the user can click anywhere outside of the RHS to collapse it.

When the App Bar was implemented, this was not taken into account, so such RHS background renders also on top of the App Bar icons, making it impossible to click on them when the RHS is expanded.

There are two simple solutions for this:
1. Make the App Bar icons to render on top of the background as it is today (this very PR).
2. Shift the RHS background to the left, so that it does not cover the App Bar. This can be accomplished by aligning it to the right of the RHS with the following change:
```diff
--- a/sass/layout/_sidebar-right.scss
+++ b/sass/layout/_sidebar-right.scss
@@ -38,7 +38,7 @@
         position: absolute;
         z-index: 5;
         top: -70px;
-        left: -500%;
+        right: 0;
         // Since the element (sidebar--right__bg) is tied to the sidebar, we need to expand beyond it, we're given an arbitrary large width and left positioning so that it may take the width completely
         width: 1000%;
         height: 110%;
```
Option 2 has the advantage of being much cleaner, as we don't mess with z-indexes. However, it has a negative consequence: the whole App Bar is no longer covered by that background, so clicking on an empty space of the App Bar does not collapse the RHS. This may be confusing for the end user, who knows that clicking anywhere outside of the RHS collapses it.

That's why I chose option 1. The complexity problem of having to deal with z-indexes is relieved with the comments added.

I could have also implemented another solution: remove the RHS background altogether and detect clicks outside of the RHS by adding a listener to the mousedown event and inspecting it, checking whether the RHS outer container was clicked or not (something like
`containerRef.contains(event.target)`). This solution was discarded because it drastically changes the original design of the RHS and this commit is being merged just a few days ago from a major release, so minimizing risks is imperative.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44685

#### Related Pull Requests
--

#### Screenshots

https://user-images.githubusercontent.com/3924815/171682317-25a2c0e7-f18c-4a4d-ba4d-328212a866a6.mp4

#### Release Note

```release-note
NONE
```
