### PR TITLE
Remove cloud-starter-legacy; we do not need it

### DIFF
--- a/components/admin_console/billing/billing_subscriptions/limits.test.tsx
+++ b/components/admin_console/billing/billing_subscriptions/limits.test.tsx
@@ -10,15 +10,15 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import {Provider} from 'react-redux';
 
+import {GlobalState} from '@mattermost/types/store';
+import {UserProfile, UsersState} from '@mattermost/types/users';
+
 import {renderWithIntl} from 'tests/react_testing_utils';
 
 import * as cloudActions from 'actions/cloud';
 
 import {FileSizes} from 'utils/file_utils';
-
-import {GlobalState} from '@mattermost/types/store';
-import {UserProfile, UsersState} from '@mattermost/types/users';
-import {Constants} from 'utils/constants';
+import {Constants, CloudProducts} from 'utils/constants';
 
 import {Subscription, Product} from '@mattermost/types/cloud';
 
@@ -63,12 +63,12 @@ function setupStore(setupOptions: SetupOptions) {
                     prod_starter: {
                         id: 'prod_starter',
                         name: 'Cloud Starter',
-                        sku: 'cloud-starter',
+                        sku: CloudProducts.STARTER,
                     } as Product,
                     prod_enterprise: {
                         id: 'prod_enterprise',
                         name: 'Cloud Enterprise',
-                        sku: 'cloud-enterprise',
+                        sku: CloudProducts.ENTERPRISE,
                     } as Product,
                 } as Record<string, Product>,
             },

--- a/components/admin_console/billing/billing_subscriptions/limits.tsx
+++ b/components/admin_console/billing/billing_subscriptions/limits.tsx
@@ -16,7 +16,7 @@ import {SalesInquiryIssue} from 'selectors/cloud';
 
 import {CloudProducts} from 'utils/constants';
 import {FileSizes} from 'utils/file_utils';
-import {asGBString, fallbackStarterLimits} from 'utils/limits';
+import {asGBString, fallbackStarterLimits, hasSomeLimits} from 'utils/limits';
 
 import useGetLimits from 'components/common/hooks/useGetLimits';
 import useGetUsage from 'components/common/hooks/useGetUsage';
@@ -43,7 +43,7 @@ const Limits = (props: Props): JSX.Element | null => {
     const openSalesLink = useOpenSalesLink(SalesInquiryIssue.UpgradeEnterprise);
     const openPricingModal = useOpenPricingModal();
 
-    if (!isCloudFreeEnabled || !limitsLoaded || !subscriptionProduct || subscriptionProduct.sku === CloudProducts.STARTER_LEGACY || subscriptionProduct.sku === CloudProducts.ENTERPRISE) {
+    if (!isCloudFreeEnabled || !subscriptionProduct || !limitsLoaded || !hasSomeLimits(cloudLimits)) {
         return null;
     }
 

--- a/components/admin_console/billing/plan_details/feature_list.tsx
+++ b/components/admin_console/billing/plan_details/feature_list.tsx
@@ -2,12 +2,9 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {useSelector} from 'react-redux';
 import {useIntl} from 'react-intl';
 
-import {cloudFreeEnabled} from 'mattermost-redux/selectors/entities/preferences';
-
-import {fallbackStarterLimits, fallbackProfessionalLimits, asGBString} from 'utils/limits';
+import {fallbackStarterLimits, fallbackProfessionalLimits, asGBString, hasSomeLimits} from 'utils/limits';
 import useGetLimits from 'components/common/hooks/useGetLimits';
 import {CloudProducts} from 'utils/constants';
 
@@ -21,7 +18,6 @@ export interface FeatureListProps {
 const FeatureList = (props: FeatureListProps) => {
     const intl = useIntl();
     const [limits] = useGetLimits();
-    const isCloudFreeEnabled = useSelector(cloudFreeEnabled);
     const featuresFreeTier = [
         intl.formatMessage({
             id: 'admin.billing.subscription.planDetails.features.10GBstoragePerUser',
@@ -212,14 +208,7 @@ const FeatureList = (props: FeatureListProps) => {
             break;
 
         case CloudProducts.STARTER:
-
-            // Pre Cloud Free launch, the Starter plan whose sku is cloud-starter-legacy was `cloud-starter.
-            // So assume that if we are still pre cloud free launch and the feature flag is off,
-            // we are referring to that old sku and should show its features.
-            features = isCloudFreeEnabled ? featuresCloudStarter : featuresCloudStarterLegacy;
-            break;
-        case CloudProducts.STARTER_LEGACY:
-            features = featuresCloudStarterLegacy;
+            features = hasSomeLimits(limits) ? featuresCloudStarter : featuresCloudStarterLegacy;
             break;
         case CloudProducts.ENTERPRISE:
             features = featuresCloudEnterprise;

--- a/components/admin_console/billing/plan_details/plan_details.tsx
+++ b/components/admin_console/billing/plan_details/plan_details.tsx
@@ -61,14 +61,6 @@ export const planDetailsTopElements = (
                 />
             );
             break;
-        case CloudProducts.STARTER_LEGACY:
-            productName = (
-                <FormattedMessage
-                    id='admin.billing.subscription.planDetails.productName.cloudStarter'
-                    defaultMessage='Cloud Starter'
-                />
-            );
-            break;
         default:
             // must be CloudProducts.LEGACY
             productName = (

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -410,10 +410,11 @@ export const EventTypes = Object.assign(
 );
 
 export const CloudProducts = {
-    STARTER_LEGACY: 'cloud-starter-legacy',
 
-    // STARTER sku is used by paid cloud subscription until the time the cloud free flag is enabled,
-    // at which time it becomes STARTER_LEGACY and the free starter plan uses STARTER sku.
+    // STARTER sku is used by both free cloud starter
+    // and paid cloud starter (legacy cloud starter).
+    // Where differentiation is needed, check whether any limits are applied.
+    // If none are applied, it must be legacy cloud starter.
     STARTER: 'cloud-starter',
     PROFESSIONAL: 'cloud-professional',
     ENTERPRISE: 'cloud-enterprise',

--- a/utils/limits.tsx
+++ b/utils/limits.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 import {FormatNumberOptions} from 'react-intl';
 
-import {CloudUsage} from '@mattermost/types/cloud';
+import {CloudUsage, Limits} from '@mattermost/types/cloud';
 
 import {FileSizes} from './file_utils';
 
@@ -58,6 +58,10 @@ export function anyUsageDeltaExceededLimit(deltas: CloudUsage) {
         }
     });
     return foundAPositive;
+}
+
+export function hasSomeLimits(limits: Limits): boolean {
+    return Object.keys(limits).length > 0;
 }
 
 export const limitThresholds = Object.freeze({


### PR DESCRIPTION
#### Summary
Previous PRs added/used cloud-starter-legacy; it overcomplicates licensing and releasing of cloud freemium, and the UI checks based on it can all be achieved by looking at whether the plan is `cloud-starter` sku and if there are any applied limits (if there are no limits, then it must by legacy/paid cloud-starter).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44440

#### Screenshots
No UI changes

#### Release Note
```release-note
NONE
```
