### PR TITLE
MM-44686: Fix squared outline using box-shadow

### DIFF
--- a/components/app_bar/app_bar.scss
+++ b/components/app_bar/app_bar.scss
@@ -55,10 +55,10 @@ $channel-view-padding: 63px;
 
             .app-bar__icon-inner,
             span {
-                outline: solid 2px var(--sidebar-text-active-border);
+                box-shadow: 0 0 0 2px var(--sidebar-text-active-border);
 
                 &:hover {
-                    outline: solid 2px rgba(var(--sidebar-text-active-border-rgb), 0.92) !important;
+                    box-shadow: 0 0 0 2px rgba(var(--sidebar-text-active-border-rgb), 0.92) !important;
                 }
             }
         }
@@ -74,7 +74,7 @@ $channel-view-padding: 63px;
             line-height: 1;
 
             &:hover {
-                outline: solid 2px rgba(var(--center-channel-color-rgb), 0.16);
+                box-shadow: 0 0 0 2px rgba(var(--center-channel-color-rgb), 0.16);
             }
 
             img {


### PR DESCRIPTION
#### Summary
Another fix for v7.0 cc/@amyblais.

The interaction of outline and border-radius is not always as one would expect, and the version of Electron used in Desktop 5.0.x seems not to apply the 50% border-radius to the outline of the App Bar icons (Desktop 5.1.x works fine).

As a workaround, we use box-shadow, which does fix the issue in Desktop 5.0.x while keeping the same behavior elsewhere.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44686

#### Related Pull Requests
--

#### Screenshots
![image](https://user-images.githubusercontent.com/3924815/171845110-d7138516-fcde-4dd7-8780-5263572a437f.png)

#### Release Note
```release-note
NONE
```
