### PR TITLE
MM44687: Add divider between the core products and the rest of icons

### DIFF
--- a/components/app_bar/__snapshots__/app_bar.test.tsx.snap
+++ b/components/app_bar/__snapshots__/app_bar.test.tsx.snap
@@ -80,6 +80,9 @@ exports[`components/app_bar/app_bar should match snapshot on mount 1`] = `
         </OverlayTrigger>
       </OverlayTrigger>
     </AppBarPluginComponent>
+    <hr
+      className="app-bar__divider"
+    />
     <AppBarBinding
       binding={
         Object {

--- a/components/app_bar/app_bar.scss
+++ b/components/app_bar/app_bar.scss
@@ -115,6 +115,13 @@ $channel-view-padding: 63px;
         }
     }
 
+    .app-bar__divider {
+        width: 28px;
+        border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+        margin-top: 14px;
+        margin-bottom: 14px;
+    }
+
     .app-bar__icon.channel-header__icon--active {
         background: rgba(var(--button-bg-rgb), 0.08);
         color: var(--button-bg);

--- a/components/app_bar/app_bar.tsx
+++ b/components/app_bar/app_bar.tsx
@@ -7,6 +7,7 @@ import {useSelector} from 'react-redux';
 import {getAppBarAppBindings} from 'mattermost-redux/selectors/entities/apps';
 
 import {getAppBarPluginComponents, getChannelHeaderPluginComponents, shouldShowAppBar} from 'selectors/plugins';
+import {PluginComponent} from 'types/store/plugins';
 
 import AppBarPluginComponent from './app_bar_plugin_component';
 import AppBarBinding from './app_bar_binding';
@@ -24,26 +25,32 @@ export default function AppBar() {
         return null;
     }
 
-    // Order the plugin components so that Playbooks is the first one,
-    // Boards is the second one, and the others remain in the same place.
-    const orderedAppBarPluginComponents = [...appBarPluginComponents];
-    orderedAppBarPluginComponents.sort((a, b) => {
-        switch (a.pluginId) {
-        case 'playbooks':
-            return -1;
+    const coreProductsIds = ['playbooks', 'focalboard'];
 
-        case 'focalboard':
-            return b.pluginId === 'playbooks' ? 1 : -1;
+    // The type guard in the filter (which removes all undefined elements) is needed for
+    // Typescript to correctly type coreProducts.
+    const coreProducts = coreProductsIds.
+        map((id) => appBarPluginComponents.find((element) => element.pluginId === id)).
+        filter((element): element is PluginComponent => Boolean(element));
 
-        default:
-            return 1;
-        }
-    });
+    const appBarPluginComponentsWithoutCoreProducts = appBarPluginComponents.filter((element) => !coreProductsIds.includes(element.pluginId));
+    const pluginComponents = appBarPluginComponentsWithoutCoreProducts.concat(channelHeaderComponents);
 
-    const pluginComponents = orderedAppBarPluginComponents.concat(channelHeaderComponents);
+    const isCoreProductsSectionNonEmpty = coreProducts.length > 0;
+    const isRegularIconsSectionNonEmpty = pluginComponents.length > 0 || appBarBindings.length > 0;
+    const isDividerVisible = isCoreProductsSectionNonEmpty && isRegularIconsSectionNonEmpty;
 
     return (
         <div className={'app-bar'}>
+            {coreProducts.map((product) => (
+                <AppBarPluginComponent
+                    key={product.id}
+                    component={product}
+                />
+            ))}
+            {isDividerVisible &&
+            <hr className={'app-bar__divider'}/>
+            }
             {pluginComponents.map((component) => (
                 <AppBarPluginComponent
                     key={component.id}

--- a/components/app_bar/app_bar.tsx
+++ b/components/app_bar/app_bar.tsx
@@ -48,9 +48,9 @@ export default function AppBar() {
                     component={product}
                 />
             ))}
-            {isDividerVisible &&
-            <hr className={'app-bar__divider'}/>
-            }
+            {isDividerVisible && (
+                <hr className={'app-bar__divider'}/>
+            )}
             {pluginComponents.map((component) => (
                 <AppBarPluginComponent
                     key={component.id}


### PR DESCRIPTION
#### Summary
This PR adds a divider between the core products section (i.e., Playbooks and Boards) and the rest of the icons in the App Bar. It is shown only when both sections are visible.

Another one for v7.0 :nerd_face: cc/ @amyblais 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44687

#### Related Pull Requests
--

#### Screenshots

https://user-images.githubusercontent.com/3924815/171902141-095c5af4-984c-4aa7-afb1-a1713324ebcb.mp4

#### Release Note
```release-note
NONE
```
