### PR TITLE
[MM-43373] Channel Switcher : Maintain selection of previous item selected if items exists in new terms received

### DIFF
--- a/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -638,9 +638,10 @@ export default class SuggestionBox extends React.PureComponent {
         const terms = suggestions.terms;
         const items = suggestions.items;
         let selection = this.state.selection;
-        if (terms.length > 0) {
+        const selectionIndex = terms.indexOf(selection);
+        if (terms.length > 0 && selectionIndex === -1) {
             selection = terms[0];
-        } else if (this.state.selection) {
+        } else if (this.state.selection && selectionIndex === -1) {
             selection = '';
         }
 


### PR DESCRIPTION
#### Summary
Maintain selection of the previous item selected in Channel Switcher if items exist in new terms received

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-43373

#### Related Pull Requests
NONE

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Channel Switcher: Maintain selection of the previous item selected if items exist in new terms received
```
