### PR TITLE
[MM-44701] Adjust trial end check in banner to June 15

### DIFF
--- a/components/announcement_bar/cloud_trial_ended_announcement_bar/index.tsx
+++ b/components/announcement_bar/cloud_trial_ended_announcement_bar/index.tsx
@@ -65,7 +65,7 @@ const CloudTrialEndAnnouncementBar: React.FC = () => {
 
         // trial_end_at values will be 0 for all freemium subscriptions after June 15
         // Subscriptions created prior to that will almost always have a trial_end_at value, guaranteed.
-        if (subscription.trial_end_at === 0 || trialEnd > now || trialEnd < new Date('2022-05-15')) {
+        if (subscription.trial_end_at === 0 || trialEnd > now || trialEnd < new Date('2022-06-15')) {
             return false;
         }
         if (!isSystemAdmin(currentUser.roles)) {


### PR DESCRIPTION
#### Summary
This was left at May 15 for testing purposes. We'll need it in June for the release.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44701
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
