### PR TITLE
MM-44100 Always open internal help pages in a new tab

### DIFF
--- a/utils/url.tsx
+++ b/utils/url.tsx
@@ -177,10 +177,14 @@ export function shouldOpenInNewTab(url: string, siteURL?: string, managedResourc
 
     const path = url.startsWith('/') ? url : url.substring(siteURL?.length || 0);
 
-    // Paths managed by plugins and public file links aren't handled by the web app
     const unhandledPaths = [
+
+        // Paths managed by plugins and public file links aren't handled by the web app
         'plugins',
         'files',
+
+        // Internal help pages should always open in a new tab
+        'help',
     ];
 
     // Paths managed by another service shouldn't be handled by the web app either


### PR DESCRIPTION
We have some links to these pages in the UI (under the old textbox), and while those normally open in a new tab, if you copy and pasted that link into a post, you could get it to open within the Desktop App. When you were there, there was no back button, so you could get stuck.

This fixes that by just making it so that they always open in a new tab.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44100

#### Release Note
```release-note
Always open links to internal help pages in a new browser tab
```
