### PR TITLE
[MM-44896] Advanced Text Editor Don't show the preview button if the input is empty

### DIFF
--- a/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/components/advanced_text_editor/advanced_text_editor.tsx
@@ -220,13 +220,6 @@ const AdvanceTextEditor = ({
         />
     );
 
-    const showFormatJSX = readOnlyChannel ? null : (
-        <ShowFormat
-            onClick={handleShowFormat}
-            active={shouldShowPreview}
-        />
-    );
-
     const getEmojiPickerRef = () => {
         return emojiPickerRef.current;
     };
@@ -288,6 +281,13 @@ const AdvanceTextEditor = ({
         <SendButton
             disabled={disableSendButton}
             handleSubmit={handleSubmit}
+        />
+    );
+
+    const showFormatJSX = disableSendButton ? null : (
+        <ShowFormat
+            onClick={handleShowFormat}
+            active={shouldShowPreview}
         />
     );
 


### PR DESCRIPTION
#### Summary
Advanced Text Editor Don't show the preview button if the input is empty

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-44896

#### Related Pull Requests
NONE

#### Screenshots
<img width="974" alt="Screenshot 2022-06-07 at 3 36 08 PM" src="https://user-images.githubusercontent.com/16203333/172354397-371d1860-d52b-43ce-b2d8-a30431de4436.png">


#### Release Note
```release-note
UI: Advanced Text Editor Don't show the preview button if the input is empty
```
