### PR TITLE
[MM-44648] - Card input not visible in darker modes

### DIFF
--- a/components/admin_console/billing/payment_info_edit.tsx
+++ b/components/admin_console/billing/payment_info_edit.tsx
@@ -11,6 +11,7 @@ import {Elements} from '@stripe/react-stripe-js';
 
 import {getCloudCustomer} from 'mattermost-redux/actions/cloud';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {completeStripeAddPaymentMethod} from 'actions/cloud';
 import BlockableLink from 'components/admin_console/blockable_link';
@@ -32,6 +33,7 @@ const PaymentInfoEdit: React.FC = () => {
     const dispatch = useDispatch();
     const isDevMode = useSelector((state: GlobalState) => getConfig(state).EnableDeveloper === 'true');
     const paymentInfo = useSelector((state: GlobalState) => state.entities.cloud.customer);
+    const theme = useSelector(getTheme);
 
     const [showCreditCardWarning, setShowCreditCardWarning] = useState(true);
     const [isSaving, setIsSaving] = useState(false);
@@ -131,6 +133,7 @@ const PaymentInfoEdit: React.FC = () => {
                                 className='PaymentInfoEdit__paymentForm'
                                 onInputChange={onPaymentInput}
                                 initialBillingDetails={billingDetails}
+                                theme={theme}
                             />
                         </Elements>
                     </div>

--- a/components/payment_form/card_input.tsx
+++ b/components/payment_form/card_input.tsx
@@ -4,29 +4,19 @@
 import React from 'react';
 import {StripeElements, StripeCardElement, StripeCardElementChangeEvent} from '@stripe/stripe-js';
 import {ElementsConsumer, CardElement} from '@stripe/react-stripe-js';
-
 import {FormattedMessage} from 'react-intl';
+
+import {Theme} from 'mattermost-redux/types/themes';
+import {toRgbValues} from 'utils/utils';
 
 import './card_input.css';
 import 'components/widgets/inputs/input/input.scss';
-
-const CARD_ELEMENT_OPTIONS = {
-    hidePostalCode: true,
-    style: {
-        base: {
-            fontFamily: "'Open Sans', sans-serif",
-            fontSize: '14px',
-            opacity: '0.5',
-            fontSmoothing: 'antialiased',
-            color: '#3f4350', // For now show a color that's visible in darker modes. To fix in https://mattermost.atlassian.net/browse/MM-44648
-        },
-    },
-};
 
 type OwnProps = {
     error?: string;
     required?: boolean;
     forwardedRef?: any;
+    theme: Theme;
 
     // Stripe doesn't give type exports
     [propName: string]: any; //eslint-disable-line @typescript-eslint/no-explicit-any
@@ -139,7 +129,26 @@ class CardInput extends React.PureComponent<Props, State> {
     }
 
     public render() {
-        const {className, error: propError, ...otherProps} = this.props;
+        const {className, error: propError, theme, ...otherProps} = this.props;
+        const CARD_ELEMENT_OPTIONS = {
+            hidePostalCode: true,
+            style: {
+                base: {
+                    fontFamily: "'Open Sans', sans-serif",
+                    fontSize: '14px',
+                    fontSmoothing: 'antialiased',
+                    color: theme.centerChannelColor,
+                    '::placeholder': {
+                        color: `rgba(${toRgbValues(theme.centerChannelColor)}, 0.64)`,
+                    },
+                },
+                invalid: {
+                    color: theme.errorTextColor,
+                    iconColor: theme.errorTextColor,
+                },
+            },
+        };
+
         const {empty, focused, error: stateError} = this.state;
         let fieldsetClass = className ? `Input_fieldset ${className}` : 'Input_fieldset';
         let fieldsetErrorClass = className ? `Input_fieldset Input_fieldset___error ${className}` : 'Input_fieldset Input_fieldset___error';

--- a/components/payment_form/payment_form.scss
+++ b/components/payment_form/payment_form.scss
@@ -27,7 +27,7 @@
 
     .section-title {
         margin-bottom: 24px;
-        color: var(--center-channel-text);
+        color: rgba(var(--center-channel-color-rgb), 0.72);
         font-size: 16px;
         font-weight: 600;
         text-align: left;
@@ -67,6 +67,7 @@
     input:-webkit-autofill:focus,
     input:-webkit-autofill:active {
         -webkit-box-shadow: 0 0 0 30px var(--center-channel-bg) inset !important;
+        -webkit-text-fill-color: var(--center-channel-color) !important;
     }
 
     .Input_fieldset {
@@ -126,7 +127,7 @@
 
     .PaymentForm-saved-title {
         margin-bottom: 16px;
-        color: #22406d;
+        color: var(--secondary-blue);
         font-family: Metropolis;
         font-size: 14px;
         font-weight: 600;
@@ -139,7 +140,7 @@
     .PaymentForm-saved-card {
         padding-bottom: 16px;
         border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-        color: #22406d;
+        color: var(--secondary-blue);
         font-family: Source Sans Pro;
         font-size: 16px;
         line-height: 24px;
@@ -148,7 +149,7 @@
     .PaymentForm-saved-address {
         margin-top: 16px;
         margin-bottom: 16px;
-        color: #22406d;
+        color: var(--secondary-blue);
         font-family: Source Sans Pro;
         font-size: 16px;
         line-height: 24px;

--- a/components/payment_form/payment_form.tsx
+++ b/components/payment_form/payment_form.tsx
@@ -12,6 +12,7 @@ import {
 import {PaymentMethod} from '@mattermost/types/cloud';
 
 import {BillingDetails} from 'types/cloud/sku';
+import {Theme} from 'mattermost-redux/types/themes';
 
 import DropdownInput from 'components/dropdown_input';
 import Input from 'components/widgets/inputs/input/input';
@@ -28,6 +29,7 @@ type Props = {
     className: string;
     initialBillingDetails?: BillingDetails;
     paymentMethod?: PaymentMethod;
+    theme: Theme;
     onCardInputChange?: (change: StripeCardElementChangeEvent) => void;
     onInputChange?: (billing: BillingDetails) => void;
     onInputBlur?: (billing: BillingDetails) => void;
@@ -151,7 +153,7 @@ export default class PaymentForm extends React.PureComponent<Props, State> {
     }
 
     public render() {
-        const {className, paymentMethod, buttonFooter} = this.props;
+        const {className, paymentMethod, buttonFooter, theme} = this.props;
         const {changePaymentMethod} = this.state;
 
         let paymentDetails: JSX.Element;
@@ -164,6 +166,7 @@ export default class PaymentForm extends React.PureComponent<Props, State> {
                             required={true}
                             onBlur={this.onBlur}
                             onCardInputChange={this.handleCardInputChange}
+                            theme={theme}
                         />
                     </div>
                     <div className='form-row'>

--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -236,7 +236,7 @@ function Content(props: ContentProps) {
                         extraBriefing={{
                             title: formatMessage({id: 'pricing_modal.extra_briefing.title', defaultMessage: 'More features'}),
                             items: [
-                                formatMessage({id: 'pricing_modal.extra_briefing.starter.calls', defaultMessage: '1:1 audio calls and screen share'}),
+                                formatMessage({id: 'pricing_modal.extra_briefing.starter.calls', defaultMessage: '1:1 voice calls and screen share'}),
                             ],
                         }}
                         planExtraInformation={<StarterDisclaimerCTA/>}

--- a/components/purchase_modal/index.ts
+++ b/components/purchase_modal/index.ts
@@ -10,6 +10,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getClientConfig} from 'mattermost-redux/actions/general';
 import {getCloudProducts, getCloudSubscription} from 'mattermost-redux/actions/cloud';
 import {Action} from 'mattermost-redux/types/actions';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {makeAsyncComponent} from 'components/async_load';
 
@@ -39,6 +40,7 @@ function mapStateToProps(state: GlobalState) {
         contactSalesLink: getCloudContactUsLink(state)(InquiryType.Sales),
         productId: subscription?.product_id,
         customer: state.entities.cloud.customer,
+        theme: getTheme(state),
     };
 }
 type Actions = {

--- a/components/purchase_modal/purchase.scss
+++ b/components/purchase_modal/purchase.scss
@@ -166,7 +166,7 @@
                     padding: 10px 24px;
                     border: none;
                     background: none;
-                    color: #1c58d9;
+                    color: var(--denim-button-bg);
                     font-size: 14px;
                     font-weight: 600;
                     line-height: 20px;
@@ -205,7 +205,7 @@
                     height: 363px;
                     padding-right: 24px;
                     padding-left: 24px;
-                    border: 1px solid #dadfe5;
+                    border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
                     background-color: var(--center-channel-bg);
                     border-radius: 0 0 4px 4px;
 
@@ -216,36 +216,36 @@
                         border: none;
                         background: none;
                         border-radius: 4px;
-                        color: #1c58d9;
+                        color: var(--denim-button-bg);
                         font-size: 14px;
                         font-weight: 700;
                         line-height: 14px;
 
                         &.grayed {
-                            background: rgba(var(--center-channel-text-rgb), 0.08);
-                            color: rgba(var(--center-channel-text-rgb), 0.32);
+                            background: rgba(var(--center-channel-color-rgb), 0.08);
+                            color: rgba(var(--center-channel-color-rgb), 0.32);
                         }
 
                         &.active {
-                            border: 1px solid #1c58d9;
+                            border: 1px solid var(--denim-button-bg);
                         }
 
                         &.special {
-                            background: #1c58d9;
-                            color: #fff;
+                            background: var(--denim-button-bg);
+                            color: var(--button-color);
                         }
                     }
 
                     .plan_price_rate_section {
                         width: 100%;
                         height: 150px;
-                        border-bottom: 1px solid #dadfe5;
+                        border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
                         font-weight: 400;
                         letter-spacing: -0.02em;
                         text-align: center;
 
                         h4 {
-                            color: rgba(33, 63, 107, 0.8);
+                            color: rgba(var(--center-channel-color-rgb), 0.72);
                             font-family: 'Metropolis';
                             font-size: 20px;
                             font-style: normal;
@@ -253,7 +253,7 @@
                         }
 
                         h1 {
-                            color: #1e325c;
+                            color: var(--center-channel-color);
                             font-family: 'Metropolis';
                             font-size: 52px;
                             font-style: normal;
@@ -266,7 +266,7 @@
                         }
 
                         p {
-                            color: #152234;
+                            color: rgba(var(--center-channel-color-rgb), 0.72);
                             font-family: 'Metropolis';
                             font-size: 18px;
                             font-style: normal;
@@ -277,7 +277,7 @@
                     .plan_payment_commencement {
                         margin-top: 16px;
                         margin-bottom: 24px;
-                        color: #3f4350;
+                        color: var(--center-channel-color-rgb);
                         font-size: 14px;
                         font-style: normal;
                         font-weight: 400;
@@ -286,7 +286,7 @@
 
                     .plan_billing_cycle {
                         margin-top: 24px;
-                        color: rgba(63, 67, 80, 0.72);
+                        color: rgba(var(--center-channel-color-rgb), 0.72);
                         font-size: 12px;
                         font-style: normal;
                         font-weight: 400;

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -499,7 +499,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                             <PlanLabel
                                 text={formatMessage({id: 'pricing_modal.planLabel.mostPopular', defaultMessage: 'MOST POPULAR'})}
                                 bgColor='var(--title-color-indigo-500)'
-                                color='var(--center-channel-bg)'
+                                color='var(--button-color)'
                                 firstSvg={<StarMarkSvg/>}
                                 secondSvg={<StarMarkSvg/>}
                             />) : undefined}

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -37,6 +37,7 @@ import StarMarkSvg from 'components/widgets/icons/star_mark_icon';
 import PricingModal from 'components/pricing_modal';
 import PlanLabel from 'components/common/plan_label';
 import {ModalData} from 'types/actions';
+import {Theme} from 'mattermost-redux/types/themes';
 
 import {getNextBillingDate} from 'utils/utils';
 
@@ -83,6 +84,7 @@ type Props = {
     isFreeTrial: boolean;
     productId: string | undefined;
     intl: IntlShape;
+    theme: Theme;
     actions: {
         openModal: <P>(modalData: ModalData<P>) => void;
         closeModal: () => void;
@@ -450,6 +452,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                         onInputChange={this.onPaymentInput}
                         onCardInputChange={this.handleCardInputChange}
                         initialBillingDetails={initialBillingDetails}
+                        theme={this.props.theme}
                     // eslint-disable-next-line react/jsx-closing-bracket-location
                     />
                     ) : (<div className='PaymentDetails'>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4150,7 +4150,7 @@
   "pricing_modal.extra_briefing.professional.guestAccess": "Guest access with MFA enforcement",
   "pricing_modal.extra_briefing.professional.ssoadLdap": "SSO support with AD/LDAP, Google, O365, OpenID",
   "pricing_modal.extra_briefing.professional.ssoSaml": "SSO with SAML 2.0, including Okta, OneLogin and ADFS",
-  "pricing_modal.extra_briefing.starter.calls": "1:1 audio calls and screen share",
+  "pricing_modal.extra_briefing.starter.calls": "1:1 voice calls and screen share",
   "pricing_modal.extra_briefing.title": "More features",
   "pricing_modal.lookingToSelfHost": "Looking to self-host?",
   "pricing_modal.planDisclaimer.starter": "This plan has data restrictions.",

--- a/utils/utils.tsx
+++ b/utils/utils.tsx
@@ -394,7 +394,7 @@ function dropAlpha(value: string): string {
 }
 
 // given '#fffff', returns '255, 255, 255' (no trailing comma)
-function toRgbValues(hexStr: string): string {
+export function toRgbValues(hexStr: string): string {
     const rgbaStr = `${parseInt(hexStr.substr(1, 2), 16)}, ${parseInt(hexStr.substr(3, 2), 16)}, ${parseInt(hexStr.substr(5, 2), 16)}`;
     return rgbaStr;
 }


### PR DESCRIPTION
#### Summary
This PR fixes a couple of theming issues (especially in darker modes) for the stripe card element and generally on the purchase modal

#### Ticket Link
[MM-44648](https://mattermost.atlassian.net/browse/MM-44648)

#### Screenshots
onyx
----
<img width="1792" alt="Screenshot 2022-06-07 at 14 09 25" src="https://user-images.githubusercontent.com/28563179/172365569-a1ae8848-fa0e-40cd-a8f9-807b3442d158.png">

indigo
----
<img width="1792" alt="Screenshot 2022-06-07 at 14 09 48" src="https://user-images.githubusercontent.com/28563179/172365615-9d3213d3-5cfb-4456-9f01-d5763d7b9daf.png">


#### Release Note

```release-note
NONE
```
