### PR TITLE
[MM-44898] Hide Markdown settings from pre release preview settings in user settings modal ( Advanced settings)

### DIFF
--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -178,7 +178,6 @@ type Props = {
     savePreferences: (userId: string, preferences: PreferenceType[]) => ActionResult;
     useCustomGroupMentions: boolean;
     emojiMap: EmojiMap;
-    markdownPreviewFeatureIsEnabled: boolean;
     isFormattingBarHidden: boolean;
 }
 

--- a/components/advanced_create_comment/index.ts
+++ b/components/advanced_create_comment/index.ts
@@ -43,7 +43,6 @@ import {getPostDraft, getIsRhsExpanded, getSelectedPostFocussedAt} from 'selecto
 import {showPreviewOnCreateComment} from 'selectors/views/textbox';
 import {setShowPreviewOnCreateComment} from 'actions/views/textbox';
 import {openModal} from 'actions/views/modals';
-import {isFeatureEnabled} from 'utils/utils';
 
 import {getEmojiMap} from 'selectors/emojis';
 import {canUploadFiles} from 'utils/file_utils';

--- a/components/advanced_create_comment/index.ts
+++ b/components/advanced_create_comment/index.ts
@@ -113,7 +113,6 @@ function makeMapStateToProps() {
             useCustomGroupMentions,
             emojiMap: getEmojiMap(state),
             canUploadFiles: canUploadFiles(config),
-            markdownPreviewFeatureIsEnabled: isFeatureEnabled(Constants.PRE_RELEASE_FEATURES.MARKDOWN_PREVIEW, state),
         };
     };
 }

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -212,7 +212,6 @@ type Props = {
     channelMemberCountsByGroup: ChannelMemberCountsByGroup;
     useLDAPGroupMentions: boolean;
     useCustomGroupMentions: boolean;
-    markdownPreviewFeatureIsEnabled: boolean;
 }
 
 type State = {

--- a/components/advanced_create_post/index.ts
+++ b/components/advanced_create_post/index.ts
@@ -130,7 +130,6 @@ function makeMapStateToProps() {
             channelMemberCountsByGroup,
             isLDAPEnabled,
             useCustomGroupMentions,
-            markdownPreviewFeatureIsEnabled: isFeatureEnabled(Constants.PRE_RELEASE_FEATURES.MARKDOWN_PREVIEW, state),
         };
     };
 }

--- a/components/advanced_create_post/index.ts
+++ b/components/advanced_create_post/index.ts
@@ -58,7 +58,6 @@ import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {openModal} from 'actions/views/modals';
 import {AdvancedTextEditor, Constants, Preferences, StoragePrefixes, UserStatuses} from 'utils/constants';
 import {canUploadFiles} from 'utils/file_utils';
-import {isFeatureEnabled} from 'utils/utils';
 import {OnboardingTourSteps, TutorialTourName} from 'components/onboarding_tour';
 
 import AdvancedCreatePost from './advanced_create_post';

--- a/components/edit_channel_header_modal/index.ts
+++ b/components/edit_channel_header_modal/index.ts
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 
 import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
 import {Channel} from '@mattermost/types/channels';
-import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getBool, getIsAdvancedTextEditorEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {patchChannel} from 'mattermost-redux/actions/channels';
 import {Preferences} from 'mattermost-redux/constants';
 import {Constants} from 'utils/constants';
@@ -19,8 +19,11 @@ import {showPreviewOnEditChannelHeaderModal} from 'selectors/views/textbox';
 import EditChannelHeaderModal from './edit_channel_header_modal';
 
 function mapStateToProps(state: GlobalState) {
+    const markdownPreview = isFeatureEnabled(Constants.PRE_RELEASE_FEATURES.MARKDOWN_PREVIEW, state);
+    const isAdvancedTextEditorEnabled = getIsAdvancedTextEditorEnabled(state);
+    const markdownPreviewFeatureIsEnabled = isAdvancedTextEditorEnabled ? true : markdownPreview;
     return {
-        markdownPreviewFeatureIsEnabled: isFeatureEnabled(Constants.PRE_RELEASE_FEATURES.MARKDOWN_PREVIEW, state),
+        markdownPreviewFeatureIsEnabled,
         shouldShowPreview: showPreviewOnEditChannelHeaderModal(state),
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
     };

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -66,7 +66,7 @@ export default class AdvancedSettingsDisplay extends React.PureComponent {
         let enabledFeatures = 0;
         for (const as of advancedSettings) {
             for (const key of preReleaseFeaturesKeys) {
-                const feature = PreReleaseFeatures[key];
+                const feature = PreReleaseFeaturesLocal[key];
 
                 if (as.name === Constants.FeatureTogglePrefix + feature.label) {
                     settings[as.name] = as.value;

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -57,7 +57,7 @@ export default class AdvancedSettingsDisplay extends React.PureComponent {
             join_leave: this.props.joinLeave,
         };
 
-        const PreReleaseFeaturesLocal = PreReleaseFeatures;
+        const PreReleaseFeaturesLocal = JSON.parse(JSON.stringify(PreReleaseFeatures));
         if (this.props.isAdvancedTextEditorEnabled) {
             delete PreReleaseFeaturesLocal.MARKDOWN_PREVIEW;
         }

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -57,7 +57,12 @@ export default class AdvancedSettingsDisplay extends React.PureComponent {
             join_leave: this.props.joinLeave,
         };
 
-        const preReleaseFeaturesKeys = Object.keys(PreReleaseFeatures);
+        const PreReleaseFeaturesLocal = PreReleaseFeatures;
+        if (this.props.isAdvancedTextEditorEnabled) {
+            delete PreReleaseFeaturesLocal.MARKDOWN_PREVIEW;
+        }
+        const preReleaseFeaturesKeys = Object.keys(PreReleaseFeaturesLocal);
+
         let enabledFeatures = 0;
         for (const as of advancedSettings) {
             for (const key of preReleaseFeaturesKeys) {
@@ -79,7 +84,7 @@ export default class AdvancedSettingsDisplay extends React.PureComponent {
         const showDeactivateAccountModal = false;
 
         return {
-            preReleaseFeatures: PreReleaseFeatures,
+            preReleaseFeatures: PreReleaseFeaturesLocal,
             settings,
             preReleaseFeaturesKeys,
             enabledFeatures,


### PR DESCRIPTION
#### Summary
 Hide Markdown settings from pre-release preview settings in the user settings modal ( Advanced settings)

#### Ticket Link
 Fixes https://mattermost.atlassian.net/browse/MM-44898

#### Related Pull Requests
NONE

#### Screenshots
|  before  |  after  |
|----|----|
| ![Image Pasted at 2022-6-3 11-12](https://user-images.githubusercontent.com/16203333/172374156-8a831c92-4fa0-4d3f-a5fa-83de4d7e1a56.png) | <img width="836" alt="Screenshot 2022-06-07 at 5 28 18 PM" src="https://user-images.githubusercontent.com/16203333/172374194-6c7d554f-25a5-4d11-8766-de3da050ff13.png"> |


#### Release Note
```release-note
 UI: Advanced Text editor Hide Markdown settings from pre-release preview settings in the user settings modal ( Advanced settings)
```
