### PR TITLE
[MM-44676] file upload shortcut in threads view

### DIFF
--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -524,7 +524,8 @@ export class FileUpload extends PureComponent {
             }
             const postTextbox = this.props.postType === 'post' && document.activeElement.id === 'post_textbox';
             const commentTextbox = this.props.postType === 'comment' && document.activeElement.id === 'reply_textbox';
-            if (postTextbox || commentTextbox) {
+            const threadTextbox = this.props.postType === 'thread' && document.activeElement.id === 'reply_textbox';
+            if (postTextbox || commentTextbox || threadTextbox) {
                 this.fileInput.current.focus();
                 this.fileInput.current.click();
             }


### PR DESCRIPTION
#### Summary
Fixes: In threads view if try to use the file upload shortcut not open the file selection modal.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-44676

#### Related Pull Requests
NONE

####  Screenshots
<img width="1496" alt="Screenshot 2022-06-07 at 7 33 44 PM" src="https://user-images.githubusercontent.com/16203333/172400325-637f9946-389b-41ad-acd6-d2efaf585c9e.png">

#### Release Note
```release-note
UI: Advanced Text Editor file upload shortcut not working in threads view
```
