### PR TITLE
MM-44634_When login credentials are auto-filled, log in button shows as disabled on hover

### DIFF
--- a/components/login/__snapshots__/login.test.tsx.snap
+++ b/components/login/__snapshots__/login.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`components/login/Login should match snapshot with base login 1`] = `
           <SaveButton
             btnClass="btn-primary"
             defaultMessage="Log in"
-            disabled={true}
+            disabled={false}
             extraClasses="login-body-card-form-button-submit large"
             onClick={[Function]}
             saving={false}

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -122,7 +122,6 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     const enableBaseLogin = enableSignInWithEmail || enableSignInWithUsername || ldapEnabled;
     const enableExternalSignup = enableSignUpWithGitLab || enableSignUpWithOffice365 || enableSignUpWithGoogle || enableSignUpWithOpenId || enableSignUpWithSaml;
     const showSignup = enableOpenServer && (enableExternalSignup || enableSignUpWithEmail || enableLdap);
-    const canSubmit = Boolean(loginId && password) && !hasError && !isWaiting;
 
     const getExternalLoginOptions = () => {
         const externalLoginOptions: ExternalLoginButtonType[] = [];
@@ -373,7 +372,7 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
                 closeSessionExpiredNotification.current = undefined;
             }
         };
-    });
+    }, []);
 
     if (initializing) {
         return (<LoadingScreen/>);
@@ -617,7 +616,7 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     };
 
     const onEnterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === Constants.KeyCodes.ENTER[0] && canSubmit) {
+        if (e.key === Constants.KeyCodes.ENTER[0]) {
             preSubmit(e);
         }
     };
@@ -747,7 +746,6 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
                                 <SaveButton
                                     extraClasses='login-body-card-form-button-submit large'
                                     saving={isWaiting}
-                                    disabled={!canSubmit}
                                     onClick={preSubmit}
                                     defaultMessage={formatMessage({id: 'login.logIn', defaultMessage: 'Log in'})}
                                     savingMessage={formatMessage({id: 'login.logingIn', defaultMessage: 'Logging in…'})}

--- a/e2e/cypress/tests/integration/signin_authentication/login_spec.js
+++ b/e2e/cypress/tests/integration/signin_authentication/login_spec.js
@@ -106,8 +106,8 @@ describe('Login page', () => {
         // # Clear password field
         cy.findByPlaceholderText('Password').clear();
 
-        // # Verify Log in button disabled
-        cy.get('#saveSetting').should('be.disabled');
+        // # Verify Log in button enabled
+        cy.get('#saveSetting').should('not.be.disabled');
     });
 
     it('MM-T3306_4 Should disable Log in button when empty email/username field', () => {
@@ -117,8 +117,8 @@ describe('Login page', () => {
         // # Enter a password
         cy.findByPlaceholderText('Password').clear().type('samplepassword');
 
-        // # Verify Log in button disabled
-        cy.get('#saveSetting').should('be.disabled');
+        // # Verify Log in button enabled
+        cy.get('#saveSetting').should('not.be.disabled');
     });
 
     it('MM-T3306_5 Should disable Log in button when empty password field', () => {
@@ -128,8 +128,8 @@ describe('Login page', () => {
         // # Clear password field
         cy.findByPlaceholderText('Password').clear();
 
-        // # Verify Log in button disabled
-        cy.get('#saveSetting').should('be.disabled');
+        // # Verify Log in button enabled
+        cy.get('#saveSetting').should('not.be.disabled');
     });
 
     it('MM-T3306_6 Should show error with invalid email/username and password', () => {

--- a/e2e/cypress/tests/support/common_login_commands.js
+++ b/e2e/cypress/tests/support/common_login_commands.js
@@ -30,8 +30,8 @@ Cypress.Commands.add('checkLoginFailed', () => {
         // * Check the password input in error
         cy.get('.login-body-card-form-password-input.Input_fieldset').should('have.class', 'Input_fieldset___error');
 
-        // * Check the Log in button disabled
-        cy.get('#saveSetting').should('be.disabled');
+        // * Check the Log in button enabled
+        cy.get('#saveSetting').should('not.be.disabled');
     });
 });
 


### PR DESCRIPTION
#### Summary
Log in button is now always enabled. Validations for filled inputs before submit are in place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44634

#### Screenshots
##### Autofill
https://user-images.githubusercontent.com/79058848/172435804-3d8a58b9-d3c5-4a27-8f88-85d31c79b446.mp4

##### Errors
<img width="543" alt="Screen Shot 2022-06-07 at 11 35 31 AM" src="https://user-images.githubusercontent.com/79058848/172435968-aa1337fb-a756-4a6f-aa69-05c96fd3cffb.png">

<img width="547" alt="Screen Shot 2022-06-07 at 11 35 51 AM" src="https://user-images.githubusercontent.com/79058848/172436015-e04f13c4-00ac-4353-ac17-633bd327a964.png">


#### Release Note
```release-note
- In the login page, the Log in button is now always enabled.
```
