### PR TITLE
MM-44883_Update the Create Team in trial tooltip text

### DIFF
--- a/components/main_menu/__snapshots__/main_menu.test.tsx.snap
+++ b/components/main_menu/__snapshots__/main_menu.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`components/Menu should match snapshot with cloud free trial 1`] = `
                   <span
                     className="title"
                   >
-                    Paid feature
+                    Professional feature
                   </span>
                   <span
                     className="message"
@@ -452,7 +452,7 @@ exports[`components/Menu should match snapshot with cloud free trial and team li
                   <span
                     className="title"
                   >
-                    Paid feature
+                    Professional feature
                   </span>
                   <span
                     className="message"

--- a/components/main_menu/__snapshots__/main_menu.test.tsx.snap
+++ b/components/main_menu/__snapshots__/main_menu.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`components/Menu should match snapshot with cloud free trial 1`] = `
                   <span
                     className="message"
                   >
-                    During your trial you are able to create multiple teams
+                    During your trial you are able to create multiple teams. These teams will be archived after your trial.
                   </span>
                 </Tooltip>
               }
@@ -457,7 +457,7 @@ exports[`components/Menu should match snapshot with cloud free trial and team li
                   <span
                     className="message"
                   >
-                    During your trial you are able to create multiple teams
+                    During your trial you are able to create multiple teams. These teams will be archived after your trial.
                   </span>
                 </Tooltip>
               }

--- a/components/main_menu/main_menu.tsx
+++ b/components/main_menu/main_menu.tsx
@@ -486,7 +486,7 @@ export class MainMenu extends React.PureComponent<Props> {
                                                 </span>
                                                 <span className='message'>
                                                     {this.props.isFreeTrial ? (
-                                                        formatMessage({id: 'navbar_dropdown.create.tooltip.cloudFreeTrial', defaultMessage: 'During your trial you are able to create multiple teams'})
+                                                        formatMessage({id: 'navbar_dropdown.create.tooltip.cloudFreeTrial', defaultMessage: 'During your trial you are able to create multiple teams. These teams will be archived after your trial.'})
                                                     ) : (
                                                         formatMessage({id: 'navbar_dropdown.create.tooltip.cloudFree', defaultMessage: 'This is a paid feature, available with a free 30-day trial'})
                                                     )}

--- a/components/main_menu/main_menu.tsx
+++ b/components/main_menu/main_menu.tsx
@@ -482,7 +482,7 @@ export class MainMenu extends React.PureComponent<Props> {
                                         overlay={(
                                             <Tooltip id={'MenuItem__icon-tooltip'}>
                                                 <span className='title'>
-                                                    {formatMessage({id: 'navbar_dropdown.create.tooltip.title', defaultMessage: 'Paid feature'})}
+                                                    {formatMessage({id: 'navbar_dropdown.create.tooltip.title', defaultMessage: 'Professional feature'})}
                                                 </span>
                                                 <span className='message'>
                                                     {this.props.isFreeTrial ? (

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3877,7 +3877,7 @@
   "navbar_dropdown.create": "Create a Team",
   "navbar_dropdown.create.tooltip.cloudFree": "This is a paid feature, available with a free 30-day trial",
   "navbar_dropdown.create.tooltip.cloudFreeTrial": "During your trial you are able to create multiple teams. These teams will be archived after your trial.",
-  "navbar_dropdown.create.tooltip.title": "Paid feature",
+  "navbar_dropdown.create.tooltip.title": "Professional feature",
   "navbar_dropdown.help": "Help",
   "navbar_dropdown.integrations": "Integrations",
   "navbar_dropdown.invitePeople": "Invite People",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3876,7 +3876,7 @@
   "navbar_dropdown.console": "System Console",
   "navbar_dropdown.create": "Create a Team",
   "navbar_dropdown.create.tooltip.cloudFree": "This is a paid feature, available with a free 30-day trial",
-  "navbar_dropdown.create.tooltip.cloudFreeTrial": "During your trial you are able to create multiple teams",
+  "navbar_dropdown.create.tooltip.cloudFreeTrial": "During your trial you are able to create multiple teams. These teams will be archived after your trial.",
   "navbar_dropdown.create.tooltip.title": "Paid feature",
   "navbar_dropdown.help": "Help",
   "navbar_dropdown.integrations": "Integrations",


### PR DESCRIPTION
#### Summary
Create Team tooltip to inform that their trial ending will archive any new teams.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44883

#### Screenshots
<img width="429" alt="Screen Shot 2022-06-07 at 12 25 54 PM" src="https://user-images.githubusercontent.com/79058848/172445449-8a72d644-25fd-491b-9984-2fb7dcd806a0.png">

<img width="432" alt="Screen Shot 2022-06-07 at 12 26 45 PM" src="https://user-images.githubusercontent.com/79058848/172445465-4f52eaa0-36f3-42a4-9218-4564ef3f6af9.png">

#### Release Note
```release-note
NONE
```
