### PR TITLE
Downgrade Romanian translations to Beta

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -339,7 +339,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 10,
-                  "text": "Română",
+                  "text": "Română (Beta)",
                   "value": "ro",
                 },
                 Object {
@@ -470,7 +470,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 10,
-                  "text": "Română",
+                  "text": "Română (Beta)",
                   "value": "ro",
                 },
                 Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -91,7 +91,7 @@ const languages = {
     },
     ro: {
         value: 'ro',
-        name: 'Română',
+        name: 'Română (Beta)',
         order: 10,
         url: ro,
     },


### PR DESCRIPTION
#### Summary
Romanian product translations haven't been actively maintained, and with this reduction in translation quality, this language is being downgraded to Beta.

#### Release Note
```release-note
Downgraded Romanian language support to Beta.
```
