### PR TITLE
add file storage usage

### DIFF
--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -152,9 +152,9 @@ export function getFilesUsage(): ActionFunc {
         try {
             const result = await Client4.getFilesUsage();
 
-            // match limit notation in bits
-            const inBits = result.bytes * 8;
             if (result) {
+                // match limit notation in bits
+                const inBits = result.bytes * 8;
                 dispatch({
                     type: CloudTypes.RECEIVED_FILES_USAGE,
                     data: inBits,

--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -149,12 +149,19 @@ export function getMessagesUsage(): ActionFunc {
 
 export function getFilesUsage(): ActionFunc {
     return async (dispatch: DispatchFunc) => {
-        dispatch({
-            type: CloudTypes.RECEIVED_FILES_USAGE,
-
-            // TODO: Fill this in with the backing client API method once it is available in the server
-            data: 0,
-        });
+        try {
+            const result = await Client4.getFilesUsage();
+            // match limit notation in bits
+            const inBits = result.bytes * 8;
+            if (result) {
+                dispatch({
+                    type: CloudTypes.RECEIVED_FILES_USAGE,
+                    data: inBits,
+                });
+            }
+        } catch (error) {
+            return error
+        }
         return {data: true};
     };
 }

--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -151,6 +151,7 @@ export function getFilesUsage(): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         try {
             const result = await Client4.getFilesUsage();
+
             // match limit notation in bits
             const inBits = result.bytes * 8;
             if (result) {
@@ -160,7 +161,7 @@ export function getFilesUsage(): ActionFunc {
                 });
             }
         } catch (error) {
-            return error
+            return error;
         }
         return {data: true};
     };

--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -77,7 +77,7 @@ import type {
     MarketplaceApp,
     MarketplacePlugin,
 } from '@mattermost/types/marketplace';
-import {Post, PostList, PostSearchResults, OpenGraphMetadata, PostsUsageResponse, TeamsUsageResponse, PaginatedPostList} from '@mattermost/types/posts';
+import {Post, PostList, PostSearchResults, OpenGraphMetadata, PostsUsageResponse, TeamsUsageResponse, PaginatedPostList, FilesUsageResponse} from '@mattermost/types/posts';
 import {BoardsUsageResponse} from '@mattermost/types/boards';
 import {Reaction} from '@mattermost/types/reactions';
 import {Role} from '@mattermost/types/roles';
@@ -3861,6 +3861,13 @@ export default class Client4 {
     getPostsUsage = () => {
         return this.doFetch<PostsUsageResponse>(
             `${this.getUsageRoute()}/posts`,
+            {method: 'get'},
+        );
+    }
+
+    getFilesUsage = () => {
+        return this.doFetch<FilesUsageResponse>(
+            `${this.getUsageRoute()}/storage`,
             {method: 'get'},
         );
     }

--- a/packages/types/src/posts.ts
+++ b/packages/types/src/posts.ts
@@ -152,6 +152,10 @@ export declare type PostsUsageResponse = {
     count: number;
 };
 
+export declare type FilesUsageResponse = {
+    bytes: number;
+};
+
 export declare type TeamsUsageResponse = {
     active: number;
     cloud_archived: number;

--- a/utils/limits.tsx
+++ b/utils/limits.tsx
@@ -7,7 +7,7 @@ import {CloudUsage, Limits} from '@mattermost/types/cloud';
 import {FileSizes} from './file_utils';
 
 export function asGBString(bits: number, formatNumber: (b: number, options: FormatNumberOptions) => string): string {
-    return `${formatNumber(bits / FileSizes.Gigabyte, {maximumFractionDigits: 0})}GB`;
+    return `${formatNumber(bits / FileSizes.Gigabyte, {maximumFractionDigits: 1})}GB`;
 }
 
 export function inK(num: number): string {


### PR DESCRIPTION
#### Summary
Fill in file storage with real data. Note that the usage is cached for 30 mintues, so you'll need to wait that long to see an update in usage numbers after adding files. And you'll need to add at least 100MB files so see it make a difference, because we round to the nearest 0.1GB in the UI.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44555

#### Screenshots
![using-files](https://user-images.githubusercontent.com/13738432/172671265-c5ad55cc-d736-4c6b-8680-6c221d116b46.png)

#### Release Note

```release-note
NONE
```