### PR TITLE
MM-44734_Freemium: Restrict create team from Join teams page

### DIFF
--- a/components/common/hocs/cloud/with_use_get_usage_deltas.tsx
+++ b/components/common/hocs/cloud/with_use_get_usage_deltas.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import useGetUsageDeltas from 'components/common/hooks/useGetUsageDeltas';
+
+const withUseGetUsageDelta = (WrappedComponent: any) => (
+    (props: any) => {
+        const usageDeltas = useGetUsageDeltas();
+
+        return (
+            <WrappedComponent
+                usageDeltas={usageDeltas}
+                {...props}
+            />
+        );
+    }
+);
+
+export default withUseGetUsageDelta;

--- a/components/main_menu/index.tsx
+++ b/components/main_menu/index.tsx
@@ -25,7 +25,6 @@ import {Permissions} from 'mattermost-redux/constants';
 
 import {RHSStates} from 'utils/constants';
 
-import {getCloudLimits} from 'actions/cloud';
 import {showMentions, showFlaggedPosts, closeRightHandSide, closeMenu as closeRhsMenu} from 'actions/views/rhs';
 import {openModal} from 'actions/views/modals';
 import {getRhsState} from 'selectors/rhs';
@@ -104,7 +103,6 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
             showFlaggedPosts,
             closeRightHandSide,
             closeRhsMenu,
-            getCloudLimits,
         }, dispatch),
     };
 }

--- a/components/main_menu/main_menu.tsx
+++ b/components/main_menu/main_menu.tsx
@@ -77,7 +77,6 @@ export type Props = {
         showFlaggedPosts: () => void;
         closeRightHandSide: () => void;
         closeRhsMenu: () => void;
-        getCloudLimits: () => void;
     };
 
 };

--- a/components/select_team/index.ts
+++ b/components/select_team/index.ts
@@ -2,21 +2,26 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {bindActionCreators, Dispatch} from 'redux';
+import {bindActionCreators, Dispatch, compose} from 'redux';
 import {withRouter} from 'react-router-dom';
 
 import {getTeams} from 'mattermost-redux/actions/teams';
 import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {Permissions} from 'mattermost-redux/constants';
 import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getSortedListableTeams, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {cloudFreeEnabled} from 'mattermost-redux/selectors/entities/preferences';
+
+import withUseGetUsageDelta from 'components/common/hocs/cloud/with_use_get_usage_deltas';
 
 import {GlobalState} from 'types/store';
 
 import {addUserToTeam} from 'actions/team_actions';
 import {isGuest} from 'mattermost-redux/utils/user_utils';
+
+import {isCloudLicense} from 'utils/license_utils';
 
 import SelectTeam from './select_team';
 
@@ -24,6 +29,10 @@ function mapStateToProps(state: GlobalState) {
     const config = getConfig(state);
     const currentUser = getCurrentUser(state);
     const myTeamMemberships = Object.values(getTeamMemberships(state));
+    const license = getLicense(state);
+
+    const isCloud = isCloudLicense(license);
+    const isCloudFreeEnabled = isCloud && cloudFreeEnabled(state);
 
     return {
         currentUserId: currentUser.id,
@@ -39,6 +48,8 @@ function mapStateToProps(state: GlobalState) {
         canJoinPrivateTeams: haveISystemPermission(state, {permission: Permissions.JOIN_PRIVATE_TEAMS}),
         siteURL: config.SiteURL,
         totalTeamsCount: state.entities.teams.totalCount || 0,
+        isCloud,
+        isCloudFreeEnabled,
     };
 }
 
@@ -52,4 +63,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SelectTeam));
+export default compose(
+    withRouter,
+    connect(mapStateToProps, mapDispatchToProps),
+    withUseGetUsageDelta,
+)(SelectTeam);

--- a/components/select_team/select_team.test.tsx
+++ b/components/select_team/select_team.test.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
+import {CloudUsage} from '@mattermost/types/cloud';
 import {Team} from '@mattermost/types/teams';
 
 import SelectTeam, {TEAMS_PER_PAGE} from 'components/select_team/select_team';
@@ -39,6 +40,13 @@ describe('components/select_team/SelectTeam', () => {
             addUserToTeam: jest.fn().mockResolvedValue({data: true}),
         },
         totalTeamsCount: 15,
+        isCloud: false,
+        isCloudFreeEnabled: false,
+        usageDeltas: {
+            teams: {
+                active: Number.MAX_VALUE,
+            },
+        } as CloudUsage,
     };
 
     test('should match snapshot', () => {

--- a/components/select_team/select_team.tsx
+++ b/components/select_team/select_team.tsx
@@ -7,6 +7,7 @@ import {Link} from 'react-router-dom';
 
 import {Permissions} from 'mattermost-redux/constants';
 
+import {CloudUsage} from '@mattermost/types/cloud';
 import {Team} from '@mattermost/types/teams';
 
 import {emitUserLoggedOutEvent} from 'actions/global_actions';
@@ -57,6 +58,9 @@ type Props = {
     siteURL?: string;
     actions: Actions;
     totalTeamsCount: number;
+    isCloud: boolean;
+    isCloudFreeEnabled: boolean;
+    usageDeltas: CloudUsage;
 };
 
 type State = {
@@ -176,7 +180,17 @@ export default class SelectTeam extends React.PureComponent<Props, State> {
             canJoinPublicTeams,
             canJoinPrivateTeams,
             totalTeamsCount,
+            isCloud,
+            isCloudFreeEnabled,
+            usageDeltas: {
+                teams: {
+                    active: usageDeltaTeams,
+                },
+            },
         } = this.props;
+
+        const teamsLimitReached = usageDeltaTeams >= 0;
+        const createTeamRestricted = isCloud && isCloudFreeEnabled && teamsLimitReached;
 
         let openContent;
         if (this.state.loadingTeamId) {
@@ -223,10 +237,17 @@ export default class SelectTeam extends React.PureComponent<Props, State> {
                 joinableTeamContents = (
                     <div className='signup-team-dir-err'>
                         <div>
-                            <FormattedMessage
-                                id='signup_team.no_open_teams_canCreate'
-                                defaultMessage='No teams are available to join. Please create a new team or ask your administrator for an invite.'
-                            />
+                            {createTeamRestricted ? (
+                                <FormattedMessage
+                                    id='signup_team.no_open_teams'
+                                    defaultMessage='No teams are available to join. Please ask your administrator for an invite.'
+                                />
+                            ) : (
+                                <FormattedMessage
+                                    id='signup_team.no_open_teams_canCreate'
+                                    defaultMessage='No teams are available to join. Please create a new team or ask your administrator for an invite.'
+                                />
+                            )}
                         </div>
                     </div>
                 );
@@ -280,7 +301,7 @@ export default class SelectTeam extends React.PureComponent<Props, State> {
             );
         }
 
-        const teamSignUp = (
+        const teamSignUp = !createTeamRestricted && (
             <SystemPermissionGate permissions={[Permissions.CREATE_TEAM]}>
                 <div
                     className='margin--extra'


### PR DESCRIPTION
#### Summary
Disabling the ability to create a team from "Join Teams" if limit has been reached.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44734

#### Screenshots

#### Release Note
```release-note
NONE
```
