### PR TITLE
[MM-44936] Members RHS: fix search not searching for users not loaded yet

### DIFF
--- a/components/channel_members_rhs/index.ts
+++ b/components/channel_members_rhs/index.ts
@@ -28,7 +28,7 @@ import {openModal} from 'actions/views/modals';
 import {closeRightHandSide, goBack, setEditChannelMembers} from 'actions/views/rhs';
 import {getIsEditingMembers, getPreviousRhsState} from 'selectors/rhs';
 import {setChannelMembersRhsSearchTerm} from 'actions/views/search';
-import {loadProfilesAndReloadChannelMembers} from 'actions/user_actions';
+import {loadProfilesAndReloadChannelMembers, searchProfilesAndChannelMembers} from 'actions/user_actions';
 import {Channel, ChannelMembership} from '@mattermost/types/channels';
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
 import {loadMyChannelMemberAndRole} from 'mattermost-redux/actions/channels';
@@ -75,12 +75,14 @@ const searchProfiles = createSelector(
     (profilesInCurrentChannel, userStatuses, teammateNameDisplaySetting, membersInCurrentChannel) => {
         const channelMembers: ChannelMember[] = [];
         profilesInCurrentChannel.forEach((profile) => {
-            channelMembers.push({
-                user: profile,
-                membership: membersInCurrentChannel[profile.id],
-                status: userStatuses[profile.id],
-                displayName: displayUsername(profile, teammateNameDisplaySetting),
-            });
+            if (membersInCurrentChannel[profile.id]) {
+                channelMembers.push({
+                    user: profile,
+                    membership: membersInCurrentChannel[profile.id],
+                    status: userStatuses[profile.id],
+                    displayName: displayUsername(profile, teammateNameDisplaySetting),
+                });
+            }
         });
         return [[] as ChannelMember[], channelMembers];
     },
@@ -155,6 +157,7 @@ function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
             loadProfilesAndReloadChannelMembers,
             loadMyChannelMemberAndRole,
             setEditChannelMembers,
+            searchProfilesAndChannelMembers,
         }, dispatch),
     };
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
The Members RHS did not allow users to search for users which were not loaded yet. This PR fixes this by triggering a server search rather than a redux store search.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44936

#### Related Pull Requests
N/A

#### Screenshots
No UI change

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed a bug causing the members RHS search input to not search all the members of a channel.
```
