### PR TITLE
MM-44514: display correctly the emojis independently of the case (should work even if the user typed some capital cases)

### DIFF
--- a/utils/emoticons.tsx
+++ b/utils/emoticons.tsx
@@ -91,7 +91,7 @@ export function handleEmoticons(
 }
 
 export function renderEmoji(name: string, matchText: string): string {
-    return `<span data-emoticon="${name}">${matchText}</span>`;
+    return `<span data-emoticon="${name.toLowerCase()}">${matchText.toLowerCase()}</span>`;
 }
 
 // if an emoji


### PR DESCRIPTION

#### Summary
Fully typed emoji that contains a capital letter fails to render as an emoji

#### Ticket Link
[MM-44514](https://mattermost.atlassian.net/browse/MM-44514)

#### Release Note
```
Fully typed emoji that contains a capital letter are now correctly displayed
```
