### PR TITLE
Automated cherry pick of #10521

### DIFF
--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -10,7 +10,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTeammateNameDisplaySetting, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId, getCurrentUser, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
-import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
+import {isSystemMessage, isUserAddedInChannel} from 'mattermost-redux/utils/post_utils';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import {isThreadOpen} from 'selectors/views/threads';
@@ -34,7 +34,7 @@ export function sendDesktopNotification(post, msgProps) {
             return;
         }
 
-        if (isSystemMessage(post)) {
+        if (isSystemMessage(post) && !isUserAddedInChannel(post, currentUserId)) {
             return;
         }
 

--- a/actions/notification_actions.test.js
+++ b/actions/notification_actions.test.js
@@ -267,6 +267,24 @@ describe('notification_actions', () => {
             });
         });
 
+        test('should notify user on add to channel', () => {
+            const store = testConfigureStore(baseState);
+            post.type = 'system_add_to_channel';
+            post.props.addedUserId = 'current_user_id';
+            return store.dispatch(sendDesktopNotification(post, msgProps)).then(() => {
+                expect(spy).toHaveBeenCalled();
+            });
+        });
+
+        test('should not notify user on other user add to channel', () => {
+            const store = testConfigureStore(baseState);
+            post.type = 'system_add_to_channel';
+            post.props.addedUserId = 'not_current_user_id';
+            return store.dispatch(sendDesktopNotification(post, msgProps)).then(() => {
+                expect(spy).not.toHaveBeenCalled();
+            });
+        });
+
         test('should not notify user on muted channels', () => {
             const store = testConfigureStore(baseState);
             post.channel_id = 'muted_channel_id';

--- a/packages/mattermost-redux/src/utils/post_utils.ts
+++ b/packages/mattermost-redux/src/utils/post_utils.ts
@@ -35,10 +35,14 @@ export function isPostEphemeral(post: Post): boolean {
     return post.type === Posts.POST_TYPES.EPHEMERAL || post.type === Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL || post.state === Posts.POST_DELETED;
 }
 
-export function shouldIgnorePost(post: Post, userId?: UserProfile['id']): boolean {
+export function isUserAddedInChannel(post: Post, userId?: UserProfile['id']): boolean {
     const postTypeCheck = post.type && (post.type === Posts.POST_TYPES.ADD_TO_CHANNEL);
     const userIdCheck = post.props && post.props.addedUserId && (post.props.addedUserId === userId);
-    if (postTypeCheck && userIdCheck) {
+    return postTypeCheck && userIdCheck;
+}
+
+export function shouldIgnorePost(post: Post, userId?: UserProfile['id']): boolean {
+    if (isUserAddedInChannel(post, userId)) {
         return false;
     }
     return Posts.IGNORE_POST_TYPES.includes(post.type);


### PR DESCRIPTION
Cherry pick of #10521 on release-7.0.

/cc  @koox00

```release-note
NONE
```