### PR TITLE
Adjust colour of archived channel icon on dark themes

### DIFF
--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -13,7 +13,6 @@ import * as UserAgent from 'utils/user_agent';
 import {localizeMessage} from 'utils/utils';
 import LocalizedInput from 'components/localized_input/localized_input';
 
-import ArchiveIcon from 'components/widgets/icons/archive_icon';
 import SharedChannelIndicator from 'components/shared_channel_indicator';
 
 import {t} from 'utils/i18n';
@@ -69,7 +68,7 @@ export default class SearchableChannelList extends React.PureComponent {
         if (shouldShowArchivedChannels) {
             archiveIcon = (
                 <div className='more-modal__icon-container'>
-                    <ArchiveIcon className='icon icon__archive'/>
+                    <i className='icon icon-archive-outline'/>
                 </div>
             );
         }

--- a/components/threading/thread_viewer/thread_viewer.scss
+++ b/components/threading/thread_viewer/thread_viewer.scss
@@ -49,7 +49,6 @@
 
         .icon {
             margin-right: 3.4px;
-            color: rgba(63, 67, 80, 0.56);
             vertical-align: text-top;
         }
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This change adjusts the colour of the icon displayed indicating a channel is archived in two places:

- `SearchableChannelList`
    - Changes icon from leveraging `ArchiveIcon` svg which doesn't change with font colour to `icon-archive-outline` from `@mattermost/compass-icons`
    - This adjustment allows the icon to match the font colour, meaning it matches the theme currently applied

- `ThreadViewer`
    - Removed the static colour assigned to the archived icon in `thread_viewer.scss` as it was only appropriate in light themes.

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/20273
  Jira: https://mattermost.atlassian.net/browse/MM-44558

#### Screenshots

SearchableChannelList changes (Light theme)

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/9254315/172717368-e1b911dc-b455-401c-a4b9-4c2e4d333af8.png) 
![image](https://user-images.githubusercontent.com/9254315/172715868-a8636d84-6e27-4c75-83df-2886738f6dcb.png) 


SearchableChannelList changes (Dark theme)

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/9254315/172717205-43ee3c6e-8132-4b6c-93b1-ddecf277d6e0.png) | ![image](https://user-images.githubusercontent.com/9254315/172716052-818f529e-cbb5-4d2d-af44-c0135879f57f.png) |


ThreadViewer changes (Light theme)

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/9254315/172717272-630fadd5-cd7c-4bb8-a0dd-2d1dd2553458.png)| 
![image](https://user-images.githubusercontent.com/9254315/172715780-89c5223e-4b32-4ec1-bae8-39618585a93b.png)
|

ThreadViewer changes (Dark theme)

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/9254315/172717131-6f345f24-1a1e-4edc-b1a2-2d099d6b30ae.png) | 
![image](https://user-images.githubusercontent.com/9254315/172715976-855ee3f1-6240-4b0a-b3ee-9b8cbe5b96e5.png)
|

#### Release Note
NONE
