### PR TITLE
MM-44849 - feature discovery pages show start trial button after trial completed

### DIFF
--- a/components/admin_console/feature_discovery/index.tsx
+++ b/components/admin_console/feature_discovery/index.tsx
@@ -11,6 +11,7 @@ import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {isCloudLicense} from 'utils/license_utils';
 
 import {cloudFreeEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {checkHadPriorTrial} from 'mattermost-redux/selectors/entities/cloud';
 import {LicenseSkus} from 'mattermost-redux/types/general';
 
 import {openModal} from 'actions/views/modals';
@@ -26,6 +27,7 @@ function mapStateToProps(state: GlobalState) {
     const license = getLicense(state);
     const isCloud = isCloudLicense(license);
     const isCloudFreeEnabled = cloudFreeEnabled(state);
+    const hasPriorTrial = checkHadPriorTrial(state);
     const isCloudTrial = subscription?.is_free_trial === 'true';
     return {
         stats: state.entities.admin.analytics,
@@ -33,7 +35,7 @@ function mapStateToProps(state: GlobalState) {
         isCloud,
         isCloudFreeEnabled,
         isCloudTrial,
-        hadPrevCloudTrial: subscription?.is_free_trial === 'false' && subscription?.trial_end_at > 0,
+        hadPrevCloudTrial: hasPriorTrial,
         isCloudFreePaidSubscription: isCloud && isCloudFreeEnabled && license?.SkuShortName !== LicenseSkus.Starter && !isCloudTrial,
     };
 }


### PR DESCRIPTION
#### Summary
This PR adds the logic for opening the upgrade modal once the trial have completed showing a call to action to upgrade from the feature discovery pages in the system console

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44849

#### Related Pull Requests
n/a

#### Screenshots

https://user-images.githubusercontent.com/10082627/172846978-b7f6dc9e-9bee-46b6-b6eb-f4da62c94313.mp4



#### Release Note
```release-note
NONE
```
