### PR TITLE
MM-44906 - add back playbooks and boards to task list when no using o…

### DIFF
--- a/components/onboarding_tasks/onboarding_tasks_manager.tsx
+++ b/components/onboarding_tasks/onboarding_tasks_manager.tsx
@@ -21,7 +21,7 @@ import LearnMoreTrialModal from 'components/learn_more_trial_modal/learn_more_tr
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 
-import {get, makeGetCategory, cloudFreeEnabled, getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferences';
+import {get, makeGetCategory, cloudFreeEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {isCurrentUserSystemAdmin, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 
@@ -101,9 +101,6 @@ export const useTasksList = () => {
     const isUserAdmin = useSelector((state: GlobalState) => isCurrentUserSystemAdmin(state));
     const isUserFirstAdmin = useSelector(isFirstAdmin);
 
-    // feature flag for ab test over the effectiveness of the onboarding workspace wizard
-    const useCaseOnboarding = useSelector(getUseCaseOnboarding);
-
     // Cloud conditions
     const subscription = useSelector((state: GlobalState) => state.entities.cloud.subscription);
     const isCloud = license?.Cloud === 'true';
@@ -121,10 +118,10 @@ export const useTasksList = () => {
     const list: Record<string, string> = {...OnboardingTasksName};
     const pluginsPreferenceState = useSelector((state: GlobalState) => get(state, Constants.Preferences.ONBOARDING, OnboardingPreferences.USE_CASE));
     const pluginsPreference = pluginsPreferenceState && JSON.parse(pluginsPreferenceState);
-    if ((pluginsPreference && !pluginsPreference.boards) || !pluginsList.focalboard || !useCaseOnboarding) {
+    if ((pluginsPreference && !pluginsPreference.boards) || !pluginsList.focalboard) {
         delete list.BOARDS_TOUR;
     }
-    if ((pluginsPreference && !pluginsPreference.playbooks) || !pluginsList.playbooks || !useCaseOnboarding) {
+    if ((pluginsPreference && !pluginsPreference.playbooks) || !pluginsList.playbooks) {
         delete list.PLAYBOOKS_TOUR;
     }
     if (!showStartTrialTask) {


### PR DESCRIPTION
#### Summary
this pr adds back the playbooks and boards to the onboarding task list when the useCaseOnboarding FF is off.

The other two scenarios where these two options are shown/hidden are already covered in the code:
- there are plugin preference values (set by the initial onboarding which means the useCaseOnboarding is on)
- these plugins are not available in the plugins list.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44906

#### Related Pull Requests
n/a

#### Screenshots
<img width="1005" alt="Captura de pantalla 2022-06-09 a las 14 31 10" src="https://user-images.githubusercontent.com/10082627/172847592-f80564b6-3a61-4fc4-a41f-dc0aed4d4ecc.png">


#### Release Note
```release-note
NONE
```
