### PR TITLE
Show desktop app download prompt on first visit to a new server

### DIFF
--- a/components/linking_landing_page/linking_landing_page.tsx
+++ b/components/linking_landing_page/linking_landing_page.tsx
@@ -50,7 +50,7 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
             navigating: false,
         };
 
-        if (Utils.isMobile() && !BrowserStore.hasSeenLandingPage()) {
+        if (!BrowserStore.hasSeenLandingPage()) {
             BrowserStore.setLandingPageSeen(true);
         }
     }

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -250,18 +250,21 @@ export default class Root extends React.PureComponent {
 
         const iosDownloadLink = getConfig(store.getState()).IosAppDownloadLink;
         const androidDownloadLink = getConfig(store.getState()).AndroidAppDownloadLink;
+        const desktopAppDownloadLink = getConfig(store.getState()).AppDownloadLink;
 
         const toResetPasswordScreen = this.props.location.pathname === '/reset_password_complete';
 
         // redirect to the mobile landing page if the user hasn't seen it before
-        let mobileLanding;
+        let landing;
         if (UserAgent.isAndroidWeb()) {
-            mobileLanding = androidDownloadLink;
+            landing = androidDownloadLink;
         } else if (UserAgent.isIosWeb()) {
-            mobileLanding = iosDownloadLink;
+            landing = iosDownloadLink;
+        } else {
+            landing = desktopAppDownloadLink;
         }
 
-        if (mobileLanding && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen && !this.props.location.pathname.includes('/landing')) {
+        if (landing && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen && !this.props.location.pathname.includes('/landing')) {
             this.props.history.push('/landing#' + this.props.location.pathname + this.props.location.search);
             BrowserStore.setLandingPageSeen(true);
         }


### PR DESCRIPTION

#### Summary
This PR adds the functionality to preview the desktop app download screen on a first visit to a new server.

Steps: 
- log out from all servers
- clear site data so that your login isn't remembered
- navigate to server home page

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36439

#### Screenshots
![Screenshot 2022-06-10 at 17 20 47](https://user-images.githubusercontent.com/16692883/173086193-6b981828-809f-425d-b6b5-834026d862d8.png)
![Screenshot 2022-06-10 at 17 20 57](https://user-images.githubusercontent.com/16692883/173086203-0ef34223-1e05-4b65-a0ac-a9a56f93e04c.png)
![Screenshot 2022-06-10 at 17 21 07](https://user-images.githubusercontent.com/16692883/173086207-8cbd6c73-8009-4a5d-8610-64baea48b808.png)

#### Release Note
```release-note
NONE
```
