### PR TITLE
Show new version bar with new server versions based on commit hashes

### DIFF
--- a/utils/server_version.test.tsx
+++ b/utils/server_version.test.tsx
@@ -46,10 +46,10 @@ describe('utils/server_version/equalServerVersions', () => {
         expect(equalServerVersions(a, b)).toEqual(false);
     });
 
-    test('should ignore different config hashes', () => {
+    test('should not ignore different config hashes', () => {
         const a = '4.7.1.12.c51676437bc02ada78f3a0a0a2203c60.true';
         const b = '4.7.1.12.c51676437bc02ada78f3a0a0a2203c61.true';
-        expect(equalServerVersions(a, b)).toEqual(true);
+        expect(equalServerVersions(a, b)).toEqual(false);
     });
 
     test('should ignore different licensed statuses', () => {

--- a/utils/server_version.tsx
+++ b/utils/server_version.tsx
@@ -17,7 +17,7 @@ export function equalServerVersions(a: string, b: string): boolean {
         return true;
     }
 
-    const ignoredComponents = 2;
+    const ignoredComponents = 1;
     const aIgnoringComponents = (a || '').split('.').slice(0, -ignoredComponents).join('.');
     const bIgnoringComponents = (b || '').split('.').slice(0, -ignoredComponents).join('.');
     if (aIgnoringComponents === bIgnoringComponents) {


### PR DESCRIPTION
#### Summary
The functionality previously would require the version bar to ignore commit hashes, but with new daily updates we would wanna show the bar with every hash. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38124

#### Release Note
```release-note
NONE
```
