### PR TITLE
Fix rhs toggle state

### DIFF
--- a/components/channel_header/channel_info_button.tsx
+++ b/components/channel_header/channel_info_button.tsx
@@ -1,16 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useCallback} from 'react';
 
 import {useDispatch, useSelector} from 'react-redux';
 
 import styled from 'styled-components';
 
 import {Channel} from '@mattermost/types/channels';
-import {getIsRhsOpen, getRhsState} from 'selectors/rhs';
-import {RHSStates} from 'utils/constants';
-import {RhsState} from 'types/store/rhs';
+import {getIsRhsOpen} from 'selectors/rhs';
+
 import {closeRightHandSide, showChannelInfo} from 'actions/views/rhs';
 
 import HeaderIconWrapper from './components/header_icon_wrapper';
@@ -31,16 +30,15 @@ const ChannelInfoButton = ({channel}: Props) => {
     const dispatch = useDispatch();
 
     const isRhsOpen: boolean = useSelector(getIsRhsOpen);
-    const rhsState: RhsState = useSelector(getRhsState);
-    const rhsOpenOnChannelInfo = isRhsOpen && rhsState === RHSStates.CHANNEL_INFO;
+    const rhsOpenOnChannelInfo = isRhsOpen;
 
-    const toggleRHS = () => {
-        if (rhsState === RHSStates.CHANNEL_INFO) {
+    const toggleRHS = useCallback(() => {
+        if (isRhsOpen) {
             dispatch(closeRightHandSide());
         } else {
             dispatch(showChannelInfo(channel.id));
         }
-    };
+    }, [isRhsOpen, channel.id, dispatch]);
 
     const tooltipKey = rhsOpenOnChannelInfo ? 'closeChannelInfo' : 'openChannelInfo';
 

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
@@ -241,9 +241,11 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
         ]
       }
     >
-      <div>
+      <div
+        className="truncated"
+      >
         <span
-          className="SidebarChannelLinkLabel truncated"
+          className="SidebarChannelLinkLabel"
         >
           channel_label
         </span>

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -181,14 +181,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         }
 
         let labelElement: JSX.Element = (
-            <span
-                className={classNames(
-                    'SidebarChannelLinkLabel',
-                    {
-                        truncated: this.state.showTooltip,
-                    },
-                )}
-            >
+            <span className='SidebarChannelLinkLabel'>
                 {wrapEmojis(label)}
             </span>
         );
@@ -205,7 +198,10 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                     overlay={displayNameToolTip}
                     onEntering={this.removeTooltipLink}
                 >
-                    <div ref={this.gmItemRef}>
+                    <div
+                        className='truncated'
+                        ref={this.gmItemRef}
+                    >
                         {labelElement}
                     </div>
                 </OverlayTrigger>

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1253,6 +1253,12 @@ $sidebarOpacityAnimationDuration: 0.15s;
         overflow: hidden;
         flex-grow: 1;
     }
+    .SidebarChannelLinkLabel_wrapper > div.truncated {
+        display: block;
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 
     .DirectChannel__profile-picture {
         height: 20px;

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1253,10 +1253,11 @@ $sidebarOpacityAnimationDuration: 0.15s;
         overflow: hidden;
         flex-grow: 1;
     }
+
     .SidebarChannelLinkLabel_wrapper > div.truncated {
         display: block;
-        width: 100%;
         overflow: hidden;
+        width: 100%;
         text-overflow: ellipsis;
     }
 

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1095,11 +1095,6 @@ $sidebarOpacityAnimationDuration: 0.15s;
             line-height: 18px;
             text-align: justify;
             white-space: nowrap;
-
-            &.truncated {
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
         }
 
         &.expanded {


### PR DESCRIPTION
#### Summary
I don't know if this is intended but the toggle for the RHS sidebar only has the active state when the RHS is on the info tab. It also doesn't hide the sidebar if you are on another tab (users for example) instead reopening the general info tab.

I think everything in the sidebar is technically channel info so I think it's a little more user friendly to use this button as a global toggle and the caret to go back to the general tab (currently both the caret and the toggle will go back to the general info tab so it's a duplication).

#### Release Note

```release-note
NONE

```
