### PR TITLE
MM-44642: Hide insights if not Professional or Enterprise SKU or if guest

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -6,6 +6,8 @@ import {createSelector} from 'reselect';
 import {General, Preferences} from 'mattermost-redux/constants';
 
 import {getConfig, getFeatureFlagValue, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {isGuest} from 'mattermost-redux/utils/user_utils';
 
 import {PreferenceType} from '@mattermost/types/preferences';
 import {GlobalState} from '@mattermost/types/store';
@@ -214,7 +216,10 @@ export function getUseCaseOnboarding(state: GlobalState): boolean {
 
 export function insightsAreEnabled(state: GlobalState): boolean {
     const license = getLicense(state);
-    return getFeatureFlagValue(state, 'InsightsEnabled') === 'true' && license?.IsLicensed === 'true' && (license.SkuShortName === LicenseSkus.Professional || license.SkuShortName === LicenseSkus.Enterprise);
+    const isLicensedForFeature = license?.IsLicensed === 'true' && (license.SkuShortName === LicenseSkus.Professional || license.SkuShortName === LicenseSkus.Enterprise);
+    const featureIsEnabled = getFeatureFlagValue(state, 'InsightsEnabled') === 'true';
+    const currentUserIsGuest = isGuest(getCurrentUser(state).roles);
+    return featureIsEnabled && isLicensedForFeature && !currentUserIsGuest;
 }
 
 export function cloudFreeEnabled(state: GlobalState): boolean {

--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -17,7 +17,6 @@ import {createShallowSelector} from 'mattermost-redux/utils/helpers';
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 import {setThemeDefaults} from 'mattermost-redux/utils/theme_utils';
 import {CollapsedThreads} from '@mattermost/types/config';
-import {LicenseSkus} from 'mattermost-redux/types/general';
 
 export function getMyPreferences(state: GlobalState): { [x: string]: PreferenceType } {
     return state.entities.preferences.myPreferences;

--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -215,11 +215,10 @@ export function getUseCaseOnboarding(state: GlobalState): boolean {
 }
 
 export function insightsAreEnabled(state: GlobalState): boolean {
-    const license = getLicense(state);
-    const isLicensedForFeature = license?.IsLicensed === 'true' && (license.SkuShortName === LicenseSkus.Professional || license.SkuShortName === LicenseSkus.Enterprise);
+    const isConfiguredForFeature = getConfig(state).InsightsEnabled === 'true';
     const featureIsEnabled = getFeatureFlagValue(state, 'InsightsEnabled') === 'true';
     const currentUserIsGuest = isGuest(getCurrentUser(state).roles);
-    return featureIsEnabled && isLicensedForFeature && !currentUserIsGuest;
+    return featureIsEnabled && isConfiguredForFeature && !currentUserIsGuest;
 }
 
 export function cloudFreeEnabled(state: GlobalState): boolean {

--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -15,6 +15,7 @@ import {createShallowSelector} from 'mattermost-redux/utils/helpers';
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 import {setThemeDefaults} from 'mattermost-redux/utils/theme_utils';
 import {CollapsedThreads} from '@mattermost/types/config';
+import {LicenseSkus} from 'mattermost-redux/types/general';
 
 export function getMyPreferences(state: GlobalState): { [x: string]: PreferenceType } {
     return state.entities.preferences.myPreferences;
@@ -212,7 +213,8 @@ export function getUseCaseOnboarding(state: GlobalState): boolean {
 }
 
 export function insightsAreEnabled(state: GlobalState): boolean {
-    return getFeatureFlagValue(state, 'InsightsEnabled') === 'true';
+    const license = getLicense(state);
+    return getFeatureFlagValue(state, 'InsightsEnabled') === 'true' && license?.IsLicensed === 'true' && (license.SkuShortName === LicenseSkus.Professional || license.SkuShortName === LicenseSkus.Enterprise);
 }
 
 export function cloudFreeEnabled(state: GlobalState): boolean {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -122,6 +122,7 @@ export type ClientConfig = {
     IosAppDownloadLink: string;
     IosLatestVersion: string;
     IosMinVersion: string;
+    InsightsEnabled: string;
     InstallationDate: string;
     IsDefaultMarketplace: string;
     LdapFirstNameAttributeSet: string;


### PR DESCRIPTION
#### Summary

Adds license and guest check to the Insights front-end feature fence.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44642

#### Release Note

```release-note
NONE
```

#### Related PR

* https://github.com/mattermost/mattermost-server/pull/20490