### PR TITLE
Fix redirect_to dropping query parameters

### DIFF
--- a/components/logged_in/logged_in.test.tsx
+++ b/components/logged_in/logged_in.test.tsx
@@ -28,6 +28,7 @@ describe('components/logged_in/LoggedIn', () => {
         showTermsOfService: false,
         location: {
             pathname: '/',
+            search: '',
         },
     };
 
@@ -68,6 +69,7 @@ describe('components/logged_in/LoggedIn', () => {
             mfaRequired: true,
             location: {
                 pathname: '/mfa/setup',
+                search: '',
             },
         };
 
@@ -86,6 +88,7 @@ describe('components/logged_in/LoggedIn', () => {
             mfaRequired: false,
             location: {
                 pathname: '/mfa/confirm',
+                search: '',
             },
         };
 
@@ -121,6 +124,7 @@ describe('components/logged_in/LoggedIn', () => {
             showTermsOfService: true,
             location: {
                 pathname: '/terms_of_service',
+                search: '',
             },
         };
 

--- a/components/logged_in/logged_in.tsx
+++ b/components/logged_in/logged_in.tsx
@@ -45,6 +45,7 @@ export type Props = {
     showTermsOfService: boolean;
     location: {
         pathname: string;
+        search: string;
     };
 }
 
@@ -118,7 +119,7 @@ export default class LoggedIn extends React.PureComponent<Props> {
             if (rootEl) {
                 rootEl.setAttribute('class', '');
             }
-            GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(this.props.location.pathname), true, false);
+            GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(`${this.props.location.pathname}${this.props.location.search}`), true, false);
         }
 
         // Prevent backspace from navigating back a page


### PR DESCRIPTION
#### Summary
If you attempt to visit a page with query parameters and you're unauthenticated, you will be redirected to the login page with a `redirect_to` value, however the query parameters for the initial page will not be preserved. This passes along the query parameters to the redirect_to value 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45051

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
