### PR TITLE
MM-45067: Reorder core products in the App Bar

### DIFF
--- a/components/app_bar/app_bar.tsx
+++ b/components/app_bar/app_bar.tsx
@@ -25,7 +25,7 @@ export default function AppBar() {
         return null;
     }
 
-    const coreProductsIds = ['playbooks', 'focalboard'];
+    const coreProductsIds = ['focalboard', 'playbooks'];
 
     // The type guard in the filter (which removes all undefined elements) is needed for
     // Typescript to correctly type coreProducts.


### PR DESCRIPTION
#### Summary
The product switcher contains: Channels, Boards, Playbooks.
![image](https://user-images.githubusercontent.com/3924815/173564084-25bb3bdd-522f-4e88-877b-8e13d2b0305a.png)

The App Bar, however, had Playbooks before Boards. This PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45067

#### Related Pull Requests
--

#### Screenshots

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/3924815/173566348-1a324915-34ab-45a9-b0b9-b975c42b1b5f.png)| ![image](https://user-images.githubusercontent.com/3924815/173566525-6d9fbdf0-e30a-4fad-b6e1-77580451e6f2.png) |

#### Release Note
```release-note
NONE
```
