### PR TITLE
Update subpackage versions to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mattermost/webapp",
-  "version": "5.36.0-0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mattermost/webapp",
-      "version": "5.36.0-0",
+      "version": "7.0.0",
       "workspaces": [
         "packages/client",
         "packages/types"
@@ -40103,7 +40103,7 @@
     },
     "packages/client": {
       "name": "@mattermost/client",
-      "version": "6.7.0-0",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -40124,7 +40124,7 @@
     },
     "packages/types": {
       "name": "@mattermost/types",
-      "version": "6.7.0-0",
+      "version": "7.0.0",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "5.36.0-0",
+  "version": "7.0.0",
   "private": true,
   "engines": {
     "npm": ">=7.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "6.7.0-0",
+  "version": "7.0.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "6.7.0-0",
+  "version": "7.0.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
I'll probably automate this eventually, but the release process for the subpackages is pretty simple since they're locked to the version of the web app. There's a more detailed version in `packages/README.md` in this repo, but for now, I'm just updating these version numbers, and then once this is merged, I'll tag the commit for future reference.

Also, for my own future reference, the published packages are available here:
- https://www.npmjs.com/package/@mattermost/client
- https://www.npmjs.com/package/@mattermost/types

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44326

#### Release Note
```release-note
NONE
```
