### PR TITLE
MM-44131 Add debug logging for DynamicSizedList and for post-related websocket events

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -657,6 +657,12 @@ const handleNewPostEventDebounced = debouncePostEvent(100);
 export function handleNewPostEvent(msg) {
     return (myDispatch, myGetState) => {
         const post = JSON.parse(msg.data.post);
+
+        if (window.logPostEvents) {
+            // eslint-disable-next-line no-console
+            console.log('handleNewPostEvent - new post received', post);
+        }
+
         myDispatch(handleNewPost(post, msg));
 
         getProfilesAndStatusesForPosts([post], myDispatch, myGetState);
@@ -684,6 +690,11 @@ export function handleNewPostEvents(queue) {
         // Note that this method doesn't properly update the sidebar state for these posts
         const posts = queue.map((msg) => JSON.parse(msg.data.post));
 
+        if (window.logPostEvents) {
+            // eslint-disable-next-line no-console
+            console.log('handleNewPostEvents - new posts received', posts);
+        }
+
         // Receive the posts as one continuous block since they were received within a short period
         const crtEnabled = isCollapsedThreadsEnabled(myGetState());
         const actions = posts.map((post) => receivedNewPost(post, crtEnabled));
@@ -700,6 +711,12 @@ export function handleNewPostEvents(queue) {
 export function handlePostEditEvent(msg) {
     // Store post
     const post = JSON.parse(msg.data.post);
+
+    if (window.logPostEvents) {
+        // eslint-disable-next-line no-console
+        console.log('handlePostEditEvent - post edit received', post);
+    }
+
     const crtEnabled = isCollapsedThreadsEnabled(getState());
     dispatch(receivedPost(post, crtEnabled));
 
@@ -717,6 +734,12 @@ export function handlePostEditEvent(msg) {
 
 async function handlePostDeleteEvent(msg) {
     const post = JSON.parse(msg.data.post);
+
+    if (window.logPostEvents) {
+        // eslint-disable-next-line no-console
+        console.log('handlePostDeleteEvent - post delete received', post);
+    }
+
     const state = getState();
     const collapsedThreads = isCollapsedThreadsEnabled(state);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "country-list": "2.2.0",
         "crypto-browserify": "3.12.0",
         "css-vars-ponyfill": "2.4.7",
-        "dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#119db968c96643c7106d4d2c965f05b2e251bc83",
+        "dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#77a0cb4c565bc239bab1ce5414b95bdd9a570963",
         "emoji-datasource": "6.1.1",
         "emoji-datasource-apple": "6.0.1",
         "emoji-regex": "10.1.0",
@@ -9868,13 +9868,20 @@
       "optional": true
     },
     "node_modules/dynamic-virtualized-list": {
-      "resolved": "git+ssh://git@github.com/mattermost/dynamic-virtualized-list.git#119db968c96643c7106d4d2c965f05b2e251bc83",
+      "version": "1.0.0-beta",
+      "resolved": "git+ssh://git@github.com/mattermost/dynamic-virtualized-list.git#77a0cb4c565bc239bab1ce5414b95bdd9a570963",
+      "integrity": "sha512-/Q5gwOK+wgHMaOH03DbgBXBpnJHORoHgRNDxsYoJ5R4GxDS4dk5xkAC7h6t/HPDLFzdobTkfXypd5o8gOybejQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"
       },
       "engines": {
         "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/dynamic-virtualized-list/node_modules/memoize-one": {
@@ -36842,8 +36849,9 @@
       "optional": true
     },
     "dynamic-virtualized-list": {
-      "version": "git+ssh://git@github.com/mattermost/dynamic-virtualized-list.git#119db968c96643c7106d4d2c965f05b2e251bc83",
-      "from": "dynamic-virtualized-list@github:mattermost/dynamic-virtualized-list#119db968c96643c7106d4d2c965f05b2e251bc83",
+      "version": "git+ssh://git@github.com/mattermost/dynamic-virtualized-list.git#77a0cb4c565bc239bab1ce5414b95bdd9a570963",
+      "integrity": "sha512-/Q5gwOK+wgHMaOH03DbgBXBpnJHORoHgRNDxsYoJ5R4GxDS4dk5xkAC7h6t/HPDLFzdobTkfXypd5o8gOybejQ==",
+      "from": "dynamic-virtualized-list@github:mattermost/dynamic-virtualized-list#77a0cb4c565bc239bab1ce5414b95bdd9a570963",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "country-list": "2.2.0",
     "crypto-browserify": "3.12.0",
     "css-vars-ponyfill": "2.4.7",
-    "dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#119db968c96643c7106d4d2c965f05b2e251bc83",
+    "dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#77a0cb4c565bc239bab1ce5414b95bdd9a570963",
     "emoji-datasource": "6.1.1",
     "emoji-datasource-apple": "6.0.1",
     "emoji-regex": "10.1.0",


### PR DESCRIPTION
This adds new debug logging for the `DynamicSizedList` component and new post events triggered by setting `logDSLEvents` and `logPostEvents` respectively to true. It's opt-in since it's fairly noisy (especially DynamicSizedList), and we'll hopefully remove it once we figure out what this long-running bug with the keep-at-bottom logic is caused by.

I linked the changes to the dynamic-virtualized-list library below

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44131

#### Related Pull Requests
https://github.com/mattermost/dynamic-virtualized-list/pull/26

#### Release Note
```release-note
NONE
```
