### PR TITLE
Handle image metadata being undefined in posts with opengraph attachments

### DIFF
--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.tsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.tsx
@@ -372,6 +372,22 @@ describe('Helpers', () => {
             expect(imageUrl).toEqual(openGraphData.images[0].secure_url);
         });
 
+        test('should handle undefined metadata', () => {
+            const openGraphData = {
+                images: [{
+                    secure_url: 'https://example.com/image.png',
+                    url: 'http://example.com/image.png',
+                }],
+            };
+
+            const imagesMetadata = {};
+
+            const imageData = getBestImage(openGraphData, imagesMetadata);
+            const imageUrl = imageData?.secure_url || imageData?.url;
+
+            expect(imageUrl).toEqual(openGraphData.images[0].secure_url);
+        });
+
         test('should return url if secure_url is not specified', () => {
             const openGraphData = {
                 images: [{

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.tsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.tsx
@@ -64,8 +64,8 @@ export function getBestImage(openGraphData?: OpenGraphMetadata, imagesMetadata?:
 
         return {
             ...image,
-            height: image.height || imagesMetadata?.[imageUrl].height || -1,
-            width: image.width || imagesMetadata?.[imageUrl].width || -1,
+            height: image.height || imagesMetadata?.[imageUrl]?.height || -1,
+            width: image.width || imagesMetadata?.[imageUrl]?.width || -1,
             format: image.type?.split('/')[1] || image.type || '',
             frameCount: 0,
         };


### PR DESCRIPTION
#### Summary
Handle image metadata being undefined in posts with opengraph attachments. This was causing some channels or threads to crash the app.

Context in these threads:

* https://community.mattermost.com/core/pl/b45bs7x35j868g1n4e36qj38fo
* https://community.mattermost.com/core/pl/zqdbxqnjxtrmtkukqxy33hfgjc

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
