### PR TITLE
Make window.store always available on community

### DIFF
--- a/stores/redux_store.jsx
+++ b/stores/redux_store.jsx
@@ -8,13 +8,8 @@ import configureStore from 'store';
 
 const store = configureStore();
 
-export function bindActionToRedux(action, ...args) {
-    return async () => {
-        await action(...args)(store.dispatch, store.getState);
-    };
-}
-
-if (process.env.NODE_ENV !== 'production') { //eslint-disable-line no-process-env
+// eslint-disable-next-line no-process-env
+if (process.env.NODE_ENV !== 'production' || window.location.origin === 'https://community.mattermost.com') {
     window.store = store;
 }
 


### PR DESCRIPTION
Having access to the store when debugging is incredibly helpful, and since we seem to have a lot of issues that we can only reproduce on community, it seems like it makes sense to expose there.

I could see an argument for doing it whenever developer mode is turned on, but that requires watching the current value in the client config which is more complicated, and I don't think we need to add that unless we find a specific need for it.

#### Related Pull Requests
This is part of https://github.com/mattermost/mattermost-webapp/pull/10617

#### Release Note
```release-note
NONE
```
