### PR TITLE
Migrate makeAsyncComponent and deferComponentRender to TS

### DIFF
--- a/components/async_load.tsx
+++ b/components/async_load.tsx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-export function makeAsyncComponent(displayName, LazyComponent, fallback = null) {
-    const Component = (props) => (
+export function makeAsyncComponent<ComponentProps>(displayName: string, LazyComponent: React.ComponentType<ComponentProps>, fallback: React.ReactNode = null) {
+    const Component = (props: ComponentProps) => (
         <React.Suspense fallback={fallback}>
             <LazyComponent {...props}/>
         </React.Suspense>

--- a/components/deferComponentRender.tsx
+++ b/components/deferComponentRender.tsx
@@ -4,6 +4,10 @@
 import hoistStatics from 'hoist-non-react-statics';
 import React from 'react';
 
+type DeferredRenderWrapperState = {
+    shouldRender: boolean;
+}
+
 /**
  * Allows two animation frames to complete to allow other components to update
  * and re-render before mounting and rendering an expensive `WrappedComponent`.
@@ -13,10 +17,10 @@ import React from 'react';
  * Based on this Twitter built component
  * https://gist.github.com/paularmstrong/cc2ead7e2a0dec37d8b2096fc8d85759#file-defercomponentrender-js
  */
-export default function deferComponentRender(WrappedComponent, PreRenderComponent = null) {
-    class DeferredRenderWrapper extends React.PureComponent {
-        constructor(props, context) {
-            super(props, context);
+export default function deferComponentRender<ComponentProps>(WrappedComponent: React.ComponentType<ComponentProps>, PreRenderComponent: React.ReactNode = null) {
+    class DeferredRenderWrapper extends React.PureComponent<ComponentProps, DeferredRenderWrapperState> {
+        constructor(props: ComponentProps) {
+            super(props);
 
             this.state = {
                 shouldRender: false,

--- a/components/file_search_results/file_search_result_item.tsx
+++ b/components/file_search_results/file_search_result_item.tsx
@@ -93,6 +93,7 @@ export default class FileSearchResultItem extends React.PureComponent<Props, Sta
             dialogProps: {
                 fileInfos: [this.props.fileInfo],
                 postId: this.props.fileInfo.post_id,
+                startIndex: 0,
             },
         });
     }

--- a/components/invitation_modal/index.tsx
+++ b/components/invitation_modal/index.tsx
@@ -93,7 +93,7 @@ export function mapStateToProps(state: GlobalState, props: OwnProps) {
 type Actions = {
     sendGuestsInvites: (teamId: string, channels: Channel[], users: UserProfile[], emails: string[], message: string) => Promise<{data: InviteResults}>;
     sendMembersInvites: (teamId: string, users: UserProfile[], emails: string[]) => Promise<{data: InviteResults}>;
-    sendMembersInvitesToChannels: (channels: Channel[], teamId: string, users: UserProfile[], emails: string[], message: string) => Promise<{data: InviteResults}>;
+    sendMembersInvitesToChannels: (teamId: string, channels: Channel[], users: UserProfile[], emails: string[], message: string) => Promise<{data: InviteResults}>;
     regenerateTeamInviteId: (teamId: string) => void;
     searchProfiles: (term: string, options?: Record<string, string>) => Promise<{data: UserProfile[]}>;
     searchChannels: (teamId: string, term: string) => ActionFunc;

--- a/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -329,8 +329,10 @@ export default class MessageAttachment extends React.PureComponent<Props, State>
                 fileInfos: [{
                     has_preview_image: false,
                     link,
-                    extension,
+                    extension: extension ?? '',
+                    name: link,
                 }],
+                startIndex: 0,
             },
         });
     }

--- a/components/single_image_view/single_image_view.tsx
+++ b/components/single_image_view/single_image_view.tsx
@@ -91,6 +91,7 @@ export default class SingleImageView extends React.PureComponent<Props, State> {
             dialogProps: {
                 fileInfos: [this.props.fileInfo],
                 postId: this.props.postId,
+                startIndex: 0,
             },
         });
     }

--- a/components/threading/thread_viewer/__snapshots__/thread_viewer.test.tsx.snap
+++ b/components/threading/thread_viewer/__snapshots__/thread_viewer.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`components/threading/ThreadViewer should match snapshot 1`] = `
             "id",
           ]
         }
-        removePost={[MockFunction]}
         selected={
           Object {
             "channel_id": "channel_id",

--- a/components/threading/thread_viewer/thread_viewer.tsx
+++ b/components/threading/thread_viewer/thread_viewer.tsx
@@ -226,12 +226,11 @@ export default class ThreadViewer extends React.PureComponent<Props, State> {
                                     onCardClick={this.handleCardClick}
                                     onCardClickPost={this.handleCardClickPost}
                                     postIds={this.props.postIds}
-                                    removePost={this.props.actions.removePost}
                                     selected={this.props.selected}
                                     useRelativeTimestamp={this.props.useRelativeTimestamp || false}
                                     highlightedPostId={this.props.highlightedPostId}
                                     selectedPostFocusedAt={this.props.selectedPostFocusedAt}
-                                    isThreadView={this.props.isCollapsedThreadsEnabled && this.props.isThreadView}
+                                    isThreadView={Boolean(this.props.isCollapsedThreadsEnabled && this.props.isThreadView)}
                                 />
                             )}
                         </>

--- a/components/threading/virtualized_thread_viewer/index.ts
+++ b/components/threading/virtualized_thread_viewer/index.ts
@@ -21,7 +21,6 @@ import ThreadViewerVirtualized from './virtualized_thread_viewer';
 
 type OwnProps = {
     channel: Channel;
-    openTime: number;
     postIds: Array<Post['id'] | FakePost['id']>;
     selected: Post | FakePost;
     useRelativeTimestamp: boolean;


### PR DESCRIPTION
Something with the newer version of TS I tried using required me to migrate these to TS. The rest of the changes are to satisfy the type checker now that it properly knows the props of deferred and async components.

#### Related Pull Requests
This is part of https://github.com/mattermost/mattermost-webapp/pull/10617

#### Release Note
```release-note
NONE
```
