### PR TITLE
Update to use boards v2 api

### DIFF
--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -3477,7 +3477,7 @@ export default class Client4 {
 
     getBoardsUsage = () => {
         return this.doFetch<BoardsUsageResponse>(
-            `/plugins/${suitePluginIds.focalboard}/api/v1/limits`,
+            `/plugins/${suitePluginIds.focalboard}/api/v2/limits`,
             {method: 'get'},
         );
     }


### PR DESCRIPTION
#### Summary
Uses boards API/V2 path when calling for limits.
For boards v7.2, this change will be necessary.

#### Release Note

```
NONE
```
