### PR TITLE
Fix z index downgrade modal

### DIFF
--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -299,7 +299,7 @@ function Content(props: ContentProps) {
                                 }
                             },
                             text: formatMessage({id: 'pricing_modal.btn.downgrade', defaultMessage: 'Downgrade'}),
-                            disabled: false,
+                            disabled: !isStarter,
                             customClass: ButtonCustomiserClasses.secondary,
                         }}
                         planLabel={

--- a/components/pricing_modal/downgrade_team_removal_modal/downgrade_team_removal_modal.scss
+++ b/components/pricing_modal/downgrade_team_removal_modal/downgrade_team_removal_modal.scss
@@ -8,7 +8,6 @@
 .DowngradeTeamRemovalModal {
     z-index: 1051;
 
-
     .modal {
         overflow: visible;
     }

--- a/components/pricing_modal/downgrade_team_removal_modal/downgrade_team_removal_modal.scss
+++ b/components/pricing_modal/downgrade_team_removal_modal/downgrade_team_removal_modal.scss
@@ -1,12 +1,13 @@
 
 @import 'utils/variables';
 
-.modal-backdrop {
+.modal-backdrop.downgrade-modal-backdrop {
     z-index: 1050;
 }
 
 .DowngradeTeamRemovalModal {
     z-index: 1051;
+
 
     .modal {
         overflow: visible;

--- a/components/pricing_modal/downgrade_team_removal_modal/downgrade_team_removal_modal.test.tsx
+++ b/components/pricing_modal/downgrade_team_removal_modal/downgrade_team_removal_modal.test.tsx
@@ -25,6 +25,15 @@ describe('components/pricing_modal/downgrade_team_removal_modal', () => {
 
     const state = {
         entities: {
+            users: {
+                currentUserId: 'user1',
+                profiles: {
+                    user1: {
+                        id: 'user1',
+                        roles: '',
+                    },
+                },
+            },
             usage: {
                 files: {
                     totalStorage: 0,
@@ -301,7 +310,6 @@ describe('components/pricing_modal/downgrade_team_removal_modal', () => {
         views: {
             modals: {
                 modalState: {
-
                     cloud_downgrade_choose_team: {
                         open: 'true',
                     },

--- a/components/pricing_modal/downgrade_team_removal_modal/index.tsx
+++ b/components/pricing_modal/downgrade_team_removal_modal/index.tsx
@@ -124,6 +124,7 @@ function DowngradeTeamRemovalModal(props: Props) {
         <Modal
             className='DowngradeTeamRemovalModal'
             show={isCloudDowngradeChooseTeamModalOpen}
+            backdropClassName={'downgrade-modal-backdrop'}
             id='downgradeTeamRemovalModal'
             onExited={onHide}
             data-testid='downgradeTeamRemovalModal'


### PR DESCRIPTION
#### Summary
`modal-backdrop` wasn't specific enough, so this z-index was leaking into other places of the webapp. This makes it so that the rule only applies to the downgrade modal. 

I also snuck in a fix for the starter button not being disabled.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
