### PR TITLE
Add registry function to register the call pluggables

### DIFF
--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -396,6 +396,28 @@ export default class PluginRegistry {
         return id;
     }
 
+    // Register a menu list item in Calls by providing some text and an action function.
+    // Accepts the following:
+    // - text - A string or React element to display in the menu
+    // - action - A function to trigger when component is clicked on
+    // Returns a unique identifier.
+    registerCallsDropdownMenuAction(text, action) {
+        const id = generateId();
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
+            name: 'CallsDropdownMenu',
+            data: {
+                id,
+                pluginId: this.id,
+                text: resolveReactElement(text),
+                action,
+            },
+        });
+
+        return id;
+    }
+
     // Register a post sub menu list item by providing some text and an action function.
     // Accepts the following:
     // - text - A string or React element to display in the menu

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -401,7 +401,7 @@ export default class PluginRegistry {
     // - text - A string or React element to display in the menu
     // - action - A function to trigger when component is clicked on
     // Returns a unique identifier.
-    registerCallsDropdownMenuAction(text, action) {
+    registerCallsDropdownMenuAction(text, icon, action) {
         const id = generateId();
 
         store.dispatch({
@@ -412,6 +412,7 @@ export default class PluginRegistry {
                 pluginId: this.id,
                 text: resolveReactElement(text),
                 action,
+                icon,
             },
         });
 


### PR DESCRIPTION
#### Summary
Add registry function to register the call pluggables.

#### Ticket Link
Hackaton

#### Related Pull Requests
https://github.com/mattermost/mattermost-plugin-calls/pull/128
https://github.com/matterpoll/matterpoll/pull/435

#### Release Note
```release-note
Added new plugin registry function to register pluggables for Calls
```
