### PR TITLE
MM-45298_User Groups not available in Cloud Enterprise

### DIFF
--- a/components/global_header/left_controls/product_menu/product_menu_list/__snapshots__/product_menu_list.test.tsx.snap
+++ b/components/global_header/left_controls/product_menu/product_menu_list/__snapshots__/product_menu_list.test.tsx.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/global/product_switcher_menu should match snapshot with cloud free 1`] = `
+<MenuItemToggleModalRedux
+  dialogProps={
+    Object {
+      "backButtonAction": [Function],
+    }
+  }
+  dialogType={
+    Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(UserGroupsModal)",
+      "type": [Function],
+    }
+  }
+  disabled={true}
+  icon={
+    <Icon
+      glyph="account-multiple-outline"
+      size={16}
+    />
+  }
+  id="userGroups"
+  modalId="user_groups"
+  show={true}
+  sibling={
+    <RestrictedIndicator
+      blocked={true}
+      messageAdminPostTrial="User groups are a way to organize users and apply actions to all users within that group. Upgrade to the Professional plan to create unlimited user groups."
+      messageAdminPreTrial="Create unlimited user groups with one of our paid plans. Get the full experience of Enterprise when you start a free, 30 day trial."
+      messageEndUser="User groups are a way to organize users and apply actions to all users within that group."
+      titleAdminPostTrial="Upgrade to create unlimited user groups"
+      titleAdminPreTrial="Try unlimited user groups with a free trial"
+      titleEndUser="User groups available in paid plans"
+      tooltipMessage="During your trial you are able to create user groups. These user groups will be archived after your trial."
+    />
+  }
+  text="User Groups"
+/>
+`;
+
 exports[`components/global/product_switcher_menu should match snapshot with cloud free trial 1`] = `
 <MenuItemToggleModalRedux
   dialogProps={

--- a/components/global_header/left_controls/product_menu/product_menu_list/__snapshots__/product_menu_list.test.tsx.snap
+++ b/components/global_header/left_controls/product_menu/product_menu_list/__snapshots__/product_menu_list.test.tsx.snap
@@ -1,89 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/global/product_switcher_menu should match snapshot with cloud free 1`] = `
-<MenuItemToggleModalRedux
-  dialogProps={
-    Object {
-      "backButtonAction": [Function],
-    }
-  }
-  dialogType={
-    Object {
-      "$$typeof": Symbol(react.memo),
-      "WrappedComponent": [Function],
-      "compare": null,
-      "displayName": "Connect(UserGroupsModal)",
-      "type": [Function],
-    }
-  }
-  disabled={true}
-  icon={
-    <Icon
-      glyph="account-multiple-outline"
-      size={16}
-    />
-  }
-  id="userGroups"
-  modalId="user_groups"
-  show={true}
-  sibling={
-    <RestrictedIndicator
-      blocked={true}
-      messageAdminPostTrial="User groups are a way to organize users and apply actions to all users within that group. Upgrade to the Professional plan to create unlimited user groups."
-      messageAdminPreTrial="Create unlimited user groups with one of our paid plans. Get the full experience of Enterprise when you start a free, 30 day trial."
-      messageEndUser="User groups are a way to organize users and apply actions to all users within that group."
-      titleAdminPostTrial="Upgrade to create unlimited user groups"
-      titleAdminPreTrial="Try unlimited user groups with a free trial"
-      titleEndUser="User groups available in paid plans"
-      tooltipMessage="During your trial you are able to create user groups. These user groups will be archived after your trial."
-    />
-  }
-  text="User Groups"
-/>
-`;
-
-exports[`components/global/product_switcher_menu should match snapshot with cloud free trial 1`] = `
-<MenuItemToggleModalRedux
-  dialogProps={
-    Object {
-      "backButtonAction": [Function],
-    }
-  }
-  dialogType={
-    Object {
-      "$$typeof": Symbol(react.memo),
-      "WrappedComponent": [Function],
-      "compare": null,
-      "displayName": "Connect(UserGroupsModal)",
-      "type": [Function],
-    }
-  }
-  disabled={false}
-  icon={
-    <Icon
-      glyph="account-multiple-outline"
-      size={16}
-    />
-  }
-  id="userGroups"
-  modalId="user_groups"
-  show={true}
-  sibling={
-    <RestrictedIndicator
-      blocked={false}
-      messageAdminPostTrial="User groups are a way to organize users and apply actions to all users within that group. Upgrade to the Professional plan to create unlimited user groups."
-      messageAdminPreTrial="Create unlimited user groups with one of our paid plans. Get the full experience of Enterprise when you start a free, 30 day trial."
-      messageEndUser="User groups are a way to organize users and apply actions to all users within that group."
-      titleAdminPostTrial="Upgrade to create unlimited user groups"
-      titleAdminPreTrial="Try unlimited user groups with a free trial"
-      titleEndUser="User groups available in paid plans"
-      tooltipMessage="During your trial you are able to create user groups. These user groups will be archived after your trial."
-    />
-  }
-  text="User Groups"
-/>
-`;
-
 exports[`components/global/product_switcher_menu should match snapshot with id 1`] = `
 <MenuGroup>
   <div
@@ -508,6 +424,121 @@ exports[`components/global/product_switcher_menu should match snapshot with most
     />
   </div>
 </MenuGroup>
+`;
+
+exports[`components/global/product_switcher_menu should match userGroups snapshot with EnableCustomGroups config 1`] = `
+<MenuItemToggleModalRedux
+  dialogProps={
+    Object {
+      "backButtonAction": [Function],
+    }
+  }
+  dialogType={
+    Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(UserGroupsModal)",
+      "type": [Function],
+    }
+  }
+  disabled={false}
+  icon={
+    <Icon
+      glyph="account-multiple-outline"
+      size={16}
+    />
+  }
+  id="userGroups"
+  modalId="user_groups"
+  show={true}
+  sibling={false}
+  text="User Groups"
+/>
+`;
+
+exports[`components/global/product_switcher_menu should match userGroups snapshot with cloud free 1`] = `
+<MenuItemToggleModalRedux
+  dialogProps={
+    Object {
+      "backButtonAction": [Function],
+    }
+  }
+  dialogType={
+    Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(UserGroupsModal)",
+      "type": [Function],
+    }
+  }
+  disabled={true}
+  icon={
+    <Icon
+      glyph="account-multiple-outline"
+      size={16}
+    />
+  }
+  id="userGroups"
+  modalId="user_groups"
+  show={true}
+  sibling={
+    <RestrictedIndicator
+      blocked={true}
+      messageAdminPostTrial="User groups are a way to organize users and apply actions to all users within that group. Upgrade to the Professional plan to create unlimited user groups."
+      messageAdminPreTrial="Create unlimited user groups with one of our paid plans. Get the full experience of Enterprise when you start a free, 30 day trial."
+      messageEndUser="User groups are a way to organize users and apply actions to all users within that group."
+      titleAdminPostTrial="Upgrade to create unlimited user groups"
+      titleAdminPreTrial="Try unlimited user groups with a free trial"
+      titleEndUser="User groups available in paid plans"
+      tooltipMessage="During your trial you are able to create user groups. These user groups will be archived after your trial."
+    />
+  }
+  text="User Groups"
+/>
+`;
+
+exports[`components/global/product_switcher_menu should match userGroups snapshot with cloud free trial 1`] = `
+<MenuItemToggleModalRedux
+  dialogProps={
+    Object {
+      "backButtonAction": [Function],
+    }
+  }
+  dialogType={
+    Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(UserGroupsModal)",
+      "type": [Function],
+    }
+  }
+  disabled={false}
+  icon={
+    <Icon
+      glyph="account-multiple-outline"
+      size={16}
+    />
+  }
+  id="userGroups"
+  modalId="user_groups"
+  show={true}
+  sibling={
+    <RestrictedIndicator
+      blocked={false}
+      messageAdminPostTrial="User groups are a way to organize users and apply actions to all users within that group. Upgrade to the Professional plan to create unlimited user groups."
+      messageAdminPreTrial="Create unlimited user groups with one of our paid plans. Get the full experience of Enterprise when you start a free, 30 day trial."
+      messageEndUser="User groups are a way to organize users and apply actions to all users within that group."
+      titleAdminPostTrial="Upgrade to create unlimited user groups"
+      titleAdminPreTrial="Try unlimited user groups with a free trial"
+      titleEndUser="User groups available in paid plans"
+      tooltipMessage="During your trial you are able to create user groups. These user groups will be archived after your trial."
+    />
+  }
+  text="User Groups"
+/>
 `;
 
 exports[`components/global/product_switcher_menu should show integrations should show integrations modal 1`] = `

--- a/components/global_header/left_controls/product_menu/product_menu_list/index.ts
+++ b/components/global_header/left_controls/product_menu/product_menu_list/index.ts
@@ -6,7 +6,7 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {Action} from 'mattermost-redux/types/actions';
 
-import {getCloudSubscription} from 'mattermost-redux/selectors/entities/cloud';
+import {getCloudSubscription, getSubscriptionProduct} from 'mattermost-redux/selectors/entities/cloud';
 import {
     getInt,
     isCustomGroupsEnabled,
@@ -24,6 +24,7 @@ import {GlobalState} from 'types/store';
 import {OnboardingTaskCategory, OnboardingTasksName, TaskNameMapToSteps} from 'components/onboarding_tasks';
 import {openModal} from 'actions/views/modals';
 import {ModalData} from 'types/actions';
+import {CloudProducts} from 'utils/constants';
 import {isCloudLicense} from 'utils/license_utils';
 
 import ProductMenuList from './product_menu_list';
@@ -53,9 +54,11 @@ function mapStateToProps(state: GlobalState) {
 
     const subscription = getCloudSubscription(state);
     const license = getLicense(state);
+    const subscriptionProduct = getSubscriptionProduct(state);
 
     const isCloud = isCloudLicense(license);
-    const isFreeTrial = subscription?.is_free_trial === 'true';
+    const isStarterFree = isCloud && subscriptionProduct?.sku === CloudProducts.STARTER;
+    const isStarterFreeTrial = isCloud && subscription?.is_free_trial === 'true';
 
     return {
         isMobile: state.views.channel.mobileView,
@@ -75,8 +78,8 @@ function mapStateToProps(state: GlobalState) {
         firstAdminVisitMarketplaceStatus: getFirstAdminVisitMarketplaceStatus(state),
         showVisitSystemConsoleTour,
         enableCustomUserGroups,
-        isCloud,
-        isFreeTrial,
+        isStarterFree,
+        isStarterFreeTrial,
     };
 }
 

--- a/components/global_header/left_controls/product_menu/product_menu_list/index.ts
+++ b/components/global_header/left_controls/product_menu/product_menu_list/index.ts
@@ -58,7 +58,7 @@ function mapStateToProps(state: GlobalState) {
 
     const isCloud = isCloudLicense(license);
     const isStarterFree = isCloud && subscriptionProduct?.sku === CloudProducts.STARTER;
-    const isStarterFreeTrial = isCloud && subscription?.is_free_trial === 'true';
+    const isFreeTrial = isCloud && subscription?.is_free_trial === 'true';
 
     return {
         isMobile: state.views.channel.mobileView,
@@ -79,7 +79,7 @@ function mapStateToProps(state: GlobalState) {
         showVisitSystemConsoleTour,
         enableCustomUserGroups,
         isStarterFree,
-        isStarterFreeTrial,
+        isFreeTrial,
     };
 }
 

--- a/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.test.tsx
+++ b/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.test.tsx
@@ -38,8 +38,8 @@ describe('components/global/product_switcher_menu', () => {
         canManageIntegrations: true,
         enablePluginMarketplace: false,
         showVisitSystemConsoleTour: false,
-        isCloud: false,
-        isFreeTrial: false,
+        isStarterFree: false,
+        isStarterFreeTrial: false,
         onClick: () => jest.fn,
         handleVisitConsoleClick: () => jest.fn,
         enableCustomUserGroups: false,
@@ -75,12 +75,23 @@ describe('components/global/product_switcher_menu', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot with cloud free', () => {
+        const props = {
+            ...defaultProps,
+            enableCustomUserGroups: true,
+            isStarterFree: true,
+            isStarterFreeTrial: false,
+        };
+        const wrapper = shallow(<ProductMenuList {...props}/>);
+        expect(wrapper.find('#userGroups')).toMatchSnapshot();
+    });
+
     test('should match snapshot with cloud free trial', () => {
         const props = {
             ...defaultProps,
             enableCustomUserGroups: true,
-            isCloud: true,
-            isFreeTrial: true,
+            isStarterFree: false,
+            isStarterFreeTrial: true,
         };
         const wrapper = shallow(<ProductMenuList {...props}/>);
         expect(wrapper.find('#userGroups')).toMatchSnapshot();

--- a/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.test.tsx
+++ b/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.test.tsx
@@ -39,7 +39,7 @@ describe('components/global/product_switcher_menu', () => {
         enablePluginMarketplace: false,
         showVisitSystemConsoleTour: false,
         isStarterFree: false,
-        isStarterFreeTrial: false,
+        isFreeTrial: false,
         onClick: () => jest.fn,
         handleVisitConsoleClick: () => jest.fn,
         enableCustomUserGroups: false,
@@ -75,23 +75,34 @@ describe('components/global/product_switcher_menu', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should match snapshot with cloud free', () => {
+    test('should match userGroups snapshot with cloud free', () => {
         const props = {
             ...defaultProps,
-            enableCustomUserGroups: true,
+            enableCustomUserGroups: false,
             isStarterFree: true,
-            isStarterFreeTrial: false,
+            isFreeTrial: false,
         };
         const wrapper = shallow(<ProductMenuList {...props}/>);
         expect(wrapper.find('#userGroups')).toMatchSnapshot();
     });
 
-    test('should match snapshot with cloud free trial', () => {
+    test('should match userGroups snapshot with cloud free trial', () => {
+        const props = {
+            ...defaultProps,
+            enableCustomUserGroups: false,
+            isStarterFree: false,
+            isFreeTrial: true,
+        };
+        const wrapper = shallow(<ProductMenuList {...props}/>);
+        expect(wrapper.find('#userGroups')).toMatchSnapshot();
+    });
+
+    test('should match userGroups snapshot with EnableCustomGroups config', () => {
         const props = {
             ...defaultProps,
             enableCustomUserGroups: true,
             isStarterFree: false,
-            isStarterFreeTrial: true,
+            isFreeTrial: false,
         };
         const wrapper = shallow(<ProductMenuList {...props}/>);
         expect(wrapper.find('#userGroups')).toMatchSnapshot();

--- a/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
+++ b/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
@@ -40,7 +40,7 @@ export type Props = {
     enablePluginMarketplace: boolean;
     showVisitSystemConsoleTour: boolean;
     isStarterFree: boolean;
-    isStarterFreeTrial: boolean;
+    isFreeTrial: boolean;
     onClick?: React.MouseEventHandler<HTMLElement>;
     handleVisitConsoleClick: React.MouseEventHandler<HTMLElement>;
     enableCustomUserGroups?: boolean;
@@ -66,7 +66,7 @@ const ProductMenuList = (props: Props): JSX.Element | null => {
         enablePluginMarketplace,
         showVisitSystemConsoleTour,
         isStarterFree,
-        isStarterFreeTrial,
+        isFreeTrial,
         onClick,
         handleVisitConsoleClick,
         isMobile = false,
@@ -146,7 +146,7 @@ const ProductMenuList = (props: Props): JSX.Element | null => {
                 <Menu.ItemToggleModalRedux
                     id='userGroups'
                     modalId={ModalIdentifiers.USER_GROUPS}
-                    show={enableCustomUserGroups || isStarterFree || isStarterFreeTrial}
+                    show={enableCustomUserGroups || isStarterFree || isFreeTrial}
                     dialogType={UserGroupsModal}
                     dialogProps={{
                         backButtonAction: openGroupsModal,
@@ -159,7 +159,7 @@ const ProductMenuList = (props: Props): JSX.Element | null => {
                         />
                     }
                     disabled={isStarterFree}
-                    sibling={(isStarterFree || isStarterFreeTrial) && (
+                    sibling={(isStarterFree || isFreeTrial) && (
                         <RestrictedIndicator
                             blocked={isStarterFree}
                             tooltipMessage={formatMessage({

--- a/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
+++ b/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
@@ -146,7 +146,7 @@ const ProductMenuList = (props: Props): JSX.Element | null => {
                 <Menu.ItemToggleModalRedux
                     id='userGroups'
                     modalId={ModalIdentifiers.USER_GROUPS}
-                    show={enableCustomUserGroups && (isStarterFree || isStarterFreeTrial)}
+                    show={enableCustomUserGroups || isStarterFree || isStarterFreeTrial}
                     dialogType={UserGroupsModal}
                     dialogProps={{
                         backButtonAction: openGroupsModal,

--- a/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
+++ b/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
@@ -39,8 +39,8 @@ export type Props = {
     canManageIntegrations: boolean;
     enablePluginMarketplace: boolean;
     showVisitSystemConsoleTour: boolean;
-    isCloud: boolean;
-    isFreeTrial: boolean;
+    isStarterFree: boolean;
+    isStarterFreeTrial: boolean;
     onClick?: React.MouseEventHandler<HTMLElement>;
     handleVisitConsoleClick: React.MouseEventHandler<HTMLElement>;
     enableCustomUserGroups?: boolean;
@@ -65,8 +65,8 @@ const ProductMenuList = (props: Props): JSX.Element | null => {
         canManageIntegrations,
         enablePluginMarketplace,
         showVisitSystemConsoleTour,
-        isCloud,
-        isFreeTrial,
+        isStarterFree,
+        isStarterFreeTrial,
         onClick,
         handleVisitConsoleClick,
         isMobile = false,
@@ -146,7 +146,7 @@ const ProductMenuList = (props: Props): JSX.Element | null => {
                 <Menu.ItemToggleModalRedux
                     id='userGroups'
                     modalId={ModalIdentifiers.USER_GROUPS}
-                    show={enableCustomUserGroups || isCloud}
+                    show={enableCustomUserGroups && (isStarterFree || isStarterFreeTrial)}
                     dialogType={UserGroupsModal}
                     dialogProps={{
                         backButtonAction: openGroupsModal,
@@ -158,10 +158,10 @@ const ProductMenuList = (props: Props): JSX.Element | null => {
                             glyph={'account-multiple-outline'}
                         />
                     }
-                    disabled={isCloud && !isFreeTrial}
-                    sibling={isCloud && (
+                    disabled={isStarterFree}
+                    sibling={(isStarterFree || isStarterFreeTrial) && (
                         <RestrictedIndicator
-                            blocked={!isFreeTrial}
+                            blocked={isStarterFree}
                             tooltipMessage={formatMessage({
                                 id: 'navbar_dropdown.userGroups.tooltip.cloudFreeTrial',
                                 defaultMessage: 'During your trial you are able to create user groups. These user groups will be archived after your trial.',


### PR DESCRIPTION
#### Summary
Regression: Only starter free should show User Groups as restricted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45298

#### Screenshots
##### Cloud free
<img width="478" alt="Screen Shot 2022-06-24 at 12 33 06 PM" src="https://user-images.githubusercontent.com/79058848/175615323-068f2941-d31c-4642-a07d-59e17f672b6b.png">

##### Cloud free trial
<img width="483" alt="Screen Shot 2022-06-24 at 12 33 49 PM" src="https://user-images.githubusercontent.com/79058848/175615366-858174b3-cfbc-4936-be87-2b99445c0cc4.png">

##### Cloud Professional
<img width="286" alt="Screen Shot 2022-06-24 at 12 51 01 PM" src="https://user-images.githubusercontent.com/79058848/175616166-901e9776-1f08-431a-b9d1-3b184069a2e4.png">

#### Release Note
```release-note
NONE
```
