### PR TITLE
MM-44954 Adjust condition when profile picture last updated date is displayed

### DIFF
--- a/components/user_settings/general/user_settings_general.tsx
+++ b/components/user_settings/general/user_settings_general.tsx
@@ -1298,7 +1298,7 @@ export class UserSettingsGeneralTab extends React.Component<Props, State> {
             if (Utils.isMobile()) {
                 minMessage = formatMessage(holders.uploadImageMobile);
             }
-            if (user.last_picture_update) {
+            if (user.last_picture_update > 0) {
                 minMessage = (
                     <FormattedMessage
                         id='user.settings.general.imageUpdated'


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Adjusts the condition when the Profile Picture "Image last updated" block is shown to support changes allowing `lastPictureUpdate` to be a negative number.

In order to support changes in the mattermost-server PR (linked below) the condition has been adjusted so negative numbers don't end up showing some date prior to the Unix epoch, since these values are being used to represent default profile picture updates we don't care about when they were actually set.

This change is **not** directly dependent on the related server change, given the fact the conditional still behaves as expected where lastPictureUpdate is only set to 0 or a positive integer.

#### Ticket Link

[Github Issue 20471](https://github.com/mattermost/mattermost-server/issues/20471)
[MM-44954](https://mattermost.atlassian.net/browse/MM-44954)

#### Related Pull Requests
- Has server changes [20544](https://github.com/mattermost/mattermost-server/pull/20544)

```release-note
NONE
```
