### PR TITLE
MM-45283 - import the getCloudSubscription action so it is available …

### DIFF
--- a/components/admin_console/feature_discovery/feature_discovery.test.tsx
+++ b/components/admin_console/feature_discovery/feature_discovery.test.tsx
@@ -32,6 +32,7 @@ describe('components/feature_discovery', () => {
                         requestTrialLicense: jest.fn(),
                         getLicenseConfig: jest.fn(),
                         getPrevTrialLicense: jest.fn(),
+                        getCloudSubscription: jest.fn(),
                         openModal: jest.fn(),
                     }}
                 />,
@@ -61,6 +62,7 @@ describe('components/feature_discovery', () => {
                         getLicenseConfig: jest.fn(),
                         getPrevTrialLicense: jest.fn(),
                         openModal: jest.fn(),
+                        getCloudSubscription: jest.fn(),
                     }}
                 />,
             );
@@ -90,6 +92,7 @@ describe('components/feature_discovery', () => {
                         getLicenseConfig: jest.fn(),
                         getPrevTrialLicense: jest.fn(),
                         openModal: jest.fn(),
+                        getCloudSubscription: jest.fn(),
                     }}
                 />,
             );

--- a/components/admin_console/feature_discovery/feature_discovery.tsx
+++ b/components/admin_console/feature_discovery/feature_discovery.tsx
@@ -45,6 +45,7 @@ type Props = {
         requestTrialLicense: (users: number, termsAccepted: boolean, receiveEmailsAccepted: boolean, featureName: string) => Promise<ActionResult>;
         getLicenseConfig: () => void;
         getPrevTrialLicense: () => void;
+        getCloudSubscription: () => void;
         openModal: <P>(modalData: ModalData<P>) => void;
     };
     isCloud: boolean;

--- a/components/admin_console/feature_discovery/index.tsx
+++ b/components/admin_console/feature_discovery/index.tsx
@@ -13,6 +13,7 @@ import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {isCloudLicense} from 'utils/license_utils';
 
 import {checkHadPriorTrial} from 'mattermost-redux/selectors/entities/cloud';
+import {getCloudSubscription} from 'mattermost-redux/actions/cloud';
 import {LicenseSkus} from 'mattermost-redux/types/general';
 
 import {openModal} from 'actions/views/modals';
@@ -44,6 +45,7 @@ type Actions = {
     requestTrialLicense: () => Promise<{error?: string; data?: null}>;
     getLicenseConfig: () => void;
     getPrevTrialLicense: () => void;
+    getCloudSubscription: () => void;
     openModal: <P>(modalData: ModalData<P>) => void;
 }
 
@@ -53,6 +55,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
             requestTrialLicense,
             getLicenseConfig,
             getPrevTrialLicense,
+            getCloudSubscription,
             openModal,
         }, dispatch),
     };

--- a/components/common/hocs/cloud/with_get_cloud_subscription.tsx
+++ b/components/common/hocs/cloud/with_get_cloud_subscription.tsx
@@ -26,9 +26,9 @@ function withGetCloudSubscription<P>(WrappedComponent: ComponentType<P>): Compon
             if (!this.props.isCloud) {
                 return;
             }
-            const {subscription, actions, isCloud, userIsAdmin} = this.props;
+            const {subscription, actions, userIsAdmin} = this.props;
 
-            if (isEmpty(subscription) && isCloud && userIsAdmin && actions?.getCloudSubscription) {
+            if (isEmpty(subscription) && userIsAdmin && actions?.getCloudSubscription) {
                 await actions.getCloudSubscription();
             }
         }

--- a/components/common/hocs/cloud/with_get_cloud_subscription.tsx
+++ b/components/common/hocs/cloud/with_get_cloud_subscription.tsx
@@ -22,12 +22,14 @@ interface UsedHocProps {
 function withGetCloudSubscription<P>(WrappedComponent: ComponentType<P>): ComponentType<any> {
     return class extends React.Component<P & UsedHocProps> {
         async componentDidMount() {
-            const {subscription, actions: {getCloudSubscription}, isCloud, userIsAdmin} = this.props;
+            // if not is cloud, not even try to destructure values from props, just return
+            if (!this.props.isCloud) {
+                return;
+            }
+            const {subscription, actions, isCloud, userIsAdmin} = this.props;
 
-            if (isEmpty(subscription) && isCloud && userIsAdmin) {
-                if (getCloudSubscription) {
-                    await getCloudSubscription();
-                }
+            if (isEmpty(subscription) && isCloud && userIsAdmin && actions?.getCloudSubscription) {
+                await actions.getCloudSubscription();
             }
         }
 


### PR DESCRIPTION
#### Summary
This pr code imports the getCloudSubscription action in the index file of the feature_discovery section so it is available in the wrapper hoc withGetCloudSubscription component. Also, makes sure in the hoc component that if is not cloud, inmediately return and don't execute any logic.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45283

#### Related Pull Requests
n/a

#### Screenshots
before:
<img width="483" alt="Screen Shot 2022-06-22 at 10 08 06 PM" src="https://user-images.githubusercontent.com/10082627/175955979-74880eb7-cb13-402f-aca8-72c2586773b2.png">

after:

https://user-images.githubusercontent.com/10082627/175956029-9bbb99e7-f737-4ad1-bda4-ad7f6aef1689.mp4



#### Release Note
```release-note
NONE
```
