### PR TITLE
Automated cherry pick of #10477

### DIFF
--- a/components/channel_layout/center_channel/index.ts
+++ b/components/channel_layout/center_channel/index.ts
@@ -12,7 +12,7 @@ import {isCollapsedThreadsEnabled, insightsAreEnabled} from 'mattermost-redux/se
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getIsRhsOpen, getIsRhsMenuOpen} from 'selectors/rhs';
 import {getIsLhsOpen} from 'selectors/lhs';
-import {getLastViewedChannelNameByTeamName, getLastViewedTypeByTeamName} from 'selectors/local_storage';
+import {getLastViewedChannelNameByTeamName, getLastViewedTypeByTeamName, getPreviousTeamId, getPreviousTeamLastViewedType} from 'selectors/local_storage';
 
 import {GlobalState} from 'types/store';
 
@@ -33,11 +33,20 @@ const mapStateToProps = (state: GlobalState, ownProps: Props) => {
     const lastViewedType = getLastViewedTypeByTeamName(state, ownProps.match.params.team);
     let channelName = getLastViewedChannelNameByTeamName(state, ownProps.match.params.team);
 
+    const previousTeamId = getPreviousTeamId(state);
+    const team = getTeamByName(state, ownProps.match.params.team);
+
+    let previousTeamLastViewedType;
+
     if (!channelName) {
-        const team = getTeamByName(state, ownProps.match.params.team);
         channelName = getRedirectChannelNameForTeam(state, team!.id);
     }
-    const shouldRouteToGlobalThreads = isCollapsedThreadsEnabled(state) && lastViewedType === PreviousViewedTypes.THREADS;
+
+    if (previousTeamId !== team?.id) {
+        previousTeamLastViewedType = getPreviousTeamLastViewedType(state);
+    }
+
+    const shouldRouteToGlobalThreads = isCollapsedThreadsEnabled(state) && (lastViewedType === PreviousViewedTypes.THREADS || previousTeamLastViewedType === PreviousViewedTypes.THREADS);
     const lastChannelPath = shouldRouteToGlobalThreads ? `${ownProps.match.url}/threads` : `${ownProps.match.url}/channels/${channelName}`;
     return {
         lastChannelPath,

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/last_viewed_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/last_viewed_spec.js
@@ -54,6 +54,28 @@ describe('Collapsed Reply Threads', () => {
         cy.visit(offTopicUrlA);
     });
 
+    it('MM-44169 should stay on threads view when switching teams', () => {
+        // # Navigate to the new teams town square
+        cy.visit(`/${teamA.name}/channels/town-square`);
+
+        // # Switch to Team B
+        cy.get(`#${teamB.name}TeamButton`, {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click();
+
+        // * Verify team display name changes correctly.
+        cy.uiGetLHSHeader().findByText(teamB.display_name);
+
+        // # Go to the ‘Threads’ view on Team B
+        cy.uiGetSidebarThreadsButton().click();
+
+        cy.wait(TIMEOUTS.ONE_SEC);
+
+        // # Switch back to Team A
+        cy.get(`#${teamA.name}TeamButton`, {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click();
+
+        // Verify url is set up for threads view
+        cy.url().should('include', `${teamA.name}/threads`);
+    });
+
     it('MM-T4843_1 should go to threads view when switching a team if that was the last view on that team', () => {
         // # Go to the ‘Threads’ view on Team A
         cy.uiGetSidebarThreadsButton().click();

--- a/selectors/local_storage.ts
+++ b/selectors/local_storage.ts
@@ -52,3 +52,10 @@ export const getPreviousTeamId = (state: GlobalState) => {
 
     return localStorageStore.getPreviousTeamId(userId);
 };
+
+export const getPreviousTeamLastViewedType = (state: GlobalState) => {
+    const previousTeamID = getPreviousTeamId(state);
+    const userId = getCurrentUserId(state);
+
+    return localStorageStore.getPreviousViewedType(userId, previousTeamID, state);
+};


### PR DESCRIPTION
Cherry pick of #10477 on cloud.

/cc  @kyeongsoosoo

```release-note
NONE
```