### PR TITLE
fix: initialize load more posts counter

### DIFF
--- a/components/post_view/post_list/post_list.jsx
+++ b/components/post_view/post_list/post_list.jsx
@@ -148,6 +148,8 @@ export default class PostList extends React.PureComponent {
             autoRetryEnable: true,
         };
 
+        this.extraPagesLoaded = 0;
+
         this.autoRetriesCount = 0;
         this.actionsForPostList = {
             loadOlderPosts: this.getPostsBefore,
@@ -290,6 +292,12 @@ export default class PostList extends React.PureComponent {
         if (this.state.loadingOlderPosts) {
             return;
         }
+
+        // Reset counter after "Load more" button click
+        if (!this.state.autoRetryEnable) {
+            this.extraPagesLoaded = 0;
+        }
+
         const oldestPostId = this.getOldestVisiblePostId();
         this.setState({loadingOlderPosts: true});
         await this.callLoadPosts(this.props.channelId, oldestPostId, PostRequestTypes.BEFORE_ID);
@@ -299,6 +307,12 @@ export default class PostList extends React.PureComponent {
         if (this.state.loadingNewerPosts) {
             return;
         }
+
+        // Reset counter after "Load more" button click
+        if (!this.state.autoRetryEnable) {
+            this.extraPagesLoaded = 0;
+        }
+
         const latestPostId = this.getLatestVisiblePostId();
         this.setState({loadingNewerPosts: true});
         await this.callLoadPosts(this.props.channelId, latestPostId, PostRequestTypes.AFTER_ID);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes broken logic of loading more posts. Counter variable is not initialized, therefore it is `undefined`, therefore when adding `+1` to it, it becomes `NaN`, therefore guard `if (this.extraPagesLoaded > MAX_EXTRA_PAGES_LOADED) {` never works.

Probably this only affects channels with lots of System Message (which can be hidden by user but loaded anyway). 
If user opens such channel with system messages hidden then _all_ messages in the channel are being loaded. Which results in heavy load on API.

Also, I added a counter reset after a user clicks on `Load more` button for better UX.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
