### PR TITLE
[MM-45269] Remove typing from insights time dropdown

### DIFF
--- a/components/activity_and_insights/insights/time_frame_dropdown/__snapshots__/time_frame_dropdown.test.tsx.snap
+++ b/components/activity_and_insights/insights/time_frame_dropdown/__snapshots__/time_frame_dropdown.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`components/activity_and_insights/insights/insights_title should match s
   defaultMenuIsOpen={false}
   defaultValue={null}
   id="insightsTemporal"
+  isSearchable={false}
   menuPortalTarget={<body />}
   onChange={[Function]}
   options={

--- a/components/activity_and_insights/insights/time_frame_dropdown/time_frame_dropdown.tsx
+++ b/components/activity_and_insights/insights/time_frame_dropdown/time_frame_dropdown.tsx
@@ -92,6 +92,7 @@ const TimeFrameDropdown = (props: Props) => {
             components={{
                 DropdownIndicator: CustomDropwdown,
             }}
+            isSearchable={false}
         />
     );
 };


### PR DESCRIPTION
#### Summary
Remove typing from insights time dropdown

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45277

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
