### PR TITLE
[MM-45164]: fix for broken images in opengraph previews

### DIFF
--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.tsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.tsx
@@ -205,7 +205,7 @@ export const PostAttachmentOpenGraphImage = memo(({imageMetadata, isInPermalink,
     }
 
     const large = getIsLargeImage(imageMetadata);
-    const src = imageMetadata.url || '';
+    const src = imageMetadata.secure_url || imageMetadata.url || '';
 
     const toggleImagePreview = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();


### PR DESCRIPTION
#### Summary
fixes broken images on opengraph previews.
The image component was not respecting the `secure_url` property on the imagesMetaData object.

#### Ticket Link
[MM-45164](https://mattermost.atlassian.net/browse/MM-45164)

#### Release Note
```release-note
NONE
```
