### PR TITLE
[MM-45263] Fixing thread badge box opacity

### DIFF
--- a/components/activity_and_insights/activity_and_insights.scss
+++ b/components/activity_and_insights/activity_and_insights.scss
@@ -412,6 +412,10 @@
                         border-radius: 4px;
                         cursor: pointer;
                     }
+
+                    .Badge__box {
+                        background: rgba(var(--center-channel-color-rgb), 0.08);
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Summary
Fixing the opacity of the channel name badge for threads

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45263

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
