### PR TITLE
rely on webhooks and websocket messages to avoid receiving stale data

### DIFF
--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -91,9 +91,13 @@ export function subscribeCloudSubscription(productId: string) {
 
 export function requestCloudTrial(page: string, subscriptionId: string, email = ''): ActionFunc {
     trackEvent('api', 'api_request_cloud_trial_license', {from_page: page});
-    return async (): Promise<any> => {
+    return async (dispatch: DispatchFunc): Promise<any> => {
         try {
-            await Client4.requestCloudTrial(subscriptionId, email);
+            const updatedSubscription = await Client4.requestCloudTrial(subscriptionId, email);
+            dispatch({
+                type: CloudTypes.RECEIVED_CLOUD_SUBSCRIPTION,
+                data: updatedSubscription,
+            });
         } catch (error) {
             return false;
         }

--- a/components/cloud_start_trial/cloud_start_trial_btn.tsx
+++ b/components/cloud_start_trial/cloud_start_trial_btn.tsx
@@ -7,12 +7,9 @@ import {useDispatch} from 'react-redux';
 
 import {DispatchFunc} from 'mattermost-redux/types/actions';
 
-import {getCloudSubscription} from 'mattermost-redux/actions/cloud';
-import {getClientConfig, getLicenseConfig} from 'mattermost-redux/actions/general';
-
 import useGetSubscription from 'components/common/hooks/useGetSubscription';
 
-import {requestCloudTrial, validateBusinessEmail, getCloudLimits} from 'actions/cloud';
+import {requestCloudTrial, validateBusinessEmail} from 'actions/cloud';
 import {trackEvent} from 'actions/telemetry_actions';
 import {openModal, closeModal} from 'actions/views/modals';
 
@@ -91,11 +88,6 @@ const CloudStartTrialButton = ({
             return TrialLoadStatus.Failed;
         }
 
-        await dispatch(getCloudSubscription());
-        await dispatch(getClientConfig());
-
-        await dispatch(getLicenseConfig());
-        await dispatch(getCloudLimits());
         if (afterTrialRequest) {
             afterTrialRequest();
         }


### PR DESCRIPTION
#### Summary
We added extra calls to get updated information when requesting trial as a stopgap to some webhooks issues we were seeing. The issue was, cloud instances run two mattermost-server nodes in a cluster, and it isn't guaranteed that the node that handled the trial request and gets the updated data is the same node through which subscription and limits info was subsequently requested.

We have improved the webhook's reliability, so we should rely on it to send correct information now. This will also improve the perceived performance of the trial request because we don't need to make and wait for 4 extra re-requests of data. And for the updated license, it is returned from the trial request, so we can use that for updated subscription immediately.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45056

#### Related Pull Requests
https://github.com/mattermost/enterprise/pull/1244

#### Screenshots

#### Release Note
```release-note
Decrease flakiness of requesting cloud trial.
```
