### PR TITLE
[MM-45239] Fixing font size of markdown headings

### DIFF
--- a/components/activity_and_insights/insights/top_threads/top_threads.scss
+++ b/components/activity_and_insights/insights/top_threads/top_threads.scss
@@ -51,6 +51,12 @@
         -webkit-line-clamp: 2;
         line-height: 16px;
 
+        .markdown__heading {
+            margin: inherit;
+            font-size: inherit;
+            line-height: inherit;
+        }
+
         .file_card {
             width: auto;
             height: 32px;


### PR DESCRIPTION
#### Summary
The heading will no longer get cut off for insights

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45261

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
