### PR TITLE
Automated cherry pick of #10629

### DIFF
--- a/actions/views/rhs.ts
+++ b/actions/views/rhs.ts
@@ -18,7 +18,7 @@ import * as PostActions from 'mattermost-redux/actions/posts';
 import {getCurrentUserId, getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getCurrentChannelId, getCurrentChannelNameForSearchShortcut} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannelId, getCurrentChannelNameForSearchShortcut, getChannel as getChannelSelector} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {makeGetUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
@@ -35,7 +35,7 @@ import {GlobalState} from 'types/store';
 import {getPostsByIds} from 'mattermost-redux/actions/posts';
 import {unsetEditingPost} from '../post_actions';
 import {loadProfilesAndReloadChannelMembers} from '../user_actions';
-import {loadMyChannelMemberAndRole} from 'mattermost-redux/actions/channels';
+import {loadMyChannelMemberAndRole, getChannel} from 'mattermost-redux/actions/channels';
 
 function selectPostFromRightHandSideSearchWithPreviousState(post: Post, previousRhsState?: RhsState) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -473,6 +473,16 @@ export function setRhsExpanded(expanded: boolean) {
 export function toggleRhsExpanded() {
     return {
         type: ActionTypes.TOGGLE_RHS_EXPANDED,
+    };
+}
+
+export function selectPostAndParentChannel(post: Post) {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const channel = getChannelSelector(getState(), post.channel_id);
+        if (!channel) {
+            await dispatch(getChannel(post.channel_id));
+        }
+        return dispatch(selectPost(post));
     };
 }
 

--- a/components/activity_and_insights/insights/top_threads/top_threads.tsx
+++ b/components/activity_and_insights/insights/top_threads/top_threads.tsx
@@ -13,7 +13,7 @@ import {Post} from '@mattermost/types/posts';
 import {TopThread} from '@mattermost/types/insights';
 import {UserProfile} from '@mattermost/types/users';
 
-import {selectPost} from 'actions/views/rhs';
+import {selectPostAndParentChannel} from 'actions/views/rhs';
 import {trackEvent} from 'actions/telemetry_actions';
 
 import Badge from 'components/widgets/badges/badge';
@@ -96,7 +96,7 @@ const TopThreads = (props: WidgetHocProps) => {
     }, []);
 
     const openRHS = async (post: Post) => {
-        dispatch(selectPost(post));
+        dispatch(selectPostAndParentChannel(post));
     };
 
     return (

--- a/components/activity_and_insights/insights/top_threads/top_threads_table/top_threads_table.tsx
+++ b/components/activity_and_insights/insights/top_threads/top_threads_table/top_threads_table.tsx
@@ -6,7 +6,7 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import classNames from 'classnames';
 
-import {selectPost} from 'actions/views/rhs';
+import {selectPostAndParentChannel} from 'actions/views/rhs';
 import {trackEvent} from 'actions/telemetry_actions';
 
 import {getMyTopThreads as fetchMyTopThreads, getTopThreadsForTeam} from 'mattermost-redux/actions/insights';
@@ -89,7 +89,7 @@ const TopThreadsTable = (props: Props) => {
 
     const openThread = (post: Post) => {
         trackEvent('insights', 'open_thread_from_top_threads_modal');
-        dispatch(selectPost(post));
+        dispatch(selectPostAndParentChannel(post));
         closeModal();
     };
 


### PR DESCRIPTION
Cherry pick of #10629 on release-7.1.

/cc  @mkraft

```release-note
NONE
```