### PR TITLE
don't show trial ended banner to non-starter worksapces

### DIFF
--- a/components/announcement_bar/cloud_trial_ended_announcement_bar/cloud_trial_ended_announcement_bar.test.tsx
+++ b/components/announcement_bar/cloud_trial_ended_announcement_bar/cloud_trial_ended_announcement_bar.test.tsx
@@ -59,6 +59,16 @@ describe('components/global/CloudTrialEndAnnouncementBar', () => {
                         sku: CloudProducts.STARTER,
                         price_per_seat: 0,
                     },
+                    test_prod_2: {
+                        id: 'test_prod_2',
+                        sku: CloudProducts.ENTERPRISE,
+                        price_per_seat: 0,
+                    },
+                    test_prod_3: {
+                        id: 'test_prod_3',
+                        sku: CloudProducts.PROFESSIONAL,
+                        price_per_seat: 0,
+                    },
                 },
                 limits: {
                     limitsLoaded: true,
@@ -259,6 +269,34 @@ describe('components/global/CloudTrialEndAnnouncementBar', () => {
         expect(
             wrapper.find('AnnouncementBar').exists(),
         ).toEqual(false);
+    });
+
+    it('should not show for enterprise workspaces', () => {
+        const state = JSON.parse(JSON.stringify(initialState));
+        state.entities.cloud.subscription.product_id = 'test_prod_2';
+
+        const store = mockStore(state);
+        const wrapper = mountWithIntl(
+            <reactRedux.Provider store={store}>
+                <CloudTrialEndAnnouncementBar/>
+            </reactRedux.Provider>,
+        );
+
+        expect(wrapper.find('AnnouncementBar').exists()).toEqual(false);
+    });
+
+    it('should not show for professional workspaces', () => {
+        const state = JSON.parse(JSON.stringify(initialState));
+        state.entities.cloud.subscription.product_id = 'test_prod_3';
+
+        const store = mockStore(state);
+        const wrapper = mountWithIntl(
+            <reactRedux.Provider store={store}>
+                <CloudTrialEndAnnouncementBar/>
+            </reactRedux.Provider>,
+        );
+
+        expect(wrapper.find('AnnouncementBar').exists()).toEqual(false);
     });
 
     it('Should not show banner if preference is set to hidden', () => {

--- a/components/announcement_bar/cloud_trial_ended_announcement_bar/index.tsx
+++ b/components/announcement_bar/cloud_trial_ended_announcement_bar/index.tsx
@@ -22,6 +22,10 @@ import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {
     getCurrentUser,
 } from 'mattermost-redux/selectors/entities/users';
+import {
+    getSubscriptionProduct,
+} from 'mattermost-redux/selectors/entities/cloud';
+import {CloudProducts} from 'utils/constants';
 
 const CloudTrialEndAnnouncementBar: React.FC = () => {
     const usageDeltas = useGetUsageDeltas();
@@ -35,11 +39,12 @@ const CloudTrialEndAnnouncementBar: React.FC = () => {
     const currentUser = useSelector((state: GlobalState) =>
         getCurrentUser(state),
     );
+    const subscriptionProduct = useSelector((state: GlobalState) => getSubscriptionProduct(state));
 
     const openPricingModal = useOpenPricingModal();
 
     const shouldShowBanner = () => {
-        if (!subscription) {
+        if (!subscription || !subscriptionProduct) {
             return false;
         }
 
@@ -52,6 +57,11 @@ const CloudTrialEndAnnouncementBar: React.FC = () => {
             return false;
         }
         if (preferences.some((pref) => pref.name === CloudBanners.HIDE && pref.value === 'true')) {
+            return false;
+        }
+
+        // Don't show this banner for professional or enterprise installations
+        if (subscriptionProduct?.sku !== CloudProducts.STARTER) {
             return false;
         }
 

--- a/components/announcement_bar/cloud_trial_ended_announcement_bar/index.tsx
+++ b/components/announcement_bar/cloud_trial_ended_announcement_bar/index.tsx
@@ -9,7 +9,12 @@ import {useSelector, useDispatch} from 'react-redux';
 import {t} from 'utils/i18n';
 
 import AnnouncementBar from '../default_announcement_bar';
-import {AnnouncementBarTypes, Preferences, CloudBanners} from 'utils/constants';
+import {
+    AnnouncementBarTypes,
+    Preferences,
+    CloudBanners,
+    CloudProducts,
+} from 'utils/constants';
 import {anyUsageDeltaExceededLimit} from 'utils/limits';
 import {GlobalState} from 'types/store';
 import useGetUsageDeltas from 'components/common/hooks/useGetUsageDeltas';
@@ -25,7 +30,6 @@ import {
 import {
     getSubscriptionProduct,
 } from 'mattermost-redux/selectors/entities/cloud';
-import {CloudProducts} from 'utils/constants';
 
 const CloudTrialEndAnnouncementBar: React.FC = () => {
     const usageDeltas = useGetUsageDeltas();


### PR DESCRIPTION
#### Summary
This banner, while dismissable, didn't have an explicit point at which it would go away. This resulted in people being downgraded to freemium, upgrading to professional, and still seeing the banner. 

This PR makes it so that the banner is only displayed to Starter instances

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45335

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
