### PR TITLE
MM-45174 - split validate business email logic

### DIFF
--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -113,6 +113,18 @@ export function validateBusinessEmail(email = '') {
     };
 }
 
+export function validateWorkspaceBusinessEmail() {
+    trackEvent('api', 'api_validate_workspace_business_email');
+    return async () => {
+        try {
+            await Client4.validateWorkspaceBusinessEmail();
+        } catch (error) {
+            return false;
+        }
+        return true;
+    };
+}
+
 export function getCloudLimits(): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         try {

--- a/components/cloud_start_trial/cloud_start_trial_btn.tsx
+++ b/components/cloud_start_trial/cloud_start_trial_btn.tsx
@@ -12,7 +12,7 @@ import {getClientConfig, getLicenseConfig} from 'mattermost-redux/actions/genera
 
 import useGetSubscription from 'components/common/hooks/useGetSubscription';
 
-import {requestCloudTrial, validateBusinessEmail, getCloudLimits} from 'actions/cloud';
+import {requestCloudTrial, validateWorkspaceBusinessEmail, getCloudLimits} from 'actions/cloud';
 import {trackEvent} from 'actions/telemetry_actions';
 import {openModal, closeModal} from 'actions/views/modals';
 
@@ -57,7 +57,7 @@ const CloudStartTrialButton = ({
     const [status, setLoadStatus] = useState(TrialLoadStatus.NotStarted);
 
     const validateBusinessEmailOnLoad = async () => {
-        const isValidBusinessEmail = await validateBusinessEmail()();
+        const isValidBusinessEmail = await validateWorkspaceBusinessEmail()();
         if (!isValidBusinessEmail) {
             setOpenBusinessEmailModal(true);
         }

--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -3847,6 +3847,13 @@ export default class Client4 {
         );
     }
 
+    validateWorkspaceBusinessEmail = () => {
+        return this.doFetchWithResponse<CloudCustomer>(
+            `${this.getCloudRoute()}/validate-workspace-business-email`,
+            {method: 'post'},
+        );
+    }
+
     getSubscription = () => {
         return this.doFetch<SubscriptionResponse>(
             `${this.getCloudRoute()}/subscription`,


### PR DESCRIPTION
#### Summary
This PR splits the logic to validate business email by creating a new endpoint where only the installation/user admin emails are validated and keep the other endpoint to validate an email that is sent as a parameter to be validated as a valid business email.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45174

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/20581

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
