### PR TITLE
Bump @mattermost/compass-icons version to v0.1.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "@floating-ui/react-dom": "0.7.1",
         "@mattermost/compass-components": "^0.2.12",
-        "@mattermost/compass-icons": "0.1.22",
+        "@mattermost/compass-icons": "0.1.24",
         "@stripe/react-stripe-js": "1.6.0",
         "@stripe/stripe-js": "1.20.3",
         "@tippyjs/react": "4.2.6",
@@ -4127,9 +4127,9 @@
       }
     },
     "node_modules/@mattermost/compass-icons": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.22.tgz",
-      "integrity": "sha512-/Fd5xkS+BiHoVffX+s8PCKvCXILmmsf0ibXfs3KEkUMEn2j6lP7XzFM/LBIkQy6R/ZUjWYBrpJxyXRj4ZptA6w==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.24.tgz",
+      "integrity": "sha512-UhLFbRPrgHvt2+lUwUq17Ecs6ag+NUtIH0T/zX6agYngvt+tUJZJ3Y2hTu+Dj4/3zeCTKCHkIhacWv6qGleU/A==",
       "dependencies": {
         "esm": "3.2.25",
         "fontello-batch-cli": "4.0.0",
@@ -32104,9 +32104,9 @@
       }
     },
     "@mattermost/compass-icons": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.22.tgz",
-      "integrity": "sha512-/Fd5xkS+BiHoVffX+s8PCKvCXILmmsf0ibXfs3KEkUMEn2j6lP7XzFM/LBIkQy6R/ZUjWYBrpJxyXRj4ZptA6w==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.24.tgz",
+      "integrity": "sha512-UhLFbRPrgHvt2+lUwUq17Ecs6ag+NUtIH0T/zX6agYngvt+tUJZJ3Y2hTu+Dj4/3zeCTKCHkIhacWv6qGleU/A==",
       "requires": {
         "esm": "3.2.25",
         "fontello-batch-cli": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "0.7.1",
     "@mattermost/compass-components": "^0.2.12",
-    "@mattermost/compass-icons": "0.1.22",
+    "@mattermost/compass-icons": "0.1.24",
     "@stripe/react-stripe-js": "1.6.0",
     "@stripe/stripe-js": "1.20.3",
     "@tippyjs/react": "4.2.6",


### PR DESCRIPTION
#### Summary

Bump `@mattermost/compass-icons` version to v0.1.24. Needed by Playbooks for https://mattermost.atlassian.net/browse/MM-45475 (I may fix that using the SVG icons from the version we explicitly added to our dependencies, but in any case it does not hurt updating the compass-icons version here :) )

#### Ticket Link
--

#### Related Pull Requests
--

#### Screenshots
--

#### Release Note
```release-note
NONE
```
