### PR TITLE
Fixed type of post parameter of createPost method.

### DIFF
--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -77,7 +77,17 @@ import type {
     MarketplaceApp,
     MarketplacePlugin,
 } from '@mattermost/types/marketplace';
-import {Post, PostList, PostSearchResults, OpenGraphMetadata, PostsUsageResponse, TeamsUsageResponse, PaginatedPostList, FilesUsageResponse} from '@mattermost/types/posts';
+import {
+    Post,
+    PostList,
+    PostSearchResults,
+    OpenGraphMetadata,
+    PostsUsageResponse,
+    TeamsUsageResponse,
+    PaginatedPostList,
+    FilesUsageResponse,
+    PostToCreate
+} from '@mattermost/types/posts';
 import {BoardsUsageResponse} from '@mattermost/types/boards';
 import {Reaction} from '@mattermost/types/reactions';
 import {Role} from '@mattermost/types/roles';
@@ -1898,7 +1908,7 @@ export default class Client4 {
 
     // Post Routes
 
-    createPost = async (post: Post) => {
+    createPost = async (post: PostToCreate) => {
         const result = await this.doFetch<Post>(
             `${this.getPostsRoute()}`,
             {method: 'post', body: JSON.stringify(post)},

--- a/packages/types/src/posts.ts
+++ b/packages/types/src/posts.ts
@@ -50,6 +50,14 @@ export type PostMetadata = {
     reactions: Reaction[];
 };
 
+export type PostToCreate = {
+    channel_id: string;
+    message: string;
+    root_id?: string;
+    file_ids?: string[];
+    props?: Record<string, any>
+}
+
 export type Post = {
     id: string;
     create_at: number;


### PR DESCRIPTION
Initially createPost method received parameter post of type Post that doesn't make sense since post isn't created yet. I added a new type PostToCreate which is a type of body for Create Post method from mattermost api reference, and changed type of post parameter to it. It won't break existing typings since PostToCreate type is subtype of Post.

#### Release Note

```release-note
NONE
```
