### PR TITLE
[MM45505]: fixed overflowing image in link preview

### DIFF
--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.scss
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.scss
@@ -140,6 +140,8 @@
 
         figure {
             overflow: hidden;
+            max-width: 392px;
+            max-height: 240px;
             border-radius: 4px;
 
             img {


### PR DESCRIPTION
#### Summary
figure tag in opengraph attachment was missing max-width/-height properties

#### Ticket Link
[MM-45505](https://mattermost.atlassian.net/browse/MM-45505)

#### Related Pull Requests
n/a

#### Screenshots
|  before  |  after  |
|----|----|
|![Screenshot 2022-07-05 at 08 46 04](https://user-images.githubusercontent.com/32863416/177267002-a4dcb2ad-6f51-45ba-8e73-b3951b7c1aea.png)|![Screenshot 2022-07-05 at 08 46 51](https://user-images.githubusercontent.com/32863416/177267025-56fddafc-9005-4915-ad36-32b62029bb8e.png)|

#### Release Note
```release-note
NONE
```
