### PR TITLE
MM-45146 - trial end banner hides product switcher

### DIFF
--- a/components/announcement_bar/default_announcement_bar/announcement_bar.tsx
+++ b/components/announcement_bar/default_announcement_bar/announcement_bar.tsx
@@ -87,6 +87,12 @@ export default class AnnouncementBar extends React.PureComponent<Props, State> {
         document.body.classList.add('announcement-bar--fixed');
     }
 
+    componentDidUpdate() {
+        if (this.props.announcementBarCount === 1) {
+            document.body.classList.add('announcement-bar--fixed');
+        }
+    }
+
     componentWillUnmount() {
         if (this.props.announcementBarCount === 1) {
             document.body.classList.remove('announcement-bar--fixed');


### PR DESCRIPTION
#### Summary

* LCH = life cycle hook

This PR makes sure to validate if the component updates and there is at least one bar to add the css class to the body element so the content is pushed down and no controls are hidden by the banner.

The main problem was that there is a sort of race conditions between the componentWillUnmount and ComponentDidMount, so if the webhook updates the redux information informing that the trial ended, the componentDidMount LCH is called first with the new trial-ended information and just after that, the componentWillUnmount (with the previous trial started banner information) is called removing the `announcement-bar--fixed` css class from body hence placing all the content at the top and getting main menu covered by banner.

The proposed solution on this PR is the less intrusive possible, minimizing the risk of regressions and taking advantage of the normal component update LCH and placing in the componentDidUpdate LCH the condition adding back the css class to the body. Handling DOM directly this way is not optimal and a bad practice but a rewrite of this component is not worth the risk of possible regressions Vs. how good it works so far.

#### PR QA Steps
- Spin up a cloud + cws spinwick server
- Start the trial
- See the trial started blue banner
- Go to Stripe test account, locate the customer ...10704... and end the enterprise trial subscription by placing 0 to the trial time.
- get back inmediately to the workspace without reloading the page, you will see the trial-started-banner replaced by the trial-ended-banner without covering the main menu.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45146

#### Related Pull Requests

#### Screenshots


#### Release Note
```release-note
NONE
```
