### PR TITLE
MM-45472 - check the value for the enable onboarding flow config to hide/show the onboarding task list

### DIFF
--- a/components/onboarding_tasklist/onboarding_tasklist.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist.tsx
@@ -14,6 +14,7 @@ import {getShowTaskListBool} from 'selectors/onboarding';
 import {getBool, getMyPreferences as getMyPreferencesSelector} from 'mattermost-redux/selectors/entities/preferences';
 import {getMyPreferences, savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {trackEvent} from 'actions/telemetry_actions';
 import checklistImg from 'images/onboarding-checklist.svg';
 import {
@@ -178,6 +179,7 @@ const OnBoardingTaskList = (): JSX.Element | null => {
     const itemsLeft = tasksList.length - completedCount;
     const isCurrentUserSystemAdmin = useIsCurrentUserSystemAdmin();
     const isFirstAdmin = useFirstAdminUser();
+    const isEnableOnboardingFlow = useSelector((state: GlobalState) => getConfig(state).EnableOnboardingFlow === 'true');
     const [showTaskList, firstTimeOnboarding] = useSelector(getShowTaskListBool);
 
     const startTask = (taskName: string) => {
@@ -272,7 +274,7 @@ const OnBoardingTaskList = (): JSX.Element | null => {
         }));
     }, []);
 
-    if (Object.keys(myPreferences).length === 0 || !showTaskList) {
+    if (Object.keys(myPreferences).length === 0 || !showTaskList || !isEnableOnboardingFlow) {
         return null;
     }
 


### PR DESCRIPTION
#### Summary
this pr adds logic to check for the enableOnboardingFlow config to hide or show the onboarding task list.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45472

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
