### PR TITLE
Removed "channel" from "channel header"

### DIFF
--- a/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.tsx.snap
+++ b/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`components/EditChannelHeaderModal edit direct message channel 1`] = `
     <div>
       <p>
         <MemoizedFormattedMessage
-          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          defaultMessage="Edit the text appearing next to the channel name in the header."
           id="edit_channel_header_modal.description"
         />
       </p>
@@ -182,7 +182,7 @@ exports[`components/EditChannelHeaderModal error with intl message 1`] = `
     <div>
       <p>
         <MemoizedFormattedMessage
-          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          defaultMessage="Edit the text appearing next to the channel name in the header."
           id="edit_channel_header_modal.description"
         />
       </p>
@@ -327,7 +327,7 @@ exports[`components/EditChannelHeaderModal error without intl message 1`] = `
     <div>
       <p>
         <MemoizedFormattedMessage
-          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          defaultMessage="Edit the text appearing next to the channel name in the header."
           id="edit_channel_header_modal.description"
         />
       </p>
@@ -464,7 +464,7 @@ exports[`components/EditChannelHeaderModal should match snapshot, init 1`] = `
     <div>
       <p>
         <MemoizedFormattedMessage
-          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          defaultMessage="Edit the text appearing next to the channel name in the header."
           id="edit_channel_header_modal.description"
         />
       </p>
@@ -591,7 +591,7 @@ exports[`components/EditChannelHeaderModal submitted 1`] = `
     <div>
       <p>
         <MemoizedFormattedMessage
-          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          defaultMessage="Edit the text appearing next to the channel name in the header."
           id="edit_channel_header_modal.description"
         />
       </p>

--- a/components/edit_channel_header_modal/edit_channel_header_modal.tsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.tsx
@@ -240,7 +240,7 @@ export default class EditChannelHeaderModal extends React.PureComponent<Props, S
                         <p>
                             <FormattedMessage
                                 id='edit_channel_header_modal.description'
-                                defaultMessage='Edit the text appearing next to the channel name in the channel header.'
+                                defaultMessage='Edit the text appearing next to the channel name in the header.'
                             />
                         </p>
                         <div className='textarea-wrapper'>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3102,7 +3102,7 @@
   "edit_category_modal.helpText": "Drag channels into this category to organize your sidebar.",
   "edit_category_modal.placeholder": "Name your category",
   "edit_channel_header_modal.cancel": "Cancel",
-  "edit_channel_header_modal.description": "Edit the text appearing next to the channel name in the channel header.",
+  "edit_channel_header_modal.description": "Edit the text appearing next to the channel name in the header.",
   "edit_channel_header_modal.error": "The text entered exceeds the character limit. The channel header is limited to {maxLength} characters.",
   "edit_channel_header_modal.save": "Save",
   "edit_channel_header_modal.title": "Edit Header for {channel}",


### PR DESCRIPTION
#### Summary
In the context of editing a channel header, this PR removes the 2nd instance of the word "channel" from the text line "Edit the text appearing next to the channel name in the channel header" both to reduce redundancy, and to ensure the text applies equally to direct messages, group messages, and channels. In its original form, it only applied to channels.

(The first instance of "channels" works well as-is since direct messages and group messages are all types of channels.)

```release-note
Updated the Edit Header modal text description to be applicable to channels, direct messages, and group messages.
```