### PR TITLE
[MM-45227] Disable edition of archived channel purpose and header in RHS

### DIFF
--- a/components/channel_info_rhs/channel_info_rhs.test.tsx
+++ b/components/channel_info_rhs/channel_info_rhs.test.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {Channel, ChannelStats} from '@mattermost/types/channels';
+import {renderWithIntl} from 'tests/react_testing_utils';
+import {UserProfile} from '@mattermost/types/users';
+import {Team} from '@mattermost/types/teams';
+
+import ChannelInfoRHS from './channel_info_rhs';
+
+const mockAboutArea = jest.fn();
+jest.mock('./about_area', () => (props: any) => {
+    mockAboutArea(props);
+    return <div>{'test-about-area'}</div>;
+});
+
+describe('channel_info_rhs', () => {
+    const OriginalProps = {
+        channel: {display_name: 'my channel title', type: 'O'} as Channel,
+        isArchived: false,
+        channelStats: {} as ChannelStats,
+        currentUser: {} as UserProfile,
+        currentTeam: {} as Team,
+        isFavorite: false,
+        isMuted: false,
+        isInvitingPeople: false,
+        isMobile: false,
+        canManageMembers: true,
+        canManageProperties: true,
+        channelMembers: [],
+        actions: {
+            closeRightHandSide: jest.fn(),
+            unfavoriteChannel: jest.fn(),
+            favoriteChannel: jest.fn(),
+            unmuteChannel: jest.fn(),
+            muteChannel: jest.fn(),
+            openModal: jest.fn(),
+            showChannelFiles: jest.fn(),
+            showPinnedPosts: jest.fn(),
+            showChannelMembers: jest.fn(),
+        },
+    };
+    let props = {...OriginalProps};
+
+    beforeEach(() => {
+        props = {...OriginalProps};
+    });
+
+    describe('about area', () => {
+        test('should be editable', () => {
+            renderWithIntl(
+                <ChannelInfoRHS
+                    {...props}
+                />,
+            );
+
+            expect(mockAboutArea).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    canEditChannelProperties: true,
+                }),
+            );
+        });
+        test('should not be editable in archived channel', () => {
+            props.isArchived = true;
+
+            renderWithIntl(
+                <ChannelInfoRHS
+                    {...props}
+                />,
+            );
+
+            expect(mockAboutArea).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    canEditChannelProperties: false,
+                }),
+            );
+        });
+    });
+});

--- a/components/channel_info_rhs/channel_info_rhs.tsx
+++ b/components/channel_info_rhs/channel_info_rhs.tsx
@@ -139,6 +139,8 @@ const ChannelInfoRhs = ({
         return user.id !== currentUser.id;
     });
 
+    const canEditChannelProperties = !isArchived && canManageProperties;
+
     return (
         <div
             id='rhsContainer'
@@ -170,7 +172,7 @@ const ChannelInfoRhs = ({
                 dmUser={dmUser}
                 gmUsers={gmUsers}
 
-                canEditChannelProperties={canManageProperties}
+                canEditChannelProperties={canEditChannelProperties}
 
                 actions={{
                     editChannelHeader,


### PR DESCRIPTION
#### Summary
Users should not be allowed to edit archived channel header/purpose.

For QA, visit the admin console and ensure `SITE CONFIGURATION > Users and Teams | Allow users to view archived channels` is set to true or you won't be able to visit an archived channel

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45227

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
