### PR TITLE
[MM-44959]: undo & redo for advanced text editor

### DIFF
--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -694,16 +694,14 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         GlobalActions.emitLocalUserTypingEvent(channelId, rootId);
     }
 
-    handleChange = (e: React.ChangeEvent<TextboxElement>) => {
-        const message = e.target.value;
-
+    handleChange = (newMessage: string) => {
         let serverError = this.state.serverError;
         if (isErrorInvalidSlashCommand(serverError)) {
             serverError = null;
         }
 
         const draft = this.state.draft!;
-        const updatedDraft = {...draft, message};
+        const updatedDraft = {...draft, message: newMessage};
 
         if (this.saveDraftFrame) {
             clearTimeout(this.saveDraftFrame);

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -780,8 +780,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         GlobalActions.emitLocalUserTypingEvent(channelId, '');
     }
 
-    handleChange = (e: React.ChangeEvent<TextboxElement>) => {
-        const message = e.target.value;
+    handleChange = (newMessage: string) => {
         const channelId = this.props.currentChannel.id;
 
         let serverError = this.state.serverError;
@@ -790,13 +789,13 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         }
 
         this.setState({
-            message,
+            message: newMessage,
             serverError,
         });
 
         const draft = {
             ...this.props.draft,
-            message,
+            message: newMessage,
         };
 
         if (this.saveDraftFrame) {
@@ -1259,7 +1258,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
                     location={Locations.CENTER}
                     currentUserId={this.props.currentUserId}
                     postError={this.state.postError}
-                    message={this.state.message}
+                    message={''}
                     showEmojiPicker={this.state.showEmojiPicker}
                     uploadsProgressPercent={this.state.uploadsProgressPercent}
                     currentChannel={this.state.currentChannel}

--- a/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/components/advanced_text_editor/advanced_text_editor.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {CSSProperties, useCallback, useRef, useState} from 'react';
+import React, {CSSProperties, useCallback, useEffect, useRef, useState} from 'react';
 import classNames from 'classnames';
 import {useIntl} from 'react-intl';
 import {EmoticonHappyOutlineIcon} from '@mattermost/compass-icons/components';
@@ -29,6 +29,8 @@ import * as Utils from 'utils/utils';
 import {ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
 import Constants, {Locations} from 'utils/constants';
 import Tooltip from '../tooltip';
+
+import {useUndoable, withUndoable} from './advanced_text_editor_context';
 
 import TexteditorActions from './texteditor_actions';
 import FormattingBar from './formatting_bar';
@@ -149,6 +151,7 @@ const AdvanceTextEditor = ({
     textboxRef,
     isThreadView,
 }: Props) => {
+    const {content, setContent} = useUndoable();
     const readOnlyChannel = !canPost;
     const {formatMessage} = useIntl();
     const ariaLabelMessageInput = Utils.localizeMessage(
@@ -160,6 +163,8 @@ const AdvanceTextEditor = ({
     const [scrollbarWidth, setScrollbarWidth] = useState(0);
     const [renderScrollbar, setRenderScrollbar] = useState(false);
 
+    useEffect(() => setContent(message), [message]);
+
     const handleHeightChange = (height: number, maxHeight: number) => {
         setRenderScrollbar(height > maxHeight);
 
@@ -170,9 +175,7 @@ const AdvanceTextEditor = ({
         });
     };
 
-    const handleShowFormat = useCallback(() => {
-        setShowPreview(!shouldShowPreview);
-    }, [shouldShowPreview, setShowPreview]);
+    const handleShowFormat = useCallback(() => setShowPreview(!shouldShowPreview), [shouldShowPreview, setShowPreview]);
 
     let serverErrorJsx = null;
     if (serverError) {
@@ -321,7 +324,7 @@ const AdvanceTextEditor = ({
         createMessage = Utils.localizeMessage('create_comment.addComment', 'Reply to this thread...');
     }
 
-    const messageValue = readOnlyChannel ? '' : message;
+    const messageValue = readOnlyChannel ? '' : content;
 
     /**
      * by getting the value directly from the textbox we eliminate all unnecessary
@@ -416,13 +419,14 @@ const AdvanceTextEditor = ({
                         {sendButton}
                     </TexteditorActions>
                 </div>
-                {showSendTutorialTip && currentChannel && prefillMessage &&
+                {showSendTutorialTip && currentChannel && prefillMessage && (
                     <SendMessageTour
                         prefillMessage={prefillMessage}
                         currentChannel={currentChannel}
                         currentUserId={currentUserId}
                         currentChannelTeammateUsername={currentChannelTeammateUsername}
-                    />}
+                    />
+                )}
             </div>
             <div
                 id='postCreateFooter'
@@ -442,4 +446,4 @@ const AdvanceTextEditor = ({
     );
 };
 
-export default AdvanceTextEditor;
+export default withUndoable(AdvanceTextEditor);

--- a/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/components/advanced_text_editor/advanced_text_editor.tsx
@@ -163,7 +163,8 @@ const AdvanceTextEditor = ({
     const [scrollbarWidth, setScrollbarWidth] = useState(0);
     const [renderScrollbar, setRenderScrollbar] = useState(false);
 
-    useEffect(() => setContent(message), [message]);
+    // disabling the rule here since this will otherwise create an infinite loop
+    useEffect(() => setContent(message), [message]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleHeightChange = (height: number, maxHeight: number) => {
         setRenderScrollbar(height > maxHeight);

--- a/components/advanced_text_editor/advanced_text_editor_context.tsx
+++ b/components/advanced_text_editor/advanced_text_editor_context.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+const MAXLEN = 10;
+
+type Context = {
+    content: string;
+    setContent: (content: string) => void;
+    isUndoable: boolean;
+    isRedoable: boolean;
+    undo: () => void;
+    redo: () => void;
+}
+
+const UndoableContext = React.createContext<Context|null>(null);
+
+interface ProviderProps {
+    children: React.ReactNode | React.ReactNodeArray;
+    maxHistoryLength?: number;
+}
+
+const UndoableProvider = ({children, maxHistoryLength = MAXLEN}: ProviderProps) => {
+    const [past, setPast] = React.useState<string[]>([]);
+    const [present, setPresent] = React.useState('');
+    const [future, setFuture] = React.useState<string[]>([]);
+
+    const setContent = (content: string) => {
+        setPast((old) => [present, ...old].slice(0, maxHistoryLength));
+        setPresent(content);
+    };
+
+    const undo = () => {
+        if (past.length < 1 || past.length > maxHistoryLength) {
+            return;
+        }
+
+        const [last, ...rest] = past;
+
+        setPast(rest);
+        setFuture((old) => [present, ...old]);
+        setPresent(last);
+    };
+
+    const redo = () => {
+        if (future.length < 1 || future.length > maxHistoryLength) {
+            return;
+        }
+
+        const [first, ...rest] = future;
+
+        setFuture(rest);
+        setPresent(first);
+        setPast((old) => [present, ...old]);
+    };
+
+    return (
+        <UndoableContext.Provider
+            value={{
+                content: present,
+                setContent,
+                undo,
+                redo,
+                isUndoable: past.length > 0,
+                isRedoable: future.length > 0,
+            }}
+        >
+            {children}
+        </UndoableContext.Provider>
+    );
+};
+
+const useUndoable = () => {
+    const state = React.useContext(UndoableContext);
+
+    if (state === null) {
+        throw new Error('## Context cannot be null ##');
+    }
+
+    return state;
+};
+
+const withUndoable = (Component: React.FC<any>) => (props: any) => {
+    return (
+        <UndoableProvider>
+            <Component {...props}/>
+        </UndoableProvider>
+    );
+};
+
+export {UndoableContext, useUndoable, UndoableProvider, withUndoable};

--- a/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
+++ b/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
@@ -7,10 +7,9 @@ import {useIntl} from 'react-intl';
 import styled from 'styled-components';
 import {useFloating, offset} from '@floating-ui/react-dom';
 import {CSSTransition} from 'react-transition-group';
-import {ArrowLeftIcon, ArrowRightIcon, DotsHorizontalIcon} from '@mattermost/compass-icons/components';
+import {DotsHorizontalIcon} from '@mattermost/compass-icons/components';
 
 import {ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
-import {useUndoable} from '../advanced_text_editor_context';
 import ToggleFormattingBar from '../toggle_formatting_bar/toggle_formatting_bar';
 
 import FormattingIcon, {IconContainer} from './formatting_icon';
@@ -144,42 +143,6 @@ interface FormattingBarProps {
      */
     location: string;
 }
-
-const UndoButton = memo(() => {
-    const {isUndoable, undo} = useUndoable();
-
-    return (
-        <IconContainer
-            disabled={!isUndoable}
-            type='button'
-            onClick={undo}
-            aria-label='undo'
-        >
-            <ArrowLeftIcon
-                color={'currentColor'}
-                size={18}
-            />
-        </IconContainer>
-    );
-});
-
-const RedoButton = memo(() => {
-    const {isRedoable, redo} = useUndoable();
-
-    return (
-        <IconContainer
-            disabled={!isRedoable}
-            type='button'
-            onClick={redo}
-            aria-label='redo'
-        >
-            <ArrowRightIcon
-                color={'currentColor'}
-                size={18}
-            />
-        </IconContainer>
-    );
-});
 
 const FormattingBar = (props: FormattingBarProps): JSX.Element => {
     const {
@@ -357,9 +320,6 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
                     })}
                 </HiddenControlsContainer>
             </CSSTransition>
-            <UndoButton/>
-            <RedoButton/>
-            <Separator show={true}/>
             {extraControls}
         </FormattingBarContainer>
     );

--- a/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
+++ b/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
@@ -7,9 +7,10 @@ import {useIntl} from 'react-intl';
 import styled from 'styled-components';
 import {useFloating, offset} from '@floating-ui/react-dom';
 import {CSSTransition} from 'react-transition-group';
-import {DotsHorizontalIcon} from '@mattermost/compass-icons/components';
+import {ArrowLeftIcon, ArrowRightIcon, DotsHorizontalIcon} from '@mattermost/compass-icons/components';
 
 import {ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
+import {useUndoable} from '../advanced_text_editor_context';
 import ToggleFormattingBar from '../toggle_formatting_bar/toggle_formatting_bar';
 
 import FormattingIcon, {IconContainer} from './formatting_icon';
@@ -143,6 +144,42 @@ interface FormattingBarProps {
      */
     location: string;
 }
+
+const UndoButton = memo(() => {
+    const {isUndoable, undo} = useUndoable();
+
+    return (
+        <IconContainer
+            disabled={!isUndoable}
+            type='button'
+            onClick={undo}
+            aria-label='undo'
+        >
+            <ArrowLeftIcon
+                color={'currentColor'}
+                size={18}
+            />
+        </IconContainer>
+    );
+});
+
+const RedoButton = memo(() => {
+    const {isRedoable, redo} = useUndoable();
+
+    return (
+        <IconContainer
+            disabled={!isRedoable}
+            type='button'
+            onClick={redo}
+            aria-label='redo'
+        >
+            <ArrowRightIcon
+                color={'currentColor'}
+                size={18}
+            />
+        </IconContainer>
+    );
+});
 
 const FormattingBar = (props: FormattingBarProps): JSX.Element => {
     const {
@@ -297,6 +334,7 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
                     <Separator show={true}/>
                 </>
             )}
+
             <CSSTransition
                 timeout={250}
                 classNames='scale'
@@ -319,6 +357,9 @@ const FormattingBar = (props: FormattingBarProps): JSX.Element => {
                     })}
                 </HiddenControlsContainer>
             </CSSTransition>
+            <UndoButton/>
+            <RedoButton/>
+            <Separator show={true}/>
             {extraControls}
         </FormattingBarContainer>
     );


### PR DESCRIPTION
#### Summary
this adds the undo/redo functionality to the `AdvancedTextEditor` component.
It also kind of adds value state management with the `UndoableContext`. It triggers on every value change from the outside. Once the state management is adjusted/refactore we might want to revisit this and change it accordingly.

> ⚠️ NOTE for UX: I designed this with a maximum of 50 items in the each history (past and future). This threshold might be reached pretty fast when typing normally, so we might want to think of a debouncing effect, or only trigger this once a full word is typed or something similar. We could also just increase the maximum length of the history to 1000 items each or so. IMO this should not have any impact on performance.
> 
> One thing to note on this: adding in a different trigger handling might take a considerable amount of work (compared to just adjust the history length) and we might need to wait for the state management refactoring on this, so keep that in mind. The way it is now it works just fine.

Another note on this: I have used `ArrowLeftIcon` and `ArrowRightIcon` for the buttons. Is that fine with UX?

#### Ticket Link
[MM-44959](https://mattermost.atlassian.net/browse/MM-44959)

#### Related Pull Requests
n/a

#### Screenshots
n/a 

#### Release Note
```release-note
adds undo and redo functionality to the advanced text editor
```
