### PR TITLE
MM-44979_Move Create Account link closer to login container

### DIFF
--- a/components/header_footer_route/content_layouts/alternate_link.scss
+++ b/components/header_footer_route/content_layouts/alternate_link.scss
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+@import 'utils/mixins';
+
+.alternate-link {
+    margin-left: auto;
+
+    &__message {
+        color: var(--center-channel-text-rgb);
+        font-size: 12px;
+        line-height: 16px;
+    }
+
+    &__link {
+        padding-left: 4px;
+
+        @include link;
+    }
+}
+
+@media screen and (max-width: 699px) {
+    .alternate-link {
+        &__message {
+            display: none;
+        }
+    }
+}

--- a/components/header_footer_route/content_layouts/alternate_link.test.tsx
+++ b/components/header_footer_route/content_layouts/alternate_link.test.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {BrowserRouter} from 'react-router-dom';
+import {shallow, mount} from 'enzyme';
+
+import AlternateLink from './alternate_link';
+
+describe('components/header_footer_route/content_layouts/alternate_link', () => {
+    it('should return default', () => {
+        const wrapper = shallow(
+            <AlternateLink/>,
+        );
+
+        expect(wrapper).toEqual({});
+    });
+
+    it('should show with message', () => {
+        const alternateMessage = 'alternateMessage';
+
+        const wrapper = shallow(
+            <AlternateLink alternateMessage={alternateMessage}/>,
+        );
+
+        expect(wrapper.find('.alternate-link__message').text()).toEqual(alternateMessage);
+    });
+
+    it('should show with link', () => {
+        const alternateLinkPath = 'alternateLinkPath';
+        const alternateLinkLabel = 'alternateLinkLabel';
+
+        const wrapper = mount(
+            <BrowserRouter>
+                <AlternateLink
+                    alternateLinkPath={alternateLinkPath}
+                    alternateLinkLabel={alternateLinkLabel}
+                />
+            </BrowserRouter>,
+        );
+
+        const link = wrapper.find('.alternate-link__link').first();
+
+        expect(link.text()).toEqual(alternateLinkLabel);
+        expect(link.props().to).toEqual({pathname: alternateLinkPath, search: ''});
+    });
+});

--- a/components/header_footer_route/content_layouts/alternate_link.tsx
+++ b/components/header_footer_route/content_layouts/alternate_link.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import classNames from 'classnames';
+import {Link} from 'react-router-dom';
+
+import './alternate_link.scss';
+
+type AlternateLinkProps = {
+    className?: string;
+    alternateMessage?: string;
+    alternateLinkPath?: string;
+    alternateLinkLabel?: string;
+}
+
+const AlternateLink = ({className, alternateMessage, alternateLinkPath, alternateLinkLabel}: AlternateLinkProps) => {
+    if (!alternateMessage && !alternateLinkPath && !alternateLinkLabel) {
+        return null;
+    }
+
+    return (
+        <div className={classNames('alternate-link', className)}>
+            {alternateMessage && (
+                <span className='alternate-link__message'>
+                    {alternateMessage}
+                </span>
+            )}
+            {alternateLinkPath && alternateLinkLabel && (
+                <Link
+                    className='alternate-link__link'
+                    to={{
+                        pathname: alternateLinkPath,
+                        search: location.search,
+                    }}
+                >
+                    {alternateLinkLabel}
+                </Link>
+            )}
+        </div>
+    );
+};
+
+export default AlternateLink;

--- a/components/header_footer_route/footer.scss
+++ b/components/header_footer_route/footer.scss
@@ -13,7 +13,6 @@
     align-items: center;
     align-self: center;
     padding: 0 40px;
-    margin-top: auto;
 
     .footer-link {
         @include link;

--- a/components/header_footer_route/header.scss
+++ b/components/header_footer_route/header.scss
@@ -36,22 +36,6 @@
                 fill: var(--center-channel-text);
             }
         }
-
-        .header-alternate-container {
-            margin-left: auto;
-
-            .header-alternate-message {
-                color: var(--center-channel-text-rgb);
-                font-size: 12px;
-                line-height: 16px;
-            }
-
-            .header-alternate-link {
-                padding-left: 4px;
-
-                @include link;
-            }
-        }
     }
 
     .header-back-button {
@@ -75,14 +59,6 @@
         .header-main {
             .header-logo-link svg {
                 width: 145px;
-            }
-
-            .header-alternate-container {
-                margin-left: 0;
-
-                .header-alternate-message {
-                    display: none;
-                }
             }
         }
 

--- a/components/header_footer_route/header.tsx
+++ b/components/header_footer_route/header.tsx
@@ -13,14 +13,12 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import './header.scss';
 
 export type HeaderProps = {
-    alternateMessage?: string;
-    alternateLinkPath?: string;
-    alternateLinkLabel?: string;
+    alternateLink?: React.ReactElement;
     backButtonURL?: string;
     onBackButtonClick?: React.EventHandler<React.MouseEvent>;
 }
 
-const Header = ({alternateMessage, alternateLinkPath, alternateLinkLabel, backButtonURL, onBackButtonClick}: HeaderProps) => {
+const Header = ({alternateLink, backButtonURL, onBackButtonClick}: HeaderProps) => {
     const {EnableCustomBrand, SiteName} = useSelector(getConfig);
 
     return (
@@ -32,21 +30,7 @@ const Header = ({alternateMessage, alternateLinkPath, alternateLinkLabel, backBu
                 >
                     {EnableCustomBrand === 'true' || SiteName !== 'Mattermost' ? SiteName : <Logo/>}
                 </Link>
-                <div className='header-alternate-container'>
-                    {alternateMessage && (
-                        <span className='header-alternate-message'>
-                            {alternateMessage}
-                        </span>
-                    )}
-                    {alternateLinkPath && alternateLinkLabel && (
-                        <Link
-                            className='header-alternate-link'
-                            to={{pathname: alternateLinkPath, search: location.search}}
-                        >
-                            {alternateLinkLabel}
-                        </Link>
-                    )}
-                </div>
+                {alternateLink}
             </div>
             {onBackButtonClick && (
                 <BackButton

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -304,23 +304,27 @@
 }
 
 @media screen and (max-width: 699px) {
-    .login-body .login-body-content {
-        min-width: 375px;
+    .login-body {
+        margin: auto 0;
 
-        .login-body-card {
-            width: 100%;
-        }
+        .login-body-content {
+            min-width: 375px;
 
-        .login-body-message {
-            width: auto;
-            align-self: flex-start;
-            padding: 24px;
+            .login-body-card {
+                width: 100%;
+            }
 
-            .login-body-message-title {
-                max-width: 271px;
-                padding-right: 0;
-                font-size: 45px;
-                line-height: 56px;
+            .login-body-message {
+                width: auto;
+                align-self: flex-start;
+                padding: 24px;
+
+                .login-body-message-title {
+                    max-width: 271px;
+                    padding-right: 0;
+                    font-size: 45px;
+                    line-height: 56px;
+                }
             }
         }
     }

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -5,8 +5,12 @@
 
 .login-body {
     display: flex;
-    flex: 1;
-    align-items: center;
+    flex-direction: column;
+    margin: auto;
+
+    .login-body-alternate-link {
+        margin-bottom: 18px;
+    }
 
     .login-body-content {
         display: flex;
@@ -214,78 +218,84 @@
 }
 
 @media screen and (max-width: 1199px) {
-    .login-body .login-body-content {
-        flex-direction: column;
-
-        .login-body-message,
-        .login-body-card {
-            width: 640px;
+    .login-body {
+        .login-body-alternate-link {
+            padding-right: 24px;
         }
 
-        .login-body-message {
-            align-self: center;
-            padding: 24px;
+        .login-body-content {
+            flex-direction: column;
 
-            .login-body-message-title {
-                padding-right: 210px;
-                font-size: 64px;
-                line-height: 76px;
+            .login-body-message,
+            .login-body-card {
+                width: 640px;
             }
 
-            .login-body-message-subtitle {
-                margin: 0;
-            }
+            .login-body-message {
+                align-self: center;
+                padding: 24px;
 
-            .login-body-message-svg {
-                display: none;
-            }
+                .login-body-message-title {
+                    padding-right: 210px;
+                    font-size: 64px;
+                    line-height: 76px;
+                }
 
-            &.custom-branding {
-                display: none;
-            }
-        }
+                .login-body-message-subtitle {
+                    margin: 0;
+                }
 
-        .login-body-card {
-            border: none;
-            margin: 0;
-            background-color: unset;
-            box-shadow: none;
-
-            .login-body-card-content {
-                padding: 16px 24px;
-
-                .login-body-card-title {
+                .login-body-message-svg {
                     display: none;
                 }
 
-                .login-body-card-banner {
-                    margin: 0 0 32px;
-                }
-
-                .login-body-card-form {
-                    .login-body-card-form-input {
-                        margin-top: 0;
-                    }
-
-                    .login-body-card-form-input,
-                    .login-body-card-form-password-input {
-                        background-color: var(--center-channel-bg);
-                    }
+                &.custom-branding {
+                    display: none;
                 }
             }
 
-            &.custom-branding {
+            .login-body-card {
+                border: none;
+                margin: 0;
+                background-color: unset;
+                box-shadow: none;
+
                 .login-body-card-content {
+                    padding: 16px 24px;
+
                     .login-body-card-title {
-                        display: block;
-                        font-size: 32px;
-                        line-height: 40px;
+                        display: none;
                     }
 
-                    .login-body-custom-branding-markdown,
-                    .login-body-message-subtitle {
-                        display: block;
+                    .login-body-card-banner {
                         margin: 0 0 32px;
+                    }
+
+                    .login-body-card-form {
+                        .login-body-card-form-input {
+                            margin-top: 0;
+                        }
+
+                        .login-body-card-form-input,
+                        .login-body-card-form-password-input {
+                            background-color: var(--center-channel-bg);
+                        }
+                    }
+                }
+
+                &.custom-branding {
+                    .login-body-card-content {
+                        .login-body-card-title {
+                            display: block;
+                            font-size: 32px;
+                            line-height: 40px;
+                        }
+
+                        .login-body-custom-branding-markdown,
+                        .login-body-message-subtitle {
+                            display: block;
+                            margin: 0 0 32px;
+                        }
                     }
                 }
             }

--- a/components/login/login.test.tsx
+++ b/components/login/login.test.tsx
@@ -19,7 +19,7 @@ import {ActionFunc} from 'mattermost-redux/types/actions';
 import {ClientConfig} from '@mattermost/types/config';
 import LocalStorageStore from 'stores/local_storage_store';
 import {GlobalState} from 'types/store';
-import Constants from 'utils/constants';
+import Constants, {WindowSizes} from 'utils/constants';
 
 let mockState: GlobalState;
 let mockLocation = {pathname: '', search: '', hash: ''};
@@ -93,6 +93,11 @@ describe('components/login/Login', () => {
             },
             storage: {
                 initialized: true,
+            },
+            views: {
+                browser: {
+                    windowSize: WindowSizes.DESKTOP_VIEW,
+                },
             },
         } as unknown as GlobalState;
 

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -357,6 +357,7 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
             return;
         }
 
+        onWindowResize();
         onWindowFocus();
 
         window.addEventListener('resize', onWindowResize);

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -331,7 +331,7 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     ), [showSignup]);
 
     const onWindowResize = throttle(() => {
-        setIsMobileView(window.innerWidth <= MOBILE_SCREEN_WIDTH);
+        setIsMobileView(window.innerWidth < MOBILE_SCREEN_WIDTH);
     }, 100);
 
     const onWindowFocus = useCallback(() => {

--- a/components/signup/__snapshots__/signup.test.tsx.snap
+++ b/components/signup/__snapshots__/signup.test.tsx.snap
@@ -4,6 +4,12 @@ exports[`components/signup/Signup should match snapshot for all signup options e
 <div
   className="signup-body"
 >
+  <AlternateLink
+    alternateLinkLabel="Log in"
+    alternateLinkPath="/login"
+    alternateMessage="Already have an account?"
+    className="signup-body-alternate-link"
+  />
   <div
     className="signup-body-content"
   >
@@ -142,6 +148,12 @@ exports[`components/signup/Signup should match snapshot for all signup options e
 <div
   className="signup-body"
 >
+  <AlternateLink
+    alternateLinkLabel="Log in"
+    alternateLinkPath="/login"
+    alternateMessage="Already have an account?"
+    className="signup-body-alternate-link"
+  />
   <div
     className="signup-body-content"
   >

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -347,24 +347,28 @@
 }
 
 @media screen and (max-width: 699px) {
-    .signup-body .signup-body-content {
-        min-width: 375px;
+    .signup-body {
+        margin: auto 0;
 
-        .signup-body-card,
-        .signup-body-no-login {
-            width: 100%;
-        }
+        .signup-body-content {
+            min-width: 375px;
 
-        .signup-body-message {
-            width: auto;
-            align-self: flex-start;
-            padding: 24px;
+            .signup-body-card,
+            .signup-body-no-login {
+                width: 100%;
+            }
 
-            .signup-body-message-title {
-                max-width: 271px;
-                padding-right: 0;
-                font-size: 45px;
-                line-height: 56px;
+            .signup-body-message {
+                width: auto;
+                align-self: flex-start;
+                padding: 24px;
+
+                .signup-body-message-title {
+                    max-width: 271px;
+                    padding-right: 0;
+                    font-size: 45px;
+                    line-height: 56px;
+                }
             }
         }
     }

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -5,8 +5,12 @@
 
 .signup-body {
     display: flex;
-    flex: 1;
-    align-items: center;
+    flex-direction: column;
+    margin: auto;
+
+    .signup-body-alternate-link {
+        margin-bottom: 18px;
+    }
 
     .signup-body-content {
         display: flex;
@@ -254,81 +258,87 @@
 }
 
 @media screen and (max-width: 1199px) {
-    .signup-body .signup-body-content {
-        flex-direction: column;
-
-        .signup-body-message,
-        .signup-body-card,
-        .signup-body-no-login {
-            width: 640px;
+    .signup-body {
+        .signup-body-alternate-link {
+            padding-right: 24px;
         }
 
-        .signup-body-message {
-            align-self: center;
-            padding: 24px;
+        .signup-body-content {
+            flex-direction: column;
 
-            .signup-body-message-title {
-                padding-right: 0;
-                font-size: 64px;
-                line-height: 76px;
+            .signup-body-message,
+            .signup-body-card,
+            .signup-body-no-login {
+                width: 640px;
             }
 
-            .signup-body-message-subtitle {
-                padding: 0;
-                margin: 0;
-            }
+            .signup-body-message {
+                align-self: center;
+                padding: 24px;
 
-            .signup-body-message-svg {
-                display: none;
-            }
+                .signup-body-message-title {
+                    padding-right: 0;
+                    font-size: 64px;
+                    line-height: 76px;
+                }
 
-            &.custom-branding {
-                display: none;
-            }
-        }
+                .signup-body-message-subtitle {
+                    padding: 0;
+                    margin: 0;
+                }
 
-        .signup-body-card {
-            border: none;
-            margin: 0;
-            background-color: unset;
-            box-shadow: none;
-
-            .signup-body-card-content {
-                padding: 16px 24px;
-
-                .signup-body-card-title {
+                .signup-body-message-svg {
                     display: none;
                 }
 
-                .signup-body-card-banner {
-                    margin: 0 0 32px;
-                }
-
-                .signup-body-card-form {
-                    .signup-body-card-form-email-input {
-                        margin-top: 0;
-                    }
-
-                    .signup-body-card-form-email-input,
-                    .signup-body-card-form-name-input,
-                    .signup-body-card-form-password-input {
-                        background-color: var(--center-channel-bg);
-                    }
+                &.custom-branding {
+                    display: none;
                 }
             }
 
-            &.custom-branding {
+            .signup-body-card {
+                border: none;
+                margin: 0;
+                background-color: unset;
+                box-shadow: none;
+
                 .signup-body-card-content {
+                    padding: 16px 24px;
+
                     .signup-body-card-title {
-                        display: block;
-                        font-size: 32px;
-                        line-height: 40px;
+                        display: none;
                     }
 
-                    .signup-body-custom-branding-markdown,
-                    .signup-body-message-subtitle {
-                        display: block;
+                    .signup-body-card-banner {
                         margin: 0 0 32px;
+                    }
+
+                    .signup-body-card-form {
+                        .signup-body-card-form-email-input {
+                            margin-top: 0;
+                        }
+
+                        .signup-body-card-form-email-input,
+                        .signup-body-card-form-name-input,
+                        .signup-body-card-form-password-input {
+                            background-color: var(--center-channel-bg);
+                        }
+                    }
+                }
+
+                &.custom-branding {
+                    .signup-body-card-content {
+                        .signup-body-card-title {
+                            display: block;
+                            font-size: 32px;
+                            line-height: 40px;
+                        }
+
+                        .signup-body-custom-branding-markdown,
+                        .signup-body-message-subtitle {
+                            display: block;
+                            margin: 0 0 32px;
+                        }
                     }
                 }
             }

--- a/components/signup/signup.test.tsx
+++ b/components/signup/signup.test.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import {shallow, ReactWrapper} from 'enzyme';
 import {IntlProvider} from 'react-intl';
+import {BrowserRouter} from 'react-router-dom';
 import {act} from '@testing-library/react';
 
 import * as global_actions from 'actions/global_actions';
@@ -18,6 +19,7 @@ import SaveButton from 'components/save_button';
 import {RequestStatus} from 'mattermost-redux/constants';
 import {ClientConfig} from '@mattermost/types/config';
 import {GlobalState} from 'types/store';
+import {WindowSizes} from 'utils/constants';
 
 let mockState: GlobalState;
 let mockLocation = {pathname: '', search: '', hash: ''};
@@ -135,6 +137,11 @@ describe('components/signup/Signup', () => {
             storage: {
                 initialized: true,
             },
+            views: {
+                browser: {
+                    windowSize: WindowSizes.DESKTOP_VIEW,
+                },
+            },
         } as unknown as GlobalState;
 
         mockConfig = {
@@ -193,7 +200,9 @@ describe('components/signup/Signup', () => {
 
         const wrapper = mountWithIntl(
             <IntlProvider {...intlProviderProps}>
-                <Signup/>
+                <BrowserRouter>
+                    <Signup/>
+                </BrowserRouter>
             </IntlProvider>,
         );
 
@@ -232,7 +241,9 @@ describe('components/signup/Signup', () => {
 
         const wrapper = mountWithIntl(
             <IntlProvider {...intlProviderProps}>
-                <Signup/>
+                <BrowserRouter>
+                    <Signup/>
+                </BrowserRouter>
             </IntlProvider>,
         );
 

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -265,6 +265,8 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         dispatch(removeGlobalItem('team'));
         trackEvent('signup', 'signup_user_01_welcome');
 
+        onWindowResize();
+
         window.addEventListener('resize', onWindowResize);
 
         if (search) {

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -258,7 +258,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
     ), []);
 
     const onWindowResize = throttle(() => {
-        setIsMobileView(window.innerWidth <= MOBILE_SCREEN_WIDTH);
+        setIsMobileView(window.innerWidth < MOBILE_SCREEN_WIDTH);
     }, 100);
 
     useEffect(() => {

--- a/e2e/cypress/tests/integration/signin_authentication/signup_spec.js
+++ b/e2e/cypress/tests/integration/signin_authentication/signup_spec.js
@@ -62,9 +62,9 @@ describe('Signup Email page', () => {
         cy.get('.header-logo-link').should('be.visible');
         cy.get('.signup-body-card-title').should('contain', config.TeamSettings.CustomDescriptionText);
         cy.get('.signup-body-message-title').should('contain', 'Let’s get started');
-        cy.get('.header-alternate-message').should('contain', 'Already have an account?');
-        cy.get('.header-alternate-link').should('contain', 'Log in');
-        cy.get('.header-alternate-link').should('have.attr', 'href', '/login');
+        cy.get('.alternate-link__message').should('contain', 'Already have an account?');
+        cy.get('.alternate-link__link').should('contain', 'Log in');
+        cy.get('.alternate-link__link').should('have.attr', 'href', '/login');
 
         cy.get('#input_email').should('be.visible');
         cy.focused().should('have.attr', 'id', 'input_email');


### PR DESCRIPTION
#### Summary
Move Login/Signup alternate links closer to the main content of the page.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44979

#### Design
https://www.figma.com/file/PZuUUM5KPZtGS4YiJYvgSg/MM-44979-Move-Create-Account-Button?node-id=0%3A1

#### Screenshots
##### Login
<img width="1515" alt="Screen Shot 2022-07-06 at 7 36 56 PM" src="https://user-images.githubusercontent.com/79058848/177665508-181fd6f9-ec63-4ae8-802c-0109f78bb5c9.png">

##### Login (Mobile)
<img width="501" alt="Screen Shot 2022-07-06 at 7 37 35 PM" src="https://user-images.githubusercontent.com/79058848/177665546-d7086aff-b320-4a95-bd68-bdaf350b2ce8.png">

##### Signup
<img width="1565" alt="Screen Shot 2022-07-06 at 7 38 07 PM" src="https://user-images.githubusercontent.com/79058848/177665574-67ce6c22-d52b-41ed-ae71-02e93b266e2a.png">

##### Signup (Mobile)
<img width="500" alt="Screen Shot 2022-07-06 at 7 37 52 PM" src="https://user-images.githubusercontent.com/79058848/177665599-a85c6d32-754b-4f0c-b966-e3c940c2f7a3.png">

#### Release Note
```release-note
NONE
```
