### PR TITLE
MM-20387: Migrate 'components/sidebar_right' module and associated tests to TypeScript

### DIFF
--- a/components/rhs_header_post/rhs_header_post.tsx
+++ b/components/rhs_header_post/rhs_header_post.tsx
@@ -19,12 +19,13 @@ import Constants, {RHSStates} from 'utils/constants';
 import {t} from 'utils/i18n';
 import CRTThreadsPaneTutorialTip
     from 'components/crt_tour/crt_threads_pane_tutorial_tip/crt_threads_pane_tutorial_tip';
+import {RhsState} from 'types/store/rhs';
 
 interface RhsHeaderPostProps {
     isExpanded: boolean;
     isMobileView: boolean;
     rootPostId: string;
-    previousRhsState?: string;
+    previousRhsState?: RhsState;
     relativeTeamUrl: string;
     channel: Channel;
     isCollapsedThreadsEnabled: boolean;

--- a/components/rhs_thread/rhs_thread.tsx
+++ b/components/rhs_thread/rhs_thread.tsx
@@ -7,7 +7,7 @@ import React, {memo} from 'react';
 import {Channel} from '@mattermost/types/channels';
 import {Post} from '@mattermost/types/posts';
 
-import {FakePost} from 'types/store/rhs';
+import {FakePost, RhsState} from 'types/store/rhs';
 
 import RhsHeaderPost from 'components/rhs_header_post';
 import ThreadViewer from 'components/threading/thread_viewer';
@@ -16,7 +16,7 @@ type Props = {
     posts: Post[];
     channel: Channel | null;
     selected: Post | FakePost;
-    previousRhsState?: string;
+    previousRhsState?: RhsState;
 }
 
 const RhsThread = ({

--- a/components/sidebar_right/index.ts
+++ b/components/sidebar_right/index.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
+import {bindActionCreators, Dispatch} from 'redux';
 
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 
@@ -18,9 +18,11 @@ import {
 } from 'selectors/rhs';
 import {RHSStates} from 'utils/constants';
 
-import SidebarRight from './sidebar_right.jsx';
+import {GlobalState} from 'types/store';
 
-function mapStateToProps(state) {
+import SidebarRight from './sidebar_right';
+
+function mapStateToProps(state: GlobalState) {
     const rhsState = getRhsState(state);
     const channel = getCurrentChannel(state);
 
@@ -46,7 +48,7 @@ function mapStateToProps(state) {
     };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators({
             setRhsExpanded,

--- a/components/sidebar_right/sidebar_right.tsx
+++ b/components/sidebar_right/sidebar_right.tsx
@@ -192,9 +192,7 @@ export default class SidebarRight extends React.PureComponent<Props, State> {
 
     handleUpdateSearchTerms = (term: string) => {
         this.props.actions.updateSearchTerms(term);
-        if (this.focusSearchBar) {
-            this.focusSearchBar();
-        }
+        this.focusSearchBar?.();
     }
 
     getSearchBarFocus = (focusSearchBar: () => void) => {

--- a/components/sidebar_right/sidebar_right.tsx
+++ b/components/sidebar_right/sidebar_right.tsx
@@ -16,7 +16,9 @@ import ChannelMembersRhs from 'components/channel_members_rhs';
 import Search from 'components/search/index';
 
 import RhsPlugin from 'plugins/rhs_plugin';
+
 import {Channel} from '@mattermost/types/channels';
+import {RhsState} from 'types/store/rhs';
 
 type Props = {
     isExpanded: boolean;
@@ -30,7 +32,7 @@ type Props = {
     isChannelInfo: boolean;
     isChannelMembers: boolean;
     isPluginView: boolean;
-    previousRhsState: string;
+    previousRhsState: RhsState;
     rhsChannel: Channel;
     selectedPostId: string;
     selectedPostCardId: string;


### PR DESCRIPTION
#### Summary
This PR migrates 'components/sidebar_right' module and associated tests to TypeScript

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16719
JIRA: https://mattermost.atlassian.net/browse/MM-20387

#### Release Note
```release-note
NONE
```
