### PR TITLE
MM-45487: Channel Switcher: Dont show channel slug name on threads

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -220,6 +220,7 @@ class SwitchChannelSuggestion extends Suggestion {
         if (channel.team_id && team) {
             teamName = (<span className='ml-2 suggestion-list__team-name'>{team.display_name}</span>);
         }
+        const showSlug = (isPartOfOnlyOneTeam || channel.type === Constants.DM_CHANNEL) && channel.type !== Constants.THREADS;
 
         return (
             <div
@@ -239,9 +240,7 @@ class SwitchChannelSuggestion extends Suggestion {
                 <div className='suggestion-list__ellipsis suggestion-list__flex'>
                     <span className='suggestion-list__main'>
                         <span className={item.unread ? 'suggestion-list__unread' : ''}>{name}</span>
-                        {(isPartOfOnlyOneTeam || channel.type === Constants.DM_CHANNEL) && (
-                            <span className='ml-2 suggestion-list__desc'>{description}</span>
-                        )}
+                        {showSlug && <span className='ml-2 suggestion-list__desc'>{description}</span>}
                     </span>
                     {customStatus}
                     {sharedIcon}


### PR DESCRIPTION
#### Summary
This PR prevent showing channel slug name when searching channels on Channel Switcher

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/20586
JIRA: https://mattermost.atlassian.net/browse/MM-45487

#### Screenshots
**Before**

https://user-images.githubusercontent.com/37421564/177885128-dc3fef44-facb-42d1-ae3e-46855cf90637.mov

**After**

https://user-images.githubusercontent.com/37421564/177885132-8db00b17-a977-4855-918d-5a171f4c3694.mov



#### Release Note
```release-note
NONE
```
