### PR TITLE
Cypress/E2E: fix failed tests

### DIFF
--- a/e2e/cypress/tests/integration/accessibility/accessibility_nav_diff_regions_spec.js
+++ b/e2e/cypress/tests/integration/accessibility/accessibility_nav_diff_regions_spec.js
@@ -93,7 +93,7 @@ describe('Verify Quick Navigation support across different regions in the app', 
                 should('have.attr', 'aria-label', 'message input complimentary region').
                 and('have.attr', 'data-a11y-sort-order', '2').
                 and('have.class', 'a11y__region');
-            cy.get('#reply_textbox').
+            cy.uiGetReplyTextBox().
                 should('have.class', 'a11y--active a11y--focused');
         });
     });

--- a/e2e/cypress/tests/integration/archived_channel/archive_channel_add_reaction_spec.js
+++ b/e2e/cypress/tests/integration/archived_channel/archive_channel_add_reaction_spec.js
@@ -29,9 +29,6 @@ describe('Archived channels', () => {
     it('MM-T1720 Cannot add reactions to existing reactions', () => {
         const messageText = 'Test add reaction in archive channels';
 
-        // * Post text box should be visible
-        cy.get('#post_textbox').should('be.visible');
-
         // # Post a message in the channel
         cy.postMessage(messageText);
 

--- a/e2e/cypress/tests/integration/archived_channel/archive_channel_operations_spec.js
+++ b/e2e/cypress/tests/integration/archived_channel/archive_channel_operations_spec.js
@@ -84,18 +84,18 @@ describe('Leave an archived channel', () => {
 
         createArchivedChannel({prefix: 'unarchive-'}, [messageText]).then(({name}) => {
             // # View the archived channel, noting that it is read-only
-            cy.get('#post_textbox').should('not.exist');
+            cy.uiGetPostTextBox({exist: false});
 
             // # Unarchive the channel:
-            cy.uiUnarchiveChannel();
+            cy.uiUnarchiveChannel().then(() => {
+                // * Channel is no longer read-only
+                cy.uiGetPostTextBox();
 
-            // * Channel is no longer read-only
-            cy.get('#post_textbox').should('be.visible');
+                // * Channel is displayed in LHS with the normal icon, not an archived channel icon
+                cy.get(`#sidebarItem_${name}`).scrollIntoView().should('be.visible');
 
-            // * Channel is displayed in LHS with the normal icon, not an archived channel icon
-            cy.get(`#sidebarItem_${name}`).scrollIntoView().should('be.visible');
-
-            cy.get(`#sidebarItem_${name}`).find('.icon-globe').should('be.visible');
+                cy.get(`#sidebarItem_${name}`).find('.icon-globe').should('be.visible');
+            });
         });
     });
 
@@ -114,12 +114,12 @@ describe('Leave an archived channel', () => {
 
         createArchivedChannel(channelOptions, [messageText]).then(({name}) => {
             // # View the archived channel, noting that it is read-only
-            cy.get('#post_textbox').should('not.exist');
+            cy.uiGetPostTextBox({exist: false});
 
             // # Unarchive the channel:
             cy.uiUnarchiveChannel().then(() => {
                 // * Channel is no longer read-only
-                cy.get('#post_textbox').should('be.visible');
+                cy.uiGetPostTextBox();
 
                 // * Channel is displayed in LHS with the normal icon, not an archived channel icon
                 cy.get(`#sidebarItem_${name}`).find('.icon-lock-outline').should('be.visible');

--- a/e2e/cypress/tests/integration/archived_channel/archive_channel_post_spec.js
+++ b/e2e/cypress/tests/integration/archived_channel/archive_channel_post_spec.js
@@ -42,9 +42,6 @@ describe('Archived channels', () => {
     });
 
     it('MM-T1716 Text box in center channel and in RHS should not be visible', () => {
-        // * Post text box should be visible
-        cy.get('#post_textbox').should('be.visible');
-
         // # Post a message in the channel
         cy.postMessage('Test archive reply');
         cy.getLastPostId().then((id) => {
@@ -60,7 +57,7 @@ describe('Archived channels', () => {
             cy.uiArchiveChannel();
 
             // * Post text box should not be visible
-            cy.get('#post_textbox').should('not.exist');
+            cy.uiGetPostTextBox({exist: false});
 
             // * RHS should not be visible
             cy.get('#rhsContainer').should('not.exist');

--- a/e2e/cypress/tests/integration/archived_channel/archive_channel_post_spec.js
+++ b/e2e/cypress/tests/integration/archived_channel/archive_channel_post_spec.js
@@ -51,7 +51,7 @@ describe('Archived channels', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // * RHS text box should be visible
-            cy.get('#reply_textbox').should('be.visible');
+            cy.uiGetReplyTextBox();
 
             // # Archive the channel
             cy.uiArchiveChannel();
@@ -68,7 +68,7 @@ describe('Archived channels', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // * RHS text box should not be visible
-            cy.get('#reply_textbox').should('not.exist');
+            cy.uiGetReplyTextBox({exist: false});
         });
     });
 
@@ -126,7 +126,7 @@ describe('Archived channels', () => {
                 cy.clickPostCommentIcon(rhsPostId, 'SEARCH');
 
                 // * RHS text box should not be visible
-                cy.get('#reply_textbox').should('not.exist');
+                cy.uiGetReplyTextBox({exist: false});
             });
     });
 });

--- a/e2e/cypress/tests/integration/archived_channel/archive_channel_reaction_spec.js
+++ b/e2e/cypress/tests/integration/archived_channel/archive_channel_reaction_spec.js
@@ -29,9 +29,6 @@ describe('Archived channels', () => {
     it('MM-T1718 Reaction icon should not be visible for archived channel posts', () => {
         const messageText = 'Test archive reaction';
 
-        // * Post text box should be visible
-        cy.get('#post_textbox').should('be.visible');
-
         // # Post a message in the channel
         cy.postMessage(messageText);
 

--- a/e2e/cypress/tests/integration/autocomplete/common_test.js
+++ b/e2e/cypress/tests/integration/autocomplete/common_test.js
@@ -7,8 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-import * as TIMEOUTS from '../../fixtures/timeouts';
-
 import {
     getPostTextboxInput,
     getQuickChannelSwitcherInput,
@@ -44,9 +42,8 @@ export function doTestUserChannelSection(prefix, testTeam, testUsers) {
     });
 
     // # Start an at mention that should return 2 users (in this case, the users share a last name)
-    cy.wait(TIMEOUTS.HALF_SEC).get('#post_textbox').
+    cy.uiGetPostTextBox().
         as('input').
-        should('be.visible').
         clear().
         type(`@${prefix}odinson`);
 

--- a/e2e/cypress/tests/integration/autocomplete/helpers.js
+++ b/e2e/cypress/tests/integration/autocomplete/helpers.js
@@ -165,9 +165,8 @@ function getTestUsers(prefix = '') {
 
 function getPostTextboxInput() {
     cy.wait(TIMEOUTS.HALF_SEC);
-    cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).
+    cy.uiGetPostTextBox().
         as('input').
-        should('be.visible').
         clear();
 }
 
@@ -194,9 +193,8 @@ function searchAndVerifyChannel(channel, shouldExist = true) {
 
 function searchAndVerifyUser(user) {
     // # Start @ mentions autocomplete with username
-    cy.get('#post_textbox').
+    cy.uiGetPostTextBox().
         as('input').
-        should('be.visible').
         clear().
         type(`@${user.username}`);
 

--- a/e2e/cypress/tests/integration/benchmark/message_spec.js
+++ b/e2e/cypress/tests/integration/benchmark/message_spec.js
@@ -51,7 +51,7 @@ describe('Message', () => {
             win.resetTrackedSelectors();
 
             // # Push a character key such as "A"
-            cy.get('#post_textbox').type('A').then(() => {
+            cy.uiGetPostTextBox().type('A').then(() => {
                 reportBenchmarkResults(cy, win);
             });
         });

--- a/e2e/cypress/tests/integration/channel/channel_mention_autocomplete_spec.js
+++ b/e2e/cypress/tests/integration/channel/channel_mention_autocomplete_spec.js
@@ -41,7 +41,7 @@ describe('Channel', () => {
 
     it('Channel autocomplete should have both lists populated correctly', () => {
         // # Type "~"
-        cy.get('#post_textbox').should('be.visible').clear().type('~').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type('~').wait(TIMEOUTS.HALF_SEC);
         cy.get('#loadingSpinner').should('not.exist');
 
         // * Should open up suggestion list for channels
@@ -61,13 +61,13 @@ describe('Channel', () => {
 
     it('Joining a channel should alter channel mention autocomplete lists accordingly', () => {
         // # Join a channel by /join slash command
-        cy.get('#post_textbox').should('be.visible').clear().wait(TIMEOUTS.HALF_SEC).type(`/join ~${otherChannel.name}`).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().wait(TIMEOUTS.HALF_SEC).type(`/join ~${otherChannel.name}`).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // * Verify that it redirects into the channel
         cy.url().should('include', `/${testTeam.name}/channels/${otherChannel.name}`);
 
         // # Type "~"
-        cy.get('#post_textbox').should('be.visible').type('~').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type('~').wait(TIMEOUTS.HALF_SEC);
         cy.get('#loadingSpinner').should('not.exist');
 
         // * Should open up suggestion list for channels
@@ -93,7 +93,7 @@ describe('Channel', () => {
             cy.visit(offTopicUrl);
 
             // # Type "~"
-            cy.get('#post_textbox').should('be.visible').clear().type('~').wait(TIMEOUTS.HALF_SEC);
+            cy.uiGetPostTextBox().clear().type('~').wait(TIMEOUTS.HALF_SEC);
             cy.get('#loadingSpinner').should('not.exist');
 
             // * Should open up suggestion list for channels

--- a/e2e/cypress/tests/integration/channel/leave_channel_spec.js
+++ b/e2e/cypress/tests/integration/channel/leave_channel_spec.js
@@ -42,9 +42,6 @@ describe('Leave channel', () => {
     });
 
     it('MM-T4429_1 Leave a channel while RHS is open', () => {
-        // * Post text box should be visible
-        cy.get('#post_textbox').should('be.visible');
-
         // # Post a message in the channel
         cy.postMessage('Test leave channel while RHS open');
         cy.getLastPostId().then((id) => {
@@ -75,8 +72,7 @@ describe('Leave channel', () => {
 
     it('MM-T4429_2 Leave a channel while RHS is open and CRT on', () => {
         // * Post text box should be visible
-        cy.get('#post_textbox').should('be.visible');
-        cy.pause();
+        cy.uiGetPostTextBox();
 
         // # Set CRT to on
         cy.uiChangeCRTDisplaySetting('ON');

--- a/e2e/cypress/tests/integration/channel/leave_channel_spec.js
+++ b/e2e/cypress/tests/integration/channel/leave_channel_spec.js
@@ -55,7 +55,7 @@ describe('Leave channel', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // * RHS text box should be visible
-            cy.get('#reply_textbox').should('be.visible');
+            cy.uiGetReplyTextBox();
 
             // # Archive the channel
             cy.uiLeaveChannel();
@@ -90,7 +90,7 @@ describe('Leave channel', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // * RHS text box should be visible
-            cy.get('#reply_textbox').should('be.visible');
+            cy.uiGetReplyTextBox();
 
             // * Close tour tip
             cy.get('#tipNextButton').should('be.visible').click();

--- a/e2e/cypress/tests/integration/channel/more_channels_spec.js
+++ b/e2e/cypress/tests/integration/channel/more_channels_spec.js
@@ -131,7 +131,7 @@ describe('Channels', () => {
 
         // * Assert that channel is archived and new messages can't be posted.
         cy.get('#channelArchivedMessage').should('contain', 'You are viewing an archived channel. New messages cannot be posted.');
-        cy.get('#post_textbox').should('not.exist');
+        cy.uiGetPostTextBox({exist: false});
 
         // # Switch to another channel
         cy.get('#sidebarItem_town-square').click();

--- a/e2e/cypress/tests/integration/channel_sidebar/category_collapsing_spec.js
+++ b/e2e/cypress/tests/integration/channel_sidebar/category_collapsing_spec.js
@@ -72,7 +72,7 @@ describe('Channel sidebar', () => {
 
             // Force a reload to ensure the unread message displays
             cy.reload();
-            cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+            cy.uiGetPostTextBox();
 
             // # Check that the CHANNELS group header is visible
             cy.get('.SidebarChannelGroupHeader:contains(CHANNELS)').should('be.visible').as('channelsGroup');
@@ -114,7 +114,7 @@ describe('Channel sidebar', () => {
 
         // # Reload the page and wait
         cy.reload();
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+        cy.uiGetPostTextBox();
 
         // * Verify that the category still appears collapsed after refresh
         cy.get('.SidebarChannelGroupHeader:contains(CHANNELS) i').should('have.class', 'icon-rotate-minus-90');
@@ -131,7 +131,7 @@ describe('Channel sidebar', () => {
 
         // # Reload the page and wait
         cy.reload();
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+        cy.uiGetPostTextBox();
 
         // * Verify that the category still appears not collapsed after refresh
         cy.get('.SidebarChannelGroupHeader:contains(CHANNELS) i').should('not.have.class', 'icon-rotate-minus-90');

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/files_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/files_spec.js
@@ -93,7 +93,7 @@ describe('Collapsed Reply Threads', () => {
         cy.get('#advancedTextEditorCell').find('#fileUploadInput').attachFile(image);
         waitUntilUploadComplete();
         cy.get('.post-image__thumbnail').should('be.visible');
-        cy.get('#post_textbox').clear().type('{enter}');
+        cy.uiGetPostTextBox().clear().type('{enter}');
 
         cy.getLastPostId().then((rootId) => {
             // # Post a reply to create a thread and follow
@@ -119,7 +119,7 @@ describe('Collapsed Reply Threads', () => {
             cy.get('#advancedTextEditorCell').find('#fileUploadInput').attachFile(file.filename);
             waitUntilUploadComplete();
             cy.get('.post-image__thumbnail').should('be.visible');
-            cy.get('#post_textbox').clear().type('{enter}');
+            cy.uiGetPostTextBox().clear().type('{enter}');
 
             cy.getLastPostId().then((rootId) => {
                 // # Post a reply to create a thread and follow

--- a/e2e/cypress/tests/integration/custom_status/custom_status_5_spec.js
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_5_spec.js
@@ -147,12 +147,12 @@ describe('Custom Status - Verifying Where Custom Status Appears', () => {
 
     it('MM-T3850_11 should show custom status emoji at autocomplete', () => {
         // # type: /message @[username]
-        cy.get('#post_textbox').should('be.visible').type(`/message @${currentUser.username}`);
+        cy.uiGetPostTextBox().type(`/message @${currentUser.username}`);
 
         // * Autocomplete shows the user along with the custom status emoji
         cy.get('#suggestionList').find('.suggestion-list__item').eq(0).contains(`@${currentUser.username}`).get('span.emoticon').should('exist').invoke('attr', 'data-emoticon').should('contain', customStatus.emoji);
 
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
     });
 
     it('MM-T3850_12 should show custom status emoji at channel switcher', () => {

--- a/e2e/cypress/tests/integration/emoji/custom_emoji_1_1_spec.js
+++ b/e2e/cypress/tests/integration/emoji/custom_emoji_1_1_spec.js
@@ -81,7 +81,7 @@ describe('Custom emojis', () => {
         cy.findAllByTestId('emojiItem').children('img').first().should('have.class', 'emoji-category--custom');
 
         // # Post a message with the emoji
-        cy.get('#post_textbox').clear().type(customEmojiWithColons.substring(0, 10));
+        cy.uiGetPostTextBox().clear().type(customEmojiWithColons.substring(0, 10));
 
         // * Suggestion list should appear
         cy.get('#suggestionList').should('be.visible');
@@ -90,7 +90,7 @@ describe('Custom emojis', () => {
         cy.findByText(customEmojiWithColons).should('be.visible');
 
         // # Hit enter to select from suggestion list and enter to post
-        cy.get('#post_textbox').type('{enter}').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}').type('{enter}');
 
         // * Check that the emoji image appears in the message - extract the image url and compare with local image
         verifyLastPostedEmoji(customEmojiWithColons, largeEmojiFileResized);

--- a/e2e/cypress/tests/integration/emoji/custom_emoji_3_spec.js
+++ b/e2e/cypress/tests/integration/emoji/custom_emoji_3_spec.js
@@ -80,7 +80,7 @@ describe('Custom emojis', () => {
         cy.postMessage(messageText);
 
         // # Post the built-in emoji
-        cy.get('#post_textbox').type('+' + builtinEmojiWithColons).wait(TIMEOUTS.HALF_SEC).type('{enter}').type('{enter}');
+        cy.uiGetPostTextBox().type('+' + builtinEmojiWithColons).wait(TIMEOUTS.HALF_SEC).type('{enter}').type('{enter}');
 
         cy.getLastPostId().then((postId) => {
             const postText = `#postMessageText_${postId}`;

--- a/e2e/cypress/tests/integration/emoji/recently_used_emoji_1_spec.js
+++ b/e2e/cypress/tests/integration/emoji/recently_used_emoji_1_spec.js
@@ -53,7 +53,7 @@ describe('Recent Emoji', () => {
 
         // # Submit post
         const message = 'hi';
-        cy.get('#post_textbox').should('be.visible').and('have.value', `:${firstEmoji}: `).type(`${message} {enter}`);
+        cy.uiGetPostTextBox().and('have.value', `:${firstEmoji}: `).type(`${message} {enter}`);
         cy.uiWaitUntilMessagePostedIncludes(message);
 
         // # Post reaction to post
@@ -101,8 +101,8 @@ describe('Recent Emoji', () => {
 
         // # Post a custom emoji
         // We let autocomplete emoji to be shown as this is a custom emoji, properties are loaded then we press enter twice, first one to auto complete add, next for post enter
-        cy.get('#post_textbox').clear().type(`${MESSAGES.TINY}-recent ${customEmojiWithColons.slice(0, -1)}`).wait(TIMEOUTS.TWO_SEC);
-        cy.get('#post_textbox').type('{enter} {enter}').wait(TIMEOUTS.TWO_SEC);
+        cy.uiGetPostTextBox().clear().type(`${MESSAGES.TINY}-recent ${customEmojiWithColons.slice(0, -1)}`).wait(TIMEOUTS.TWO_SEC);
+        cy.uiGetPostTextBox().type('{enter} {enter}').wait(TIMEOUTS.TWO_SEC);
 
         // # Hover over the last post by opening dot menu on it
         cy.clickPostDotMenu();

--- a/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_input_fields_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_input_fields_spec.js
@@ -115,10 +115,10 @@ describe('Verify Accessibility Support in different input fields', () => {
             cy.apiAddUserToTeam(testTeam.id, user.id).then(() => {
                 cy.apiAddUserToChannel(testChannel.id, user.id).then(() => {
                     // * Verify Accessibility support in post input field
-                    cy.get('#post_textbox').should('have.attr', 'aria-label', `write to ${testChannel.display_name}`).clear().focus();
+                    cy.uiGetPostTextBox().should('have.attr', 'aria-label', `write to ${testChannel.display_name}`).clear().focus();
 
                     // # Ensure User list is cached once in UI
-                    cy.get('#post_textbox').type('@').wait(TIMEOUTS.FIVE_SEC);
+                    cy.uiGetPostTextBox().type('@').wait(TIMEOUTS.FIVE_SEC);
 
                     // # Select the first user in the list
                     cy.get('#suggestionList').find('.suggestion-list__item').eq(0).within((el) => {
@@ -128,7 +128,7 @@ describe('Verify Accessibility Support in different input fields', () => {
                     });
 
                     // # Trigger the user autocomplete again
-                    cy.get('#post_textbox').clear().type('@').wait(TIMEOUTS.FIVE_SEC).type('{uparrow}{uparrow}{downarrow}');
+                    cy.uiGetPostTextBox().clear().type('@').wait(TIMEOUTS.FIVE_SEC).type('{uparrow}{uparrow}{downarrow}');
 
                     // * Verify Accessibility Support in message autocomplete
                     verifyMessageAutocomplete(1);
@@ -140,10 +140,10 @@ describe('Verify Accessibility Support in different input fields', () => {
                     verifyMessageAutocomplete(0);
 
                     // # Trigger the channel autocomplete filter and ensure channel list is cached once
-                    cy.get('#post_textbox').clear().type('~').wait(TIMEOUTS.FIVE_SEC);
+                    cy.uiGetPostTextBox().clear().type('~').wait(TIMEOUTS.FIVE_SEC);
 
                     // # Trigger the channel autocomplete again
-                    cy.get('#post_textbox').clear().type('~').wait(TIMEOUTS.FIVE_SEC).type('{downarrow}{downarrow}');
+                    cy.uiGetPostTextBox().clear().type('~').wait(TIMEOUTS.FIVE_SEC).type('{downarrow}{downarrow}');
 
                     // * Verify Accessibility Support in message autocomplete
                     verifyMessageAutocomplete(2, 'channel');
@@ -161,7 +161,7 @@ describe('Verify Accessibility Support in different input fields', () => {
     it('MM-T1458 Verify Accessibility Support in Main Post Input', () => {
         cy.get('#advancedTextEditorCell').within(() => {
             // * Verify Accessibility Support in Main Post input
-            cy.get('#post_textbox').should('have.attr', 'aria-label', `write to ${testChannel.display_name}`).and('have.attr', 'role', 'textbox').clear().focus().type('test').tab({shift: true}).tab().tab();
+            cy.uiGetPostTextBox().should('have.attr', 'aria-label', `write to ${testChannel.display_name}`).and('have.attr', 'role', 'textbox').clear().focus().type('test').tab({shift: true}).tab().tab();
 
             // * Verify if the focus is on the preview button
             cy.get('#PreviewInputTextButton').should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'preview').tab();
@@ -209,7 +209,7 @@ describe('Verify Accessibility Support in different input fields', () => {
 
     it('MM-T1490 Verify Accessibility Support in RHS Input', () => {
         // # Wait till page is loaded
-        cy.get('#post_textbox').should('be.visible').clear();
+        cy.uiGetPostTextBox().clear();
 
         // # Post a message and open RHS
         const message = `hello${Date.now()}`;

--- a/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_input_fields_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_input_fields_spec.js
@@ -221,7 +221,7 @@ describe('Verify Accessibility Support in different input fields', () => {
 
         cy.get('#rhsContainer').within(() => {
             // * Verify Accessibility Support in RHS input
-            cy.get('#reply_textbox').should('have.attr', 'aria-label', 'reply to this thread...').and('have.attr', 'role', 'textbox').focus().type('test').tab({shift: true}).tab().tab();
+            cy.uiGetReplyTextBox().should('have.attr', 'aria-label', 'reply to this thread...').and('have.attr', 'role', 'textbox').focus().type('test').tab({shift: true}).tab().tab();
 
             // * Verify if the focus is on the preview button
             cy.get('#PreviewInputTextButton').should('have.class', 'a11y--active a11y--focused').and('have.attr', 'aria-label', 'preview').tab();

--- a/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_modals_dialogs_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_modals_dialogs_spec.js
@@ -206,7 +206,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
 
         // * Verify accessibility support in Invite People Dialog
         cy.get('.InvitationModal').should('have.attr', 'aria-modal', 'true').and('have.attr', 'aria-labelledby', 'invitation_modal_title').and('have.attr', 'role', 'dialog');
-        cy.get('#invitation_modal_title').should('be.visible').and('contain.text', 'Invite members to');
+        cy.get('#invitation_modal_title').should('be.visible').and('contain.text', 'Invite people to');
 
         // # Press tab
         cy.get('button.icon-close').focus().tab({shift: true}).tab();

--- a/e2e/cypress/tests/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
+++ b/e2e/cypress/tests/integration/enterprise/elasticsearch_autocomplete/helpers/index.js
@@ -233,9 +233,8 @@ module.exports = {
     },
     searchAndVerifyUser: (user) => {
         // # Start @ mentions autocomplete with username
-        cy.get('#post_textbox').
+        cy.uiGetPostTextBox().
             as('input').
-            should('be.visible').
             clear().
             type(`@${user.username}`);
 

--- a/e2e/cypress/tests/integration/enterprise/group_mentions/group_mentions_permissions_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/group_mentions/group_mentions_permissions_spec.js
@@ -126,7 +126,7 @@ describe('Group Mentions', () => {
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
 
             // # Type the Group Name
-            cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+            cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
             // * Verify if autocomplete dropdown is not displayed
             cy.get('#suggestionList').should('not.exist');
@@ -157,7 +157,7 @@ describe('Group Mentions', () => {
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
 
             // # Type the Group Name
-            cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+            cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
             // * Verify if autocomplete dropdown is displayed
             cy.get('#suggestionList').should('be.visible').children().within((el) => {
@@ -203,7 +203,7 @@ describe('Group Mentions', () => {
                 cy.visit(`/${team.name}/channels/${channel.name}`);
 
                 // # Type the Group Name
-                cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+                cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
                 // * Verify if autocomplete dropdown is not displayed
                 cy.get('#suggestionList').should('not.exist');
@@ -234,7 +234,7 @@ describe('Group Mentions', () => {
                 cy.visit(`/${team.name}/channels/${channel.name}`);
 
                 // # Type the Group Name
-                cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+                cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
                 // * Verify if autocomplete dropdown is displayed
                 cy.get('#suggestionList').should('be.visible').children().within((el) => {
@@ -290,7 +290,7 @@ describe('Group Mentions', () => {
                 cy.visit(`/${testTeam.name}/channels/${channel.name}`);
 
                 // # Type the Group Name
-                cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+                cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
                 // * Verify if autocomplete dropdown is not displayed
                 cy.get('#suggestionList').should('not.exist');
@@ -321,7 +321,7 @@ describe('Group Mentions', () => {
                 cy.visit(`/${testTeam.name}/channels/${channel.name}`);
 
                 // # Type the Group Name
-                cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+                cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
                 // * Verify if autocomplete dropdown is displayed
                 cy.get('#suggestionList').should('be.visible').children().within((el) => {

--- a/e2e/cypress/tests/integration/enterprise/group_mentions/group_mentions_posts_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/group_mentions/group_mentions_posts_spec.js
@@ -140,10 +140,10 @@ describe('Group Mentions', () => {
         cy.apiCreateChannel(testTeam.id, 'group-mention', 'Group Mentions').then(({channel}) => {
             // # Visit the channel
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
-            cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+            cy.uiGetPostTextBox();
 
             // # Type the Group Name to check if Autocomplete dropdown is not displayed
-            cy.get('#post_textbox').should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+            cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
             // * Verify if autocomplete dropdown is not displayed
             cy.get('#suggestionList').should('not.exist');
@@ -171,7 +171,7 @@ describe('Group Mentions', () => {
         // # Login as a regular user
         cy.apiLogin(regularUser);
         cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+        cy.uiGetPostTextBox();
 
         // # Trigger DM with a user
         cy.uiAddDirectMessage().click();
@@ -179,7 +179,7 @@ describe('Group Mentions', () => {
         cy.uiGetButton('Go').click();
 
         // # Type the Group Name to check if Autocomplete dropdown is displayed
-        cy.get('#post_textbox').should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+        cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
         // * Verify if autocomplete dropdown is displayed
         cy.get('#suggestionList').should('be.visible').children().within((el) => {
@@ -212,7 +212,7 @@ describe('Group Mentions', () => {
         // # Login as a regular user
         cy.apiLogin(regularUser);
         cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+        cy.uiGetPostTextBox();
 
         // # Trigger DM with couple of users
         cy.uiAddDirectMessage().click();
@@ -220,7 +220,7 @@ describe('Group Mentions', () => {
         cy.uiGetButton('Go').click();
 
         // # Type the Group Name to check if Autocomplete dropdown is displayed
-        cy.get('#post_textbox').should('be.visible').clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
+        cy.uiGetPostTextBox().clear().type(`@${groupName}`).wait(TIMEOUTS.TWO_SEC);
 
         // * Verify if autocomplete dropdown is displayed
         cy.get('#suggestionList').should('be.visible').children().within((el) => {
@@ -273,7 +273,7 @@ describe('Group Mentions', () => {
 
                     // # Visit the channel
                     cy.visit(`/${testTeam.name}/channels/${channel.name}`);
-                    cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+                    cy.uiGetPostTextBox();
 
                     cy.postMessage(`@${groupName2} `);
 

--- a/e2e/cypress/tests/integration/enterprise/group_mentions/group_mentions_system_messages_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/group_mentions/group_mentions_system_messages_spec.js
@@ -106,7 +106,7 @@ describe('Group Mentions', () => {
         cy.apiCreateChannel(testTeam.id, 'group-mention', 'Group Mentions').then(({channel}) => {
             // # Visit the channel
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
-            cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+            cy.uiGetPostTextBox();
 
             // # Submit a post containing the group mention
             cy.postMessage(`@${groupName} `);
@@ -142,7 +142,7 @@ describe('Group Mentions', () => {
 
                     // # Visit the channel
                     cy.visit(`/${team.name}/channels/${channel.name}`);
-                    cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+                    cy.uiGetPostTextBox();
 
                     // # Submit a post containing the group mention
                     cy.postMessage(`@${groupName} `);
@@ -189,7 +189,7 @@ describe('Group Mentions', () => {
 
                 // # Visit the channel
                 cy.visit(`/${testTeam.name}/channels/${channel.name}`);
-                cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+                cy.uiGetPostTextBox();
 
                 // # Submit a post containing the group mention
                 cy.postMessage(`@${groupName} `);
@@ -228,7 +228,7 @@ describe('Group Mentions', () => {
 
             // # Visit the channel
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
-            cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+            cy.uiGetPostTextBox();
 
             // # Submit a post containing the group mention
             cy.postMessage(`@${groupName} `);

--- a/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -213,7 +213,7 @@ describe('Guest Account - Guest User Experience', () => {
         });
 
         // # Wait for page to load and then logout
-        cy.get('#post_textbox').should('be.visible').wait(TIMEOUTS.TWO_SEC);
+        cy.uiGetPostTextBox().wait(TIMEOUTS.TWO_SEC);
         cy.apiLogout();
         cy.visit('/');
 

--- a/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
@@ -192,7 +192,7 @@ describe('Verify Guest User Identification in different screens', () => {
 
     it('Verify Guest Badge in @mentions Autocomplete', () => {
         // # Start a draft in Channel containing "@user"
-        cy.get('#post_textbox').type(`@${guest.username}`);
+        cy.uiGetPostTextBox().type(`@${guest.username}`);
 
         // * Verify Guest Badge is displayed at mention auto-complete
         cy.get('#suggestionList').should('be.visible');

--- a/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_invitation_ui_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_invitation_ui_spec.js
@@ -119,7 +119,7 @@ describe('Guest Account - Guest User Invitation Flow', () => {
         cy.uiOpenTeamMenu('Invite People');
 
         // * Verify if Invite Members modal is displayed when guest account feature is disabled
-        cy.findByTestId('invitationModal').find('h1').should('have.text', `Invite members to ${testTeam.display_name}`);
+        cy.findByTestId('invitationModal').find('h1').should('have.text', `Invite people to ${testTeam.display_name}`);
 
         // * Verify Share Link Header and helper text
         cy.findByTestId('InviteView__copyInviteLink').should('be.visible').within(() => {

--- a/e2e/cypress/tests/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -56,7 +56,7 @@ describe('Guest Account - Member Invitation Flow', () => {
 
         // * Verify UI Elements in initial step
         cy.findByTestId('invitationModal').within(() => {
-            cy.get('h1').should('have.text', `Invite members to ${testTeam.display_name}`);
+            cy.get('h1').should('have.text', `Invite people to ${testTeam.display_name}`);
         });
 
         stubClipboard().as('clipboard');

--- a/e2e/cypress/tests/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -88,7 +88,7 @@ describe('Guest Account - Member Invitation Flow', () => {
 
     it('MM-T1324 Invite Members - Team Link - New User', () => {
         // # Wait for page to load and then logout. Else invite members link will be redirected to login page
-        cy.get('#post_textbox').should('be.visible').wait(TIMEOUTS.TWO_SEC);
+        cy.uiGetPostTextBox().wait(TIMEOUTS.TWO_SEC);
         const inviteMembersLink = `/signup_user_complete/?id=${testTeam.invite_id}`;
         cy.apiLogout();
 
@@ -124,7 +124,7 @@ describe('Guest Account - Member Invitation Flow', () => {
         cy.apiCreateTeam('team', 'Team').then(({team}) => {
             // # Visit the team and wait for page to load and then logout.
             cy.visit(`/${team.name}/channels/town-square`);
-            cy.get('#post_textbox').should('be.visible').wait(TIMEOUTS.TWO_SEC);
+            cy.uiGetPostTextBox().wait(TIMEOUTS.TWO_SEC);
             const inviteMembersLink = `/signup_user_complete/?id=${team.invite_id}`;
             cy.apiLogout();
 

--- a/e2e/cypress/tests/integration/enterprise/ldap_group/group_mentions_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/ldap_group/group_mentions_spec.js
@@ -40,13 +40,13 @@ const assertGroupMentionDisabled = (groupName) => {
     cy.visit(`/${testTeam.name}/channels/off-topic`);
 
     // # Type suggestion in channel post text box
-    cy.get('#post_textbox').should('be.visible').clear().type(`@${suggestion}`).wait(TIMEOUTS.HALF_SEC);
+    cy.uiGetPostTextBox().clear().type(`@${suggestion}`).wait(TIMEOUTS.HALF_SEC);
 
     // * Should not open up suggestion list for groups
     cy.get('#suggestionList').should('not.exist');
 
     // # Type @groupName and post it to the channel
-    cy.get('#post_textbox').clear().type(`@${groupName}{enter}{enter}`);
+    cy.uiGetPostTextBox().clear().type(`@${groupName}{enter}{enter}`);
 
     // # Get last post message text
     cy.getLastPostId().then((postId) => {
@@ -80,7 +80,7 @@ const assertGroupMentionEnabled = (groupName) => {
     cy.visit(`/${testTeam.name}/channels/off-topic`);
 
     // # Type suggestion in channel post text box
-    cy.get('#post_textbox').should('be.visible').clear().type(`@${suggestion}`).wait(TIMEOUTS.HALF_SEC);
+    cy.uiGetPostTextBox().clear().type(`@${suggestion}`).wait(TIMEOUTS.HALF_SEC);
 
     // * Should open up suggestion list for groups
     // * Should match group item and group label
@@ -90,7 +90,7 @@ const assertGroupMentionEnabled = (groupName) => {
     });
 
     // # Type @groupName and post it to the channel
-    cy.get('#post_textbox').clear().type(`@${groupName}{enter}{enter}`).wait(TIMEOUTS.HALF_SEC);
+    cy.uiGetPostTextBox().clear().type(`@${groupName}{enter}{enter}`).wait(TIMEOUTS.HALF_SEC);
 
     // # Get last post message text
     cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/tests/integration/enterprise/system_console/compliance/helpers.js
+++ b/e2e/cypress/tests/integration/enterprise/system_console/compliance/helpers.js
@@ -49,7 +49,7 @@ export function verifyExportedMessagesCount(expectedNumber) {
 
 export function editLastPost(message) {
     cy.getLastPostId().then(() => {
-        cy.get('#post_textbox').clear().type('{uparrow}');
+        cy.uiGetPostTextBox().clear().type('{uparrow}');
 
         // # Edit Post Input should appear
         cy.get('#edit_textbox').should('be.visible');
@@ -63,32 +63,29 @@ export function editLastPost(message) {
 }
 
 export function gotoTeamAndPostImage() {
-    cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-
-    // # Remove images from post message footer if exist
-    cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
-        if (el.find('.post-image.normal').length > 0) {
-            cy.get('.file-preview__remove > .icon').click();
+    cy.uiGetPostTextBox().then((createPostEl) => {
+        if (createPostEl.find('.file-preview__container').length === 1) {
+            // # Remove images from post message footer if exist
+            cy.waitUntil(() => cy.uiGetFileUploadPreview().then((filePreviewEl) => {
+                if (filePreviewEl.find('.post-image.normal').length > 0) {
+                    cy.get('.file-preview__remove > .icon').click();
+                }
+                return filePreviewEl.find('.post-image.normal').length === 0;
+            }));
         }
-        return el.find('.post-image.normal').length === 0;
-    }));
-    const file = {
-        filename: 'image-400x400.jpg',
-        originalSize: {width: 400, height: 400},
-        thumbnailSize: {width: 400, height: 400},
-    };
-    cy.get('#fileUploadInput').attachFile(file.filename);
 
-    // # Wait until the image is uploaded
-    cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
-        return el.find('.post-image.normal').length > 0;
-    }), {
-        timeout: TIMEOUTS.FIVE_MIN,
-        interval: TIMEOUTS.ONE_SEC,
-        errorMsg: 'Unable to upload attachment in time',
+        const file = {
+            filename: 'image-400x400.jpg',
+            originalSize: {width: 400, height: 400},
+            thumbnailSize: {width: 400, height: 400},
+        };
+        cy.get('#fileUploadInput').attachFile(file.filename);
+
+        // # Wait until the image is uploaded
+        cy.uiWaitForFileUploadPreview();
+
+        cy.postMessage(`file uploaded-${file.filename}`);
     });
-
-    cy.postMessage(`file uploaded-${file.filename}`);
 }
 
 export function gotoGlobalPolicy() {

--- a/e2e/cypress/tests/integration/enterprise/system_console/system_scheme_permission_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/system_console/system_scheme_permission_spec.js
@@ -10,7 +10,6 @@
 // Stage: @prod
 // Group: @enterprise @system_console
 
-import * as TIMEOUTS from '../../../fixtures/timeouts';
 import {getAdminAccount} from '../../../support/env';
 
 describe('System Scheme Channel Mentions Permissions Test', () => {
@@ -118,11 +117,11 @@ const channelMentionsPermissionCheck = (enabled) => {
 const createPostPermissionCheck = (enabled) => {
     if (enabled) {
         // # Try post it to the channel
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('not.be.disabled');
+        cy.uiGetPostTextBox().and('not.be.disabled');
         cy.postMessage('test');
     } else {
         // # Ensure the input is disabled
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('be.disabled');
+        cy.uiGetPostTextBox().and('be.disabled');
     }
 
     // # Get last post message text

--- a/e2e/cypress/tests/integration/enterprise/system_console/team_scheme_permission_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/system_console/team_scheme_permission_spec.js
@@ -154,11 +154,11 @@ const channelMentionsPermissionCheck = (enabled) => {
 const createPostPermissionCheck = (enabled) => {
     if (enabled) {
         // # Try post it to the channel
-        cy.get('#post_textbox').should('not.be.disabled');
+        cy.uiGetPostTextBox().should('not.be.disabled');
         cy.postMessage('test');
     } else {
         // # Ensure the input is disabled
-        cy.get('#post_textbox').should('be.disabled');
+        cy.uiGetPostTextBox().should('be.disabled');
     }
 
     // # Get last post message text

--- a/e2e/cypress/tests/integration/files_and_attachments/cancel_file_upload_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/cancel_file_upload_spec.js
@@ -49,7 +49,7 @@ describe('Upload Files', () => {
         // # Post a different file in center channel
         const filename = 'long_text_post.txt';
         cy.get('#advancedTextEditorCell').find('#fileUploadInput').attachFile(filename);
-        cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+        cy.uiGetPostTextBox().clear().type('{enter}');
 
         // * Verify the file is successfully posted as last post
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/tests/integration/files_and_attachments/channel_files_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/channel_files_spec.js
@@ -64,7 +64,7 @@ function attachFile(file) {
         attachFile(file);
     waitUntilUploadComplete();
     cy.get('.post-image__thumbnail').should('be.visible');
-    cy.get('#post_textbox').clear().type('{enter}');
+    cy.uiGetPostTextBox().clear().type('{enter}');
 }
 
 function filterSearchBy(option, returnedFiles) {

--- a/e2e/cypress/tests/integration/files_and_attachments/disabled_file_upload_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/disabled_file_upload_spec.js
@@ -39,11 +39,13 @@ describe('Upload Files - Settings', () => {
     });
 
     it('MM-T1147_1 Disallow file sharing in the channel', () => {
-        // * Attachment input should not exist in the DOM
-        cy.get('#advancedTextEditorCell').find('#fileUploadInput').should('not.exist');
+        cy.get('.post-create__container .AdvancedTextEditor').should('be.visible').within(() => {
+            // * Attachment input should not exist in the DOM
+            cy.get('#fileUploadInput').should('not.exist');
 
-        // * Paper clip icon should not be visible in the center channel
-        cy.get('#advancedTextEditorCell').find('#fileUploadButton').should('not.exist');
+            // * Paper clip icon should not be visible in the center channel
+            cy.get('#fileUploadButton').should('not.exist');
+        });
 
         // * Channel header file icon should not be visible
         cy.get('#channel-header').find('#channelHeaderFilesButton').should('not.exist');
@@ -54,11 +56,13 @@ describe('Upload Files - Settings', () => {
         // # Open RHS
         cy.getLastPost().click();
 
-        // * Attachment input should not exist in the DOM
-        cy.get('.post-create-body.comment-create-body').find('#fileUploadInput').should('not.exist');
+        cy.get('.post-right-comments-container .AdvancedTextEditor').should('be.visible').within(() => {
+            // * Attachment input should not exist in the DOM
+            cy.get('#fileUploadInput').should('not.exist');
 
-        // * Paper clip icon should not be visible in the RHS
-        cy.get('.post-create-body.comment-create-body').find('#fileUploadButton').should('not.exist');
+            // * Paper clip icon should not be visible in the RHS
+            cy.get('#fileUploadButton').should('not.exist');
+        });
 
         // # Click on the search input
         cy.uiGetSearchBox().click();
@@ -80,17 +84,17 @@ describe('Upload Files - Settings', () => {
         const filename = 'mattermost-icon.png';
 
         // # Drag and drop file in center channel
-        cy.get('#channel_view').trigger('dragenter');
+        cy.get('.row.main').trigger('dragenter');
         cy.fixture(filename).then((img) => {
             const blob = Cypress.Blob.base64StringToBlob(img, 'image/png');
             cy.window().then((win) => {
                 const file = new win.File([blob], filename);
                 const dataTransfer = new win.DataTransfer();
                 dataTransfer.items.add(file);
-                cy.get('#channel_view').trigger('drop', {dataTransfer});
+                cy.get('.row.main').trigger('drop', {dataTransfer});
 
                 // * An error should be visible saying 'File attachments are disabled'
-                cy.get('#postCreateFooter').find('.has-error').should('contain.text', 'File attachments are disabled.');
+                cy.get('#create_post #postCreateFooter').find('.has-error').should('contain.text', 'File attachments are disabled.');
             });
         });
 
@@ -111,7 +115,7 @@ describe('Upload Files - Settings', () => {
                 cy.get('.ThreadViewer').trigger('drop', {dataTransfer});
 
                 // * An error should be visible saying 'File attachments are disabled'
-                cy.get('.ThreadViewer').find('.post-create-footer').find('.has-error').should('contain.text', 'File attachments are disabled.');
+                cy.get('.ThreadViewer #postCreateFooter').find('.has-error').should('contain.text', 'File attachments are disabled.');
             });
         });
 
@@ -125,7 +129,7 @@ describe('Upload Files - Settings', () => {
         // # Paste a file in the center channel
         cy.fixture(filename).then((img) => {
             const blob = Cypress.Blob.base64StringToBlob(img, 'image/png');
-            cy.get('#create_post').trigger('paste', {clipboardData: {
+            cy.uiGetPostTextBox().trigger('paste', {clipboardData: {
                 items: [{
                     name: filename,
                     kind: 'file',
@@ -150,7 +154,7 @@ describe('Upload Files - Settings', () => {
         // # Paste a file in the RHS
         cy.fixture(filename).then((img) => {
             const blob = Cypress.Blob.base64StringToBlob(img, 'image/png');
-            cy.get('#reply_textbox').trigger('paste', {clipboardData: {
+            cy.uiGetReplyTextBox().trigger('paste', {clipboardData: {
                 items: [{
                     name: filename,
                     kind: 'file',
@@ -163,7 +167,7 @@ describe('Upload Files - Settings', () => {
             }});
 
             // * An error should be visible saying 'File attachments are disabled'
-            cy.get('.ThreadViewer').find('.post-create-footer').find('.has-error').should('contain.text', 'File attachments are disabled.');
+            cy.get('.ThreadViewer #postCreateFooter').find('.has-error').should('contain.text', 'File attachments are disabled.');
         });
 
         // # Delete the post
@@ -172,7 +176,7 @@ describe('Upload Files - Settings', () => {
 
     it('MM-T1147_4 keyboard shortcut CMD/CTRL+U should produce an error', () => {
         // # Type CMD/CRTL+U shortcut
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{U}');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{U}');
 
         // * An error should be visible saying 'File attachments are disabled'
         cy.get('#postCreateFooter').find('.has-error').should('contain.text', 'File attachments are disabled.');

--- a/e2e/cypress/tests/integration/files_and_attachments/edit_message_with_attachment_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/edit_message_with_attachment_spec.js
@@ -49,7 +49,7 @@ describe('Edit Message with Attachment', () => {
         });
 
         // # Open the edit dialog
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
 
         // # Add some more text and save
         cy.get('#edit_textbox').type(' with some edit');

--- a/e2e/cypress/tests/integration/files_and_attachments/file_preview_audio_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/file_preview_audio_spec.js
@@ -111,7 +111,7 @@ function testAudioFile(properties) {
 
     // # Wait until file upload is complete then submit
     waitUntilUploadComplete();
-    cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+    cy.uiGetPostTextBox().clear().type('{enter}');
     cy.wait(TIMEOUTS.ONE_SEC);
 
     // # Open file preview

--- a/e2e/cypress/tests/integration/files_and_attachments/file_preview_generic_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/file_preview_generic_spec.js
@@ -94,7 +94,7 @@ function testGenericFile(properties) {
 
     // # Wait until file upload is complete then submit
     waitUntilUploadComplete();
-    cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+    cy.uiGetPostTextBox().clear().type('{enter}');
     cy.wait(TIMEOUTS.ONE_SEC);
 
     // # Open file preview

--- a/e2e/cypress/tests/integration/files_and_attachments/file_preview_image_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/file_preview_image_spec.js
@@ -117,7 +117,7 @@ function testImage(properties) {
 
     // # Wait until file upload is complete then submit
     waitUntilUploadComplete();
-    cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+    cy.uiGetPostTextBox().clear().type('{enter}');
     cy.wait(TIMEOUTS.FIVE_SEC);
 
     // # Open file preview

--- a/e2e/cypress/tests/integration/files_and_attachments/file_preview_video_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/file_preview_video_spec.js
@@ -110,7 +110,7 @@ export function testVideoFile(properties) {
 
     // # Wait until file upload is complete then submit
     waitUntilUploadComplete();
-    cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+    cy.uiGetPostTextBox().clear().type('{enter}');
     cy.wait(TIMEOUTS.ONE_SEC);
 
     // # Open file preview

--- a/e2e/cypress/tests/integration/files_and_attachments/paste_image_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/paste_image_spec.js
@@ -31,7 +31,7 @@ describe('Paste Image', () => {
         // # Paste image
         cy.fixture(filename).then((img) => {
             const blob = Cypress.Blob.base64StringToBlob(img, 'image/png');
-            cy.get('#create_post').trigger('paste', {clipboardData: {
+            cy.uiGetPostTextBox().trigger('paste', {clipboardData: {
                 items: [{
                     name: filename,
                     kind: 'file',
@@ -43,12 +43,10 @@ describe('Paste Image', () => {
                 types: [],
             }});
 
-            cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
-                return el.find('.post-image.normal').length > 0;
-            }));
+            cy.uiWaitForFileUploadPreview();
         });
 
-        cy.uiGetFileUploadPreview().within(() => {
+        cy.uiGetFileUploadPreview().should('be.visible').within(() => {
             // * Type is correct
             cy.get('.post-image__type').should('contain.text', 'PNG');
 

--- a/e2e/cypress/tests/integration/files_and_attachments/upload_files_1_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/upload_files_1_spec.js
@@ -9,8 +9,6 @@
 
 // Group: @files_and_attachments
 
-import * as TIMEOUTS from '../../fixtures/timeouts';
-
 import {
     downloadAttachmentAndVerifyItsProperties,
     interceptFileUpload,
@@ -38,7 +36,7 @@ describe('Upload Files', () => {
         const aspectRatio = 1;
 
         cy.visit(channelUrl);
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+        cy.uiGetPostTextBox();
 
         // # Attach file
         cy.get('#advancedTextEditorCell').find('#fileUploadInput').attachFile(filename);

--- a/e2e/cypress/tests/integration/files_and_attachments/upload_files_spec.js
+++ b/e2e/cypress/tests/integration/files_and_attachments/upload_files_spec.js
@@ -47,7 +47,7 @@ describe('Upload Files', () => {
         // # Post an image in center channel
         cy.get('#advancedTextEditorCell').find('#fileUploadInput').attachFile(filename);
         waitUntilUploadComplete();
-        cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+        cy.uiGetPostTextBox().clear().type('{enter}');
 
         // # Click reply arrow to open the reply thread in RHS
         cy.clickPostCommentIcon();
@@ -193,7 +193,7 @@ describe('Upload Files', () => {
         // # Post an image in center channel
         cy.get('#advancedTextEditorCell').find('#fileUploadInput').attachFile(filename);
         waitUntilUploadComplete();
-        cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+        cy.uiGetPostTextBox().clear().type('{enter}');
 
         // # Login as testUser
         cy.apiLogin(testUser);
@@ -275,7 +275,7 @@ describe('Upload Files', () => {
         });
 
         // # Now post with the message attachment
-        cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+        cy.uiGetPostTextBox().clear().type('{enter}');
 
         // * Check that the image in the post is with valid source link
         cy.uiGetFileThumbnail(imageFilename).should('have.attr', 'src').then((src) => {
@@ -314,7 +314,7 @@ describe('Upload Files', () => {
         const minimumSeparation = 5;
 
         cy.visit(channelUrl);
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+        cy.uiGetPostTextBox();
 
         // # Upload files
         Cypress._.forEach(attachmentFilesList, ({filename}) => {

--- a/e2e/cypress/tests/integration/integrations/builtin_commands/common_commands_1_spec.js
+++ b/e2e/cypress/tests/integration/integrations/builtin_commands/common_commands_1_spec.js
@@ -46,7 +46,7 @@ describe('Integrations', () => {
 
     it('MM-T573 / autocomplete list can scroll', () => {
         // # Clear post textbox
-        cy.get('#post_textbox').clear().type('/');
+        cy.uiGetPostTextBox().clear().type('/');
 
         // * Suggestion list should be visible
         // # Scroll to bottom and verify that the last command "/shrug" is visible
@@ -85,7 +85,7 @@ describe('Integrations', () => {
         const message = getRandomId();
 
         // # Type "/echo message 3"
-        cy.get('#post_textbox').clear().type(`/echo ${message} 3{enter}`);
+        cy.uiGetPostTextBox().clear().type(`/echo ${message} 3{enter}`);
 
         // * Verify that post is not shown after 1 second
         cy.wait(TIMEOUTS.ONE_SEC);

--- a/e2e/cypress/tests/integration/integrations/builtin_commands/common_commands_2_spec.js
+++ b/e2e/cypress/tests/integration/integrations/builtin_commands/common_commands_2_spec.js
@@ -34,7 +34,7 @@ describe('Integrations', () => {
 
     beforeEach(() => {
         cy.get('#sidebarItem_off-topic').click();
-        cy.get('#post_textbox').should('be.visible');
+        cy.uiGetPostTextBox();
     });
 
     it('MM-T683 /join', () => {
@@ -134,7 +134,7 @@ describe('Integrations', () => {
 
     it('MM-T2834 Slash command help stays visible for system slash command', () => {
         // # Type the rename slash command in textbox
-        cy.get('#post_textbox').clear().type('/rename ');
+        cy.uiGetPostTextBox().clear().type('/rename ');
 
         // # Scan inside of suggestion list
         cy.get('#suggestionList').should('exist').and('be.visible').within(() => {
@@ -144,13 +144,13 @@ describe('Integrations', () => {
         });
 
         // # Append Hello to /rename and hit enter
-        cy.get('#post_textbox').type('Hello{enter}').wait(TIMEOUTS.HALF_SEC);
-        cy.get('#post_textbox').invoke('text').should('be.empty');
+        cy.uiGetPostTextBox().type('Hello{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().invoke('text').should('be.empty');
     });
 
     it('MM-T686 /logout', () => {
         // # Type "/logout"
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type('/logout {enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().should('be.visible').clear().type('/logout {enter}').wait(TIMEOUTS.HALF_SEC);
 
         // * Ensure that the user was redirected to the login page
         cy.url().should('include', '/login');

--- a/e2e/cypress/tests/integration/integrations/builtin_commands/helper.js
+++ b/e2e/cypress/tests/integration/integrations/builtin_commands/helper.js
@@ -8,7 +8,7 @@ export function loginAndVisitChannel(user, channelUrl) {
     cy.visit(channelUrl);
 
     cy.get('#postListContent', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-    cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+    cy.uiGetPostTextBox();
 }
 
 export function verifyEphemeralMessage(message) {

--- a/e2e/cypress/tests/integration/integrations/builtin_commands/invalid_commands_spec.js
+++ b/e2e/cypress/tests/integration/integrations/builtin_commands/invalid_commands_spec.js
@@ -75,7 +75,7 @@ describe('Invalid slash command', () => {
         });
 
         // # Type a incorrect slash command and press enter in RHS
-        cy.get('#reply_textbox').type(`/${incorrectCommand1} {enter}`);
+        cy.uiGetReplyTextBox().type(`/${incorrectCommand1} {enter}`);
 
         // # Move the text search for error inside the RHS container only, so we are certain it is rendered below RHS textbox
         cy.get('#rhsContainer').within(() => {
@@ -89,14 +89,14 @@ describe('Invalid slash command', () => {
             and('not.have.id', 'post_textbox');
 
         // * Verify hitting backspace in the textbox removes the error message
-        cy.get('#reply_textbox').type('{backspace}');
+        cy.uiGetReplyTextBox().type('{backspace}');
         cy.get('#rhsContainer').within(() => {
             // * Verify error message is not displayed
             verifyNonCommandErrorMessageIsNotDisplayed(incorrectCommand1);
         });
 
         // # Press enter once with incorrect to allow the error message to show
-        cy.get('#reply_textbox').clear().type(`/${incorrectCommand2} {enter}`);
+        cy.uiGetReplyTextBox().clear().type(`/${incorrectCommand2} {enter}`);
 
         // * Check that error message of incorrect command is displayed
         cy.get('#rhsContainer').within(() => {
@@ -104,13 +104,13 @@ describe('Invalid slash command', () => {
         });
 
         // # Lets press enter again to submit it as plain text after error message is shown
-        cy.get('#reply_textbox').type('{enter}');
+        cy.uiGetReplyTextBox().type('{enter}');
 
         // * Verify incorrect command got posted as plain text message via twice enter press
         verifyLastPostedMessageContainsPlainTextOfCommand(incorrectCommand2);
 
         // # Lets add another incorrect command and press enter
-        cy.get('#reply_textbox').clear().type(`/${incorrectCommand3} {enter}`);
+        cy.uiGetReplyTextBox().clear().type(`/${incorrectCommand3} {enter}`);
 
         // * Check that error message of incorrect command is displayed
         cy.get('#rhsContainer').within(() => {

--- a/e2e/cypress/tests/integration/integrations/builtin_commands/invalid_commands_spec.js
+++ b/e2e/cypress/tests/integration/integrations/builtin_commands/invalid_commands_spec.js
@@ -27,7 +27,7 @@ describe('Invalid slash command', () => {
 
     it('MM-T667 - Start message with slash and non-command', () => {
         // # Type a incorrect slash command and press enter
-        cy.get('#post_textbox').type(`/${incorrectCommand1} {enter}`);
+        cy.uiGetPostTextBox().type(`/${incorrectCommand1} {enter}`);
 
         // * Check that error message of incorrect command is displayed
         verifyNonCommandErrorMessageIsDisplayed(incorrectCommand1);
@@ -36,11 +36,11 @@ describe('Invalid slash command', () => {
         cy.focused().should('have.id', 'post_textbox');
 
         // # Backspace in the center textbox and verify error message disappeared
-        cy.get('#post_textbox').type('{backspace}');
+        cy.uiGetPostTextBox().type('{backspace}');
         verifyNonCommandErrorMessageIsNotDisplayed(incorrectCommand1);
 
         // # Type another incorrect slash command
-        cy.get('#post_textbox').clear().type(`/${incorrectCommand2} {enter}`);
+        cy.uiGetPostTextBox().clear().type(`/${incorrectCommand2} {enter}`);
 
         // * Check that error message of incorrect command is displayed again
         verifyNonCommandErrorMessageIsDisplayed(incorrectCommand2);
@@ -52,13 +52,13 @@ describe('Invalid slash command', () => {
         verifyLastPostedMessageContainsPlainTextOfCommand(incorrectCommand2);
 
         // # Lets try to post incorrect message as plain text via twice enter press
-        cy.get('#post_textbox').clear().type(`/${incorrectCommand3} {enter}`);
+        cy.uiGetPostTextBox().clear().type(`/${incorrectCommand3} {enter}`);
 
         // * Check that error message of incorrect command is displayed again
         verifyNonCommandErrorMessageIsDisplayed(incorrectCommand3);
 
         // # Lets press enter again in the textbox after error message is shown to submit command as plain text
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Verify incorrect command got posted as plain text message via twice enter press
         verifyLastPostedMessageContainsPlainTextOfCommand(incorrectCommand3);

--- a/e2e/cypress/tests/integration/integrations/builtin_commands/user_status_commands_spec.js
+++ b/e2e/cypress/tests/integration/integrations/builtin_commands/user_status_commands_spec.js
@@ -44,7 +44,7 @@ describe('Integrations', () => {
 
         testCases.forEach((testCase) => {
             // # Type "/" on textbox
-            cy.get('#post_textbox').clear().type('/');
+            cy.uiGetPostTextBox().clear().type('/');
 
             // # Verify that the suggestion list is visible
             cy.get('#suggestionList').should('be.visible').then((container) => {
@@ -53,7 +53,7 @@ describe('Integrations', () => {
             });
 
             // # Hit enter and verify user status
-            cy.get('#post_textbox').type(' {enter}');
+            cy.uiGetPostTextBox().type(' {enter}');
             verifyUserStatus(testCase, false);
         });
     });

--- a/e2e/cypress/tests/integration/integrations/builtin_commands/user_status_spec.js
+++ b/e2e/cypress/tests/integration/integrations/builtin_commands/user_status_spec.js
@@ -75,13 +75,13 @@ function setStatus(status, icon) {
 
 function verifyUserStatus(testCase) {
     // # Clear then type '/'
-    cy.get('#post_textbox').should('be.visible').clear().type('/');
+    cy.uiGetPostTextBox().clear().type('/');
 
     // * Verify that the suggestion list is visible
     cy.get('#suggestionList').should('be.visible');
 
     // # Post slash command to change user status
-    cy.get('#post_textbox').type(`${testCase.name}{enter}`).wait(TIMEOUTS.ONE_HUNDRED_MILLIS).type('{enter}');
+    cy.uiGetPostTextBox().type(`${testCase.name}{enter}`).wait(TIMEOUTS.ONE_HUNDRED_MILLIS).type('{enter}');
 
     // * Get last post and verify system message
     cy.getLastPost().within(() => {

--- a/e2e/cypress/tests/integration/integrations/custom_slash_commands/custom_slash_commands_spec.js
+++ b/e2e/cypress/tests/integration/integrations/custom_slash_commands/custom_slash_commands_spec.js
@@ -146,7 +146,7 @@ describe('Slash commands', () => {
         cy.visit(`/${team1.name}/channels/town-square`);
 
         // # Run slash command
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type(`/${trigger} {enter}`);
+        cy.uiGetPostTextBox().clear().type(`/${trigger} {enter}`);
         cy.wait(TIMEOUTS.TWO_SEC);
 
         // * Verify error
@@ -249,14 +249,14 @@ describe('Slash commands', () => {
         cy.visit(`/${team1.name}/channels/town-square`);
 
         // # Type slash
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type('/');
+        cy.uiGetPostTextBox().clear().type('/');
         cy.wait(TIMEOUTS.TWO_SEC);
 
         // * Verify that command is in the list
         cy.contains(`${trigger}`);
 
         // # Type full command
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').type(`${trigger}`);
+        cy.uiGetPostTextBox().type(`${trigger}`);
         cy.wait(TIMEOUTS.TWO_SEC);
 
         // * Verify that autocomplete info is correct
@@ -276,7 +276,7 @@ describe('Slash commands', () => {
         cy.visit(`/${team1.name}/channels/town-square`);
 
         // # Run slash command
-        cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type('/');
+        cy.uiGetPostTextBox().clear().type('/');
         cy.wait(TIMEOUTS.TWO_SEC);
 
         // * Verify that command is not in the list

--- a/e2e/cypress/tests/integration/integrations/custom_slash_commands/helpers.js
+++ b/e2e/cypress/tests/integration/integrations/custom_slash_commands/helpers.js
@@ -43,7 +43,7 @@ export function runSlashCommand(linkToVisit, trigger) {
     cy.visit(linkToVisit);
 
     // # Run slash command
-    cy.get('#post_textbox', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').clear().type(`/${trigger}{enter}{enter}`);
+    cy.uiGetPostTextBox().clear().type(`/${trigger}{enter}{enter}`);
     cy.wait(TIMEOUTS.TWO_SEC);
 
     // # Get last post message text

--- a/e2e/cypress/tests/integration/integrations/integrations_spec.js
+++ b/e2e/cypress/tests/integration/integrations/integrations_spec.js
@@ -427,7 +427,7 @@ describe('Integrations page', () => {
         const first2LettersOfCommandTrigger = commandTrigger.slice(0, 2);
 
         // # Type first 2 letters of the command trigger word
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`/${first2LettersOfCommandTrigger}`);
+        cy.uiGetPostTextBox().should('be.visible').clear().type(`/${first2LettersOfCommandTrigger}`);
 
         // # Scan inside of suggestion list
         cy.get('#suggestionList').should('exist').and('be.visible').within(() => {
@@ -439,8 +439,8 @@ describe('Integrations page', () => {
         });
 
         // # Append Hello to custom slash command and hit enter
-        cy.get('#post_textbox').type('{enter}').wait(TIMEOUTS.HALF_SEC).type('Hello{enter}').wait(TIMEOUTS.HALF_SEC);
-        cy.get('#post_textbox').invoke('text').should('be.empty');
+        cy.uiGetPostTextBox().type('{enter}').wait(TIMEOUTS.HALF_SEC).type('Hello{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().invoke('text').should('be.empty');
     });
 });
 

--- a/e2e/cypress/tests/integration/integrations/message_to_channel_via_slash_command_spec.js
+++ b/e2e/cypress/tests/integration/integrations/message_to_channel_via_slash_command_spec.js
@@ -54,7 +54,7 @@ describe('Integrations', () => {
             cy.findByLabelText('off-topic public channel').should('exist');
 
             // # Post a slash command that sends message to off-topic channel
-            cy.get('#post_textbox').should('be.visible').
+            cy.uiGetPostTextBox().
                 clear().
                 type(`/${slashCommand.trigger} {enter}`);
 

--- a/e2e/cypress/tests/integration/integrations/poll_spec.js
+++ b/e2e/cypress/tests/integration/integrations/poll_spec.js
@@ -80,7 +80,7 @@ describe('/poll', () => {
 
         cy.uiGetRHS().within(() => {
             // # In RHS, post `/poll reply`
-            cy.get('#reply_textbox').type('/poll reply');
+            cy.uiGetReplyTextBox().type('/poll reply');
             cy.findByTestId('SendMessageButton').click();
 
             // * Poll displays as expected in RHS.

--- a/e2e/cypress/tests/integration/integrations/slash_commands_spec.js
+++ b/e2e/cypress/tests/integration/integrations/slash_commands_spec.js
@@ -215,7 +215,7 @@ describe('Integrations', () => {
         cy.clickPostCommentIcon();
 
         // # Type uppercase letter
-        cy.get('#reply_textbox').type('/C');
+        cy.uiGetReplyTextBox().type('/C');
 
         // # Scan inside of suggestion list
         cy.get('#suggestionList').should('exist').and('be.visible').within(() => {
@@ -224,7 +224,7 @@ describe('Integrations', () => {
         });
 
         // # Hit enter to send the message
-        cy.get('#reply_textbox').type('{enter}');
+        cy.uiGetReplyTextBox().type('{enter}');
 
         cy.get('@postID').then((postID) => {
             cy.get(`#rhsPost_${postID}`).should('be.visible').within(() => {

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/backspace_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/backspace_spec.js
@@ -38,17 +38,17 @@ describe('Keyboard Shortcuts', () => {
         cy.url().should('include', `/${testTeam.name}/messages/@${testUser.username}`);
 
         // # Type/edit some text and remove focus from the input field
-        cy.get('#post_textbox').clear().type('This is a normal sentence.').type('{backspace}{backspace}').blur();
+        cy.uiGetPostTextBox().clear().type('This is a normal sentence.').type('{backspace}{backspace}').blur();
 
         // * Verify that the backspace key presses modified the input correctly
-        cy.get('#post_textbox').should('have.value', 'This is a normal sentenc');
+        cy.uiGetPostTextBox().should('have.value', 'This is a normal sentenc');
 
         // # Select the body to remove focus from the input field
         cy.get('body').type('{backspace}');
         cy.get('body').type('{backspace}');
 
         // * Verify that the additional backspace key presses on blur doesn't affect the input
-        cy.get('#post_textbox').should('have.value', 'This is a normal sentenc');
+        cy.uiGetPostTextBox().should('have.value', 'This is a normal sentenc');
 
         // * Verify that the URL doesn't change from the last URL
         cy.url().should('include', `/${testTeam.name}/messages/@${testUser.username}`);

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_at_username_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_at_username_spec.js
@@ -30,7 +30,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1246 CTRL/CMD+K - @ at beginning of username', () => {
         // # Type CTRL/CMD+K
-        cy.get('#post_textbox').cmdOrCtrlShortcut('k');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('k');
 
         // # Enter @ followed by the first 2 characters of username of the other user
         cy.get('#quickSwitchInput').type('@' + otherUser.username.slice(0, 3));

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_channel_switch_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_channel_switch_spec.js
@@ -20,7 +20,7 @@ describe('Keyboard Shortcuts', () => {
         const message = 'Hello World!';
 
         // # Type CTRL/CMD+K to open 'Switch Channels'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // * Verify that the suggestion list is visible
         cy.get('#suggestionList').should('be.visible');
@@ -32,6 +32,6 @@ describe('Keyboard Shortcuts', () => {
         cy.get('body').type(message);
 
         // * Textbox should have text equal to message
-        cy.get('#post_textbox').should('have.text', message);
+        cy.uiGetPostTextBox().should('have.text', message);
     });
 });

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_focuses_message_box_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_focuses_message_box_spec.js
@@ -23,7 +23,7 @@ describe('Keyboard Shortcuts', () => {
     it('MM-T1243 CTRL/CMD+K - Open public channel using arrow keys and Enter, click out of current channel message box first', () => {
         // # To remove focus from message text box
         cy.get('#postListContent').click();
-        cy.get('#post_textbox').should('not.be.focused');
+        cy.uiGetPostTextBox().should('not.be.focused');
 
         // # Press CTRL/CMD+K
         cy.get('body').cmdOrCtrlShortcut('K');
@@ -41,6 +41,6 @@ describe('Keyboard Shortcuts', () => {
 
         // * Confirm that channel is open, and post text box has focus
         cy.contains('#channelHeaderTitle', 'Off-Topic');
-        cy.get('#post_textbox').should('be.focused');
+        cy.uiGetPostTextBox().should('be.focused');
     });
 });

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_open_gm_with_mouse_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_open_gm_with_mouse_spec.js
@@ -42,7 +42,7 @@ describe('Keyboard Shortcuts', () => {
         // # Create a GM channel
         cy.apiCreateGroupChannel([firstUser.id, secondUser.id, thirdUser.id]).then(() => {
             // # Press Cmd/Ctrl-K to open "Switch Channels" modal
-            cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+            cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
             // # Click on the GM link to go to channel
             cy.get('.status--group').click();

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_unreads_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_k_unreads_spec.js
@@ -85,7 +85,7 @@ describe('Keyboard Shortcuts', () => {
         cy.visit(`/${team2.name}/channels/off-topic`);
 
         // # Type CTRL/CMD+K
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // # Verify that the mentions in the channels of this team are displayed, channel will come based on recency of post
         cy.wait(TIMEOUTS.HALF_SEC);
@@ -135,7 +135,7 @@ describe('Keyboard Shortcuts', () => {
                     channelId: teamAndChannels[0].channels[2].id,
                 }).then(() => {
                     // # Press keyboard shortcut for channel switcher
-                    cy.get('#post_textbox').cmdOrCtrlShortcut('k');
+                    cy.uiGetPostTextBox().cmdOrCtrlShortcut('k');
 
                     // * Verify channel switcher shows up
                     cy.get('.a11y__modal.channel-switcher').should('exist').and('be.visible').as('channelSwitcherDialog');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_l_set_message_focus_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_l_set_message_focus_spec.js
@@ -27,7 +27,7 @@ describe('Keyboard Shortcuts', () => {
             cy.findByText('Reply').click();
 
             // * Confirm that reply text box has focus
-            cy.get('#reply_textbox').should('be.focused');
+            cy.uiGetReplyTextBox().should('be.focused');
 
             // * Confirm the RHS is shown
             cy.get('#rhsCloseButton').should('exist');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_l_set_message_focus_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_l_set_message_focus_spec.js
@@ -36,7 +36,7 @@ describe('Keyboard Shortcuts', () => {
             cy.get('body').cmdOrCtrlShortcut('{shift}L');
 
             // * Confirm the message box has focus
-            cy.get('#post_textbox').should('be.focused');
+            cy.uiGetPostTextBox().should('be.focused');
         });
     });
 
@@ -51,6 +51,6 @@ describe('Keyboard Shortcuts', () => {
         cy.get('body').cmdOrCtrlShortcut('{shift}L');
 
         // * Confirm the message box has focus
-        cy.get('#post_textbox').should('be.focused');
+        cy.uiGetPostTextBox().should('be.focused');
     });
 });

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_a_account_settings_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_a_account_settings_spec.js
@@ -18,7 +18,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T4441_1 CTRL/CMD+SHIFT+A - Settings should open in desktop view', () => {
         // # Type CTRL/CMD+SHIFT+A to open 'Settings'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}A');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}A');
 
         // * Ensure account settings modal is open
         cy.get('#accountSettingsModal').should('be.visible');
@@ -31,7 +31,7 @@ describe('Keyboard Shortcuts', () => {
         cy.viewport('iphone-6');
 
         // # Type CTRL/CMD+SHIFT+A to open 'Settings'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}A');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}A');
 
         // * Ensure Settings modal is open
         cy.get('#accountSettingsModal').should('be.visible');
@@ -41,7 +41,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('CTRL+A - Should not open Settings', () => {
         // # Type CTRL/CMD+A to select the text
-        cy.get('#post_textbox').cmdOrCtrlShortcut('A');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('A');
 
         // * Ensure Settings modal is not open
         cy.get('#accountSettingsModal').should('not.exist');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_l_does_not_change_focus_to_msgbox_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_l_does_not_change_focus_to_msgbox_spec.js
@@ -26,7 +26,7 @@ describe('Keyboard Shortcuts', () => {
         cy.get('body').cmdOrCtrlShortcut('{shift+l}');
 
         // * Verify channel message box is not focused
-        cy.get('#post_textbox').should('not.be.focused');
+        cy.uiGetPostTextBox().should('not.be.focused');
 
         // # Close settings modal
         cy.uiClose();
@@ -38,7 +38,7 @@ describe('Keyboard Shortcuts', () => {
         cy.get('body').cmdOrCtrlShortcut('{shift+l}');
 
         // * Verify channel message box is not focused
-        cy.get('#post_textbox').should('not.be.focused');
+        cy.uiGetPostTextBox().should('not.be.focused');
 
         // # Close invite members full-page screen
         cy.uiClose();

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_m_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_m_spec.js
@@ -54,7 +54,7 @@ describe('Keyboard Shortcuts', () => {
         cy.postMessage(messagePrefix + message2);
 
         // # Type user name mention and post it to the channel
-        cy.get('#post_textbox').clear().type(messagePrefix + message3).type('{enter}{enter}');
+        cy.uiGetPostTextBox().clear().type(messagePrefix + message3).type('{enter}{enter}');
 
         // # Type "words that trigger mentions"
         cy.postMessage('mention @here ');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_slash/helpers.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_slash/helpers.js
@@ -14,7 +14,7 @@ export function doReactToLastMessageShortcut(from) {
             clear().
             cmdOrCtrlShortcut('{shift}\\');
     } else if (from === 'RHS') {
-        cy.get('#reply_textbox').
+        cy.uiGetReplyTextBox().
             focus().
             clear().
             cmdOrCtrlShortcut('{shift}\\');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_slash/helpers.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_shift_slash/helpers.js
@@ -9,7 +9,7 @@ import * as TIMEOUTS from '../../../fixtures/timeouts';
  */
 export function doReactToLastMessageShortcut(from) {
     if (from === 'CENTER') {
-        cy.get('#post_textbox').
+        cy.uiGetPostTextBox().
             focus().
             clear().
             cmdOrCtrlShortcut('{shift}\\');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_up_down_no_action_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/ctrl_cmd_up_down_no_action_spec.js
@@ -23,23 +23,23 @@ describe('Keyboard Shortcuts', () => {
         const message = 'Test message from User 1';
 
         // # Type a message in the input box but do not post it
-        cy.get('#post_textbox').type(message).wait(TIMEOUTS.ONE_SEC);
+        cy.uiGetPostTextBox().type(message).wait(TIMEOUTS.ONE_SEC);
 
         // # Press CMD/CTRL+DOWN arrow
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{downarrow}');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{downarrow}');
 
         // * Check the focus after pressing CTRL/CMD + DOWN then check match the text and the cursor position respectively
-        cy.get('#post_textbox').
+        cy.uiGetPostTextBox().
             should('be.focused').
             and('have.text', message).
             and('have.prop', 'selectionStart', message.length).
             and('have.prop', 'selectionEnd', message.length);
 
         // # Press CMD/CTRL+UP arrow
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{uparrow}');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{uparrow}');
 
         // * Check the focus after pressing CTRL/CMD + UP then check match the text and the cursor position respectively
-        cy.get('#post_textbox').
+        cy.uiGetPostTextBox().
             should('be.focused').
             and('have.text', message).
             and('have.prop', 'selectionStart', 0).

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/dot_menu_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/dot_menu_spec.js
@@ -38,7 +38,7 @@ describe('Keyboard Shortcuts', () => {
             cy.uiPostDropdownMenuShortcut(postId, 'Reply', 'R');
 
             // * Verify reply text box is focused
-            cy.get('#reply_textbox').should('be.focused');
+            cy.uiGetReplyTextBox().should('be.focused');
 
             // # Mark as unread
             cy.uiPostDropdownMenuShortcut(postId, 'Mark as Unread', 'U');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/keyboard_shortcuts_1_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/keyboard_shortcuts_1_spec.js
@@ -414,7 +414,7 @@ describe('Keyboard Shortcuts', () => {
         cy.getLastPostId().then((postId) => {
             // # Mouseover the post and click post comment icon.
             cy.clickPostCommentIcon(postId);
-            cy.get('#reply_textbox').focus().should('be.focused');
+            cy.uiGetReplyTextBox().focus().should('be.focused');
         }).then(() => {
             // # Type CTRL/CMD+SHIFT+L
             cy.get('body').cmdOrCtrlShortcut('{shift}L');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/keyboard_shortcuts_1_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/keyboard_shortcuts_1_spec.js
@@ -43,7 +43,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1227 - CTRL/CMD+K - Join public channel', () => {
         // # Type CTRL/CMD+K
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         cy.apiCreateUser({prefix: 'temp-'}).then(({user: tempUser}) => {
             // # Add user to team but not to test channel
@@ -102,7 +102,7 @@ describe('Keyboard Shortcuts', () => {
             cy.apiCreateDirectChannel([testUser.id, otherUser.id]).wait(TIMEOUTS.ONE_SEC).then(({channel}) => {
                 dmChannels.push(channel);
                 cy.visit(`/${team.name}/channels/${testUser.id}__${otherUser.id}`);
-                cy.get('#post_textbox').clear().type(`message from ${testUser.username}`).type('{enter}');
+                cy.uiGetPostTextBox().clear().type(`message from ${testUser.username}`).type('{enter}');
             });
 
             // # Add posts by second user to the newly created channels in the first team
@@ -111,13 +111,13 @@ describe('Keyboard Shortcuts', () => {
                 cy.visit(`/${team.name}/channels/off-topic`);
 
                 cy.get('#sidebarItem_' + publicChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type('message to public channel').type('{enter}');
+                cy.uiGetPostTextBox().clear().type('message to public channel').type('{enter}');
 
                 cy.get('#sidebarItem_' + privateChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type('message to private channel').type('{enter}');
+                cy.uiGetPostTextBox().clear().type('message to private channel').type('{enter}');
 
                 cy.get('#sidebarItem_' + dmChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type(`direct message from ${otherUser.username}`).type('{enter}');
+                cy.uiGetPostTextBox().clear().type(`direct message from ${otherUser.username}`).type('{enter}');
             });
 
             cy.apiLogout();
@@ -175,7 +175,7 @@ describe('Keyboard Shortcuts', () => {
             cy.apiCreateDirectChannel([testUser.id, otherUser.id]).wait(TIMEOUTS.ONE_SEC).then(({channel}) => {
                 favDMChannels.push(channel);
                 cy.visit(`/${team.name}/channels/${testUser.id}__${otherUser.id}`);
-                cy.get('#post_textbox').clear().type(`message from ${testUser.username}`).type('{enter}');
+                cy.uiGetPostTextBox().clear().type(`message from ${testUser.username}`).type('{enter}');
                 markAsFavorite(channel.name);
             });
 
@@ -185,13 +185,13 @@ describe('Keyboard Shortcuts', () => {
                 cy.visit(`/${team.name}/channels/off-topic`);
 
                 cy.get('#sidebarItem_' + favPublicChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type('message to public channel').type('{enter}');
+                cy.uiGetPostTextBox().clear().type('message to public channel').type('{enter}');
 
                 cy.get('#sidebarItem_' + favPrivateChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type('message to private channel').type('{enter}');
+                cy.uiGetPostTextBox().clear().type('message to private channel').type('{enter}');
 
                 cy.get('#sidebarItem_' + favDMChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type(`direct message from ${otherUser.username}`).type('{enter}');
+                cy.uiGetPostTextBox().clear().type(`direct message from ${otherUser.username}`).type('{enter}');
             });
 
             cy.apiLogout();
@@ -261,7 +261,7 @@ describe('Keyboard Shortcuts', () => {
             cy.apiCreateDirectChannel([testUser.id, otherUser.id]).wait(TIMEOUTS.ONE_SEC).then(({channel}) => {
                 dmChannels.push(channel);
                 cy.visit(`/${team.name}/channels/${testUser.id}__${otherUser.id}`);
-                cy.get('#post_textbox').clear().type(`message from ${testUser.username}`).type('{enter}');
+                cy.uiGetPostTextBox().clear().type(`message from ${testUser.username}`).type('{enter}');
             });
 
             // # Add posts by second user to the newly created channels in the first team
@@ -270,13 +270,13 @@ describe('Keyboard Shortcuts', () => {
                 cy.visit(`/${team.name}/channels/off-topic`);
 
                 cy.get('#sidebarItem_' + publicChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type('message to public channel').type('{enter}');
+                cy.uiGetPostTextBox().clear().type('message to public channel').type('{enter}');
 
                 cy.get('#sidebarItem_' + privateChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type('message to private channel').type('{enter}');
+                cy.uiGetPostTextBox().clear().type('message to private channel').type('{enter}');
 
                 cy.get('#sidebarItem_' + dmChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type(`direct message from ${otherUser.username}`).type('{enter}');
+                cy.uiGetPostTextBox().clear().type(`direct message from ${otherUser.username}`).type('{enter}');
             });
 
             cy.apiLogout();
@@ -334,7 +334,7 @@ describe('Keyboard Shortcuts', () => {
             cy.apiCreateDirectChannel([testUser.id, otherUser.id]).wait(TIMEOUTS.ONE_SEC).then(({channel}) => {
                 favDMChannels.push(channel);
                 cy.visit(`/${team.name}/channels/${testUser.id}__${otherUser.id}`);
-                cy.get('#post_textbox').clear().type(`message from ${testUser.username}`).type('{enter}');
+                cy.uiGetPostTextBox().clear().type(`message from ${testUser.username}`).type('{enter}');
                 markAsFavorite(channel.name);
             });
 
@@ -344,13 +344,13 @@ describe('Keyboard Shortcuts', () => {
                 cy.visit(`/${team.name}/channels/off-topic`);
 
                 cy.get('#sidebarItem_' + favPublicChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type('message to public channel').type('{enter}');
+                cy.uiGetPostTextBox().clear().type('message to public channel').type('{enter}');
 
                 cy.get('#sidebarItem_' + favPrivateChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type('message to private channel').type('{enter}');
+                cy.uiGetPostTextBox().clear().type('message to private channel').type('{enter}');
 
                 cy.get('#sidebarItem_' + favDMChannels[0].name).scrollIntoView().click();
-                cy.get('#post_textbox').clear().type(`direct message from ${otherUser.username}`).type('{enter}');
+                cy.uiGetPostTextBox().clear().type(`direct message from ${otherUser.username}`).type('{enter}');
             });
 
             cy.apiLogout();
@@ -389,7 +389,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1240 - CTRL/CMD+K: Open and close', () => {
         // # Type CTRL/CMD+K to open 'Switch Channels' modal
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K').then(() => {
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K').then(() => {
             // * Channel switcher hint should be visible and focused on
             cy.get('#quickSwitchHint').should('be.visible');
             cy.findByRole('textbox', {name: 'quick switch input'}).should('be.focused');
@@ -405,7 +405,7 @@ describe('Keyboard Shortcuts', () => {
         cy.get('#searchBox').click().should('be.focused').then(() => {
             // # Type CTRL/CMD+SHIFT+L
             cy.get('body').cmdOrCtrlShortcut('{shift}L');
-            cy.get('#post_textbox').should('be.focused');
+            cy.uiGetPostTextBox().should('be.focused');
         });
 
         // # Post a message and open RHS
@@ -418,13 +418,13 @@ describe('Keyboard Shortcuts', () => {
         }).then(() => {
             // # Type CTRL/CMD+SHIFT+L
             cy.get('body').cmdOrCtrlShortcut('{shift}L');
-            cy.get('#post_textbox').should('be.focused');
+            cy.uiGetPostTextBox().should('be.focused');
         });
     });
 
     it('MM-T1252 - CTRL/CMD+SHIFT+A', () => {
         // # Type CTRL/CMD+SHIFT+A to open 'Profile' modal
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}A');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}A');
         cy.uiGetSettingsModal().should('be.visible');
 
         // # Type CTRL/CMD+SHIFT+A to close 'Profile' modal
@@ -434,7 +434,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1278 - CTRL/CMD+SHIFT+K', () => {
         // # Type CTRL/CMD+SHIFT+K to open 'Direct Messages' modal
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}K');
         cy.get('#moreDmModal').should('be.visible').contains('Direct Messages');
 
         // # Type CTRL/CMD+SHIFT+K to close 'Direct Messages' modal
@@ -450,13 +450,13 @@ describe('Keyboard Shortcuts', () => {
         cy.clickPostCommentIcon();
 
         // # Type CTRL/CMD+SHIFT+. to expand 'RHS'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}.');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}.');
 
         // * Verify RHS is now expanded
         cy.uiGetRHS().isExpanded();
 
         // # Type CTRL/CMD+SHIFT+. to collapse 'RHS'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}.');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}.');
 
         // * Verify RHS is now in collapsed state
         cy.get('#sidebar-right').should('be.visible').and('not.have.class', 'sidebar--right--expanded');
@@ -464,19 +464,19 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T4452 - CTRL/CMD+SHIFT+. Expand or collapse RHS when RHS is in closed state', () => {
         // # Type CTRL/CMD+SHIFT+. to open 'RHS'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}.');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}.');
 
         // * Verify RHS is now open and is in collapsed state
         cy.get('#sidebar-right').should('be.visible').and('not.have.class', 'sidebar--right--expanded');
 
         // # Type CTRL/CMD+SHIFT+. to expand 'RHS'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}.');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}.');
 
         // * Verify RHS is now fully expanded
         cy.uiGetRHS().isExpanded();
 
         // # Type CTRL/CMD+SHIFT+. to collapse 'RHS'
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{shift}.');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{shift}.');
 
         // * Verify RHS is now in collapsed state
         cy.get('#sidebar-right').should('be.visible').and('not.have.class', 'sidebar--right--expanded');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/keyboard_shortcuts_2_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/keyboard_shortcuts_2_spec.js
@@ -41,7 +41,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1239 - CTRL+/ and CMD+/ and /shortcuts', () => {
         // # Type CTRL/CMD+/
-        cy.get('#post_textbox').cmdOrCtrlShortcut('/');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('/');
 
         // # Verify that the 'Keyboard Shortcuts' modal is open
         modalShouldOpen();
@@ -64,7 +64,7 @@ describe('Keyboard Shortcuts', () => {
         cy.get('#shortcutsModalLabel').should('not.exist');
 
         // # Type /shortcuts
-        cy.get('#post_textbox').clear().type('/shortcuts{enter}');
+        cy.uiGetPostTextBox().clear().type('/shortcuts{enter}');
         modalShouldOpen();
 
         // # Close the 'Keyboard Shortcuts' modal using the x button
@@ -72,7 +72,7 @@ describe('Keyboard Shortcuts', () => {
         cy.get('#shortcutsModalLabel').should('not.exist');
 
         // # Type /shortcuts
-        cy.get('#post_textbox').clear().type('/shortcuts{enter}');
+        cy.uiGetPostTextBox().clear().type('/shortcuts{enter}');
 
         // # Close the 'Keyboard Shortcuts' modal by pressing ESC key
         cy.get('body').type('{esc}');
@@ -92,25 +92,25 @@ describe('Keyboard Shortcuts', () => {
 
         for (let index = 0; index < count; index++) {
             // # Type CTRL/CMD+UP
-            cy.get('#post_textbox').cmdOrCtrlShortcut('{uparrow}');
+            cy.uiGetPostTextBox().cmdOrCtrlShortcut('{uparrow}');
 
             // # Verify that the previous message is displayed
             message = messagePrefix + (4 - index);
-            cy.get('#post_textbox').contains(message);
+            cy.uiGetPostTextBox().contains(message);
         }
 
         // # One extra CTRL/CMD+UP does not change the displayed message
-        cy.get('#post_textbox').cmdOrCtrlShortcut('{uparrow}');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('{uparrow}');
         message = messagePrefix + '0';
-        cy.get('#post_textbox').contains(message);
+        cy.uiGetPostTextBox().contains(message);
 
         for (let index = 1; index < count; index++) {
             // # Type CTRL/CMD+DOWN
-            cy.get('#post_textbox').cmdOrCtrlShortcut('{downarrow}');
+            cy.uiGetPostTextBox().cmdOrCtrlShortcut('{downarrow}');
 
             // # Verify that the next message is displayed
             message = messagePrefix + index;
-            cy.get('#post_textbox').contains(message);
+            cy.uiGetPostTextBox().contains(message);
         }
     });
 
@@ -119,11 +119,11 @@ describe('Keyboard Shortcuts', () => {
         const editMessage = 'Edit Test';
 
         // # Post message text
-        cy.get('#post_textbox').clear().type(message).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type(message).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // # Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -144,7 +144,7 @@ describe('Keyboard Shortcuts', () => {
         const userName = `${testUser.username}`;
 
         // # Enter the first characters of a user name
-        cy.get('#post_textbox').should('be.visible').clear().type('@' + userName.substring(0, 5)).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type('@' + userName.substring(0, 5)).wait(TIMEOUTS.HALF_SEC);
 
         // # Select the focused on user from the list using TAB
         cy.get('#suggestionList').should('be.visible').within(() => {
@@ -152,17 +152,17 @@ describe('Keyboard Shortcuts', () => {
         });
 
         // # Verify that the correct user name has been selected
-        cy.get('#post_textbox').should('be.visible').should('contain', userName);
+        cy.uiGetPostTextBox().should('contain', userName);
 
         // # Clear the message box
-        cy.get('#post_textbox').clear();
+        cy.uiGetPostTextBox().clear();
     });
 
     it('MM-T1274 - :[character]+TAB', () => {
         const emojiName = ':tomato';
 
         // # Enter the first characters of an emoji name
-        cy.get('#post_textbox').should('be.visible').clear().type(emojiName.substring(0, 3)).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type(emojiName.substring(0, 3)).wait(TIMEOUTS.HALF_SEC);
 
         // # Go down the list of emojis
         cy.get('body').type('{downarrow}').wait(TIMEOUTS.HALF_SEC);
@@ -176,7 +176,7 @@ describe('Keyboard Shortcuts', () => {
         });
 
         // # Verify that the correct selection has been made
-        cy.get('#post_textbox').should('be.visible').should('contain', emojiName);
+        cy.uiGetPostTextBox().should('contain', emojiName);
     });
 
     it('MM-T1275 - SHIFT+UP', () => {
@@ -186,7 +186,7 @@ describe('Keyboard Shortcuts', () => {
         cy.postMessage(message);
 
         // # Press SHIFT+UP
-        cy.get('#post_textbox').type('{shift}{uparrow}');
+        cy.uiGetPostTextBox().type('{shift}{uparrow}');
 
         // # Verify that the RHS reply box is focused
         cy.get('#reply_textbox').should('be.focused');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/keyboard_shortcuts_2_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/keyboard_shortcuts_2_spec.js
@@ -189,7 +189,7 @@ describe('Keyboard Shortcuts', () => {
         cy.uiGetPostTextBox().type('{shift}{uparrow}');
 
         // # Verify that the RHS reply box is focused
-        cy.get('#reply_textbox').should('be.focused');
+        cy.uiGetReplyTextBox().should('be.focused');
 
         // * Verify that the recently posted message is shown in the RHS
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/shift_up_focuses_on_rhs_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/shift_up_focuses_on_rhs_spec.js
@@ -21,7 +21,7 @@ describe('Keyboard Shortcuts', () => {
 
     it('MM-T1277 SHIFT+UP', () => {
         // # Press shift+up to open the latest thread in the channel in the RHS
-        cy.get('#post_textbox').type('{shift}{uparrow}');
+        cy.uiGetPostTextBox().type('{shift}{uparrow}');
 
         // * RHS Opens up
         cy.get('.sidebar--right__header').should('be.visible');
@@ -30,10 +30,10 @@ describe('Keyboard Shortcuts', () => {
         cy.get('#reply_textbox').should('be.focused');
 
         // # Click into the post textbox in the center channel
-        cy.get('#post_textbox').click();
+        cy.uiGetPostTextBox().click();
 
         // # Press shift+up again
-        cy.get('#post_textbox').type('{shift}{uparrow}');
+        cy.uiGetPostTextBox().type('{shift}{uparrow}');
 
         // * RHS textbox should be focused
         cy.get('#reply_textbox').should('be.focused');

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/shift_up_focuses_on_rhs_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/shift_up_focuses_on_rhs_spec.js
@@ -27,7 +27,7 @@ describe('Keyboard Shortcuts', () => {
         cy.get('.sidebar--right__header').should('be.visible');
 
         // * RHS textbox should be focused
-        cy.get('#reply_textbox').should('be.focused');
+        cy.uiGetReplyTextBox().should('be.focused');
 
         // # Click into the post textbox in the center channel
         cy.uiGetPostTextBox().click();
@@ -36,6 +36,6 @@ describe('Keyboard Shortcuts', () => {
         cy.uiGetPostTextBox().type('{shift}{uparrow}');
 
         // * RHS textbox should be focused
-        cy.get('#reply_textbox').should('be.focused');
+        cy.uiGetReplyTextBox().should('be.focused');
     });
 });

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/up_arrow_edit_message_rhs_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/up_arrow_edit_message_rhs_spec.js
@@ -26,8 +26,8 @@ describe('Keyboard Shortcuts', () => {
             cy.clickPostDotMenu(postId);
             cy.findByText('Reply').click();
             const replyMessage = 'Well, hello there.';
-            cy.get('#reply_textbox').type(replyMessage);
-            cy.get('#reply_textbox').type('{enter}');
+            cy.uiGetReplyTextBox().type(replyMessage);
+            cy.uiGetReplyTextBox().type('{enter}');
             cy.uiWaitUntilMessagePostedIncludes(replyMessage);
 
             // # Press up arrow key

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/up_arrow_edit_message_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/up_arrow_edit_message_spec.js
@@ -50,7 +50,7 @@ describe('Keyboard Shortcuts', () => {
         cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
         // # Press UP arrow
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
 
         // * Verify that Edit modal should not be visible
         cy.get('#edit_textbox').should('not.exist');
@@ -82,7 +82,7 @@ describe('Keyboard Shortcuts', () => {
         cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
         // # Press UP arrow
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
 
         // * Verify that the Edit Post Input is visible
         cy.get('#edit_textbox').should('be.visible');
@@ -104,7 +104,7 @@ describe('Keyboard Shortcuts', () => {
             // * Verify that testuser sees post
             cy.get(`#postMessageText_${postID}`).should('contain', message);
 
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Validate that edit box contains just posted message
             cy.get('#edit_textbox').should('have.text', message);
@@ -154,7 +154,7 @@ describe('Keyboard Shortcuts', () => {
         cy.uiGetFileThumbnail(filename).should('be.visible');
 
         // # Press up arrow
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
         cy.wait(TIMEOUTS.HALF_SEC);
 
         // # Clear all text and confirm
@@ -213,7 +213,7 @@ describe('Keyboard Shortcuts', () => {
 
         cy.getLastPostId().then((postID) => {
             // # Press UP arrow
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             cy.wait(TIMEOUTS.HALF_SEC);
 
@@ -240,12 +240,12 @@ describe('Keyboard Shortcuts', () => {
         cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
         // # Post code block message from User 1
-        cy.get('#post_textbox').type(messageWithCodeblock1).type('{enter}');
+        cy.uiGetPostTextBox().type(messageWithCodeblock1).type('{enter}');
 
         cy.uiWaitUntilMessagePostedIncludes('codeblock1');
 
         // # Press UP arrow
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
 
         // # Edit text
         cy.get('#edit_textbox').clear().type(messageWithCodeblock2).type('{enter}');
@@ -288,7 +288,7 @@ describe('Keyboard Shortcuts', () => {
         // # Wait for file to upload
         cy.wait(TIMEOUTS.TWO_SEC);
 
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         cy.getLastPost().within(() => {
             // * Attachment should exist
@@ -299,7 +299,7 @@ describe('Keyboard Shortcuts', () => {
         });
 
         // # Press UP arrow
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
 
         // # Add some text to the previous message and save
         cy.get('#edit_textbox').type('Test').type('{enter}');

--- a/e2e/cypress/tests/integration/messaging/autocomplete_shown_each_channel_spec.js
+++ b/e2e/cypress/tests/integration/messaging/autocomplete_shown_each_channel_spec.js
@@ -35,7 +35,7 @@ describe('Identical Message Drafts', () => {
 
     it('MM-T132 Identical Message Drafts - Autocomplete shown in each channel', () => {
         // # Start a draft in Channel A containing just "@"
-        cy.get('#post_textbox').should('be.visible').type('@');
+        cy.uiGetPostTextBox().type('@');
 
         // * At mention auto-complete appears in Channel A
         cy.get('#suggestionList').should('be.visible');
@@ -49,7 +49,7 @@ describe('Identical Message Drafts', () => {
         cy.get('#suggestionList').should('not.exist');
 
         // # Start a draft in Channel B containing just "@"
-        cy.get('#post_textbox').should('be.visible').type('@');
+        cy.uiGetPostTextBox().type('@');
 
         // * At mention auto-complete appears in Channel B
         cy.get('#suggestionList').should('be.visible');
@@ -61,7 +61,7 @@ describe('Identical Message Drafts', () => {
         // * Validate if the channel has been opened
         // * At mention auto-complete is preserved in Channel A
         cy.url().should('include', `/channels/${testChannelA.name}`);
-        cy.get('#post_textbox').should('be.visible');
+        cy.uiGetPostTextBox();
         cy.get('#suggestionList').should('be.visible');
     });
 });

--- a/e2e/cypress/tests/integration/messaging/autocomplete_spec.js
+++ b/e2e/cypress/tests/integration/messaging/autocomplete_spec.js
@@ -62,7 +62,7 @@ describe('autocomplete', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Clear then type @  and user name
-        cy.get('#post_textbox').should('be.visible').clear().type(`@${testUser.username}`);
+        cy.uiGetPostTextBox().clear().type(`@${testUser.username}`);
 
         // * Verify that the item is displayed or not as expected.
         cy.get('#suggestionList').should('be.visible').within(() => {
@@ -84,7 +84,7 @@ describe('autocomplete', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Clear then type @ and user nickname
-        cy.get('#post_textbox').should('be.visible').clear().type(`@${testUser.nickname}`);
+        cy.uiGetPostTextBox().clear().type(`@${testUser.nickname}`);
 
         // * Verify that the item is displayed or not as expected.
         cy.get('#suggestionList').within(() => {
@@ -93,7 +93,7 @@ describe('autocomplete', () => {
         });
 
         // # Post user mention
-        cy.get('#post_textbox').type('{enter}{enter}');
+        cy.uiGetPostTextBox().type('{enter}{enter}');
         cy.uiWaitUntilMessagePostedIncludes(`${testUser.username}`);
 
         // # Check that the user name has been posted
@@ -106,7 +106,7 @@ describe('autocomplete', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Clear then type @  and user first names
-        cy.get('#post_textbox').should('be.visible').clear().type(`@${testUser.first_name}`);
+        cy.uiGetPostTextBox().clear().type(`@${testUser.first_name}`);
 
         // * Verify that the item is displayed or not as expected.
         cy.get('#suggestionList').within(() => {
@@ -115,7 +115,7 @@ describe('autocomplete', () => {
         });
 
         // # Post user mention
-        cy.get('#post_textbox').type('{enter}{enter}');
+        cy.uiGetPostTextBox().type('{enter}{enter}');
         cy.uiWaitUntilMessagePostedIncludes(`${testUser.username}`);
 
         // # Check that the user name has been posted
@@ -128,7 +128,7 @@ describe('autocomplete', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Clear then type @ and user email
-        cy.get('#post_textbox').should('be.visible').clear().type(`@${testUser.email}`);
+        cy.uiGetPostTextBox().clear().type(`@${testUser.email}`);
 
         // * Verify that the item is displayed or not as expected.
         cy.get('#suggestionList').should('not.exist');
@@ -140,16 +140,16 @@ describe('autocomplete', () => {
         cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
         // # Clear then type @
-        cy.get('#post_textbox').should('be.visible').clear().type('@');
+        cy.uiGetPostTextBox().clear().type('@');
 
         // * Verify that the suggestion list is visible
         cy.get('#suggestionList').should('be.visible');
 
         // # Type user name
-        cy.get('#post_textbox').type(`${notInChannelUser.username}`);
+        cy.uiGetPostTextBox().type(`${notInChannelUser.username}`);
 
         // # Post user mention
-        cy.get('#post_textbox').type('{enter}{enter}');
+        cy.uiGetPostTextBox().type('{enter}{enter}');
         cy.uiWaitUntilMessagePostedIncludes('They will have access to all message history.');
         cy.getLastPostId().then((postId) => {
             // * Verify that the correct system message is displayed or not
@@ -178,16 +178,16 @@ describe('autocomplete', () => {
                 cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
                 // # Clear then type @
-                cy.get('#post_textbox').should('be.visible').clear().type('@');
+                cy.uiGetPostTextBox().clear().type('@');
 
                 // * Verify that the suggestion list is visible
                 cy.get('#suggestionList').should('be.visible');
 
                 // # Type user name
-                cy.get('#post_textbox').type(`${tempUser.username}`);
+                cy.uiGetPostTextBox().type(`${tempUser.username}`);
 
                 // # Post user name mention
-                cy.get('#post_textbox').type('{enter}{enter}');
+                cy.uiGetPostTextBox().type('{enter}{enter}');
                 cy.uiWaitUntilMessagePostedIncludes('They will have access to all message history.');
 
                 // * Verify that the correct system message is displayed
@@ -239,16 +239,16 @@ describe('autocomplete', () => {
             cy.visit(`/${testTeam.name}/channels/${gmChannel.name}`);
 
             // # Clear then type @
-            cy.get('#post_textbox').should('be.visible').clear().type('@');
+            cy.uiGetPostTextBox().clear().type('@');
 
             // * Verify that the suggestion list is visible
             cy.get('#suggestionList').should('be.visible');
 
             // # Type user name
-            cy.get('#post_textbox').type(`${notInChannelUser.username}`);
+            cy.uiGetPostTextBox().type(`${notInChannelUser.username}`);
 
             // # Post user name mention
-            cy.get('#post_textbox').type('{enter}{enter}');
+            cy.uiGetPostTextBox().type('{enter}{enter}');
             cy.uiWaitUntilMessagePostedIncludes(`${notInChannelUser.username}`);
 
             // # Check that the user name has been posted
@@ -269,14 +269,14 @@ describe('autocomplete', () => {
             cy.visit(`/${testTeam.name}/channels/${testUser.id}__${otherUser.id}`);
 
             // # Clear then type @
-            cy.get('#post_textbox').should('be.visible').clear().type('@');
+            cy.uiGetPostTextBox().clear().type('@');
 
             // * Verify that the suggestion list is visible
             cy.get('#suggestionList').should('be.visible');
 
             // # Type user name
-            cy.get('#post_textbox').type(`${notInChannelUser.username}`);
-            cy.get('#post_textbox').type('{enter}{enter}');
+            cy.uiGetPostTextBox().type(`${notInChannelUser.username}`);
+            cy.uiGetPostTextBox().type('{enter}{enter}');
             cy.uiWaitUntilMessagePostedIncludes(`${notInChannelUser.username}`);
 
             cy.getLastPostId().then((postId) => {
@@ -296,7 +296,7 @@ describe('autocomplete', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Type input suffixed with '.'
-        cy.get('#post_textbox').clear().type(`@${sysadmin.username}.`).type('{enter}{enter}');
+        cy.uiGetPostTextBox().clear().type(`@${sysadmin.username}.`).type('{enter}{enter}');
         cy.uiWaitUntilMessagePostedIncludes(`${sysadmin.username}`);
 
         cy.getLastPostId().then((postId) => {
@@ -308,7 +308,7 @@ describe('autocomplete', () => {
         });
 
         // # Type input suffixed with '_'
-        cy.get('#post_textbox').clear().type(`@${sysadmin.username}_`).type('{enter}{enter}');
+        cy.uiGetPostTextBox().clear().type(`@${sysadmin.username}_`).type('{enter}{enter}');
         cy.uiWaitUntilMessagePostedIncludes(`${sysadmin.username}`);
 
         cy.getLastPostId().then((postId) => {
@@ -335,7 +335,7 @@ describe('autocomplete', () => {
             });
         });
 
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
         cy.uiWaitUntilMessagePostedIncludes(`${otherUser.username}`);
 
         // # Check that the @ mention of username has been posted

--- a/e2e/cypress/tests/integration/messaging/autocomplete_with_space_spec.js
+++ b/e2e/cypress/tests/integration/messaging/autocomplete_with_space_spec.js
@@ -62,13 +62,13 @@ describe('Messaging', () => {
 
 function verifySuggestionList({input, isChannel = false, expected, withoutSuggestion}) {
     // # Clear then type ~ or @
-    cy.get('#post_textbox').should('be.visible').clear().type(isChannel ? '~' : '@');
+    cy.uiGetPostTextBox().clear().type(isChannel ? '~' : '@');
 
     // * Verify that the suggestion list is visible
     cy.get('#suggestionList').should('be.visible');
 
     // # Type input
-    cy.get('#post_textbox').type(input);
+    cy.uiGetPostTextBox().type(input);
 
     // * Verify that the item is displayed or not as expected.
     if (withoutSuggestion) {

--- a/e2e/cypress/tests/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/tests/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -76,7 +76,7 @@ describe('Messaging', () => {
         cy.uiGetPostTextBox().should('not.be.focused');
 
         // # Post several replies
-        cy.get('#reply_textbox').clear().should('be.visible').as('replyTextBox');
+        cy.uiGetReplyTextBox().clear().should('be.visible').as('replyTextBox');
         for (let i = 1; i <= maxReplyCount; i++) {
             cy.get('@replyTextBox').type(`post ${i}`).type('{enter}');
         }

--- a/e2e/cypress/tests/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/tests/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -52,7 +52,7 @@ describe('Messaging', () => {
         cy.apiLogin(testUser);
 
         // # Post a new message to ensure there will be a post to click on
-        cy.get('#post_textbox').type(firstMessage).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(firstMessage).type('{enter}').wait(TIMEOUTS.HALF_SEC);
     });
 
     it('MM-T210 Center channel input box doesn\'t overlap with RHS', () => {
@@ -62,7 +62,7 @@ describe('Messaging', () => {
         const maxReplyCount = 15;
 
         // * Check if center channel post text box is focused
-        cy.get('#post_textbox').should('be.focused');
+        cy.uiGetPostTextBox().should('be.focused');
 
         // # Click "Reply"
         cy.getLastPostId().then((postId) => {
@@ -73,7 +73,7 @@ describe('Messaging', () => {
         // Although visually post text box is not visible to user,
         // cypress still considers it visible so the assertion
         // should('not.exist') will fail
-        cy.get('#post_textbox').should('not.be.focused');
+        cy.uiGetPostTextBox().should('not.be.focused');
 
         // # Post several replies
         cy.get('#reply_textbox').clear().should('be.visible').as('replyTextBox');
@@ -93,7 +93,7 @@ describe('Messaging', () => {
         setSendMessagesOnCtrlEnter('On for all messages');
 
         // # [1] Post message
-        cy.get('#post_textbox').type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // * Check that the message has not been posted
         cy.getLastPostId().then((postId) => {
@@ -110,7 +110,7 @@ describe('Messaging', () => {
 
         // # [3] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -126,7 +126,7 @@ describe('Messaging', () => {
         });
 
         // # [5] Post message with quotes
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`${messageWithCodeblock1}{enter}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().should('be.visible').clear().type(`${messageWithCodeblock1}{enter}`).wait(TIMEOUTS.HALF_SEC);
 
         // * Check that the message has not been posted
         cy.getLastPostId().then((postId) => {
@@ -143,7 +143,7 @@ describe('Messaging', () => {
 
         // # [7] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -159,7 +159,7 @@ describe('Messaging', () => {
         });
 
         // # [9] Post message with quotes
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`${messageWithCodeblockIncomplete2}{enter}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().should('be.visible').clear().type(`${messageWithCodeblockIncomplete2}{enter}`).wait(TIMEOUTS.HALF_SEC);
 
         // * Check that the message has not been posted
         cy.getLastPostId().then((postId) => {
@@ -176,7 +176,7 @@ describe('Messaging', () => {
 
         // # [11] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -192,7 +192,7 @@ describe('Messaging', () => {
         });
 
         // # [13] Post message with quotes with caret in the middle
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}{enter}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().should('be.visible').clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}{enter}`).wait(TIMEOUTS.HALF_SEC);
 
         // * Check that the message has not been posted
         cy.getLastPostId().then((postId) => {
@@ -201,7 +201,7 @@ describe('Messaging', () => {
 
         // # [14] Press CTRL+ENTER
         // * Post message again (previous one is broken)
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().should('be.visible').clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}`).wait(TIMEOUTS.HALF_SEC);
 
         cy.typeCmdOrCtrl().type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
@@ -212,7 +212,7 @@ describe('Messaging', () => {
 
         // # [15] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -240,7 +240,7 @@ describe('Messaging', () => {
         setSendMessagesOnCtrlEnter('On only for code blocks starting with ```');
 
         // # [17] Post message
-        cy.get('#post_textbox').type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // * Check that the message has been posted
         cy.getLastPostId().then((postId) => {
@@ -249,7 +249,7 @@ describe('Messaging', () => {
 
         // # [18] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -264,8 +264,8 @@ describe('Messaging', () => {
         });
 
         // # [19] Post message with quotes
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`${messageWithCodeblock1}`).wait(TIMEOUTS.HALF_SEC);
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().should('be.visible').clear().type(`${messageWithCodeblock1}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Check that the message has been posted
         cy.getLastPostId().then((postId) => {
@@ -274,7 +274,7 @@ describe('Messaging', () => {
 
         // # [20] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -289,8 +289,8 @@ describe('Messaging', () => {
         });
 
         // # [21] Post message with quotes incomplete
-        cy.get('#post_textbox').should('be.visible').clear().type(`${messageWithCodeblockIncomplete2}`).wait(TIMEOUTS.HALF_SEC);
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().clear().type(`${messageWithCodeblockIncomplete2}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Check that the message has not been posted
         cy.getLastPostId().then((postId) => {
@@ -307,7 +307,7 @@ describe('Messaging', () => {
 
         // # [23] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -328,7 +328,7 @@ describe('Messaging', () => {
         });
 
         // # [25] Post message with quotes with caret in the middle
-        cy.get('#post_textbox').should('be.visible').clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}{enter}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}{enter}`).wait(TIMEOUTS.HALF_SEC);
 
         // * Check that the message has not been posted
         cy.getLastPostId().then((postId) => {
@@ -337,7 +337,7 @@ describe('Messaging', () => {
 
         // # [26] Press CTRL+ENTER
         // * Post message again (previous one is broken)
-        cy.get('#post_textbox').should('be.visible').clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}`).wait(TIMEOUTS.HALF_SEC);
 
         cy.typeCmdOrCtrl().type('{enter}');
 
@@ -348,7 +348,7 @@ describe('Messaging', () => {
 
         // # [27] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -378,8 +378,8 @@ describe('Messaging', () => {
         setSendMessagesOnCtrlEnter('Off');
 
         // # [29] Post message
-        cy.get('#post_textbox').type(message1).wait(TIMEOUTS.HALF_SEC);
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type(message1).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Check that the message has been posted
         cy.getLastPostId().then((postId) => {
@@ -388,7 +388,7 @@ describe('Messaging', () => {
 
         // # [30] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -403,8 +403,8 @@ describe('Messaging', () => {
         });
 
         // # [31] Post message with quotes
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type(`${messageWithCodeblock1}`).wait(TIMEOUTS.HALF_SEC);
-        cy.get('#post_textbox').type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().should('be.visible').clear().type(`${messageWithCodeblock1}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // * Check that the message has been posted
         cy.getLastPostId().then((postId) => {
@@ -413,7 +413,7 @@ describe('Messaging', () => {
 
         // # [32] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -428,8 +428,8 @@ describe('Messaging', () => {
         });
 
         // # [33] Post message with quotes incomplete
-        cy.get('#post_textbox').should('be.visible').clear().type(`${messageWithCodeblockIncomplete2}`).wait(TIMEOUTS.HALF_SEC);
-        cy.get('#post_textbox').type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type(`${messageWithCodeblockIncomplete2}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // * Check that the message has been posted
         cy.getLastPostId().then((postId) => {
@@ -438,7 +438,7 @@ describe('Messaging', () => {
 
         // # [34] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -454,8 +454,8 @@ describe('Messaging', () => {
         });
 
         // # [35] Post message with quotes with caret in the middle
-        cy.get('#post_textbox').should('be.visible').clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}`).wait(TIMEOUTS.HALF_SEC);
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().clear().type(`${messageWithCodeblockIncomplete3}{leftArrow}{leftArrow}{leftArrow}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Check that the message has been posted
         cy.getLastPostId().then((postId) => {
@@ -464,7 +464,7 @@ describe('Messaging', () => {
 
         // # [36] Edit previous post
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -506,7 +506,7 @@ describe('Messaging', () => {
         cy.viewport('iphone-6');
 
         // # Post message
-        cy.get('#post_textbox').type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // # Edit post by opening modal
         cy.getLastPostId().then((postId) => {
@@ -541,7 +541,7 @@ describe('Messaging', () => {
         cy.viewport(1280, 900);
 
         // # Post message
-        cy.get('#post_textbox').type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // # Click "Reply"
         cy.getLastPostId().then((postId) => {
@@ -584,7 +584,7 @@ describe('Messaging', () => {
         const numberedListTextPart2 = new Array(32).fill('Two').join(' ');
 
         // # Post message
-        cy.get('#post_textbox').type(messageText).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(messageText).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // # Edit post by opening modal
         cy.getLastPostId().then((postId) => {
@@ -615,7 +615,7 @@ describe('Messaging', () => {
         const updateMessageText = ' update';
 
         // # Post message
-        cy.get('#post_textbox').type(codeBlockMessage).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(codeBlockMessage).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // # Edit post by opening modal
         cy.getLastPostId().then((postId) => {
@@ -645,11 +645,11 @@ describe('Messaging', () => {
 
     it('MM-T2144 Up arrow, edit', () => {
         // # Post message
-        cy.get('#post_textbox').type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // # Edit the post by opening modal
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -673,11 +673,11 @@ describe('Messaging', () => {
 
     it('MM-T2145 Other user sees "Edited"', () => {
         // # Post message
-        cy.get('#post_textbox').type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         // # Edit the post by opening modal
         cy.getLastPostId().then(() => {
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear
             cy.get('#edit_textbox').should('be.visible');
@@ -746,7 +746,7 @@ describe('Messaging', () => {
 
     it('MM-T2152 Edit long message - edit box expands to larger size', () => {
         // # Post message
-        cy.get('#post_textbox').
+        cy.uiGetPostTextBox().
             clear().
             invoke('val', MESSAGES.HUGE).
             wait(TIMEOUTS.HALF_SEC).
@@ -782,7 +782,7 @@ describe('Messaging', () => {
 
     it('MM-T2204 @ autocomplete from within edit modal', () => {
         // # Post message
-        cy.get('#post_textbox').type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);
 
         cy.getLastPostId().then((postId) => {
             cy.clickPostDotMenu(postId);

--- a/e2e/cypress/tests/integration/messaging/channel_and_posts_links_spec.js
+++ b/e2e/cypress/tests/integration/messaging/channel_and_posts_links_spec.js
@@ -50,7 +50,7 @@ describe('Message permalink', () => {
         // # Post 25 messages
         let index = 0;
         for (index = 0; index < 25; index++) {
-            cy.get('#post_textbox').clear().type(String(index)).type('{enter}');
+            cy.uiGetPostTextBox().clear().type(String(index)).type('{enter}');
         }
 
         // # Search for a message in the current channel
@@ -89,7 +89,7 @@ describe('Message permalink', () => {
         cy.visit(`/${testTeam.name}/channels/off-topic`);
 
         // # Clear then type ~ and prefix of channel name
-        cy.get('#post_textbox').should('be.visible').clear().type('~' + publicChannelName.substring(0, 3)).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type('~' + publicChannelName.substring(0, 3)).wait(TIMEOUTS.HALF_SEC);
 
         // * Verify that the item is displayed or not as expected.
         cy.get('#suggestionList').should('be.visible').within(() => {
@@ -97,7 +97,7 @@ describe('Message permalink', () => {
         });
 
         // # Post channel mention
-        cy.get('#post_textbox').type('{enter}{enter}');
+        cy.uiGetPostTextBox().type('{enter}{enter}');
 
         // # Check that the user name has been posted
         cy.getLastPostId().then((postId) => {
@@ -111,7 +111,7 @@ describe('Message permalink', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Clear then type ~ and prefix of channel name
-        cy.get('#post_textbox').should('be.visible').clear().type(`~${testChannel.display_name}`).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type(`~${testChannel.display_name}`).wait(TIMEOUTS.HALF_SEC);
 
         // * Verify that the item is displayed or not as expected.
         cy.get('#suggestionList').within(() => {
@@ -119,7 +119,7 @@ describe('Message permalink', () => {
         });
 
         // # Post channel mention
-        cy.get('#post_textbox').
+        cy.uiGetPostTextBox().
             type('{enter}').
             should('contain', testChannel.name).
             type('{enter}');
@@ -214,7 +214,7 @@ describe('Message permalink', () => {
             cy.visit(`/${testTeam.name}/channels/off-topic`);
 
             // # Clear then type channel url
-            cy.get('#post_textbox').should('be.visible').clear().type(`${Cypress.config('baseUrl')}/${testTeam.name}/channels/${testChannel.name}`).type('{enter}');
+            cy.uiGetPostTextBox().clear().type(`${Cypress.config('baseUrl')}/${testTeam.name}/channels/${testChannel.name}`).type('{enter}');
 
             // # Login as the temporary user
             cy.apiLogout();

--- a/e2e/cypress/tests/integration/messaging/channel_users_interactions_spec.js
+++ b/e2e/cypress/tests/integration/messaging/channel_users_interactions_spec.js
@@ -61,7 +61,7 @@ describe('Channel users interactions', () => {
             and('have.text', 'New Messages');
 
         // # Post a message on current channel
-        cy.get('#post_textbox').clear().type('message123{enter}');
+        cy.uiGetPostTextBox().clear().type('message123{enter}');
 
         // * Verify that last posted message is visible
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/tests/integration/messaging/ctrl_cmd_k_find_gm_by_matching_name_spec.js
+++ b/e2e/cypress/tests/integration/messaging/ctrl_cmd_k_find_gm_by_matching_name_spec.js
@@ -47,7 +47,7 @@ describe('Messaging', () => {
             cy.get('#sidebarItem_off-topic').click();
 
             // # Type either cmd+K / ctrl+K depending on OS and type in the first 7 of the second user's last name
-            cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+            cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
             cy.focused().type(`${secondUser.last_name.slice(0, 7)}`);
 
             // * The suggestion for the GM channel with the user that was searched for should show the username of the user and verify the suggestion for the GM channel with the user that was searched for should show the 'G' text

--- a/e2e/cypress/tests/integration/messaging/ctrl_cmd_k_open_dm_with_mouse_spec.js
+++ b/e2e/cypress/tests/integration/messaging/ctrl_cmd_k_open_dm_with_mouse_spec.js
@@ -38,7 +38,7 @@ describe('Messaging', () => {
 
     it('MM-T1224 - CTRL/CMD+K - Open DM using mouse', () => {
         // # Type CTRL/CMD+K
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // # In the "Switch Channels" modal type the first 6 characters of the username
         cy.findByRole('textbox', {name: 'quick switch input'}).should('be.focused').type(secondUser.username.substring(0, 6)).wait(TIMEOUTS.HALF_SEC);
@@ -61,7 +61,7 @@ describe('Messaging', () => {
         });
 
         // # Verify that the focus is on the message box
-        cy.get('#post_textbox').should('be.focused');
+        cy.uiGetPostTextBox().should('be.focused');
 
         // # Send a DM
         cy.postMessage(`Hi there, ${secondUser.username}!`);

--- a/e2e/cypress/tests/integration/messaging/direct_message_spec.js
+++ b/e2e/cypress/tests/integration/messaging/direct_message_spec.js
@@ -62,8 +62,8 @@ describe('Direct Message', () => {
             cy.visit(`/${testTeam.name}/messages/@${otherUser.username}`);
 
             // # Edit the last post
-            cy.get('#post_textbox').should('be.visible');
-            cy.get('#post_textbox').clear().type('{uparrow}');
+            cy.uiGetPostTextBox();
+            cy.uiGetPostTextBox().clear().type('{uparrow}');
 
             // * Edit post Input should appear, and edit the post
             cy.get('#edit_textbox').should('be.visible');

--- a/e2e/cypress/tests/integration/messaging/draft_with_only_2_byte_characters_spec.js
+++ b/e2e/cypress/tests/integration/messaging/draft_with_only_2_byte_characters_spec.js
@@ -52,6 +52,6 @@ describe('Messaging', () => {
         cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
         // * Assert that the message textbox is empty
-        cy.get('#post_textbox').should('have.value', '');
+        cy.uiGetPostTextBox().should('have.value', '');
     });
 });

--- a/e2e/cypress/tests/integration/messaging/edit_message_spec.js
+++ b/e2e/cypress/tests/integration/messaging/edit_message_spec.js
@@ -32,7 +32,7 @@ describe('Edit Message', () => {
         cy.postMessage('Hello World!');
 
         // # Hit the up arrow to open the "edit modal"
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
 
         // # In the modal type @
         cy.get('#edit_textbox').type(' @');
@@ -134,7 +134,7 @@ describe('Edit Message', () => {
             cy.get(postText).should('have.text', secondMessage);
 
             // # Edit the last post
-            cy.get('#post_textbox').type('{uparrow}');
+            cy.uiGetPostTextBox().type('{uparrow}');
 
             // * Edit Post Input should appear, and edit the post
             cy.get('#edit_textbox').should('be.visible');

--- a/e2e/cypress/tests/integration/messaging/emoji_insert_position_spec.js
+++ b/e2e/cypress/tests/integration/messaging/emoji_insert_position_spec.js
@@ -20,10 +20,10 @@ describe('Messaging', () => {
 
     it('MM-T95 Selecting an emoji from emoji picker should insert it at the cursor position', () => {
         // # Write some text in the send box.
-        cy.get('#post_textbox').type('HelloWorld!');
+        cy.uiGetPostTextBox().type('HelloWorld!');
 
         // # Move the cursor to the middle of the text.
-        cy.get('#post_textbox').type('{leftarrow}{leftarrow}{leftarrow}{leftarrow}{leftarrow}{leftarrow}');
+        cy.uiGetPostTextBox().type('{leftarrow}{leftarrow}{leftarrow}{leftarrow}{leftarrow}{leftarrow}');
 
         // # Open emoji picker
         cy.uiOpenEmojiPicker();
@@ -32,8 +32,8 @@ describe('Messaging', () => {
         cy.clickEmojiInEmojiPicker('grinning');
 
         // * The emoji should be inserted where the cursor is at the time of selection.
-        cy.get('#post_textbox').should('have.value', 'Hello :grinning: World!');
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().should('have.value', 'Hello :grinning: World!');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * The emoji should be displayed in the post at the position inserted.
         cy.getLastPost().find('p').should('have.html', `Hello <span data-emoticon="grinning"><span alt=":grinning:" class="emoticon" title=":grinning:" style="background-image: url(&quot;${Cypress.config('baseUrl')}/static/emoji/1f600.png&quot;);">:grinning:</span></span> World!`);

--- a/e2e/cypress/tests/integration/messaging/emoji_keyboard_entry_spec.js
+++ b/e2e/cypress/tests/integration/messaging/emoji_keyboard_entry_spec.js
@@ -96,7 +96,7 @@ describe('MM-T154 Use keyboard navigation in emoji picker', () => {
             cy.get('#emojiPickerSearch').type('{enter}');
 
             // # Post message with keyboard
-            cy.get('#post_textbox').type('{enter}');
+            cy.uiGetPostTextBox().type('{enter}');
 
             // * Compare selected emoji with last post
             cy.getLastPost().find('.emoticon').should('have.attr', 'title', selectedEmoji);

--- a/e2e/cypress/tests/integration/messaging/emoji_size_spec.js
+++ b/e2e/cypress/tests/integration/messaging/emoji_size_spec.js
@@ -23,7 +23,7 @@ describe('Messaging', () => {
 
         // # Post a message beginning with a new line and followed by emojis
         cy.postMessage('hello');
-        cy.get('#post_textbox').type('\n' + emojis.join(' ')).type('{enter}');
+        cy.uiGetPostTextBox().type('\n' + emojis.join(' ')).type('{enter}');
 
         // # Get last post message text
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/tests/integration/messaging/file_upload_in_center_channel_spec.js
+++ b/e2e/cypress/tests/integration/messaging/file_upload_in_center_channel_spec.js
@@ -25,7 +25,7 @@ describe('Messaging', () => {
         // # upload an image
         const IMAGE_NAME = 'huge-image.jpg';
         cy.get('#fileUploadInput').attachFile(IMAGE_NAME);
-        waitForImageUpload();
+        cy.uiWaitForFileUploadPreview();
 
         // # post it with a message
         const IMAGE_WITH_POST_TEXT = `image in compact display setting ${Date.now()}`;
@@ -53,10 +53,3 @@ describe('Messaging', () => {
         });
     });
 });
-
-function waitForImageUpload() {
-    // * Verify that the image exists in the post message footer
-    cy.waitUntil(() => cy.get('#postCreateFooter').then((el) => {
-        return el.find('.post-image.normal').length > 0;
-    }));
-}

--- a/e2e/cypress/tests/integration/messaging/focus_move_spec.js
+++ b/e2e/cypress/tests/integration/messaging/focus_move_spec.js
@@ -34,21 +34,21 @@ describe('Messaging', () => {
 
         // # Click the save icon to move focus out of the main input box
         cy.uiGetSavedPostButton().click();
-        cy.get('#post_textbox').should('not.be.focused');
+        cy.uiGetPostTextBox().should('not.be.focused');
 
         // # Push a character key such as "A"
         // # Expect to have "A" value in main input
         cy.get('body').type('A');
-        cy.get('#post_textbox').should('be.focused');
+        cy.uiGetPostTextBox().should('be.focused');
 
         // # Click the @-mention icon to move focus out of the main input box
         cy.uiGetRecentMentionButton().click();
-        cy.get('#post_textbox').should('not.be.focused');
+        cy.uiGetPostTextBox().should('not.be.focused');
 
         // # Push a character key such as "B"
         // # Expect to have "B" value in main input
         cy.get('body').type('B');
-        cy.get('#post_textbox').should('be.focused');
+        cy.uiGetPostTextBox().should('be.focused');
     });
 
     it('MM-T204 Focus will move to main input box after a new channel has been opened', () => {
@@ -74,7 +74,7 @@ describe('Messaging', () => {
         cy.get('#channelHeaderTitle').should('be.visible').should('contain', testChannelName);
 
         // * Verify focus is moved to main input box when the channel is opened
-        cy.get('#post_textbox').should('be.focused');
+        cy.uiGetPostTextBox().should('be.focused');
     });
 
     it('MM-T205 Focus to remain in RHS textbox each time Reply arrow is clicked', () => {
@@ -108,7 +108,7 @@ describe('Messaging', () => {
 
         // # Click the save icon to move focus out of the main input box
         cy.uiGetSavedPostButton().click();
-        cy.get('#post_textbox').should('not.be.focused');
+        cy.uiGetPostTextBox().should('not.be.focused');
 
         // Keycodes for keys that don't have a special character sequence for cypress.type()
         const numLockKeycode = 144;
@@ -120,7 +120,7 @@ describe('Messaging', () => {
             cy.get('body').trigger('keydown', {keyCode: keycode, which: keycode});
 
             // # Make sure main input is not focused
-            cy.get('#post_textbox').should('not.be.focused');
+            cy.uiGetPostTextBox().should('not.be.focused');
         });
 
         // For other keys we can use cypress.type() with a special character sequence.
@@ -129,7 +129,7 @@ describe('Messaging', () => {
             cy.get('body').type(key);
 
             // # Make sure main input is not focused
-            cy.get('#post_textbox').should('not.be.focused');
+            cy.uiGetPostTextBox().should('not.be.focused');
         });
     });
 });
@@ -167,5 +167,5 @@ function verifyFocusInAddChannelMemberModal() {
 
     // * Focus is not moved anywhere. Neither the search box or main input box has the focus
     cy.get('#selectItems input').should('not.be.focused').and('have.value', 'A');
-    cy.get('#post_textbox').should('not.be.focused');
+    cy.uiGetPostTextBox().should('not.be.focused');
 }

--- a/e2e/cypress/tests/integration/messaging/focus_move_spec.js
+++ b/e2e/cypress/tests/integration/messaging/focus_move_spec.js
@@ -59,7 +59,7 @@ describe('Messaging', () => {
         cy.clickPostCommentIcon();
 
         // # Place the focus inside the RHS input box
-        cy.get('#reply_textbox').focus().should('be.focused');
+        cy.uiGetReplyTextBox().focus().should('be.focused');
 
         // # Use CTRL+K or CMD+K to open the channel switcher depending on OS
         cy.typeCmdOrCtrl().type('K', {release: true});
@@ -85,7 +85,7 @@ describe('Messaging', () => {
         cy.clickPostCommentIcon();
 
         // * Verify RHS textbox is focused the first time Reply arrow is clicked
-        cy.get('#reply_textbox').should('be.focused');
+        cy.uiGetReplyTextBox().should('be.focused');
 
         // # Focus away from RHS textbox
         cy.get('#rhsContainer .post-right__content').click();
@@ -94,7 +94,7 @@ describe('Messaging', () => {
         cy.clickPostCommentIcon();
 
         // * Verify RHS textbox is again focused the second time, when already open
-        cy.get('#reply_textbox').should('be.focused');
+        cy.uiGetReplyTextBox().should('be.focused');
     });
 
     it('MM-T203 Focus does not move when it has already been set elsewhere', () => {

--- a/e2e/cypress/tests/integration/messaging/group_message_spec.js
+++ b/e2e/cypress/tests/integration/messaging/group_message_spec.js
@@ -76,7 +76,7 @@ describe('Group Message', () => {
         cy.findByText('Go').click();
 
         // # Post something to create a GM
-        cy.get('#post_textbox').type('Hi!').type('{enter}');
+        cy.uiGetPostTextBox().type('Hi!').type('{enter}');
 
         // # Click on '+' sign to open DM modal
         cy.uiAddDirectMessage().click();

--- a/e2e/cypress/tests/integration/messaging/image_attachment_spec.js
+++ b/e2e/cypress/tests/integration/messaging/image_attachment_spec.js
@@ -155,15 +155,8 @@ describe('Image attachment', () => {
 });
 
 function verifyImageInPostFooter(verifyExistence = true) {
-    if (verifyExistence) {
-        // * Verify that the image exists in the post message footer
-        cy.get('#postCreateFooter').should('be.visible').find('div.post-image__column').
-            should('exist').
-            and('be.visible');
-    } else {
-        // * Verify that the image no longer exists in the post message footer
-        cy.get('#postCreateFooter').find('div.post-image__column').should('not.exist');
-    }
+    // * Verify that the image exists or not
+    cy.get('#advancedTextEditorCell').find('.file-preview').should(verifyExistence ? 'be.visible' : 'not.exist');
 }
 
 function verifyFileThumbnail({filename, actualImage = {}, container = {}, clickPreview}) {

--- a/e2e/cypress/tests/integration/messaging/inline_images_open_preview_window_spec.js
+++ b/e2e/cypress/tests/integration/messaging/inline_images_open_preview_window_spec.js
@@ -20,16 +20,6 @@ describe('Messaging', () => {
     });
 
     it('MM-T187 Inline markdown images open preview window', () => {
-        // # Open 'Advanced' section of 'Settings' modal
-        cy.uiOpenSettingsModal('Advanced').within(() => {
-            // # Open 'Preview Pre-release Features' setting and check 'Show markdown preview option in message input box'
-            cy.findByRole('heading', {name: 'Preview Pre-release Features'}).should('be.visible').click();
-            cy.findByRole('checkbox', {name: 'Show markdown preview option in message input box'}).click().should('be.checked');
-
-            // # Save and close the modal
-            cy.uiSaveAndClose();
-        });
-
         // # Post the image link to the channel
         cy.postMessage('Hello ![test image](https://raw.githubusercontent.com/furqanmlk/furqanmlk.github.io/main/images/image-small-height.png)');
 

--- a/e2e/cypress/tests/integration/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e/cypress/tests/integration/messaging/inline_markdown_image_link_open_link_spec.js
@@ -20,14 +20,6 @@ describe('Messaging', () => {
     });
 
     it('MM-T188 - Inline markdown image that is a link, opens the link', () => {
-        // * Open settings modal - Advanced section
-        cy.uiOpenSettingsModal('Advanced').within(() => {
-            // # Click on the 'Advanced Preview Features Edit' button and check the 'Show markdown preview option in message input box' and save
-            cy.get('#advancedPreviewFeaturesEdit').should('be.visible').click();
-            cy.get('#advancedPreviewFeaturesmarkdown_preview').check();
-            cy.uiSaveAndClose();
-        });
-
         const linkUrl = 'https://www.google.com';
         const imageUrl = 'https://docs.mattermost.com/_images/icon-76x76.png';
         const label = 'Build Status';

--- a/e2e/cypress/tests/integration/messaging/input_box_expands_spec.js
+++ b/e2e/cypress/tests/integration/messaging/input_box_expands_spec.js
@@ -34,8 +34,8 @@ describe('Messaging', () => {
         cy.get('#rhsCloseButton').should('not.exist');
 
         // # Get initial height of the post textbox
-        cy.get('#post_textbox').should('be.visible').clear();
-        cy.get('#post_textbox').then((post) => {
+        cy.uiGetPostTextBox().clear();
+        cy.uiGetPostTextBox().then((post) => {
             cy.wrap(parseInt(post[0].clientHeight, 10)).as('previousHeight');
         });
 
@@ -47,9 +47,9 @@ describe('Messaging', () => {
         // # Write lines until maximum height
         for (let i = 0; i < 13; i++) {
             // # Post the line
-            cy.get('#post_textbox').type('{shift}{enter}');
+            cy.uiGetPostTextBox().type('{shift}{enter}');
 
-            cy.get('#post_textbox').then((post) => {
+            cy.uiGetPostTextBox().then((post) => {
                 const height = parseInt(post[0].clientHeight, 10);
 
                 // * Previous height should be lower than the current height
@@ -61,8 +61,8 @@ describe('Messaging', () => {
         }
 
         // * Check that height does not keep increasing.
-        cy.get('#post_textbox').type('{shift}{enter}');
-        cy.get('#post_textbox').then((post) => {
+        cy.uiGetPostTextBox().type('{shift}{enter}');
+        cy.uiGetPostTextBox().then((post) => {
             const height = parseInt(post[0].clientHeight, 10);
             cy.get('@previousHeight').should('equal', height);
         });
@@ -72,7 +72,7 @@ describe('Messaging', () => {
         });
 
         // # Clear textbox to test from a different post
-        cy.get('#post_textbox').should('be.visible').clear();
+        cy.uiGetPostTextBox().clear();
 
         // # Scroll to a previous post
         cy.getNthPostId(-29).then((postId) => {
@@ -81,7 +81,7 @@ describe('Messaging', () => {
 
         // #  Again, write lines until the textbox reaches the maximum height
         for (let i = 0; i < 14; i++) {
-            cy.get('#post_textbox').type('{shift}{enter}');
+            cy.uiGetPostTextBox().type('{shift}{enter}');
         }
 
         // * Previous post should be visible

--- a/e2e/cypress/tests/integration/messaging/input_box_expands_with_rhs_spec.js
+++ b/e2e/cypress/tests/integration/messaging/input_box_expands_with_rhs_spec.js
@@ -38,8 +38,8 @@ describe('Messaging', () => {
         cy.get('#rhsCloseButton').should('exist');
 
         // # Get initial height of the post textbox
-        cy.get('#post_textbox').should('be.visible').clear();
-        cy.get('#post_textbox').then((post) => {
+        cy.uiGetPostTextBox().clear();
+        cy.uiGetPostTextBox().then((post) => {
             cy.wrap(parseInt(post[0].clientHeight, 10)).as('previousHeight');
         });
 
@@ -51,9 +51,9 @@ describe('Messaging', () => {
         // # Write lines until maximum height
         for (let i = 0; i < 13; i++) {
             // # Post the line
-            cy.get('#post_textbox').type('{shift}{enter}');
+            cy.uiGetPostTextBox().type('{shift}{enter}');
 
-            cy.get('#post_textbox').then((post) => {
+            cy.uiGetPostTextBox().then((post) => {
                 const height = parseInt(post[0].clientHeight, 10);
 
                 // * Previous height should be lower than the current heigh
@@ -65,8 +65,8 @@ describe('Messaging', () => {
         }
 
         // * Check that height does not keep increasing.
-        cy.get('#post_textbox').type('{shift}{enter}');
-        cy.get('#post_textbox').then((post) => {
+        cy.uiGetPostTextBox().type('{shift}{enter}');
+        cy.uiGetPostTextBox().then((post) => {
             const height = parseInt(post[0].clientHeight, 10);
             cy.get('@previousHeight').should('equal', height);
         });
@@ -76,7 +76,7 @@ describe('Messaging', () => {
         });
 
         // # Clear textbox to test from a different post
-        cy.get('#post_textbox').should('be.visible').clear();
+        cy.uiGetPostTextBox().clear();
 
         // # Scroll to a previous post
         cy.getNthPostId(-29).then((postId) => {
@@ -85,7 +85,7 @@ describe('Messaging', () => {
 
         // # Write again all the long message
         for (let i = 0; i < 14; i++) {
-            cy.get('#post_textbox').type('{shift}{enter}');
+            cy.uiGetPostTextBox().type('{shift}{enter}');
         }
 
         // * Previous post should be visible

--- a/e2e/cypress/tests/integration/messaging/long_draft_spec.js
+++ b/e2e/cypress/tests/integration/messaging/long_draft_spec.js
@@ -39,7 +39,7 @@ describe('Messaging', () => {
         ];
 
         // # Get the height before starting to write
-        cy.get('#post_textbox').should('be.visible').clear().invoke('height').as('initialHeight').as('previousHeight');
+        cy.uiGetPostTextBox().clear().invoke('height').as('initialHeight').as('previousHeight');
 
         // # Write all lines
         writeLinesToPostTextBox(lines);
@@ -53,7 +53,7 @@ describe('Messaging', () => {
         verifyPostTextbox('@previousHeight', lines.join('\n'));
 
         // # Clear the textbox
-        cy.get('#post_textbox').clear();
+        cy.uiGetPostTextBox().clear();
         cy.postMessage('World!');
 
         // # Write all lines again
@@ -75,14 +75,14 @@ describe('Messaging', () => {
 function writeLinesToPostTextBox(lines) {
     Cypress._.forEach(lines, (line, i) => {
         // # Add the text
-        cy.get('#post_textbox').type(line, {delay: TIMEOUTS.ONE_HUNDRED_MILLIS}).wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().type(line, {delay: TIMEOUTS.ONE_HUNDRED_MILLIS}).wait(TIMEOUTS.HALF_SEC);
 
         if (i < lines.length - 1) {
             // # Add new line
-            cy.get('#post_textbox').type('{shift}{enter}').wait(TIMEOUTS.HALF_SEC);
+            cy.uiGetPostTextBox().type('{shift}{enter}').wait(TIMEOUTS.HALF_SEC);
 
             // * Verify new height
-            cy.get('#post_textbox').invoke('height').then((height) => {
+            cy.uiGetPostTextBox().invoke('height').then((height) => {
                 // * Verify previous height should be lower than the current height
                 cy.get('@previousHeight').should('be.lessThan', parseInt(height, 10));
 
@@ -95,7 +95,7 @@ function writeLinesToPostTextBox(lines) {
 }
 
 function verifyPostTextbox(heightSelector, text) {
-    cy.get('#post_textbox').should('be.visible').and('have.text', text).invoke('height').then((currentHeight) => {
+    cy.uiGetPostTextBox().and('have.text', text).invoke('height').then((currentHeight) => {
         cy.get(heightSelector).should('be.gte', currentHeight);
     });
 }

--- a/e2e/cypress/tests/integration/messaging/long_post_attachments_spec.js
+++ b/e2e/cypress/tests/integration/messaging/long_post_attachments_spec.js
@@ -93,7 +93,7 @@ function postAttachments() {
 
     // # Copy and paste the text below into the message box and post
     cy.fixture('long_text_post.txt', 'utf-8').then((text) => {
-        cy.get('#post_textbox').then((textbox) => {
+        cy.uiGetPostTextBox().then((textbox) => {
             textbox.val(text);
         }).type(' {backspace}{enter}');
     });

--- a/e2e/cypress/tests/integration/messaging/long_post_attachments_spec.js
+++ b/e2e/cypress/tests/integration/messaging/long_post_attachments_spec.js
@@ -71,15 +71,8 @@ describe('Messaging', () => {
 });
 
 function verifyImageInPostFooter(verifyExistence = true) {
-    if (verifyExistence) {
-        // * Verify that the image exists in the post message footer
-        cy.get('#postCreateFooter').should('be.visible').find('div.post-image__column').
-            should('exist').
-            and('be.visible');
-    } else {
-        // * Verify that the image no longer exists in the post message footer
-        cy.get('#postCreateFooter').find('div.post-image__column').should('not.exist');
-    }
+    // * Verify that the image exists or not
+    cy.get('#advancedTextEditorCell').find('.file-preview').should(verifyExistence ? 'be.visible' : 'not.exist');
 }
 
 function postAttachments() {

--- a/e2e/cypress/tests/integration/messaging/markdown_preview_inline_image_spec.js
+++ b/e2e/cypress/tests/integration/messaging/markdown_preview_inline_image_spec.js
@@ -24,17 +24,17 @@ describe('Messaging', () => {
         const message = '![make it so](https://i.stack.imgur.com/MNeE7.jpg)';
 
         // # Get the height before starting to write
-        cy.get('#post_textbox').should('be.visible').clear().then(() => {
+        cy.uiGetPostTextBox().clear().then(() => {
             cy.get('#post-create').then((postArea) => {
                 cy.wrap(parseInt(postArea[0].clientHeight, 10)).as('initialHeight');
             });
         });
 
         // # Post first line to use
-        cy.get('#post_textbox').type(message).type('{shift}{enter}').type(message);
+        cy.uiGetPostTextBox().type(message).type('{shift}{enter}').type(message);
 
         // # Click on Preview button
-        cy.get('#previewLink').click({force: true});
+        cy.findByLabelText('preview').click();
 
         cy.get('#post-list').then((postList) => {
             cy.get('#create_post').within(() => {

--- a/e2e/cypress/tests/integration/messaging/markdown_quotation_paragraphs_spec.js
+++ b/e2e/cypress/tests/integration/messaging/markdown_quotation_paragraphs_spec.js
@@ -23,9 +23,9 @@ describe('Messaging', () => {
         const messageParts = ['this is', 'really', 'three quote lines'];
 
         // # Post message to use
-        cy.get('#post_textbox').clear().type('>' + messageParts[0]).type('{shift}{enter}{enter}');
-        cy.get('#post_textbox').type('>' + messageParts[1]).type('{shift}{enter}{enter}');
-        cy.get('#post_textbox').type('>' + messageParts[2]).type('{enter}');
+        cy.uiGetPostTextBox().clear().type('>' + messageParts[0]).type('{shift}{enter}{enter}');
+        cy.uiGetPostTextBox().type('>' + messageParts[1]).type('{shift}{enter}{enter}');
+        cy.uiGetPostTextBox().type('>' + messageParts[2]).type('{enter}');
 
         var firstPartLeft;
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/tests/integration/messaging/mention_autocomplete_overlap_spec.js
+++ b/e2e/cypress/tests/integration/messaging/mention_autocomplete_overlap_spec.js
@@ -97,15 +97,15 @@ function uploadFileAndAddAutocompleteThenVerifyNoOverlap() {
     cy.get('#fileUploadInput').attachFile('mattermost-icon.png');
 
     // # Create and then type message to use
-    cy.get('#post_textbox').clear();
+    cy.uiGetPostTextBox().clear();
     let message = 'h{shift}';
     for (let i = 0; i < 12; i++) {
         message += '{enter}h';
     }
-    cy.get('#post_textbox').type(message);
+    cy.uiGetPostTextBox().type(message);
 
     // # Add the mention
-    cy.get('#post_textbox').type('{shift}{enter}').type('@');
+    cy.uiGetPostTextBox().type('{shift}{enter}').type('@');
 
     cy.get('#channel-header').should('be.visible').then((header) => {
         cy.get('#suggestionList').should('be.visible').then((list) => {

--- a/e2e/cypress/tests/integration/messaging/mention_autocomplete_overlap_spec.js
+++ b/e2e/cypress/tests/integration/messaging/mention_autocomplete_overlap_spec.js
@@ -32,9 +32,9 @@ describe('Messaging', () => {
         cy.get('#rhsContainer').should('be.visible');
 
         // # Enter @ to allow opening of autocomplete box
-        cy.get('#reply_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type('@');
+        cy.uiGetReplyTextBox().clear().type('@');
 
-        cy.get('#reply_textbox').then((replyTextbox) => {
+        cy.uiGetReplyTextBox().then((replyTextbox) => {
             cy.get('#suggestionList').then((suggestionList) => {
                 // * Verify that the suggestion box opened below the textbox
                 expect(replyTextbox[0].getBoundingClientRect().top).to.be.lessThan(suggestionList[0].getBoundingClientRect().top);
@@ -57,7 +57,7 @@ describe('Messaging', () => {
 
         // # Make a series of post so we are way past the first message in terms of scroll
         Cypress._.times(2, () => {
-            cy.get('#reply_textbox').
+            cy.uiGetReplyTextBox().
                 clear().
                 invoke('val', MESSAGES.HUGE).
                 wait(TIMEOUTS.ONE_SEC).
@@ -65,9 +65,9 @@ describe('Messaging', () => {
         });
 
         // # Enter @ to allow opening of autocomplete box
-        cy.get('#reply_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().type('@');
+        cy.uiGetReplyTextBox().clear().type('@');
 
-        cy.get('#reply_textbox').then((replyTextbox) => {
+        cy.uiGetReplyTextBox().then((replyTextbox) => {
             cy.get('#suggestionList').then((suggestionList) => {
                 // * Verify that the suggestion box opened above the textbox
                 expect(replyTextbox[0].getBoundingClientRect().top).to.be.greaterThan(suggestionList[0].getBoundingClientRect().top);

--- a/e2e/cypress/tests/integration/messaging/message_bullets_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_bullets_spec.js
@@ -20,7 +20,7 @@ describe('Message', () => {
 
     it('MM-T87 Text in bullet points is the same size as text above and below it', () => {
         // # Post a message
-        cy.get('#post_textbox').clear().
+        cy.uiGetPostTextBox().clear().
             type('This is a normal sentence.').
             type('{shift}{enter}{enter}').
             type('1. this is point 1').
@@ -67,7 +67,7 @@ describe('Message', () => {
 
         bulletMessages.forEach((bulletMessage) => {
             // # Post the message containing bullets
-            cy.get('#post_textbox').
+            cy.uiGetPostTextBox().
                 clear().
                 type(bulletMessage.text).
                 type('{enter}');

--- a/e2e/cypress/tests/integration/messaging/message_by_aeroplane_icon_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_by_aeroplane_icon_spec.js
@@ -24,7 +24,7 @@ describe('Messaging', () => {
     it('MM-T73 Mobile view: Clicking on airplane icon does not open file attachment modal but sends the message', () => {
         // # type some characters in the message box
         const message = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ';
-        cy.get('#post_textbox').clear().type(message);
+        cy.uiGetPostTextBox().clear().type(message);
 
         // # click send
         cy.findByTestId('SendMessageButton').click();

--- a/e2e/cypress/tests/integration/messaging/message_channel_draw_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_channel_draw_spec.js
@@ -37,7 +37,7 @@ describe('M17448 Does not post draft message', () => {
 
     it('on successful upload via "Draw" plugin', () => {
         const draft = `Draft message ${getRandomId()}`;
-        cy.get('#post_textbox').clear().type(draft);
+        cy.uiGetPostTextBox().clear().type(draft);
 
         // # Open file upload options and select draw plugin
         cy.get('#fileUploadButton').click();
@@ -46,14 +46,14 @@ describe('M17448 Does not post draft message', () => {
         // * Upload a file and verify drafted message still exist in textbox
         cy.get('canvas').trigger('pointerdown').trigger('pointerup').click();
         cy.findByText('Upload').should('be.visible').click();
-        cy.get('#post_textbox').
-            should('be.visible').wait(TIMEOUTS.HALF_SEC).
+        cy.uiGetPostTextBox().
+            wait(TIMEOUTS.HALF_SEC).
             should('have.text', draft);
     });
 
     it('on upload cancel via "Draw" plugin', () => {
         const draft = `Draft message ${getRandomId()}`;
-        cy.get('#post_textbox').clear().type(draft);
+        cy.uiGetPostTextBox().clear().type(draft);
 
         // # Open file upload options and select draw plugin
         cy.get('#fileUploadButton').click();
@@ -61,21 +61,21 @@ describe('M17448 Does not post draft message', () => {
 
         // * Cancel file upload process and verify drafted message still exist in textbox
         cy.findByText('Cancel').should('be.visible').click();
-        cy.get('#post_textbox').
-            should('be.visible').wait(TIMEOUTS.HALF_SEC).
+        cy.uiGetPostTextBox().
+            wait(TIMEOUTS.HALF_SEC).
             should('have.text', draft);
     });
 
     it('on upload attempt via "Your Computer', () => {
         const draft = `Draft message ${getRandomId()}`;
-        cy.get('#post_textbox').clear().type(draft);
+        cy.uiGetPostTextBox().clear().type(draft);
 
         // # Open file upload options and select "Your Computer"
         cy.get('#fileUploadButton').click();
         cy.get('#fileUploadOptions').findByText('Your computer').click();
 
         // * Verify drafted message still exist in textbox
-        cy.get('#post_textbox').should('be.visible').wait(TIMEOUTS.HALF_SEC).
+        cy.uiGetPostTextBox().wait(TIMEOUTS.HALF_SEC).
             should('have.text', draft);
     });
 });

--- a/e2e/cypress/tests/integration/messaging/message_channel_reference_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_channel_reference_spec.js
@@ -27,7 +27,7 @@ describe('Messaging', () => {
         cy.postMessage(msg);
 
         // # Hit the "up" arrow to open the edit modal
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
 
         // # Insert a tilde (~) at the beginning of the post to be edited
         cy.get('#edit_textbox').should('be.visible').wait(TIMEOUTS.HALF_SEC).type('{home}~');

--- a/e2e/cypress/tests/integration/messaging/message_deleted_on_reply_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_deleted_on_reply_spec.js
@@ -38,7 +38,7 @@ describe('Messaging', () => {
         cy.clickPostCommentIcon();
 
         // # Write message on reply box
-        cy.get('#reply_textbox').type(draftMessage);
+        cy.uiGetReplyTextBox().type(draftMessage);
 
         // # Remove message from the other user
         cy.getLastPostId().then((postId) => {
@@ -55,7 +55,7 @@ describe('Messaging', () => {
             });
 
             // # Send message
-            cy.get('#reply_textbox').type('{enter}');
+            cy.uiGetReplyTextBox().type('{enter}');
 
             // * Post Deleted Modal should be visible
             cy.findAllByTestId('postDeletedModal').should('be.visible');
@@ -69,10 +69,10 @@ describe('Messaging', () => {
             });
 
             // * Textbox should still have the draft message
-            cy.get('#reply_textbox').should('contain', draftMessage);
+            cy.uiGetReplyTextBox().should('contain', draftMessage);
 
             // # Try to post the message one more time pressing enter
-            cy.get('#reply_textbox').type('{enter}');
+            cy.uiGetReplyTextBox().type('{enter}');
 
             // * The modal should have appeared again
             cy.findAllByTestId('postDeletedModal').should('be.visible');
@@ -86,7 +86,7 @@ describe('Messaging', () => {
             });
 
             // * Textbox should still have the draft message
-            cy.get('#reply_textbox').should('contain', draftMessage);
+            cy.uiGetReplyTextBox().should('contain', draftMessage);
 
             // # Change to the other user and go to test channel
             cy.apiAdminLogin();

--- a/e2e/cypress/tests/integration/messaging/message_draft_persistance_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_draft_persistance_spec.js
@@ -38,14 +38,14 @@ describe('Message Draft Persistance', () => {
         cy.visit(offTopicUrl);
 
         // # Type some text into the post textbox
-        cy.get('#post_textbox').type(testText);
+        cy.uiGetPostTextBox().type(testText);
 
         // # Reload the page
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500).reload();
 
         // * Ensure the draft is back in the post textbox
-        cy.get('#post_textbox').should('have.text', testText);
+        cy.uiGetPostTextBox().should('have.text', testText);
     });
 
     it('MM-T4640 Persisting a draft in another channel', () => {
@@ -55,13 +55,13 @@ describe('Message Draft Persistance', () => {
         cy.visit(offTopicUrl);
 
         // # Type some text into the post textbox
-        cy.get('#post_textbox').type(testText);
+        cy.uiGetPostTextBox().type(testText);
 
         // # Switch to another channel
         cy.get(`#sidebarItem_${testChannel.name}`).click();
 
         // * Ensure the post textbox was cleared
-        cy.get('#post_textbox').should('be.empty');
+        cy.uiGetPostTextBox().should('be.empty');
 
         // * Ensure Off-Topic has the draft icon
         verifyDraftIcon('off-topic', true);
@@ -71,7 +71,7 @@ describe('Message Draft Persistance', () => {
         cy.wait(500).reload();
 
         // * Ensure the post textbox is still empty
-        cy.get('#post_textbox').should('be.empty');
+        cy.uiGetPostTextBox().should('be.empty');
 
         // * Ensure Off-Topic still has the draft icon
         cy.get('#sidebarItem_off-topic').
@@ -83,7 +83,7 @@ describe('Message Draft Persistance', () => {
         cy.get('#sidebarItem_off-topic').click();
 
         // * Ensure the draft is back in the post textbox
-        cy.get('#post_textbox').should('have.text', testText);
+        cy.uiGetPostTextBox().should('have.text', testText);
     });
 
     it('MM-T4641 Migration of drafts from redux-persist@4.0.0', () => {
@@ -115,6 +115,6 @@ describe('Message Draft Persistance', () => {
         cy.get(`#sidebarItem_${testChannel.name}`).click();
 
         // * Ensure the draft is in the post textbox
-        cy.get('#post_textbox').should('have.text', testText);
+        cy.uiGetPostTextBox().should('have.text', testText);
     });
 });

--- a/e2e/cypress/tests/integration/messaging/message_draft_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_draft_spec.js
@@ -26,7 +26,7 @@ describe('Message Draft', () => {
         cy.get('#sidebarItem_off-topic').findByTestId('draftIcon').should('not.exist');
 
         // # Type in some text into the text area of the opened channel
-        cy.get('#post_textbox').type('comm');
+        cy.uiGetPostTextBox().type('comm');
 
         // # Go to another test channel without submitting the draft in the previous channel
         cy.get('#sidebarItem_town-square').click({force: true});

--- a/e2e/cypress/tests/integration/messaging/message_pinning_unpinning_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_pinning_unpinning_spec.js
@@ -34,7 +34,7 @@ describe('Messaging', () => {
 
     it('MM-T142 Pinning or un-pinning older message does not cause it to display at bottom of channel Pinned posts display in RHS with newest at top', () => {
         // * Ensure that the channel view is loaded
-        cy.get('#post_textbox').should('be.visible');
+        cy.uiGetPostTextBox();
 
         // # Post messages
         const olderPost = 7;

--- a/e2e/cypress/tests/integration/messaging/message_reply_part2_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_reply_part2_spec.js
@@ -58,13 +58,13 @@ describe('Message Reply', () => {
         cy.uiGetReply().should('be.disabled');
 
         // # Type a character in the comment box
-        cy.get('#reply_textbox').type('A');
+        cy.uiGetReplyTextBox().type('A');
 
         // * Reply button is not disabled
         cy.uiGetReply().should('not.be.disabled');
 
         // # Clear comment box
-        cy.get('#reply_textbox').clear();
+        cy.uiGetReplyTextBox().clear();
 
         // # Close RHS
         cy.uiCloseRHS();
@@ -77,7 +77,7 @@ describe('Message Reply', () => {
         const msg = 'reply1';
 
         // # Type message
-        cy.get('#reply_textbox').type(msg);
+        cy.uiGetReplyTextBox().type(msg);
 
         // # Post reply
         cy.uiReply();
@@ -108,10 +108,10 @@ describe('Message Reply', () => {
         const msg = 'reply2';
 
         // # Type message
-        cy.get('#reply_textbox').type(msg);
+        cy.uiGetReplyTextBox().type(msg);
 
         // # Press `Enter`
-        cy.get('#reply_textbox').type('{enter}');
+        cy.uiGetReplyTextBox().type('{enter}');
 
         cy.getLastPostId().then((replyId) => {
             // * Message displays in center
@@ -139,7 +139,7 @@ describe('Message Reply', () => {
         const msg = 'reply3';
 
         // # Type message
-        cy.get('#reply_textbox').type(msg);
+        cy.uiGetReplyTextBox().type(msg);
 
         // # Post reply
         cy.uiReply().wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/tests/integration/messaging/message_reply_part2_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_reply_part2_spec.js
@@ -35,10 +35,10 @@ describe('Message Reply', () => {
     it('MM-T2132 - Message sends: just text', () => {
         // # Type `Hello` in center message box
         const msg = 'Hello';
-        cy.get('#post_textbox').type(msg);
+        cy.uiGetPostTextBox().type(msg);
 
         // # Press `Enter`
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Message displays in center
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/tests/integration/messaging/message_reply_scrollable_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_reply_scrollable_spec.js
@@ -42,7 +42,7 @@ describe('Message reply scrollable', () => {
         });
 
         // * Check that after opening RHS it's scrolled to bottom
-        cy.get('#addCommentButton').should('be.visible');
+        cy.uiGetRHS().findByLabelText('Send a message');
     });
 
     it('MM-T4083_2 correctly scrolls to the bottom when the user types in the comment box', () => {
@@ -53,6 +53,6 @@ describe('Message reply scrollable', () => {
         cy.get('#reply_textbox').type('foo', {scrollBehavior: false}); // without scrollBehavior=false cypress automatically scrolls to replyTextBox. We need to check if application does that.
 
         // * Check if RHS scrolled to bottom
-        cy.get('#addCommentButton').should('be.visible');
+        cy.uiGetRHS().findByLabelText('Send a message');
     });
 });

--- a/e2e/cypress/tests/integration/messaging/message_reply_scrollable_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_reply_scrollable_spec.js
@@ -50,7 +50,7 @@ describe('Message reply scrollable', () => {
         cy.get('.post-right__content > div > div').first().scrollIntoView();
 
         // # Type into comment box
-        cy.get('#reply_textbox').type('foo', {scrollBehavior: false}); // without scrollBehavior=false cypress automatically scrolls to replyTextBox. We need to check if application does that.
+        cy.uiGetReplyTextBox().type('foo', {scrollBehavior: false}); // without scrollBehavior=false cypress automatically scrolls to replyTextBox. We need to check if application does that.
 
         // * Check if RHS scrolled to bottom
         cy.uiGetRHS().findByLabelText('Send a message');

--- a/e2e/cypress/tests/integration/messaging/message_reply_too_long_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_reply_too_long_spec.js
@@ -37,18 +37,18 @@ describe('Message Reply too long', () => {
         // # Enter too long text into RHS
         const maxReplyLength = 16383;
         const replyTooLong = replyValid.repeat((maxReplyLength / replyValid.length) + 1);
-        cy.get('#reply_textbox').invoke('val', replyTooLong).trigger('input');
+        cy.uiGetReplyTextBox().invoke('val', replyTooLong).trigger('input');
 
         // * Check warning doesn't overlap textbox
         cy.get('.post-error').should('be.visible');
-        cy.get('#reply_textbox').should('be.visible');
+        cy.uiGetReplyTextBox();
 
         // # Type "enter" into RHS
-        cy.get('#reply_textbox').type('{enter}');
+        cy.uiGetReplyTextBox().type('{enter}');
 
         // * Check warning
         cy.get('.post-error').should('be.visible').and('have.text', `Your message is too long. Character count: ${replyTooLong.length}/${maxReplyLength}`);
-        cy.get('#reply_textbox').should('be.visible');
+        cy.uiGetReplyTextBox();
 
         // * Check last reply is the last valid one
         cy.getLastPostId().then((replyId) => {

--- a/e2e/cypress/tests/integration/messaging/message_shortlinking_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_shortlinking_spec.js
@@ -30,7 +30,7 @@ describe('Message', () => {
         const longLink = `~${testChannel.display_name}`;
 
         cy.postMessage('hello');
-        cy.get('#post_textbox').type(shortLink).type('{enter}');
+        cy.uiGetPostTextBox().type(shortLink).type('{enter}');
 
         cy.getLastPostId().then((postId) => {
             // # Grab last message with the long link url and go to the link

--- a/e2e/cypress/tests/integration/messaging/message_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_spec.js
@@ -149,7 +149,7 @@ describe('Message', () => {
         cy.clickPostCommentIcon();
 
         // # Add some text to RHS text box
-        cy.get('#reply_textbox').type(MESSAGES.TINY);
+        cy.uiGetReplyTextBox().type(MESSAGES.TINY);
 
         // # Click on Preview
         cy.get('#PreviewInputTextButton').click();
@@ -158,7 +158,7 @@ describe('Message', () => {
         cy.uiReply();
 
         // * Focus to remain in the RHS text box
-        cy.get('#reply_textbox').should('be.focused');
+        cy.uiGetReplyTextBox().should('be.focused');
     });
 });
 

--- a/e2e/cypress/tests/integration/messaging/message_spec.js
+++ b/e2e/cypress/tests/integration/messaging/message_spec.js
@@ -64,13 +64,13 @@ describe('Message', () => {
             cy.get(divPostId).click();
 
             // # Push a character key such as "A"
-            cy.get('#post_textbox').type('A');
+            cy.uiGetPostTextBox().type('A');
 
             // # Open the "..." menu on a post in the main to move the focus out of the main input box
             cy.clickPostDotMenu(postId);
 
             // # Push a character key such as "A"
-            cy.get('#post_textbox').type('A');
+            cy.uiGetPostTextBox().type('A');
 
             // * Focus is moved back to the main input and the keystroke is captured
             cy.focused().should('have.id', 'post_textbox');

--- a/e2e/cypress/tests/integration/messaging/mobile_message_deletion_spec.js
+++ b/e2e/cypress/tests/integration/messaging/mobile_message_deletion_spec.js
@@ -23,7 +23,7 @@ describe('Delete Parent Message', () => {
 
     it('MM-T110 Delete a parent message that has a reply: Reply RHS', () => {
         // # Close Hamburger menu, post a message, and add replies
-        cy.get('#post_textbox').click({force: true});
+        cy.uiGetPostTextBox().click({force: true});
         cy.postMessage('Parent Message');
 
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/tests/integration/messaging/no_matches_for_autocomplete_spec.js
+++ b/e2e/cypress/tests/integration/messaging/no_matches_for_autocomplete_spec.js
@@ -21,13 +21,13 @@ describe('No Matches for Autocomplete', () => {
     it('MM-T270 No matches for user autocomplete', () => {
         // # Type non-existent user name
         const nonExistentUser = 'nonExistentUser';
-        cy.get('#post_textbox').clear().type(`@${nonExistentUser}`);
+        cy.uiGetPostTextBox().clear().type(`@${nonExistentUser}`);
 
         // * Verify suggestion list does not exist
         cy.get('#suggestionList').should('not.exist');
 
         // # Hit enter to post non-existent user name
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Verify that the last message posted contains the user name and is not linked
         cy.getLastPost().within(() => {
@@ -39,13 +39,13 @@ describe('No Matches for Autocomplete', () => {
     it('MM-T269 No matches for channel autocomplete', () => {
         // # Type non-existent channel name
         const nonExistentChannel = 'nonExistentChannel';
-        cy.get('#post_textbox').clear().clear().type(`~${nonExistentChannel}`);
+        cy.uiGetPostTextBox().clear().clear().type(`~${nonExistentChannel}`);
 
         // * Verify suggestion list does not exist
         cy.get('#suggestionList').should('not.exist');
 
         // # Hit enter to post non-existent channel name
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Verify that the last message posted contains the channel name and is not linked
         cy.getLastPost().should('include.text', `~${nonExistentChannel}`).within(() => {

--- a/e2e/cypress/tests/integration/messaging/pinned_parent_post_spec.js
+++ b/e2e/cypress/tests/integration/messaging/pinned_parent_post_spec.js
@@ -50,7 +50,7 @@ describe('Messaging', () => {
             cy.get(`#post_${postId}`).trigger('mouseover');
             cy.get(`#CENTER_commentIcon_${postId}`).click({force: true});
             for (let i = 0; i < 5; i++) {
-                cy.get('#reply_textbox').click().should('be.visible').type(`Hello to you too ${i}`);
+                cy.uiGetReplyTextBox().click().should('be.visible').type(`Hello to you too ${i}`);
                 cy.uiGetReply().should('be.enabled').click();
             }
             cy.get('#rhsCloseButton').click();

--- a/e2e/cypress/tests/integration/messaging/post_header_spec.js
+++ b/e2e/cypress/tests/integration/messaging/post_header_spec.js
@@ -79,7 +79,7 @@ describe('Post Header', () => {
             });
 
             // # Click to other location like post textbox
-            cy.get('#post_textbox').click();
+            cy.uiGetPostTextBox().click();
 
             // * Check that the center dot menu and dropdown are hidden
             cy.get(`#post_${postId}`).should('be.visible').within(() => {
@@ -111,7 +111,7 @@ describe('Post Header', () => {
             cy.clickPostReactionIcon(postId);
 
             // # Click on textbox to focus away from emoji area
-            cy.get('#post_textbox').click();
+            cy.uiGetPostTextBox().click();
 
             // * Check that the center post reaction icon and emoji picker are not visible
             cy.get(`#CENTER_reaction_${postId}`).should('not.exist');

--- a/e2e/cypress/tests/integration/messaging/post_html_table_spec.js
+++ b/e2e/cypress/tests/integration/messaging/post_html_table_spec.js
@@ -28,7 +28,7 @@ describe('Post HTML', () => {
         });
 
         // # Paste HTML data from clipboard to the message box.
-        cy.get('#create_post').trigger('paste', {clipboardData: {
+        cy.uiGetPostTextBox().trigger('paste', {clipboardData: {
             items: [1],
             types: ['text/html'],
             getData: () => '<table><img src="null" onerror="alert(\'xss\')" /></table>',

--- a/e2e/cypress/tests/integration/messaging/post_textbox_height_spec.js
+++ b/e2e/cypress/tests/integration/messaging/post_textbox_height_spec.js
@@ -60,6 +60,6 @@ describe('Messaging', () => {
     });
 
     const getTextBox = () => {
-        return cy.get('#reply_textbox');
+        return cy.uiGetReplyTextBox();
     };
 });

--- a/e2e/cypress/tests/integration/messaging/private_channel_open_spec.js
+++ b/e2e/cypress/tests/integration/messaging/private_channel_open_spec.js
@@ -38,7 +38,7 @@ describe('Messaging - Opening a private channel using keyboard shortcuts', () =>
             cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Private channel').wait(TIMEOUTS.HALF_SEC);
 
             // * Focus in the message box
-            cy.get('#post_textbox').should('be.focused');
+            cy.uiGetPostTextBox().should('be.focused');
         });
     });
 });

--- a/e2e/cypress/tests/integration/messaging/quick_send_spec.js
+++ b/e2e/cypress/tests/integration/messaging/quick_send_spec.js
@@ -23,7 +23,7 @@ describe('Messaging', () => {
         // # Build a message and send
         for (let i = 9; i >= 0; i--) {
             const message = i + '{enter}';
-            cy.get('#post_textbox').type(message, {delay: 0});
+            cy.uiGetPostTextBox().type(message, {delay: 0});
         }
 
         for (let i = 10; i > 0; i--) {

--- a/e2e/cypress/tests/integration/messaging/strikethrough_spec.js
+++ b/e2e/cypress/tests/integration/messaging/strikethrough_spec.js
@@ -27,7 +27,7 @@ describe('Messaging', () => {
         cy.postMessage(message);
 
         // # Hit up arrow to open edit modal
-        cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).clear().type('{uparrow}').wait(TIMEOUTS.HALF_SEC);
+        cy.uiGetPostTextBox().clear().type('{uparrow}').wait(TIMEOUTS.HALF_SEC);
 
         // # Type first tilde (a{backspace} used so cursor is in the textbox and {home} gets us to the beginning of the line)
         cy.get('#edit_textbox').type('a{backspace}{home}~').wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/tests/integration/messaging/typing_on_middle_spec.js
+++ b/e2e/cypress/tests/integration/messaging/typing_on_middle_spec.js
@@ -22,18 +22,18 @@ describe('Messaging', () => {
 
     it('MM-T96 Trying to type in middle of text should not send the cursor to end of textbox', () => {
         // # Type message to use
-        cy.get('#post_textbox').clear().type('aa');
+        cy.uiGetPostTextBox().clear().type('aa');
 
         // # Move the cursor and keep typing
-        cy.get('#post_textbox').click().type('{leftarrow}b');
+        cy.uiGetPostTextBox().click().type('{leftarrow}b');
 
         // # Wait for the cursor to move in failing case
         cy.wait(TIMEOUTS.FIVE_SEC);
 
         // # Write another letter
-        cy.get('#post_textbox').type('c');
+        cy.uiGetPostTextBox().type('c');
 
         // * Should contain abca instead of aabc or abac
-        cy.get('#post_textbox').should('contain', 'abca');
+        cy.uiGetPostTextBox().should('contain', 'abca');
     });
 });

--- a/e2e/cypress/tests/integration/messaging/typing_should_show_up_when_editing_spec.js
+++ b/e2e/cypress/tests/integration/messaging/typing_should_show_up_when_editing_spec.js
@@ -25,7 +25,7 @@ describe('Messaging', () => {
         cy.postMessage('test post 1');
 
         // # Press the up arrow to open the edit modal
-        cy.get('#post_textbox').type('{uparrow}');
+        cy.uiGetPostTextBox().type('{uparrow}');
 
         // # Immediately after opening the edit modal, type more text and assert that the text has been inputted
         cy.get('#edit_textbox').type(' and test post 2').should('have.text', 'test post 1 and test post 2');

--- a/e2e/cypress/tests/integration/modals/quick_switcher_spec.js
+++ b/e2e/cypress/tests/integration/modals/quick_switcher_spec.js
@@ -54,7 +54,7 @@ describe('Quick switcher', () => {
         cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Type either cmd+K / ctrl+K depending on OS
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // # This is to remove the unread channel created on apiInitSetup
         cy.focused().type(testChannel.display_name).wait(TIMEOUTS.HALF_SEC).type('{enter}');
@@ -64,7 +64,7 @@ describe('Quick switcher', () => {
         // # Go to the DM channel of second user
         cy.goToDm(secondUser.username);
 
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // # Search with the term a
         cy.focused().type('a');
@@ -81,7 +81,7 @@ describe('Quick switcher', () => {
         cy.goToDm(thirdUser.username);
 
         // # Type either cmd+K / ctrl+K depending on OS
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // # Search with the term a
         cy.focused().type('a');
@@ -96,7 +96,7 @@ describe('Quick switcher', () => {
         // # Go to the DM channel of second user
         cy.goToDm(secondUser.username);
 
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
         cy.focused().type('a');
 
         // * Should have recently interacted DM on top
@@ -105,7 +105,7 @@ describe('Quick switcher', () => {
     });
 
     it('MM-T3447_3 Should match interacted users even with a partial match', () => {
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // # Search with the term z2
         cy.focused().type('z2');
@@ -114,7 +114,7 @@ describe('Quick switcher', () => {
         cy.get('.suggestion--selected').should('exist').and('contain.text', secondUser.username);
 
         cy.get('body').type('{esc}', {force: true});
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // # Search with the term z3
         cy.focused().type('z3');
@@ -130,7 +130,7 @@ describe('Quick switcher', () => {
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
             cy.postMessage('Hello to GM');
 
-            cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+            cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
             cy.focused().type(userPrefix);
 
             // * Should have recently interacted GM on top, Matching as Gaz because we have G prefixed for GM's
@@ -144,7 +144,7 @@ describe('Quick switcher', () => {
             cy.goToDm(thirdUser.username);
             cy.postMessage('Hello to DM');
 
-            cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+            cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
             cy.focused().type(userPrefix);
 
             // * Should have recently interacted DM on top
@@ -157,7 +157,7 @@ describe('Quick switcher', () => {
             // # Visit the newly created group message
             cy.visit(`/${testTeam.name}/channels/${channel.name}`);
 
-            cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+            cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
             cy.focused().type(`${testUser.username} az3`);
 
             // * Should have the GM listed in the results

--- a/e2e/cypress/tests/integration/multi_team_and_dm/check_user_status_spec.js
+++ b/e2e/cypress/tests/integration/multi_team_and_dm/check_user_status_spec.js
@@ -79,13 +79,13 @@ function setStatus(status, icon) {
 
 function verifyUserStatus(testCase) {
     // # Clear then type '/'
-    cy.get('#post_textbox').should('be.visible').clear().type('/');
+    cy.uiGetPostTextBox().clear().type('/');
 
     // * Verify that the suggestion list is visible
     cy.get('#suggestionList').should('be.visible');
 
     // # Post slash command to change user status
-    cy.get('#post_textbox').type(`${testCase.name}{enter}`).wait(TIMEOUTS.ONE_HUNDRED_MILLIS).type('{enter}');
+    cy.uiGetPostTextBox().type(`${testCase.name}{enter}`).wait(TIMEOUTS.ONE_HUNDRED_MILLIS).type('{enter}');
 
     // * Get last post and verify system message
     cy.getLastPost().within(() => {

--- a/e2e/cypress/tests/integration/multi_team_and_dm/close_current_dm_redirects_spec.js
+++ b/e2e/cypress/tests/integration/multi_team_and_dm/close_current_dm_redirects_spec.js
@@ -120,7 +120,7 @@ const sendDirectMessageToUser = (user, message) => {
     cy.get('#channelHeaderTitle').should('be.visible').and('contain.text', user.username);
 
     // # Type message and send it to the user
-    cy.get('#post_textbox').
+    cy.uiGetPostTextBox().
         type(message).
         type('{enter}');
 };

--- a/e2e/cypress/tests/integration/notifications/channel_links_show_as_links_spec.js
+++ b/e2e/cypress/tests/integration/notifications/channel_links_show_as_links_spec.js
@@ -116,7 +116,7 @@ describe('Notifications', () => {
                 );
                 verifyEmailBody(expectedEmailBody, body);
 
-                const permalink = body[3].split(' ')[3];
+                const permalink = body[3].split(' ')[4];
                 const permalinkPostId = permalink.split('/')[6];
 
                 // # Visit permalink (e.g. click on email link) then view in browser to proceed

--- a/e2e/cypress/tests/integration/notifications/desktop_notifications_1_spec.js
+++ b/e2e/cypress/tests/integration/notifications/desktop_notifications_1_spec.js
@@ -123,7 +123,7 @@ describe('Desktop notifications', () => {
             spyNotificationAs('withoutNotification', 'granted');
 
             // # Post the following: /dnd
-            cy.get('#post_textbox').clear().type('/dnd{enter}');
+            cy.uiGetPostTextBox().clear().type('/dnd{enter}');
 
             // # Have another user send you a DM
             cy.postMessageAs({sender: otherUser, message: MESSAGES.TINY, channelId: channel.id});

--- a/e2e/cypress/tests/integration/scroll/default_images_collapsed_spec.js
+++ b/e2e/cypress/tests/integration/scroll/default_images_collapsed_spec.js
@@ -31,7 +31,7 @@ describe('Scroll', () => {
 
         cy.get('.post-image').should('be.visible');
 
-        cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+        cy.uiGetPostTextBox().clear().type('{enter}');
 
         // * Observe image preview is collapsed
         cy.uiGetFileThumbnail(filename).should('not.exist');

--- a/e2e/cypress/tests/integration/scroll/fixed_width_spec.js
+++ b/e2e/cypress/tests/integration/scroll/fixed_width_spec.js
@@ -52,7 +52,7 @@ describe('Scroll', () => {
         cy.postMessage('This is the last post');
         cy.getLastPostId().as('lastPostId');
 
-        // Getting height of all postes before applying 'Fixed width, centered' option and assigning alias
+        // Getting height of all posts before applying 'Fixed width, centered' option and assigning alias
         getUserNameTitle().eq(0).invoke('height').as('initialUserNameHeight');
         getFirstTextPost().invoke('height').as('initialFirstPostHeight');
         getMp3Post().invoke('height').as('initialMp3Height');
@@ -104,7 +104,7 @@ describe('Scroll', () => {
                 getInlineImgPost().should('have.css', 'height', (originalHeight + 2) + 'px');
             });
             cy.get('@initialAttachmentHeight').then((originalHeight) => {
-                getAttachmentPost().should('have.css', 'height', (originalHeight + 2) + 'px');
+                getAttachmentPost().should('have.css', 'height', originalHeight + 'px');
             });
         });
     });
@@ -145,7 +145,7 @@ describe('Scroll', () => {
     // Getting element using link preview Post Id, then finding its child file thumbnail post and assigning to const variable for later use
     const getAttachmentPost = () => {
         return cy.get('@linkPreviewId').then((postId) => {
-            cy.get(`#${postId}_message`).find('img[aria-label="file thumbnail"]');
+            cy.get(`#${postId}_message`).find('.PostAttachmentOpenGraph__image');
         });
     };
 

--- a/e2e/cypress/tests/integration/search/search_group_message_spec.js
+++ b/e2e/cypress/tests/integration/search/search_group_message_spec.js
@@ -87,7 +87,7 @@ describe('Search', () => {
             // # Post file to group
             cy.get('#advancedTextEditorCell').find('#fileUploadInput').attachFile('word-file.doc');
             cy.get('.post-image__thumbnail').should('be.visible');
-            cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+            cy.uiGetPostTextBox().clear().type('{enter}');
 
             //# Type "in:" text in search input
             cy.get('#searchBox').type('in:');

--- a/e2e/cypress/tests/integration/search/search_user_file_spec.js
+++ b/e2e/cypress/tests/integration/search/search_user_file_spec.js
@@ -57,7 +57,7 @@ describe('Search in DMs', () => {
         // # Post file to user
         cy.get('#advancedTextEditorCell').find('#fileUploadInput').attachFile('word-file.doc');
         cy.get('.post-image__thumbnail').should('be.visible');
-        cy.get('#post_textbox').should('be.visible').clear().type('{enter}');
+        cy.uiGetPostTextBox().clear().type('{enter}');
 
         // # Type `in:` in searchbox
         cy.get('#searchBox').type('in:');

--- a/e2e/cypress/tests/integration/search_autocomplete/renaming_spec.js
+++ b/e2e/cypress/tests/integration/search_autocomplete/renaming_spec.js
@@ -156,9 +156,8 @@ function searchAndVerifyChannel(channel) {
 
 function searchAndVerifyUser(user) {
     // # Start @ mentions autocomplete with username
-    cy.get('#post_textbox').
+    cy.uiGetPostTextBox().
         as('input').
-        should('be.visible').
         clear().
         type(`@${user.username}`);
 

--- a/e2e/cypress/tests/integration/settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/tests/integration/settings/display/message_display_mode_spec.js
@@ -38,7 +38,7 @@ function verifyLineBreaksRemainIntact(display) {
     const secondLine = 'Second line';
 
     // # Enter in text
-    cy.get('#post_textbox').
+    cy.uiGetPostTextBox().
         clear().
         type(firstLine).
         type('{shift}{enter}{enter}').

--- a/e2e/cypress/tests/integration/settings/sidebar/channel_switcher_not_cloud_spec.js
+++ b/e2e/cypress/tests/integration/settings/sidebar/channel_switcher_not_cloud_spec.js
@@ -30,7 +30,7 @@ describe('Settings > Sidebar > Channel Switcher', () => {
 
     it('Cmd/Ctrl+Shift+L closes Channel Switch modal and sets focus to post textbox', () => {
         // # Type CTRL/CMD+K
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // * Channel switcher hint should be visible
         cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');
@@ -42,7 +42,7 @@ describe('Settings > Sidebar > Channel Switcher', () => {
         cy.get('#suggestionList').should('not.exist');
 
         // * focus should be on the input box
-        cy.get('#post_textbox').should('be.focused');
+        cy.uiGetPostTextBox().should('be.focused');
     });
 
     it('Cmd/Ctrl+Shift+M closes Channel Switch modal and sets focus to mentions', () => {
@@ -50,7 +50,7 @@ describe('Settings > Sidebar > Channel Switcher', () => {
         cy.apiPatchMe({notify_props: {first_name: 'false', mention_keys: testUser.username}});
 
         // # Type CTRL/CMD+K
-        cy.get('#post_textbox').cmdOrCtrlShortcut('K');
+        cy.uiGetPostTextBox().cmdOrCtrlShortcut('K');
 
         // * Channel switcher hint should be visible
         cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use UP/DOWN to browse, ENTER to select, ESC to dismiss.');

--- a/e2e/cypress/tests/integration/settings/sidebar/fullname_spec.js
+++ b/e2e/cypress/tests/integration/settings/sidebar/fullname_spec.js
@@ -53,19 +53,19 @@ describe('Settings > Sidebar > General', () => {
         cy.visit(offTopicUrl);
 
         // # Type in user's first name substring
-        cy.get('#post_textbox').clear().type(`@${newFirstName.substring(0, 11)}`);
+        cy.uiGetPostTextBox().clear().type(`@${newFirstName.substring(0, 11)}`);
 
         // * Verify that the testUser is selected from mention autocomplete
         cy.uiVerifyAtMentionInSuggestionList({...testUser, first_name: newFirstName}, true);
 
         // # Press tab on text input
-        cy.get('#post_textbox').tab();
+        cy.uiGetPostTextBox().tab();
 
         // * Verify that after enter user's username match
-        cy.get('#post_textbox').should('have.value', `@${username} `);
+        cy.uiGetPostTextBox().should('have.value', `@${username} `);
 
         // # Click enter in post textbox
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Verify that message has been post in chat
         cy.get(`[data-mention="${username}"]`).

--- a/e2e/cypress/tests/integration/slash_commands/autocomplete_spec.js
+++ b/e2e/cypress/tests/integration/slash_commands/autocomplete_spec.js
@@ -27,13 +27,13 @@ describe('Integrations', () => {
 
     it('MM-T2829 Test an example of plugin that uses sub commands', () => {
         // # Post a slash command with trailing space
-        cy.get('#post_textbox').clear().type('/jira ');
+        cy.uiGetPostTextBox().clear().type('/jira ');
 
         // * Verify suggestion list is visible and includes 'info'
         cy.get('#suggestionList').findByText('info').scrollIntoView().should('be.visible');
 
         // # Narrow down list to show info only suggestion
-        cy.get('#post_textbox').type('inf');
+        cy.uiGetPostTextBox().type('inf');
 
         // * Verify suggestion list is visible with only 1 child
         cy.get('#suggestionList').should('be.visible').children().should('have.length', 1);
@@ -43,7 +43,7 @@ describe('Integrations', () => {
 
         // # click the info subcommand and hit enter
         cy.get('#suggestionList').findByText('info').should('be.visible').click();
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Verify message is sent and (only visible to you)
         cy.getLastPostId().then((postId) => {
@@ -55,13 +55,13 @@ describe('Integrations', () => {
 
     it('MM-T2830 Test an example of a plugin using static list', () => {
         // # Post a slash command with trailing space
-        cy.get('#post_textbox').clear().type('/jira ');
+        cy.uiGetPostTextBox().clear().type('/jira ');
 
         // * Verify suggestion includes instance subcommand and is visible
         cy.get('#suggestionList').should('contain.text', 'instance').scrollIntoView().should('be.visible');
 
         // # Narrow down list to show info only suggestion
-        cy.get('#post_textbox').type('i');
+        cy.uiGetPostTextBox().type('i');
 
         // * Verify suggestion list is visible with three children (issue, instance, info)
         cy.get('#suggestionList').should('be.visible').children().
@@ -70,13 +70,13 @@ describe('Integrations', () => {
             should('contain.text', 'info');
 
         // # Clear test and post a slash command with trailing space
-        cy.get('#post_textbox').clear().type('/jira instance settings ');
+        cy.uiGetPostTextBox().clear().type('/jira instance settings ');
 
         // * Verify suggestion notifications is visible
         cy.get('#suggestionList').should('contain.text', 'notifications').scrollIntoView().should('be.visible');
 
         // # Clear test and Post a slash command with trailing space
-        cy.get('#post_textbox').type('notifications ');
+        cy.uiGetPostTextBox().type('notifications ');
 
         // * Verify notifications suggestion is visible and lists on/off options
         cy.get('#suggestionList').should('be.visible').children().
@@ -85,10 +85,10 @@ describe('Integrations', () => {
 
         // # down arrow to highlight the second suggestion
         // # enter to push to send command to post textbox
-        cy.get('#post_textbox').type('{downarrow}{downarrow}{enter}');
+        cy.uiGetPostTextBox().type('{downarrow}{downarrow}{enter}');
 
         // # Send the command
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Verify message is sent and (only visible to you)
         cy.getLastPostId().then((postId) => {
@@ -100,7 +100,7 @@ describe('Integrations', () => {
 
     it('MM-T2831 Test an example of plugin using dynamic list', () => {
         // # Post a slash command with trailing space
-        cy.get('#post_textbox').clear().type('/autocomplete_test dynamic-arg ');
+        cy.uiGetPostTextBox().clear().type('/autocomplete_test dynamic-arg ');
 
         // * Verify suggestion list is visible with at three children (issue, instance, info)
         cy.get('#suggestionList').should('be.visible').children().
@@ -109,10 +109,10 @@ describe('Integrations', () => {
 
         // # down arrow to highlight the second suggestion
         // # enter to push to send command to post textbox
-        cy.get('#post_textbox').type('{downarrow}{downarrow}{enter}');
+        cy.uiGetPostTextBox().type('{downarrow}{downarrow}{enter}');
 
         // # Send the command
-        cy.get('#post_textbox').type('{enter}');
+        cy.uiGetPostTextBox().type('{enter}');
 
         // * Verify correct message is sent,  (only visible to you)
         cy.getLastPostId().then((postId) => {
@@ -124,7 +124,7 @@ describe('Integrations', () => {
 
     it('MM-T2832 Use a slash command that omits the optional argument', () => {
         // # Post a slash command that omits the optional argument
-        cy.get('#post_textbox').clear().type('/autocomplete_test optional-arg {enter}');
+        cy.uiGetPostTextBox().clear().type('/autocomplete_test optional-arg {enter}');
 
         // * Verify item is sent and is (only visible to you)
         cy.getLastPostId().then((postId) => {
@@ -134,7 +134,7 @@ describe('Integrations', () => {
 
     it('MM-T2833 Use a slash command that accepts an optional argument', () => {
         // # Post a slash command that accepts an optional argument
-        cy.get('#post_textbox').clear().type('/autocomplete_test optional-arg --name1 testarg {enter}');
+        cy.uiGetPostTextBox().clear().type('/autocomplete_test optional-arg --name1 testarg {enter}');
 
         // * Verify item is sent and is (only visible to you)
         cy.getLastPostId().then((postId) => {
@@ -144,7 +144,7 @@ describe('Integrations', () => {
 
     it('MM-T2834 Slash command help stays visible for system slash command', () => {
         // # Post a slash command without trailing space
-        cy.get('#post_textbox').type('/rename');
+        cy.uiGetPostTextBox().type('/rename');
 
         // * Verify suggestion list is visible with only 1 child
         cy.get('#suggestionList').should('be.visible').children().should('have.length', 1);
@@ -153,7 +153,7 @@ describe('Integrations', () => {
         cy.get('#suggestionList').children().eq(0).findByText('Rename the channel').should('be.visible');
 
         // # Add trailing space to '/rename' command
-        cy.get('#post_textbox').type(' ');
+        cy.uiGetPostTextBox().type(' ');
 
         // * Verify command text is no longer visible after space is added
         cy.findByText('Rename the channel').should('not.exist');
@@ -170,7 +170,7 @@ describe('Integrations', () => {
 
     it('MM-T2835 Slash command help stays visible for plugin', () => {
         // # Post a slash command with trailing space
-        cy.get('#post_textbox').clear().type('/jira ');
+        cy.uiGetPostTextBox().clear().type('/jira ');
 
         // * Verify suggestion list is visible with 11 children
         cy.get('#suggestionList').should('be.visible').children().should('have.length', 11);

--- a/e2e/cypress/tests/integration/system_console/user_management_not_cloud_spec.js
+++ b/e2e/cypress/tests/integration/system_console/user_management_not_cloud_spec.js
@@ -95,7 +95,7 @@ describe('User Management', () => {
         // * Verify that new messages cannot be posted.
         cy.get('#moreDmModal').should('be.visible').within(() => {
             cy.get('#selectItems input').type(otherUser.email + '{enter}').wait(TIMEOUTS.HALF_SEC);
-            cy.get('#post_textbox').should('not.exist');
+            cy.uiGetPostTextBox({exist: false});
         });
 
         // # Restore the user.

--- a/e2e/cypress/tests/integration/team_settings/invite_members_spec.js
+++ b/e2e/cypress/tests/integration/team_settings/invite_members_spec.js
@@ -159,7 +159,7 @@ function verifyInvitationError(team, user) {
 function verifyInviteMembersModal(team) {
     // * Verify the header has changed in the modal
     cy.findByTestId('invitationModal').within(($el) => {
-        cy.wrap($el).find('h1').should('have.text', `Invite members to ${team.display_name}`);
+        cy.wrap($el).find('h1').should('have.text', `Invite people to ${team.display_name}`);
     });
 
     // * Verify Share Link Header and helper text

--- a/e2e/cypress/tests/support/ui/channel.js
+++ b/e2e/cypress/tests/support/ui/channel.js
@@ -49,9 +49,9 @@ Cypress.Commands.add('uiArchiveChannel', () => {
 });
 
 Cypress.Commands.add('uiUnarchiveChannel', () => {
-    cy.get('#channelHeaderDropdownIcon').click();
-    cy.get('#channelUnarchiveChannel').click();
-    return cy.get('#unarchiveChannelModalDeleteButton').click();
+    cy.get('#channelHeaderDropdownIcon').should('be.visible').click();
+    cy.get('#channelUnarchiveChannel').should('be.visible').click();
+    return cy.get('#unarchiveChannelModalDeleteButton').should('be.visible').click();
 });
 
 Cypress.Commands.add('uiLeaveChannel', (isPrivate = false) => {

--- a/e2e/cypress/tests/support/ui/file_preview.d.ts
+++ b/e2e/cypress/tests/support/ui/file_preview.d.ts
@@ -36,6 +36,14 @@ declare namespace Cypress {
         uiGetFileUploadPreview(): Chainable;
 
         /**
+         * Wait for file upload preview located below post textbox
+         *
+         * @example
+         *   cy.uiGetFileUploadPreview();
+         */
+        uiGetFileUploadPreview(): Chainable;
+
+        /**
          * Get file preview modal
          *
          * @param {bool} option.exist - Set to false to not verify if the element exists. Otherwise, true (default) to check existence.

--- a/e2e/cypress/tests/support/ui/file_preview.js
+++ b/e2e/cypress/tests/support/ui/file_preview.js
@@ -6,7 +6,13 @@ Cypress.Commands.add('uiGetFileThumbnail', (filename) => {
 });
 
 Cypress.Commands.add('uiGetFileUploadPreview', () => {
-    return cy.get('.file-preview__container').should('be.visible');
+    return cy.get('.file-preview__container');
+});
+
+Cypress.Commands.add('uiWaitForFileUploadPreview', () => {
+    cy.waitUntil(() => cy.uiGetFileUploadPreview().then((el) => {
+        return el.find('.post-image.normal').length > 0;
+    }));
 });
 
 Cypress.Commands.add('uiGetFilePreviewModal', (options = {exist: true}) => {

--- a/e2e/cypress/tests/support/ui/post.d.ts
+++ b/e2e/cypress/tests/support/ui/post.d.ts
@@ -18,6 +18,26 @@ declare namespace Cypress {
     interface Chainable {
 
         /**
+         * Get post textbox
+         *
+         * @param {bool} option.exist - Set to false to check whether element should not exist. Otherwise, true (default) to check visibility.
+         *
+         * @example
+         *   cy.uiGetPostTextBox();
+         */
+        uiGetPostTextBox(option: {exist: boolean}): Chainable;
+
+        /**
+         * Get reply textbox
+         *
+         * @param {bool} option.exist - Set to false to check whether element should not exist. Otherwise, true (default) to check visibility.
+         *
+         * @example
+         *   cy.uiGetReplyTextBox();
+         */
+        uiGetReplyTextBox(option: {exist: boolean}): Chainable;
+
+        /**
          * Get post profile image of a given post ID or the last post if post ID is not given
          *
          * @param {string} - postId (optional)

--- a/e2e/cypress/tests/support/ui/post.js
+++ b/e2e/cypress/tests/support/ui/post.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('uiGetPostHeader', (postId) => {
 
 Cypress.Commands.add('uiGetPostBody', (postId) => {
     return getPost(postId).within(() => {
-        return cy.get('.post__body').should('be.visible');
+        return cy.get('.post__body').scrollIntoView().should('be.visible');
     });
 });
 

--- a/e2e/cypress/tests/support/ui/post.js
+++ b/e2e/cypress/tests/support/ui/post.js
@@ -1,6 +1,22 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+Cypress.Commands.add('uiGetPostTextBox', (option = {exist: true}) => {
+    if (option.exist) {
+        return cy.get('#post_textbox').should('be.visible');
+    }
+
+    return cy.get('#post_textbox').should('not.exist');
+});
+
+Cypress.Commands.add('uiGetReplyTextBox', (option = {exist: true}) => {
+    if (option.exist) {
+        return cy.get('#reply_textbox').should('be.visible');
+    }
+
+    return cy.get('#reply_textbox').should('not.exist');
+});
+
 Cypress.Commands.add('uiGetPostProfileImage', (postId) => {
     return getPost(postId).within(() => {
         return cy.get('.post__img').should('be.visible');

--- a/e2e/cypress/tests/support/ui_commands.js
+++ b/e2e/cypress/tests/support/ui_commands.js
@@ -66,10 +66,10 @@ Cypress.Commands.add('postMessageReplyInRHS', (message) => {
 });
 
 Cypress.Commands.add('uiPostMessageQuickly', (message) => {
-    cy.get('#post_textbox', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible').clear().
+    cy.uiGetPostTextBox().should('be.visible').clear().
         invoke('val', message).wait(TIMEOUTS.HALF_SEC).type(' {backspace}{enter}');
     cy.waitUntil(() => {
-        return cy.get('#post_textbox').then((el) => {
+        return cy.uiGetPostTextBox().then((el) => {
             return el[0].textContent === '';
         });
     });
@@ -274,9 +274,7 @@ Cypress.Commands.add('sendDirectMessageToUser', (user, message) => {
     cy.uiGotoDirectMessageWithUser(user);
 
     // # Type message and send it to the user
-    cy.get('#post_textbox').
-        type(message).
-        type('{enter}');
+    cy.postMessage(message);
 });
 
 /**
@@ -314,9 +312,7 @@ Cypress.Commands.add('sendDirectMessageToUsers', (users, message) => {
     });
 
     // # Type message and send it to the user
-    cy.get('#post_textbox').
-        type(message).
-        type('{enter}');
+    cy.postMessage(message);
 });
 
 // ***********************************************************
@@ -443,7 +439,7 @@ Cypress.Commands.add('leaveTeam', () => {
 
 Cypress.Commands.add('clearPostTextbox', (channelName = 'town-square') => {
     cy.get(`#sidebarItem_${channelName}`).click({force: true});
-    cy.get('#post_textbox').clear();
+    cy.uiGetPostTextBox().clear();
 });
 
 // ***********************************************************


### PR DESCRIPTION
#### Summary
Sorry for this huge changes. This includes the following:
- introduced `cy.uiGetReplyTextBox()` for `#reply_textbox`
- introduced `cy.uiGetPostTextBox()` for `#post_textbox`
- introduced `cy.uiGetFileUploadPreview` to easily access file preview in ATE
- fixed tests related to ATE like when uploading/rendering/pasting a file/preview
- fixed other random tests
- removed unnecessary line of code like
```javascript
// * Post text box should be visible
cy.get('#post_textbox').should('be.visible');
```
when already followed by `cy.postMessage(messageText);`

#### Release Note
```release-note
NONE
```
