### PR TITLE
MM-44470 - Fix SVG not rendering without width and height in Chrome

### DIFF
--- a/components/file_preview_modal/image_preview.jsx
+++ b/components/file_preview_modal/image_preview.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {getFilePreviewUrl, getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
+import {FileTypes} from 'utils/constants';
 
 import './image_preview.scss';
 
@@ -25,6 +26,8 @@ export default function ImagePreview({fileInfo, canDownloadFiles}) {
         return <img src={previewUrl}/>;
     }
 
+    const svgStyleAttribute = fileInfo.extension === FileTypes.SVG && {style: {width: fileInfo.width}};
+
     return (
         <a
             className='image_preview'
@@ -35,6 +38,7 @@ export default function ImagePreview({fileInfo, canDownloadFiles}) {
                 data-testid='imagePreview'
                 alt={'preview url image'}
                 src={previewUrl}
+                {...svgStyleAttribute}
             />
         </a>
     );

--- a/components/file_preview_modal/image_preview.jsx
+++ b/components/file_preview_modal/image_preview.jsx
@@ -26,7 +26,10 @@ export default function ImagePreview({fileInfo, canDownloadFiles}) {
         return <img src={previewUrl}/>;
     }
 
-    const svgStyleAttribute = fileInfo.extension === FileTypes.SVG && {style: {width: fileInfo.width}};
+    let svgStyleAttribute = {};
+    if (fileInfo) {
+        svgStyleAttribute = fileInfo.extension === FileTypes.SVG && {style: {width: fileInfo.width}};
+    }
 
     return (
         <a

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -13,6 +13,7 @@ import {t} from 'utils/i18n';
 import LoadingImagePreview from 'components/loading_image_preview';
 import Tooltip from 'components/tooltip';
 import OverlayTrigger from 'components/overlay_trigger';
+import {FileTypes} from 'utils/constants';
 
 const MIN_IMAGE_SIZE = 48;
 const MIN_IMAGE_SIZE_FOR_INTERNAL_BUTTONS = 100;
@@ -110,18 +111,15 @@ export default class SizeAwareImage extends React.PureComponent {
         return width < MIN_IMAGE_SIZE || height < MIN_IMAGE_SIZE;
     }
 
-    handleLoad = (event) => {
+    handleLoad = () => {
         if (this.mounted) {
-            const image = event.target;
-            const isSmallImage = this.isSmallImage(image.naturalWidth, image.naturalHeight);
             this.setState({
                 loaded: true,
                 error: false,
-                isSmallImage,
-                imageWidth: image.naturalWidth,
+                imageWidth: this.props.dimensions.width,
             }, () => { // Call onImageLoaded prop only after state has already been set
-                if (this.props.onImageLoaded && image.naturalHeight) {
-                    this.props.onImageLoaded({height: image.naturalHeight, width: image.naturalWidth});
+                if (this.props.onImageLoaded && this.props.dimensions.height) {
+                    this.props.onImageLoaded({height: this.props.dimensions.height, width: this.props.dimensions.width});
                 }
             });
         }
@@ -181,6 +179,8 @@ export default class SizeAwareImage extends React.PureComponent {
             ariaLabelImage += ` ${fileInfo.name}`.toLowerCase();
         }
 
+        const svgStyleAttribute = fileInfo.extension === FileTypes.SVG && {style: {width: this.state.imageWidth}};
+
         const image = (
             <img
                 {...props}
@@ -195,6 +195,7 @@ export default class SizeAwareImage extends React.PureComponent {
                 src={src}
                 onError={this.handleError}
                 onLoad={this.handleLoad}
+                {...svgStyleAttribute}
             />
         );
 

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -84,10 +84,14 @@ export default class SizeAwareImage extends React.PureComponent {
         super(props);
         const {dimensions} = props;
 
+        const isDimensionAvailable = this.dimensionsAvailable(dimensions);
+
         this.state = {
             loaded: false,
-            isSmallImage: this.dimensionsAvailable(dimensions) ? this.isSmallImage(
+            isSmallImage: isDimensionAvailable ? this.isSmallImage(
                 dimensions.width, dimensions.height) : false,
+            imageWidth: isDimensionAvailable ? dimensions.width : MIN_IMAGE_SIZE,
+            imageHeight: isDimensionAvailable ? dimensions.height : MIN_IMAGE_SIZE,
             linkCopiedRecently: false,
             linkCopyInProgress: false,
         };
@@ -116,10 +120,9 @@ export default class SizeAwareImage extends React.PureComponent {
             this.setState({
                 loaded: true,
                 error: false,
-                imageWidth: this.props.dimensions.width,
             }, () => { // Call onImageLoaded prop only after state has already been set
-                if (this.props.onImageLoaded && this.props.dimensions.height) {
-                    this.props.onImageLoaded({height: this.props.dimensions.height, width: this.props.dimensions.width});
+                if (this.props.onImageLoaded && this.state.imageHeight) {
+                    this.props.onImageLoaded({height: this.state.imageHeight, width: this.state.imageWidth});
                 }
             });
         }
@@ -175,11 +178,11 @@ export default class SizeAwareImage extends React.PureComponent {
         Reflect.deleteProperty(props, 'getFilePublicLink');
 
         let ariaLabelImage = localizeMessage('file_attachment.thumbnail', 'file thumbnail');
+        let svgStyleAttribute = {};
         if (fileInfo) {
             ariaLabelImage += ` ${fileInfo.name}`.toLowerCase();
+            svgStyleAttribute = fileInfo.extension === FileTypes.SVG && {style: {width: this.state.imageWidth}};
         }
-
-        const svgStyleAttribute = fileInfo.extension === FileTypes.SVG && {style: {width: this.state.imageWidth}};
 
         const image = (
             <img

--- a/components/size_aware_image.test.jsx
+++ b/components/size_aware_image.test.jsx
@@ -73,12 +73,12 @@ describe('components/SizeAwareImage', () => {
     });
 
     test('should set loaded state when img loads and call onImageLoaded prop', () => {
-        const height = 123;
-        const width = 1234;
+        const height = baseProps.dimensions.height;
+        const width = baseProps.dimensions.width;
 
         const wrapper = shallow(<SizeAwareImage {...baseProps}/>);
 
-        wrapper.find('img').prop('onLoad')({target: {naturalHeight: height, naturalWidth: width}});
+        wrapper.find('img').prop('onLoad')();
         expect(wrapper.state('loaded')).toBe(true);
         expect(baseProps.onImageLoaded).toHaveBeenCalledWith({height, width});
     });


### PR DESCRIPTION
#### Summary
##### Fix SVG not rendering without width and height in Chrome.

The source of the problem was `event.target` giving different values depending on the browser when width and height is not set in the SVG image.

Default values if no width and height:
Firefox was returning 0x0. https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox
Chrome was returning 350x154.

The SVG image was rendered in Firefox even if dimensions was 0x0 because a small-image CSS class was added that set the width and height to 48px by 48px.
In Chrome, it was the normal image CSS class that was added because of intrinsic value. But the image was rendered inside the `<figure>` inline-block with 0 width so the image wasn't show.

Now, the value is the same with each browsers because values is from the database for both and a CSS width is always set when a SVG image is rendered.

##### Fix SVG not rendering without width and height in preview in both browsers
`event.target` was also causing SVG without width and height to not render in `image_preview.jsx`.

#### Ticket Link
Fix https://github.com/mattermost/mattermost-server/issues/20271

#### Screenshots
SVG without width and height in Chrome.
|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/103535117/178015217-5f676622-1257-4b53-a45b-8d8aa0dce734.png) | ![image](https://user-images.githubusercontent.com/103535117/178015692-34abc704-8cf2-48ae-a337-ca9e82d9c5ee.png) |

SVG without width and height not rendering in preview
(The SVG hand image have no background color)
|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/103535117/178019579-c4bc65c0-30e8-4f60-bbe6-7734855b99a3.png)| ![image](https://user-images.githubusercontent.com/103535117/178019875-57c5946d-558c-47e7-bd53-4825d5187d5c.png) |

#### Release Note
```release-note
Fixed SVG not rendering without width and height in Chrome.
```
