### PR TITLE
Automated cherry pick of #10685

### DIFF
--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -14,6 +14,7 @@ import * as GlobalActions from 'actions/global_actions';
 import Constants, {AdvancedTextEditor, Locations, ModalIdentifiers, Preferences} from 'utils/constants';
 import {PreferenceType} from '@mattermost/types/preferences';
 import * as UserAgent from 'utils/user_agent';
+import {isMac} from 'utils/utils';
 import * as Utils from 'utils/utils';
 import {
     specialMentionsInText,
@@ -835,7 +836,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
             e.stopPropagation();
             e.preventDefault();
             this.toggleEmojiPicker();
-        } else if (ctrlShiftCombo && Utils.isKeyPressed(e, KeyCodes.P)) {
+        } else if (((isMac() && ctrlShiftCombo) || (!isMac() && ctrlAltCombo)) && Utils.isKeyPressed(e, KeyCodes.P) && draft.message.length) {
             this.setShowPreview(!this.props.shouldShowPreview);
         } else if (ctrlAltCombo && Utils.isKeyPressed(e, KeyCodes.T)) {
             this.toggleAdvanceTextEditor();

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -555,6 +555,8 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             useCustomGroupMentions,
         } = this.props;
 
+        this.setShowPreview(false);
+
         const notificationsToChannel = this.props.enableConfirmNotificationsToChannel && this.props.useChannelMentions;
         let memberNotifyCount = 0;
         let channelTimezoneCount = 0;
@@ -1078,7 +1080,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             e.stopPropagation();
             e.preventDefault();
             this.toggleEmojiPicker();
-        } else if (((isMac() && ctrlShiftCombo) || (!isMac() && ctrlAltCombo)) && Utils.isKeyPressed(e, KeyCodes.P)) {
+        } else if (((isMac() && ctrlShiftCombo) || (!isMac() && ctrlAltCombo)) && Utils.isKeyPressed(e, KeyCodes.P) && this.state.message.length) {
             this.setShowPreview(!this.props.shouldShowPreview);
         } else if (ctrlAltCombo && Utils.isKeyPressed(e, KeyCodes.T)) {
             this.toggleAdvanceTextEditor();

--- a/components/keyboard_shortcuts/keyboard_shortcuts_sequence/keyboard_shortcuts.ts
+++ b/components/keyboard_shortcuts/keyboard_shortcuts_sequence/keyboard_shortcuts.ts
@@ -329,7 +329,7 @@ export const KEYBOARD_SHORTCUTS = {
     msgMarkdownPreview: {
         default: {
             id: t('shortcuts.msgs.markdown.preview'),
-            defaultMessage: 'Show/Hide Preview:\tCtrl|Shift|P',
+            defaultMessage: 'Show/Hide Preview:\tCtrl|Alt|P',
         },
         mac: {
             id: t('shortcuts.msgs.markdown.preview.mac'),

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4380,7 +4380,7 @@
   "shortcuts.msgs.markdown.link.mac": "Link:\t⌘|Alt|K",
   "shortcuts.msgs.markdown.ordered": "Numbered List",
   "shortcuts.msgs.markdown.ordered.mac": "Numbered List",
-  "shortcuts.msgs.markdown.preview": "Show/Hide Preview:\tCtrl|Shift|P",
+  "shortcuts.msgs.markdown.preview": "Show/Hide Preview:\tCtrl|Alt|P",
   "shortcuts.msgs.markdown.preview.mac": "Show/Hide Preview:\t⌘|Shift|P",
   "shortcuts.msgs.markdown.quote": "Quote",
   "shortcuts.msgs.markdown.quote.mac": "Quote",


### PR DESCRIPTION
Cherry pick of #10685 on release-7.1.

/cc  @AshishDhama

```release-note
NONE
```