### PR TITLE
MM-44637_Site description removes "Log in" text from login screen

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1983,9 +1983,7 @@ const AdminDefinition = {
                         label: t('admin.team.brandDescriptionTitle'),
                         label_default: 'Site Description: ',
                         help_text: t('admin.team.brandDescriptionHelp'),
-                        help_text_default: 'Description of service shown in login screens and UI. When not specified, "All team communication in one place, searchable and accessible anywhere" is displayed.',
-                        placeholder: t('web.root.signup_info'),
-                        placeholder_default: 'All team communication in one place, searchable and accessible anywhere',
+                        help_text_default: 'Displays as a title above the login form. When not specified, the phrase "Log in" is displayed.',
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.CUSTOMIZATION)),
                     },
                     {

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -196,6 +196,8 @@
                 font-size: 18px;
                 font-weight: 400;
                 line-height: 28px;
+                text-align: justify;
+                text-align-last: center;
                 white-space: pre-wrap;
                 word-break: break-word;
             }

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -60,12 +60,18 @@
 
                 &.with-brand-image {
                     align-self: center;
+
+                    .login-body-message-subtitle,
+                    .login-body-custom-branding-markdown {
+                        text-align: center;
+                    }
                 }
 
                 .login-body-custom-branding-image {
                     max-height: 540px;
                     flex: 1;
                     align-self: center;
+                    margin-bottom: 28px;
                     border-radius: 8px;
                 }
             }
@@ -173,7 +179,6 @@
 
         .login-body-custom-branding-markdown {
             flex: 1;
-            margin-top: 28px;
 
             ul + p,
             ol + p {
@@ -196,7 +201,6 @@
                 font-size: 18px;
                 font-weight: 400;
                 line-height: 28px;
-                text-align: center;
                 white-space: pre-wrap;
                 word-break: break-word;
             }
@@ -296,6 +300,7 @@
                         .login-body-message-subtitle {
                             display: block;
                             margin: 0 0 32px;
+                            text-align: left;
                         }
                     }
                 }

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -196,8 +196,7 @@
                 font-size: 18px;
                 font-weight: 400;
                 line-height: 28px;
-                text-align: justify;
-                text-align-last: center;
+                text-align: center;
                 white-space: pre-wrap;
                 word-break: break-word;
             }

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -659,8 +659,8 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     };
 
     const getMessageSubtitle = () => {
-        if (enableCustomBrand) {
-            return CustomBrandText && (
+        if (enableCustomBrand && CustomBrandText) {
+            return (
                 <div className='login-body-custom-branding-markdown'>
                     <Markdown
                         message={CustomBrandText}

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -659,8 +659,8 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     };
 
     const getMessageSubtitle = () => {
-        if (enableCustomBrand && CustomBrandText) {
-            return (
+        if (enableCustomBrand) {
+            return CustomBrandText && (
                 <div className='login-body-custom-branding-markdown'>
                     <Markdown
                         message={CustomBrandText}

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -224,6 +224,8 @@
                 font-size: 18px;
                 font-weight: 400;
                 line-height: 28px;
+                text-align: justify;
+                text-align-last: center;
                 white-space: pre-wrap;
                 word-break: break-word;
             }

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -86,12 +86,18 @@
 
                 &.with-brand-image {
                     align-self: center;
+
+                    .signup-body-message-subtitle,
+                    .signup-body-custom-branding-markdown {
+                        text-align: center;
+                    }
                 }
 
                 .signup-body-custom-branding-image {
                     max-height: 540px;
                     flex: 1;
                     align-self: center;
+                    margin-bottom: 28px;
                     border-radius: 8px;
                 }
             }
@@ -201,7 +207,6 @@
 
         .signup-body-custom-branding-markdown {
             flex: 1;
-            margin-top: 28px;
 
             ul + p,
             ol + p {
@@ -224,7 +229,6 @@
                 font-size: 18px;
                 font-weight: 400;
                 line-height: 28px;
-                text-align: center;
                 white-space: pre-wrap;
                 word-break: break-word;
             }
@@ -339,6 +343,7 @@
                         .signup-body-message-subtitle {
                             display: block;
                             margin: 0 0 32px;
+                            text-align: left;
                         }
                     }
                 }

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -224,8 +224,7 @@
                 font-size: 18px;
                 font-weight: 400;
                 line-height: 28px;
-                text-align: justify;
-                text-align-last: center;
+                text-align: center;
                 white-space: pre-wrap;
                 word-break: break-word;
             }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2362,7 +2362,7 @@
   "admin.team_settings.team_row.managementMethod.inviteOnly": "Invite Only",
   "admin.team_settings.title": "Teams",
   "admin.team.brandDesc": "Enable custom branding to show an image of your choice, uploaded below, and some help text, written below, on the login page.",
-  "admin.team.brandDescriptionHelp": "Description of service shown in login screens and UI. When not specified, \"All team communication in one place, searchable and accessible anywhere\" is displayed.",
+  "admin.team.brandDescriptionHelp": "Displays as a title above the login form. When not specified, the phrase \"Log in\" is displayed.",
   "admin.team.brandDescriptionTitle": "Site Description: ",
   "admin.team.brandImageTitle": "Custom Brand Image:",
   "admin.team.brandTextDescription": "Text that will appear below your custom brand image on your login screen. Supports Markdown-formatted text. Maximum 500 characters allowed.",

--- a/utils/admin_console_index.test.tsx
+++ b/utils/admin_console_index.test.tsx
@@ -36,8 +36,8 @@ describe('AdminConsoleIndex.generateIndex', () => {
             'environment/rate_limiting',
         ]);
         expect(idx.search('characters')).toEqual([
-            'authentication/password',
             'site_config/customization',
+            'authentication/password',
         ]);
         expect(idx.search('caracteres')).toEqual([]);
         expect(idx.search('notexistingword')).toEqual([]);


### PR DESCRIPTION
#### Summary
Some updates to the Customization options for Login/Signup pages.

- Custom Brand Text:
  - Shows centered

- Site Description:
  - Help text updated to: "Displays as a title above the login form. When not specified, the phrase "Log in" is displayed."
  - Placeholder removed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44637

#### Screenshots
##### No Custom Brand Text
<img width="1096" alt="Screen Shot 2022-07-14 at 1 55 06 PM" src="https://user-images.githubusercontent.com/79058848/179072617-f53c963a-3390-48b5-8d0d-bc21994bc623.png">

##### Short Custom Brand Text
<img width="1250" alt="Screen Shot 2022-07-13 at 10 23 54 AM" src="https://user-images.githubusercontent.com/79058848/178771165-ed243766-114f-4de7-9b44-6525a0df9209.png">


##### Long Custom Brand Text
<img width="1191" alt="Screen Shot 2022-07-13 at 9 18 49 AM" src="https://user-images.githubusercontent.com/79058848/178770276-aad1d3b0-43a9-446e-b443-bca1b44036f9.png">

#### Release Note
```release-note
- Custom Brand Text now shows centered.
- Site Description configuration does not show placeholder and help text now reads "Displays as a title above the login form. When not specified, the phrase "Log in" is displayed."
```
