### PR TITLE
Mm 36402: Display leave,archive channel action as destructure

### DIFF
--- a/components/channel_header_dropdown/__snapshots__/channel_header_dropdown.test.jsx.snap
+++ b/components/channel_header_dropdown/__snapshots__/channel_header_dropdown.test.jsx.snap
@@ -355,6 +355,7 @@ exports[`components/ChannelHeaderDropdown should match snapshot with no plugin i
       }
     >
       <MenuItemToggleModalRedux
+        className="MenuItem__dangerous"
         dialogProps={
           Object {
             "channel": Object {
@@ -800,6 +801,7 @@ exports[`components/ChannelHeaderDropdown should match snapshot with plugins 1`]
       }
     >
       <MenuItemToggleModalRedux
+        className="MenuItem__dangerous"
         dialogProps={
           Object {
             "channel": Object {

--- a/components/channel_header_dropdown/channel_header_dropdown_items.js
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.js
@@ -278,6 +278,7 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                             id='channelArchiveChannel'
                             show={!isArchived && !isDefault && channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL}
                             modalId={ModalIdentifiers.DELETE_CHANNEL}
+                            className="MenuItem__dangerous"
                             dialogType={DeleteChannelModal}
                             dialogProps={{
                                 channel,

--- a/components/channel_header_dropdown/channel_header_dropdown_items.js
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.js
@@ -278,7 +278,7 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                             id='channelArchiveChannel'
                             show={!isArchived && !isDefault && channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL}
                             modalId={ModalIdentifiers.DELETE_CHANNEL}
-                            className="MenuItem__dangerous"
+                            className='MenuItem__dangerous'
                             dialogType={DeleteChannelModal}
                             dialogProps={{
                                 channel,

--- a/components/channel_header_dropdown/menu_items/leave_channel/__snapshots__/leave_channel.test.tsx.snap
+++ b/components/channel_header_dropdown/menu_items/leave_channel/__snapshots__/leave_channel.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`components/ChannelHeaderDropdown/MenuItem.LeaveChannel should be hidden if the channel is default channel 1`] = `
 <MenuItemAction
+  isDangerous={true}
   onClick={[Function]}
   show={false}
   text="Leave Channel"
@@ -10,6 +11,7 @@ exports[`components/ChannelHeaderDropdown/MenuItem.LeaveChannel should be hidden
 
 exports[`components/ChannelHeaderDropdown/MenuItem.LeaveChannel should be hidden if the channel type is DM or GM 1`] = `
 <MenuItemAction
+  isDangerous={true}
   onClick={[Function]}
   show={false}
   text="Leave Channel"
@@ -18,6 +20,7 @@ exports[`components/ChannelHeaderDropdown/MenuItem.LeaveChannel should be hidden
 
 exports[`components/ChannelHeaderDropdown/MenuItem.LeaveChannel should be hidden if the channel type is DM or GM 2`] = `
 <MenuItemAction
+  isDangerous={true}
   onClick={[Function]}
   show={false}
   text="Leave Channel"
@@ -26,6 +29,7 @@ exports[`components/ChannelHeaderDropdown/MenuItem.LeaveChannel should be hidden
 
 exports[`components/ChannelHeaderDropdown/MenuItem.LeaveChannel should match snapshot 1`] = `
 <MenuItemAction
+  isDangerous={true}
   onClick={[Function]}
   show={true}
   text="Leave Channel"

--- a/components/channel_header_dropdown/menu_items/leave_channel/leave_channel.tsx
+++ b/components/channel_header_dropdown/menu_items/leave_channel/leave_channel.tsx
@@ -75,6 +75,8 @@ export default class LeaveChannel extends React.PureComponent<Props> {
                 show={(!isDefault || isGuestUser) && channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL}
                 onClick={this.handleLeave}
                 text={localizeMessage('channel_header.leave', 'Leave Channel')}
+                isDangerous={true}
+
             />
         );
     }

--- a/components/channel_header_dropdown/menu_items/leave_channel/leave_channel.tsx
+++ b/components/channel_header_dropdown/menu_items/leave_channel/leave_channel.tsx
@@ -76,7 +76,6 @@ export default class LeaveChannel extends React.PureComponent<Props> {
                 onClick={this.handleLeave}
                 text={localizeMessage('channel_header.leave', 'Leave Channel')}
                 isDangerous={true}
-
             />
         );
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR applies the destructive action color to `Archive Channel` and `Leave Channel` menu actions. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Issue: [Web app - Leave channel & archive channel actions should display as destructive](https://github.com/mattermost/mattermost-server/issues/19791)

Jira Link: [MM-36402](https://mattermost.atlassian.net/browse/MM-36402)

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |
-->
|  before  |  after  |
|----|----|
|<img width="1786" alt="168078853-2afdd4d7-c178-421f-95f6-e3495be489eb" src="https://user-images.githubusercontent.com/36856709/178643764-3a54d345-7006-44a9-8cc3-119512162ac3.png">|<img width="1512" alt="Screen Shot 2022-07-12 at 10 11 08 PM" src="https://user-images.githubusercontent.com/36856709/178643576-5e9ee113-5398-4e71-b442-1c6429d61d3a.png">

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added the destructive action color to `Archive Channel` and `Leave Channel` menu actions. 
```

