### PR TITLE
MM-20445: Migrate 'components/integrations/bots/add_bot' module and associated tests to TypeScript

### DIFF
--- a/components/integrations/bots/add_bot/add_bot.test.tsx
+++ b/components/integrations/bots/add_bot/add_bot.test.tsx
@@ -28,7 +28,6 @@ describe('components/integrations/bots/AddBot', () => {
                 maxFileSize={100}
                 team={team}
                 editingUserHasManageSystem={true}
-                location={{search: ''}}
                 actions={actions}
             />,
         );
@@ -65,7 +64,6 @@ describe('components/integrations/bots/AddBot', () => {
                 maxFileSize={100}
                 team={team}
                 editingUserHasManageSystem={true}
-                location={{search: ''}}
                 actions={actions}
             />,
         );

--- a/components/integrations/bots/add_bot/add_bot.test.tsx
+++ b/components/integrations/bots/add_bot/add_bot.test.tsx
@@ -4,13 +4,23 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import TestHelper from 'tests/helpers/client-test-helper';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
-import AddBot from './add_bot.jsx';
+import {TestHelper} from 'utils/test_helper';
+
+import AddBot from './add_bot';
 
 describe('components/integrations/bots/AddBot', () => {
-    const team = TestHelper.fakeTeam();
+    const team = TestHelper.getTeamMock();
+
+    const actions = {
+        createBot: jest.fn(),
+        patchBot: jest.fn(),
+        uploadProfileImage: jest.fn(),
+        setDefaultProfileImage: jest.fn(),
+        createUserAccessToken: jest.fn(),
+        updateUserRoles: jest.fn(),
+    };
 
     it('blank', () => {
         const wrapper = shallow(
@@ -18,6 +28,8 @@ describe('components/integrations/bots/AddBot', () => {
                 maxFileSize={100}
                 team={team}
                 editingUserHasManageSystem={true}
+                location={{search: ''}}
+                actions={actions}
             />,
         );
         expect(wrapper.containsMatchingElement(
@@ -46,13 +58,15 @@ describe('components/integrations/bots/AddBot', () => {
     });
 
     it('edit bot', () => {
-        const bot = TestHelper.fakeBot();
+        const bot = TestHelper.getBotMock({});
         const wrapper = shallow(
             <AddBot
                 bot={bot}
                 maxFileSize={100}
                 team={team}
                 editingUserHasManageSystem={true}
+                location={{search: ''}}
+                actions={actions}
             />,
         );
         expect(wrapper.containsMatchingElement(

--- a/components/integrations/bots/add_bot/add_bot.tsx
+++ b/components/integrations/bots/add_bot/add_bot.tsx
@@ -32,7 +32,7 @@ import {ActionResult} from 'mattermost-redux/types/actions';
 const roleOptionSystemAdmin = 'System Admin';
 const roleOptionMember = 'Member';
 
-type Props = {
+export type Props = {
 
     /**
      *  Only used for routing since backstage is team based.
@@ -63,6 +63,11 @@ type Props = {
      * Editing user has the MANAGE_SYSTEM permission
      */
     editingUserHasManageSystem: boolean;
+
+    /**
+     * TODO
+     */
+    location: {search: string};
 
     /**
      * Bot to edit
@@ -101,7 +106,7 @@ type Props = {
     };
 };
 
-type State = {
+export type State = {
     username: string;
     displayName: string | undefined;
     description: string | undefined;
@@ -110,7 +115,7 @@ type State = {
     postChannels: boolean;
     error: JSX.Element | string;
     adding: boolean;
-    image: any;
+    image: string;
     orientationStyles: {transform: string; transformOrigin: string};
     pictureFile: File | null | string;
 };
@@ -182,7 +187,7 @@ export default class AddBot extends React.PureComponent<Props, State> {
                 const orientationStyles = FileUtils.getOrientationStyles(orientation);
 
                 this.setState({
-                    image: this.previewBlob,
+                    image: this.previewBlob || '',
                     orientationStyles,
                 });
             };
@@ -190,7 +195,7 @@ export default class AddBot extends React.PureComponent<Props, State> {
             e.target.value = '';
             this.setState({pictureFile});
         } else {
-            this.setState({pictureFile: null, image: null});
+            this.setState({pictureFile: null, image: ''});
         }
     }
 

--- a/components/integrations/bots/add_bot/add_bot.tsx
+++ b/components/integrations/bots/add_bot/add_bot.tsx
@@ -65,11 +65,6 @@ export type Props = {
     editingUserHasManageSystem: boolean;
 
     /**
-     * Search query for the bot
-     */
-    location: {search: string};
-
-    /**
      * Bot to edit
      */
     actions: {

--- a/components/integrations/bots/add_bot/add_bot.tsx
+++ b/components/integrations/bots/add_bot/add_bot.tsx
@@ -65,7 +65,7 @@ export type Props = {
     editingUserHasManageSystem: boolean;
 
     /**
-     * TODO
+     * Search query for the bot
      */
     location: {search: string};
 

--- a/components/integrations/bots/add_bot/index.js
+++ b/components/integrations/bots/add_bot/index.js
@@ -12,7 +12,7 @@ import {getUser} from 'mattermost-redux/selectors/entities/users';
 import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 
-import AddBot from './add_bot.jsx';
+import AddBot from './add_bot';
 
 function mapStateToProps(state, ownProps) {
     const config = getConfig(state);

--- a/components/integrations/bots/add_bot/index.ts
+++ b/components/integrations/bots/add_bot/index.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
+import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {updateUserRoles, uploadProfileImage, setDefaultProfileImage, createUserAccessToken} from 'mattermost-redux/actions/users';
 import {createBot, patchBot} from 'mattermost-redux/actions/bots';
@@ -12,17 +12,21 @@ import {getUser} from 'mattermost-redux/selectors/entities/users';
 import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 
-import AddBot from './add_bot';
+import {GlobalState} from 'types/store';
 
-function mapStateToProps(state, ownProps) {
+import {ActionFunc} from 'mattermost-redux/types/actions';
+
+import AddBot, {Props} from './add_bot';
+
+function mapStateToProps(state: GlobalState, ownProps: Props) {
     const config = getConfig(state);
     const botId = (new URLSearchParams(ownProps.location.search)).get('id');
     const bots = getBotAccounts(state);
-    const bot = bots ? bots[botId] : null;
-    const user = bot ? getUser(state, bot.user_id) : null;
-    const roles = user ? user.roles : null;
+    const bot = (bots && botId) ? bots[botId] : undefined;
+    const user = bot ? getUser(state, bot.user_id) : undefined;
+    const roles = user ? user.roles : undefined;
     return {
-        maxFileSize: parseInt(config.MaxFileSize, 10),
+        maxFileSize: parseInt(config.MaxFileSize!, 10),
         bot,
         roles,
         editingUserHasManageSystem: haveISystemPermission(state, {permission: Permissions.MANAGE_SYSTEM}),
@@ -30,9 +34,9 @@ function mapStateToProps(state, ownProps) {
     };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
-        actions: bindActionCreators({
+        actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Props['actions']>({
             createBot,
             patchBot,
             uploadProfileImage,

--- a/components/integrations/bots/add_bot/index.ts
+++ b/components/integrations/bots/add_bot/index.ts
@@ -4,6 +4,8 @@
 import {connect} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
+import {RouteComponentProps} from 'react-router-dom';
+
 import {updateUserRoles, uploadProfileImage, setDefaultProfileImage, createUserAccessToken} from 'mattermost-redux/actions/users';
 import {createBot, patchBot} from 'mattermost-redux/actions/bots';
 import {getBotAccounts} from 'mattermost-redux/selectors/entities/bots';
@@ -11,14 +13,21 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
 import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
+import {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {GlobalState} from 'types/store';
 
-import {ActionFunc} from 'mattermost-redux/types/actions';
-
 import AddBot, {Props} from './add_bot';
 
-function mapStateToProps(state: GlobalState, ownProps: Props) {
+type OwnProps = {
+
+    /**
+     * Search query for the bot
+     */
+    location: RouteComponentProps['location'];
+}
+
+function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const config = getConfig(state);
     const botId = (new URLSearchParams(ownProps.location.search)).get('id');
     const bots = getBotAccounts(state);


### PR DESCRIPTION
#### Summary
This PR migrates 'components/integrations/bots/add_bot' module and associated tests to TypeScript

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16129
JIRA: https://mattermost.atlassian.net/browse/MM-20445

#### Release Note
```release-note
NONE
```
