### PR TITLE
[MM-34969] search dropdown options should allow focusing with tab

### DIFF
--- a/components/search/search.tsx
+++ b/components/search/search.tsx
@@ -196,12 +196,12 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
     };
 
     const handleOnSearchTypeSelected = (searchType || searchTerms) ? undefined : (value: SearchType) => {
-        actions.updateSearchType(value); 
-        if(!searchType){
+        actions.updateSearchType(value);
+        if (!searchType) {
             setDropdownFocused(false);
         }
         setFocused(true);
-    }
+    };
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
         const term = e.target.value;

--- a/components/search/search.tsx
+++ b/components/search/search.tsx
@@ -87,6 +87,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
 
     // generate intial component state and setters
     const [focused, setFocused] = useState<boolean>(false);
+    const [dropdownFocused, setDropdownFocused] = useState<boolean>(false);
     const [keepInputFocused, setKeepInputFocused] = useState<boolean>(false);
     const [indexChangedViaKeyPress, setIndexChangedViaKeyPress] = useState<boolean>(false);
     const [highlightedSearchHintIndex, setHighlightedSearchHintIndex] = useState<number>(-1);
@@ -167,8 +168,28 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
                 setFocused(false);
             }
         }, 0);
-
         updateHighlightedSearchHint();
+    };
+
+    const handleDropdownBlur = () => setDropdownFocused(false);
+
+    const handleDropdownFocus = () => setDropdownFocused(true);
+
+    const isKeyNumericOrAlfanumeric = (code: number) => (code >= 48 && code <= 90) || (code >= 96 && code <= 111);
+
+    const handleDropdownKeyDown = (e: React.KeyboardEvent) => {
+        // allow navigation keys to continue normal behavior
+        if (e.key === 'Tab' || e.key === 'Shift' || e.key === 'Space') {
+            return;
+        }
+
+        e.preventDefault();
+
+        // copy the typed character to the search box as the focus is not in place yet
+        if (isKeyNumericOrAlfanumeric(e.keyCode)) {
+            actions.updateSearchTerms(e.key);
+        }
+        setFocused(true);
     };
 
     const handleSearchHintSelection = (): void => {
@@ -405,7 +426,7 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
             return <></>;
         }
 
-        const helpClass = `search-help-popover${(focused && termsUsed <= 2) ? ' visible' : ''}`;
+        const helpClass = `search-help-popover${((dropdownFocused || focused) && termsUsed <= 2) ? ' visible' : ''}`;
 
         return (
             <Popover
@@ -421,6 +442,9 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
                     highlightedIndex={highlightedSearchHintIndex}
                     onOptionHover={setHoverHintIndex}
                     onSearchTypeSelected={(searchType || searchTerms) ? undefined : (value: SearchType) => actions.updateSearchType(value)}
+                    onElementBlur={handleDropdownBlur}
+                    onElementFocus={handleDropdownFocus}
+                    onKeyDown={handleDropdownKeyDown}
                     searchType={searchType}
                 />
             </Popover>

--- a/components/search/search.tsx
+++ b/components/search/search.tsx
@@ -175,23 +175,6 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
 
     const handleDropdownFocus = () => setDropdownFocused(true);
 
-    const isKeyNumericOrAlfanumeric = (code: number) => (code >= 48 && code <= 90) || (code >= 96 && code <= 111);
-
-    const handleDropdownKeyDown = (e: React.KeyboardEvent) => {
-        // allow navigation keys to continue normal behavior
-        if (e.key === 'Tab' || e.key === 'Shift' || e.key === 'Space') {
-            return;
-        }
-
-        e.preventDefault();
-
-        // copy the typed character to the search box as the focus is not in place yet
-        if (isKeyNumericOrAlfanumeric(e.keyCode)) {
-            actions.updateSearchTerms(e.key);
-        }
-        setFocused(true);
-    };
-
     const handleSearchHintSelection = (): void => {
         if (focused) {
             setKeepInputFocused(true);
@@ -211,6 +194,14 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
         actions.updateSearchTerms(terms);
         updateHighlightedSearchHint();
     };
+
+    const handleOnSearchTypeSelected = (searchType || searchTerms) ? undefined : (value: SearchType) => {
+        actions.updateSearchType(value); 
+        if(!searchType){
+            setDropdownFocused(false);
+        }
+        setFocused(true);
+    }
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
         const term = e.target.value;
@@ -441,10 +432,9 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
                     onMouseDown={handleSearchHintSelection}
                     highlightedIndex={highlightedSearchHintIndex}
                     onOptionHover={setHoverHintIndex}
-                    onSearchTypeSelected={(searchType || searchTerms) ? undefined : (value: SearchType) => actions.updateSearchType(value)}
+                    onSearchTypeSelected={handleOnSearchTypeSelected}
                     onElementBlur={handleDropdownBlur}
                     onElementFocus={handleDropdownFocus}
-                    onKeyDown={handleDropdownKeyDown}
                     searchType={searchType}
                 />
             </Popover>

--- a/components/search_hint/__snapshots__/search_hint.test.tsx.snap
+++ b/components/search_hint/__snapshots__/search_hint.test.tsx.snap
@@ -396,7 +396,6 @@ exports[`components/SearchHint should match snapshot, without searchType 1`] = `
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
     >
       <i
         className="icon icon-message-text-outline"
@@ -411,7 +410,6 @@ exports[`components/SearchHint should match snapshot, without searchType 1`] = `
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
     >
       <i
         className="icon icon-file-text-outline"

--- a/components/search_hint/__snapshots__/search_hint.test.tsx.snap
+++ b/components/search_hint/__snapshots__/search_hint.test.tsx.snap
@@ -393,7 +393,10 @@ exports[`components/SearchHint should match snapshot, without searchType 1`] = `
   >
     <button
       className=""
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
     >
       <i
         className="icon icon-message-text-outline"
@@ -405,7 +408,10 @@ exports[`components/SearchHint should match snapshot, without searchType 1`] = `
     </button>
     <button
       className=""
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
     >
       <i
         className="icon icon-file-text-outline"

--- a/components/search_hint/search_hint.tsx
+++ b/components/search_hint/search_hint.tsx
@@ -26,7 +26,6 @@ type Props = {
     onSearchTypeSelected?: (searchType: 'files' | 'messages') => void;
     onElementBlur?: () => void;
     onElementFocus?: () => void;
-    onKeyDown?: (e: React.KeyboardEvent) => void;
     searchType?: 'files' | 'messages' | '';
 }
 
@@ -58,7 +57,6 @@ const SearchHint = (props: Props): JSX.Element => {
                             onClick={() => props.onSearchTypeSelected && props.onSearchTypeSelected('messages')}
                             onBlur={() => props.onElementBlur && props.onElementBlur()}
                             onFocus={() => props.onElementFocus && props.onElementFocus()}
-                            onKeyDown={(e: React.KeyboardEvent) => props.onKeyDown && props.onKeyDown(e)}
                         >
                             <i className='icon icon-message-text-outline'/>
                             <FormattedMessage
@@ -72,7 +70,6 @@ const SearchHint = (props: Props): JSX.Element => {
                                 onClick={() => props.onSearchTypeSelected && props.onSearchTypeSelected('files')}
                                 onBlur={() => props.onElementBlur && props.onElementBlur()}
                                 onFocus={() => props.onElementFocus && props.onElementFocus()}
-                                onKeyDown={(e: React.KeyboardEvent) => props.onKeyDown && props.onKeyDown(e)}
                             >
                                 <i className='icon icon-file-text-outline'/>
                                 <FormattedMessage

--- a/components/search_hint/search_hint.tsx
+++ b/components/search_hint/search_hint.tsx
@@ -24,6 +24,9 @@ type Props = {
     highlightedIndex?: number;
     onOptionHover?: (index: number) => void;
     onSearchTypeSelected?: (searchType: 'files' | 'messages') => void;
+    onElementBlur?: () => void;
+    onElementFocus?: () => void;
+    onKeyDown?: (e: React.KeyboardEvent) => void;
     searchType?: 'files' | 'messages' | '';
 }
 
@@ -53,6 +56,9 @@ const SearchHint = (props: Props): JSX.Element => {
                         <button
                             className={classNames({highlighted: props.highlightedIndex === 0})}
                             onClick={() => props.onSearchTypeSelected && props.onSearchTypeSelected('messages')}
+                            onBlur={() => props.onElementBlur && props.onElementBlur()}
+                            onFocus={() => props.onElementFocus && props.onElementFocus()}
+                            onKeyDown={(e: React.KeyboardEvent) => props.onKeyDown && props.onKeyDown(e)}
                         >
                             <i className='icon icon-message-text-outline'/>
                             <FormattedMessage
@@ -64,6 +70,9 @@ const SearchHint = (props: Props): JSX.Element => {
                             <button
                                 className={classNames({highlighted: props.highlightedIndex === 1})}
                                 onClick={() => props.onSearchTypeSelected && props.onSearchTypeSelected('files')}
+                                onBlur={() => props.onElementBlur && props.onElementBlur()}
+                                onFocus={() => props.onElementFocus && props.onElementFocus()}
+                                onKeyDown={(e: React.KeyboardEvent) => props.onKeyDown && props.onKeyDown(e)}
                             >
                                 <i className='icon icon-file-text-outline'/>
                                 <FormattedMessage

--- a/e2e/cypress/tests/integration/search/search_bar_popup_focus_spec.js
+++ b/e2e/cypress/tests/integration/search/search_bar_popup_focus_spec.js
@@ -32,7 +32,7 @@ describe('Search', () => {
         cy.get('#searchbar-help-popup').should('be.visible');
     });
 
-    it('MM-34969 - Search bar popup should be hidden when focus is out of search bar items', () => {
+    it('MM-T4945_2 - Search bar popup should be hidden when focus is out of search bar items', () => {
         //# clicks on the search box
         cy.uiGetSearchBox().click();
 

--- a/e2e/cypress/tests/integration/search/search_bar_popup_focus_spec.js
+++ b/e2e/cypress/tests/integration/search/search_bar_popup_focus_spec.js
@@ -18,7 +18,7 @@ describe('Search', () => {
         });
     });
 
-    it('MM-34969 - Search bar popup should be visible when focus changes to one of its buttons', () => {
+    it('MM-T4945_1 - Search bar popup should be visible when focus changes to one of its buttons', () => {
         //# clicks on the search box
         cy.uiGetSearchBox().click();
 

--- a/e2e/cypress/tests/integration/search/search_bar_popup_focus_spec.js
+++ b/e2e/cypress/tests/integration/search/search_bar_popup_focus_spec.js
@@ -48,7 +48,7 @@ describe('Search', () => {
         cy.get('#searchbar-help-popup').should('not.be.visible');
     });
 
-    it('MM-34969 - Search bar popup should be open when focus back to search box', () => {
+    it('MM-T4945_3 - Search bar popup should be open when focus back to search box', () => {
         //# clicks on the search box
         cy.uiGetSearchBox().click();
 

--- a/e2e/cypress/tests/integration/search/search_bar_popup_focus_spec.js
+++ b/e2e/cypress/tests/integration/search/search_bar_popup_focus_spec.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @search
+
+describe('Search', () => {
+    before(() => {
+        // # Login as test user and visit off-topic
+        cy.apiInitSetup({loginAfter: true}).then(({offTopicUrl}) => {
+            cy.visit(offTopicUrl);
+        });
+    });
+
+    it('MM-34969 - Search bar popup should be visible when focus changes to one of its buttons', () => {
+        //# clicks on the search box
+        cy.uiGetSearchBox().click();
+
+        //* search bar popup should be visibl
+        cy.get('#searchbar-help-popup').should('be.visible');
+
+        //# moves the focus to the next button (in this case Messages)
+        cy.focused().tab();
+
+        //* search bar popup should be visible
+        cy.get('#searchbar-help-popup').should('be.visible');
+    });
+
+    it('MM-34969 - Search bar popup should be hidden when focus is out of search bar items', () => {
+        //# clicks on the search box
+        cy.uiGetSearchBox().click();
+
+        //* search bar popup should be visibl
+        cy.get('#searchbar-help-popup').should('be.visible');
+
+        //# press tab three times to move focus out of the search bar componment
+        cy.focused().tab();
+        cy.focused().tab();
+        cy.focused().tab();
+
+        //* now the popup should be closed
+        cy.get('#searchbar-help-popup').should('not.be.visible');
+    });
+
+    it('MM-34969 - Search bar popup should be open when focus back to search box', () => {
+        //# clicks on the search box
+        cy.uiGetSearchBox().click();
+
+        //* search bar popup should be visibl
+        cy.get('#searchbar-help-popup').should('be.visible');
+
+        //# moves the focus to the next button (in this case Messages)
+        cy.focused().tab();
+
+        //* search bar popup should be visible
+        cy.get('#searchbar-help-popup').should('be.visible');
+
+        //# moves the focus back to the search box
+        cy.focused().tab({shift: true});
+
+        //* search bar popup should still be visible
+        cy.get('#searchbar-help-popup').should('be.visible');
+    });
+});


### PR DESCRIPTION
#### Summary
This PR modifies the search box to not hide the dropdown (with messages/files buttons) when the focus is set from the search box to one element inside the dropdown

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/17734
Jira: https://mattermost.atlassian.net/browse/MM-34969

#### Related Pull Requests
This pull request has no related prs


#### Release Note

```release-note
NONE

```