### PR TITLE
Cypress/E2E: Fix tests for authentication, accessibility, dot menu

### DIFF
--- a/e2e/cypress/tests/integration/auth_sso/authentication_4_spec.js
+++ b/e2e/cypress/tests/integration/auth_sso/authentication_4_spec.js
@@ -131,11 +131,11 @@ describe('Authentication', () => {
             cy.visit('/admin_console/authentication/password');
             cy.get('.admin-console__header').should('be.visible').and('have.text', 'Password');
 
-            cy.findByTestId('passwordMinimumLengthinput').should('be.visible').and('have.value', '10');
-            cy.findByRole('checkbox', {name: 'At least one lowercase letter'}).should('be.checked');
-            cy.findByRole('checkbox', {name: 'At least one uppercase letter'}).should('be.checked');
-            cy.findByRole('checkbox', {name: 'At least one number'}).should('be.checked');
-            cy.findByRole('checkbox', {name: 'At least one symbol (e.g. "~!@#$%^&*()")'}).should('be.checked');
+            cy.findByTestId('passwordMinimumLengthinput').should('be.visible').and('have.value', '8');
+            cy.findByLabelText('At least one lowercase letter').get('input').should('not.be.checked');
+            cy.findByLabelText('At least one uppercase letter').get('input').should('not.be.checked');
+            cy.findByLabelText('At least one number').get('input').should('not.be.checked');
+            cy.findByLabelText('At least one symbol (e.g. "~!@#$%^&*()")').get('input').should('not.be.checked');
 
             if (!isCloudLicensed) {
                 cy.findByTestId('maximumLoginAttemptsinput').should('be.visible').and('have.value', '10');

--- a/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_input_fields_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_input_fields_spec.js
@@ -241,6 +241,24 @@ describe('Verify Accessibility Support in different input fields', () => {
             // * Verify if the focus is on the hidden controls button
             cy.get('#HiddenControlsButtonRHS_COMMENT').should('be.focused').and('have.attr', 'aria-label', 'show hidden formatting options').tab();
 
+            // * Verify if the focus is on the hidden heading button
+            cy.get('#FormattingControl_heading').should('be.focused').and('have.attr', 'aria-label', 'heading').tab();
+
+            // * Verify if the focus is on the hidden link button
+            cy.get('#FormattingControl_link').should('be.focused').and('have.attr', 'aria-label', 'link').tab();
+
+            // * Verify if the focus is on the hidden code button
+            cy.get('#FormattingControl_code').should('be.focused').and('have.attr', 'aria-label', 'code').tab();
+
+            // * Verify if the focus is on the hidden quote button
+            cy.get('#FormattingControl_quote').should('be.focused').and('have.attr', 'aria-label', 'quote').tab();
+
+            // * Verify if the focus is on the hidden bulleted list button
+            cy.get('#FormattingControl_ul').should('be.focused').and('have.attr', 'aria-label', 'bulleted list').tab();
+
+            // * Verify if the focus is on the hidden numbered list button
+            cy.get('#FormattingControl_ol').should('be.focused').and('have.attr', 'aria-label', 'numbered list').tab();
+
             // * Verify if the focus is on the attachment icon
             cy.get('#fileUploadButton').should('be.focused').and('have.attr', 'aria-label', 'attachment').tab();
 

--- a/e2e/cypress/tests/integration/keyboard_shortcuts/dot_menu_spec.js
+++ b/e2e/cypress/tests/integration/keyboard_shortcuts/dot_menu_spec.js
@@ -100,13 +100,13 @@ describe('Keyboard Shortcuts', () => {
             cy.viewport('iphone-6');
 
             // # Save Post
-            cy.uiPostDropdownMenuShortcut(postId, 'Save', 'S');
+            cy.uiPostDropdownMenuShortcut(postId, 'Save', 'S', 'RHS_ROOT');
 
             // * Verify post is Saved
             cy.get(`#post_${postId}`).find('.post-pre-header').should('be.visible').and('have.text', 'Saved');
 
             // # Unsave Post
-            cy.uiPostDropdownMenuShortcut(postId, 'Remove from Saved', 'S');
+            cy.uiPostDropdownMenuShortcut(postId, 'Remove from Saved', 'S', 'RHS_ROOT');
 
             // * Verify post is unsaved
             cy.get(`#post_${postId}`).and('not.have.text', 'Saved');


### PR DESCRIPTION
#### Summary
Misc maintenance fixes:
- Fixed `MM-T1770 - Default password settings`
- Fixed `MM-T1490 Verify Accessibility Support in RHS Input`
- Fixed `MM-T4801 Dot menu keyboard shortcuts`

#### Ticket Link
N/A

#### Screenshots
![Screen Shot 2022-07-18 at 4 35 39 PM](https://user-images.githubusercontent.com/487991/179639460-c57c239c-c28b-4f94-85a0-b3c343707f87.png)
![Screen Shot 2022-07-18 at 4 55 14 PM](https://user-images.githubusercontent.com/487991/179639463-4f38bb90-7518-4ae4-a5fd-2c40b0dfca09.png)
![Screen Shot 2022-07-18 at 5 29 25 PM](https://user-images.githubusercontent.com/487991/179639466-21d7ba3e-347b-4852-8fd6-5c1167fa6c37.png)

#### Release Note
```release-note
NONE
```
