### PR TITLE
Support hiding plugin settings based on hosting environment

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -5435,7 +5435,6 @@ const AdminDefinition = {
         custom: {
             url: 'plugins/plugin_:plugin_id',
             isDisabled: it.not(it.userHasWritePermissionOnResource('plugins')),
-            // isHidden: it.hostingMatches(),
             schema: {
                 id: 'CustomPluginSettings',
                 component: CustomPluginSettings,

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -215,6 +215,13 @@ export const it = {
     userHasReadPermissionOnResource: (key) => (config, state, license, enterpriseReady, consoleAccess) => consoleAccess?.read?.[key],
     userHasReadPermissionOnSomeResources: (key) => Object.values(key).some((resource) => it.userHasReadPermissionOnResource(resource)),
     userHasWritePermissionOnResource: (key) => (config, state, license, enterpriseReady, consoleAccess) => consoleAccess?.write?.[key],
+    hostingMatches: () => (config, state, license, enterpriseReady, consoleAccess, cloud, isSystemAdmin, setting) => {
+        if (setting && setting.hosting) {
+            return true;
+        }
+
+        return false;
+    },
     isSystemAdmin: (config, state, license, enterpriseReady, consoleAccess, icloud, isSystemAdmin) => isSystemAdmin,
 };
 
@@ -5428,6 +5435,7 @@ const AdminDefinition = {
         custom: {
             url: 'plugins/plugin_:plugin_id',
             isDisabled: it.not(it.userHasWritePermissionOnResource('plugins')),
+            // isHidden: it.hostingMatches(),
             schema: {
                 id: 'CustomPluginSettings',
                 component: CustomPluginSettings,

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -375,8 +375,9 @@ export default class SchemaAdminSettings extends React.PureComponent {
     }
 
     isHidden = (setting) => {
+        const enterpriseReady = this.props.config.BuildEnterpriseReady === 'true';
         if (typeof setting.isHidden === 'function') {
-            return setting.isHidden(this.props.config, this.state, this.props.license);
+            return setting.isHidden(this.props.config, this.state, this.props.license, enterpriseReady, this.props.consoleAccess, this.props.cloud, this.props.isCurrentUserSystemAdmin, setting);
         }
         return Boolean(setting.isHidden);
     }

--- a/packages/types/src/plugins.ts
+++ b/packages/types/src/plugins.ts
@@ -51,6 +51,7 @@ export type PluginSetting = {
     placeholder: string;
     default: any;
     options?: PluginSettingOption[];
+    hosting?: 'on-prem' | 'cloud';
 };
 
 export type PluginSettingOption = {


### PR DESCRIPTION
#### Summary

This PR makes it so a given plugin can hide specific plugin settings based on the hosting environment of the server.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-44843

#### Release Note

```release-note
NONE
```
