### PR TITLE
MM-45713 - change 500 error to json object during validate business email request

### DIFF
--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -110,14 +110,10 @@ export function validateBusinessEmail(email = '') {
     return async () => {
         try {
             const res = await Client4.validateBusinessEmail(email);
-            if (res.data.is_valid === 'true') {
-                return true;
-            }
-            return false;
+            return res.data.is_valid;
         } catch (error) {
             return false;
         }
-        return true;
     };
 }
 
@@ -126,10 +122,7 @@ export function validateWorkspaceBusinessEmail() {
     return async () => {
         try {
             const res = await Client4.validateWorkspaceBusinessEmail();
-            if (res.data.is_valid === 'true') {
-                return true;
-            }
-            return false;
+            return res.data.is_valid;
         } catch (error) {
             return false;
         }

--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -109,7 +109,11 @@ export function validateBusinessEmail(email = '') {
     trackEvent('api', 'api_validate_business_email');
     return async () => {
         try {
-            await Client4.validateBusinessEmail(email);
+            const res = await Client4.validateBusinessEmail(email);
+            if (res.data.is_valid === 'true') {
+                return true;
+            }
+            return false;
         } catch (error) {
             return false;
         }
@@ -121,11 +125,14 @@ export function validateWorkspaceBusinessEmail() {
     trackEvent('api', 'api_validate_workspace_business_email');
     return async () => {
         try {
-            await Client4.validateWorkspaceBusinessEmail();
+            const res = await Client4.validateWorkspaceBusinessEmail();
+            if (res.data.is_valid === 'true') {
+                return true;
+            }
+            return false;
         } catch (error) {
             return false;
         }
-        return true;
     };
 }
 

--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -12,7 +12,7 @@ import type {AppBinding, AppCallRequest, AppCallResponse} from '@mattermost/type
 import {Audit} from '@mattermost/types/audits';
 import {UserAutocomplete, AutocompleteSuggestion} from '@mattermost/types/autocomplete';
 import {Bot, BotPatch} from '@mattermost/types/bots';
-import {Product, SubscriptionResponse, CloudCustomer, Address, CloudCustomerPatch, Invoice, Limits, IntegrationsUsage, NotifyAdminRequest} from '@mattermost/types/cloud';
+import {Product, SubscriptionResponse, CloudCustomer, Address, CloudCustomerPatch, Invoice, Limits, IntegrationsUsage, NotifyAdminRequest, Subscription, ValidBusinessEmail} from '@mattermost/types/cloud';
 import {ChannelCategory, OrderedChannelCategories} from '@mattermost/types/channel_categories';
 import {
     Channel,
@@ -3834,21 +3834,21 @@ export default class Client4 {
     }
 
     requestCloudTrial = (subscriptionId: string, email = '') => {
-        return this.doFetchWithResponse<CloudCustomer>(
+        return this.doFetchWithResponse<Subscription>(
             `${this.getCloudRoute()}/request-trial`,
             {method: 'put', body: JSON.stringify({email, subscription_id: subscriptionId})},
         );
     }
 
     validateBusinessEmail = (email = '') => {
-        return this.doFetchWithResponse<CloudCustomer>(
+        return this.doFetchWithResponse<ValidBusinessEmail>(
             `${this.getCloudRoute()}/validate-business-email`,
             {method: 'post', body: JSON.stringify({email})},
         );
     }
 
     validateWorkspaceBusinessEmail = () => {
-        return this.doFetchWithResponse<CloudCustomer>(
+        return this.doFetchWithResponse<ValidBusinessEmail>(
             `${this.getCloudRoute()}/validate-workspace-business-email`,
             {method: 'post'},
         );

--- a/packages/types/src/cloud.ts
+++ b/packages/types/src/cloud.ts
@@ -191,5 +191,5 @@ export type TeamsUsage = {
 }
 
 export type ValidBusinessEmail = {
-    is_valid: string;
+    is_valid: boolean;
 }

--- a/packages/types/src/cloud.ts
+++ b/packages/types/src/cloud.ts
@@ -189,3 +189,7 @@ export type TeamsUsage = {
     cloudArchived: number;
     teamsLoaded: boolean;
 }
+
+export type ValidBusinessEmail = {
+    is_valid: string;
+}


### PR DESCRIPTION
#### Summary
This PR changes the response from being a plain 500 to be a json object containing the key is_valid which its values could be either true or false. This in order to prevent raising alarms and increasing the SLOs to SRE team for server errors.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45713

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/20682

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
