### PR TITLE
Cypress/E2E: Fix mark as read, messaging, multi team and dm tests

### DIFF
--- a/e2e/cypress/tests/integration/mark_as_unread/mark_gm_as_unread_spec.js
+++ b/e2e/cypress/tests/integration/mark_as_unread/mark_gm_as_unread_spec.js
@@ -60,6 +60,7 @@ describe('Mark as Unread', () => {
 
             // # Go to the group message channel
             cy.get(`#sidebarItem_${gmChannel.name}`).click();
+            cy.reload();
 
             // # Mark the post to be unread
             cy.getNthPostId(-2).then((postId) => {
@@ -70,19 +71,19 @@ describe('Mark as Unread', () => {
             verifyPostNextToNewMessageSeparator(`this is from user: ${otherUser1.id}, 7`);
 
             // * Verify the group message in LHS is unread
-            cy.get(`#sidebarItem_${gmChannel.name}`).should('have.class', 'unread-title');
+            cy.get(`#sidebarItem_${gmChannel.name}`).should('have.attr', 'aria-label', `${otherUser1.username}, ${otherUser2.username} unread`);
 
             // # Leave the group message channel
             cy.get('#sidebarItem_town-square').click();
 
             // * Verify the group message in LHS is unread
-            cy.get(`#sidebarItem_${gmChannel.name}`).should('have.class', 'unread-title');
+            cy.get(`#sidebarItem_${gmChannel.name}`).should('have.attr', 'aria-label', `${otherUser1.username}, ${otherUser2.username} unread`);
 
             // # Go to the group message channel
             cy.get(`#sidebarItem_${gmChannel.name}`).click().wait(TIMEOUTS.ONE_SEC);
 
             // * Verify the group message in LHS is read
-            cy.get(`#sidebarItem_${gmChannel.name}`).should('exist').should('not.have.class', 'unread-title');
+            cy.get(`#sidebarItem_${gmChannel.name}`).should('exist').should('not.have.attr', 'aria-label', `${otherUser1.username}, ${otherUser2.username} unread`);
 
             // * Verify the notification separator line exists and present before the unread message
             verifyPostNextToNewMessageSeparator(`this is from user: ${otherUser1.id}, 7`);

--- a/e2e/cypress/tests/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/tests/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -504,6 +504,7 @@ describe('Messaging', () => {
     it('MM-T2140 Edited message displays edits and "Edited" in center and RHS', () => {
         // # Mobile app
         cy.viewport('iphone-6');
+        cy.reload();
 
         // # Post message
         cy.uiGetPostTextBox().type(message1).type('{enter}').wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/tests/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/tests/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -551,7 +551,7 @@ describe('Messaging', () => {
 
         // # Edit post by opening modal
         cy.getLastPostId().then((postId) => {
-            cy.clickPostDotMenu(postId);
+            cy.clickPostDotMenu(postId, 'RHS_ROOT');
 
             // * Click edit post
             cy.get(`#edit_post_${postId}`).scrollIntoView().should('be.visible').click();

--- a/e2e/cypress/tests/integration/messaging/private_channel_open_spec.js
+++ b/e2e/cypress/tests/integration/messaging/private_channel_open_spec.js
@@ -32,7 +32,7 @@ describe('Messaging - Opening a private channel using keyboard shortcuts', () =>
             // # Type the first letter of a private channel in the "Switch Channels" modal message box
             // # Use up/down arrow keys to highlight a private channel
             // # Press ENTER
-            cy.findByRole('textbox', {name: 'quick switch input'}).type('P').type('{downarrow}').type('{enter}');
+            cy.findByRole('textbox', {name: 'quick switch input'}).type('Pr').type('{downarrow}').type('{enter}');
 
             // * Private channel opens
             cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Private channel').wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/tests/integration/multi_team_and_dm/close_current_dm_redirects_spec.js
+++ b/e2e/cypress/tests/integration/multi_team_and_dm/close_current_dm_redirects_spec.js
@@ -4,6 +4,8 @@
 // Stage: @prod
 // Group: @multi_team_and_dm
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 describe('Direct messages: redirections', () => {
     let testUser;
     let secondDMUser;
@@ -99,7 +101,7 @@ const sendDirectMessageToUser = (user, message) => {
     cy.uiAddDirectMessage().click();
 
     // # Type username
-    cy.get('#selectItems input').should('be.enabled').typeWithForce(`@${user.username}`);
+    cy.get('#selectItems input').should('be.enabled').typeWithForce(`@${user.username}`).wait(TIMEOUTS.ONE_SEC);
 
     // * Expect user count in the list to be 1
     cy.get('#multiSelectList').


### PR DESCRIPTION
#### Summary
Misc maintenance fixes:
- Fixed `MM-T2140 Edited message displays edits and "Edited" in center and RHS`
- Fixed `MM-T1225 CTRL/CMD+K - Open private channel using arrow keys and Enter`
- Fixed `MM-T249 Mark GM post as unread`
- Fixed `MM-T453_2 Closing a different direct message should not affect active direct message`

#### Ticket Link
N/A

#### Screenshots
![Screen Shot 2022-07-19 at 8 22 08 AM](https://user-images.githubusercontent.com/487991/179801653-bf24c03d-fbac-4a8f-9a24-8aa715eaf8d8.png)
![Screen Shot 2022-07-19 at 8 48 21 AM](https://user-images.githubusercontent.com/487991/179801656-08736aca-19bf-49c2-9aa9-b1b63e286f5a.png)
![Screen Shot 2022-07-19 at 9 00 47 AM](https://user-images.githubusercontent.com/487991/179801660-351c2478-c820-409c-8131-de002a9fc55d.png)
![Screen Shot 2022-07-19 at 9 16 34 AM](https://user-images.githubusercontent.com/487991/179801664-8fb30347-1e37-40b8-a2fb-5d40b31f1f14.png)

#### Release Note
```release-note
NONE
```
