### PR TITLE
[MM-44224] Fixing input header and search icon

### DIFF
--- a/components/user_groups_modal/__snapshots__/user_groups_modal.test.tsx.snap
+++ b/components/user_groups_modal/__snapshots__/user_groups_modal.test.tsx.snap
@@ -42,10 +42,14 @@ exports[`component/user_groups_modal should match snapshot with groups 1`] = `
     <div
       className="user-groups-search"
     >
-      <SearchIcon />
       <ForwardRef
         className="user-group-search-input"
         data-testid="searchInput"
+        inputPrefix={
+          <i
+            className="icon icon-magnify"
+          />
+        }
         onChange={[Function]}
         placeholder="Search Groups"
         type="text"
@@ -197,10 +201,14 @@ exports[`component/user_groups_modal should match snapshot with groups, myGroups
     <div
       className="user-groups-search"
     >
-      <SearchIcon />
       <ForwardRef
         className="user-group-search-input"
         data-testid="searchInput"
+        inputPrefix={
+          <i
+            className="icon icon-magnify"
+          />
+        }
         onChange={[Function]}
         placeholder="Search Groups"
         type="text"

--- a/components/user_groups_modal/user_groups_modal.scss
+++ b/components/user_groups_modal/user_groups_modal.scss
@@ -53,11 +53,10 @@
 
         .user-groups-search {
             position: relative;
-            margin: 2px 24px 8px;
+            margin: 6px 24px 8px;
 
             .Input_container {
                 .Input_wrapper {
-                    padding-left: 40px;
                     margin: 6px 0;
                     line-height: 38px;
                 }
@@ -258,7 +257,7 @@
 
             .group-mention-input-wrapper,
             .group-name-input-wrapper {
-                padding: 2px 24px 12px;
+                padding: 6px 24px 12px;
 
                 .Input_container {
                     :focus {

--- a/components/user_groups_modal/user_groups_modal.tsx
+++ b/components/user_groups_modal/user_groups_modal.tsx
@@ -7,7 +7,6 @@ import {Modal} from 'react-bootstrap';
 
 import Constants from 'utils/constants';
 
-import FaSearchIcon from 'components/widgets/icons/fa_search_icon';
 import * as Utils from 'utils/utils';
 import {Group, GroupSearachParams} from '@mattermost/types/groups';
 

--- a/components/user_groups_modal/user_groups_modal.tsx
+++ b/components/user_groups_modal/user_groups_modal.tsx
@@ -236,7 +236,6 @@ export default class UserGroupsModal extends React.PureComponent<Props, State> {
                         /> :
                         <>
                             <div className='user-groups-search'>
-                                <FaSearchIcon/>
                                 <Input
                                     type='text'
                                     placeholder={Utils.localizeMessage('user_groups_modal.searchGroups', 'Search Groups')}
@@ -244,6 +243,7 @@ export default class UserGroupsModal extends React.PureComponent<Props, State> {
                                     value={this.props.searchTerm}
                                     data-testid='searchInput'
                                     className={'user-group-search-input'}
+                                    inputPrefix={<i className={'icon icon-magnify'}/>}
                                 />
                             </div>
                             <div className='more-modal__dropdown'>

--- a/components/view_user_group_modal/__snapshots__/view_user_group_modal.test.tsx.snap
+++ b/components/view_user_group_modal/__snapshots__/view_user_group_modal.test.tsx.snap
@@ -54,10 +54,14 @@ exports[`component/view_user_group_modal should match snapshot 1`] = `
     <div
       className="user-groups-search"
     >
-      <SearchIcon />
       <ForwardRef
         className="user-group-search-input"
         data-testid="searchInput"
+        inputPrefix={
+          <i
+            className="icon icon-magnify"
+          />
+        }
         onChange={[Function]}
         placeholder="Search group members"
         type="text"

--- a/components/view_user_group_modal/view_user_group_modal.tsx
+++ b/components/view_user_group_modal/view_user_group_modal.tsx
@@ -11,7 +11,6 @@ import {UserProfile} from '@mattermost/types/users';
 
 import Constants from 'utils/constants';
 
-import FaSearchIcon from 'components/widgets/icons/fa_search_icon';
 import * as Utils from 'utils/utils';
 import LoadingScreen from 'components/loading_screen';
 import {Group} from '@mattermost/types/groups';

--- a/components/view_user_group_modal/view_user_group_modal.tsx
+++ b/components/view_user_group_modal/view_user_group_modal.tsx
@@ -219,7 +219,6 @@ export default class ViewUserGroupModal extends React.PureComponent<Props, State
                         /> :
                         <>
                             <div className='user-groups-search'>
-                                <FaSearchIcon/>
                                 <Input
                                     type='text'
                                     placeholder={Utils.localizeMessage('search_bar.searchGroupMembers', 'Search group members')}
@@ -227,6 +226,7 @@ export default class ViewUserGroupModal extends React.PureComponent<Props, State
                                     value={this.props.searchTerm}
                                     data-testid='searchInput'
                                     className={'user-group-search-input'}
+                                    inputPrefix={<i className={'icon icon-magnify'}/>}
                                 />
                             </div>
                             <div


### PR DESCRIPTION
#### Summary
Input header was being cut off by the modal header, I also updated the search icon to use compass icons

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44224

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.



-->
**Before:**
![before-change](https://user-images.githubusercontent.com/14115924/179979236-c4439978-5bed-4d64-9c28-3182fdde5d48.png)
**After:**
![Screen Shot 2022-07-20 at 8 13 23 AM](https://user-images.githubusercontent.com/14115924/179979297-1efdcf30-7e5a-4eb5-a74e-cbcbb73f6e8b.png)
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
