### PR TITLE
[MM-39394] - Fix Autocomplete z-indexing issues when RHS is open

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -371,7 +371,6 @@
 }
 
 .post-create__container {
-    z-index: 12;
     width: 100%;
     flex: 0 0 auto;
     background: var(--center-channel-bg);


### PR DESCRIPTION

#### Summary
Channels autocomplete was being hidden behind the RHS. Removing the restrictive z-index on the parent, which wasn't necessary as the parent isn't positioned absolutely, allows the Autocomplete popover to rely on its own z-indexing and is now a top level component

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39394

#### Release Note
```release-note
NONE
```
