### PR TITLE
[MM-42526] When a profile picture fails to load,  fall back to the user's default picture

### DIFF
--- a/components/suggestion/at_mention_provider/__snapshots__/at_mention_suggestion.test.tsx.snap
+++ b/components/suggestion/at_mention_provider/__snapshots__/at_mention_suggestion.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`at mention suggestion Should display nick name of non signed in user 1`
           <img
             alt="user2 profile image"
             className="Avatar Avatar-sm"
+            onError={[Function]}
             src="/api/v4/users/userid2/image?_=0"
             tabIndex={0}
           />
@@ -141,6 +142,7 @@ exports[`at mention suggestion Should not display nick name of the signed in use
           <img
             alt="user profile image"
             className="Avatar Avatar-sm"
+            onError={[Function]}
             src="/api/v4/users/userid1/image?_=0"
             tabIndex={0}
           />

--- a/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
+++ b/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
@@ -257,6 +257,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
                         <img
                           alt="user profile image"
                           className="Avatar Avatar-sm"
+                          onError={[Function]}
                           src="/api/v4/users/5/image?_=0"
                           style={
                             Object {
@@ -466,6 +467,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
                         <img
                           alt="user profile image"
                           className="Avatar Avatar-sm"
+                          onError={[Function]}
                           src="/api/v4/users/4/image?_=0"
                           style={
                             Object {
@@ -675,6 +677,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
                         <img
                           alt="user profile image"
                           className="Avatar Avatar-sm"
+                          onError={[Function]}
                           src="/api/v4/users/3/image?_=0"
                           style={
                             Object {
@@ -1355,6 +1358,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
                         <img
                           alt="user profile image"
                           className="Avatar Avatar-sm"
+                          onError={[Function]}
                           src="/api/v4/users/5/image?_=0"
                           style={
                             Object {
@@ -1564,6 +1568,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
                         <img
                           alt="user profile image"
                           className="Avatar Avatar-sm"
+                          onError={[Function]}
                           src="/api/v4/users/4/image?_=0"
                           style={
                             Object {
@@ -1773,6 +1778,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
                         <img
                           alt="user profile image"
                           className="Avatar Avatar-sm"
+                          onError={[Function]}
                           src="/api/v4/users/3/image?_=0"
                           style={
                             Object {

--- a/components/widgets/users/avatar/__snapshots__/avatar.test.tsx.snap
+++ b/components/widgets/users/avatar/__snapshots__/avatar.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`components/widgets/users/Avatar should match the snapshot 1`] = `
 <img
   alt="test-username profile image"
   className="Avatar Avatar-xl"
+  onError={[Function]}
   src="test-url"
   tabIndex={0}
 />
@@ -20,6 +21,7 @@ exports[`components/widgets/users/Avatar should match the snapshot only with url
 <img
   alt="user profile image"
   className="Avatar Avatar-md"
+  onError={[Function]}
   src="test-url"
   tabIndex={0}
 />

--- a/components/widgets/users/avatar/avatar.tsx
+++ b/components/widgets/users/avatar/avatar.tsx
@@ -6,6 +6,9 @@ import classNames from 'classnames';
 
 import './avatar.scss';
 
+import {Client4} from 'mattermost-redux/client';
+import BotDefaultIcon from 'images/bot_default_icon.png';
+
 export type TAvatarSizeToken = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
 type Props = {
@@ -16,6 +19,9 @@ type Props = {
 };
 
 type Attrs = HTMLAttributes<HTMLElement>;
+
+const isURLForUser = (url: string | undefined): url is string => Boolean(url && url.startsWith(Client4.getUsersRoute()));
+const replaceURLWithDefaultImageURL = (url: string) => url.replace(/\?_=(\w+)/, '/default');
 
 const Avatar = ({
     url,
@@ -43,6 +49,19 @@ const Avatar = ({
             tabIndex={0}
             alt={`${username || 'user'} profile image`}
             src={url}
+            onError={(e) => {
+                let fallbackSrc = '';
+
+                if (isURLForUser(url)) {
+                    fallbackSrc = replaceURLWithDefaultImageURL(url);
+                } else {
+                    fallbackSrc = BotDefaultIcon;
+                }
+
+                if (e.currentTarget.src !== fallbackSrc) {
+                    e.currentTarget.src = fallbackSrc;
+                }
+            }}
         />
     );
 };

--- a/components/widgets/users/avatar/avatar.tsx
+++ b/components/widgets/users/avatar/avatar.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 type Attrs = HTMLAttributes<HTMLElement>;
 
-const isURLForUser = (url: string | undefined): url is string => Boolean(url && url.startsWith(Client4.getUsersRoute()));
+const isURLForUser = (url: string) => url.startsWith(Client4.getUsersRoute());
 const replaceURLWithDefaultImageURL = (url: string) => url.replace(/\?_=(\w+)/, '/default');
 
 const Avatar = ({
@@ -50,13 +50,7 @@ const Avatar = ({
             alt={`${username || 'user'} profile image`}
             src={url}
             onError={(e) => {
-                let fallbackSrc = '';
-
-                if (isURLForUser(url)) {
-                    fallbackSrc = replaceURLWithDefaultImageURL(url);
-                } else {
-                    fallbackSrc = BotDefaultIcon;
-                }
+                const fallbackSrc = (url && isURLForUser(url)) ? replaceURLWithDefaultImageURL(url) : BotDefaultIcon;
 
                 if (e.currentTarget.src !== fallbackSrc) {
                     e.currentTarget.src = fallbackSrc;

--- a/components/widgets/users/avatars/__snapshots__/avatars.test.tsx.snap
+++ b/components/widgets/users/avatars/__snapshots__/avatars.test.tsx.snap
@@ -211,6 +211,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/1/image?_=1620680333191"
                       style={
                         Object {
@@ -420,6 +421,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/6/image?_=0"
                       style={
                         Object {
@@ -629,6 +631,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/7/image?_=0"
                       style={
                         Object {
@@ -979,6 +982,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/1/image?_=1620680333191"
                       style={
                         Object {
@@ -1188,6 +1192,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/2/image?_=1620680333191"
                       style={
                         Object {
@@ -1397,6 +1402,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/3/image?_=1620680333191"
                       style={
                         Object {
@@ -1745,6 +1751,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/1/image?_=1620680333191"
                       style={
                         Object {
@@ -1954,6 +1961,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/2/image?_=1620680333191"
                       style={
                         Object {
@@ -2163,6 +2171,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
                     <img
                       alt="user profile image"
                       className="Avatar Avatar-xl"
+                      onError={[Function]}
                       src="/api/v4/users/3/image?_=1620680333191"
                       style={
                         Object {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

If user's profile picture fails to load, replace src with default profile src(I used the regex).
`Client4.getUsersRoute() + '/' + userId + '/image?_=' + lastPictureUpdate` 
-> 
`Client4.getUsersRoute() + '/' + userId + '/image/default'` 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/mattermost-server/issues/19815

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
add fallback src to an avatar
```
