### PR TITLE
MM-42718 : Do not render ChannelHeaderMobile when not in mobile view

### DIFF
--- a/components/channel_layout/center_channel/center_channel.test.tsx
+++ b/components/channel_layout/center_channel/center_channel.test.tsx
@@ -23,6 +23,7 @@ describe('components/channel_layout/CenterChannel', () => {
         isOnboardingHidden: true,
         enableTipsViewRoute: false,
         insightsAreEnabled: true,
+        isMobileView: false,
         actions: {
             getProfiles: jest.fn,
         },

--- a/components/channel_layout/center_channel/center_channel.tsx
+++ b/components/channel_layout/center_channel/center_channel.tsx
@@ -39,6 +39,7 @@ type Props = {
     isCollapsedThreadsEnabled: boolean;
     currentUserId: string;
     insightsAreEnabled: boolean;
+    isMobileView: boolean;
     actions: {
         getProfiles: (page?: number, perPage?: number, options?: Record<string, string | boolean>) => ActionFunc;
     };
@@ -74,8 +75,9 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
     }
 
     render() {
-        const {lastChannelPath, isCollapsedThreadsEnabled, insightsAreEnabled} = this.props;
+        const {lastChannelPath, isCollapsedThreadsEnabled, insightsAreEnabled, isMobileView} = this.props;
         const url = this.props.match.url;
+
         return (
             <div
                 key='inner-wrap'
@@ -85,11 +87,13 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
                     'move--left-small': this.props.rhsMenuOpen,
                 })}
             >
-                <div className='row header'>
-                    <div id='navbar_wrapper'>
-                        <ChannelHeaderMobile/>
+                {isMobileView && (
+                    <div className='row header'>
+                        <div id='navbar_wrapper'>
+                            <ChannelHeaderMobile/>
+                        </div>
                     </div>
-                </div>
+                )}
                 <div className='row main'>
                     <Switch>
                         <Route

--- a/components/channel_layout/center_channel/index.ts
+++ b/components/channel_layout/center_channel/index.ts
@@ -4,12 +4,14 @@
 import {connect} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
-import {getProfiles} from 'mattermost-redux/actions/users';
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
+import {getProfiles} from 'mattermost-redux/actions/users';
 import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
 import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {isCollapsedThreadsEnabled, insightsAreEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import {getIsMobileView} from 'selectors/views/browser';
 import {getIsRhsOpen, getIsRhsMenuOpen} from 'selectors/rhs';
 import {getIsLhsOpen} from 'selectors/lhs';
 import {getLastViewedChannelNameByTeamName, getLastViewedTypeByTeamName, getPreviousTeamId, getPreviousTeamLastViewedType} from 'selectors/local_storage';
@@ -63,6 +65,7 @@ const mapStateToProps = (state: GlobalState, ownProps: Props) => {
         isCollapsedThreadsEnabled: isCollapsedThreadsEnabled(state),
         currentUserId: getCurrentUserId(state),
         insightsAreEnabled: insightsAreEnabled(state),
+        isMobileView: getIsMobileView(state),
     };
 };
 


### PR DESCRIPTION
#### Summary
Doesnt renders the mobile's channel header in non mobile mode

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42718

#### Related Pull Requests


#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
