### PR TITLE
Cypress/E2E: Fix long post attachments spec

### DIFF
--- a/e2e/cypress/tests/integration/messaging/long_post_attachments_spec.js
+++ b/e2e/cypress/tests/integration/messaging/long_post_attachments_spec.js
@@ -10,6 +10,8 @@
 // Stage: @prod
 // Group: @messaging
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 describe('Messaging', () => {
     before(() => {
         // # Create new team and new user and visit off-topic
@@ -72,7 +74,7 @@ describe('Messaging', () => {
 
 function verifyImageInPostFooter(verifyExistence = true) {
     // * Verify that the image exists or not
-    cy.get('#advancedTextEditorCell').find('.file-preview').should(verifyExistence ? 'be.visible' : 'not.exist');
+    cy.get('#advancedTextEditorCell').find('.file-preview').should(verifyExistence ? 'be.visible' : 'not.exist').wait(TIMEOUTS.THREE_SEC);
 }
 
 function postAttachments() {

--- a/e2e/cypress/tests/integration/messaging/mention_autocomplete_overlap_spec.js
+++ b/e2e/cypress/tests/integration/messaging/mention_autocomplete_overlap_spec.js
@@ -21,7 +21,7 @@ describe('Messaging', () => {
         });
     });
 
-    it('At-mention user autocomplete should open below the textbox in RHS when only one message is present', () => {
+    it('At-mention user autocomplete should open below the textbox in RHS when only one message is present -- KNOWN ISSUE: MM-45597', () => {
         // # Add a single message to center textbox
         cy.postMessage(MESSAGES.TINY);
 


### PR DESCRIPTION
#### Summary
Misc maintenance fixes:
- Fixed `MM-T105 Long post with multiple attachments`
- Add `KNOWN ISSUE: MM-45597` to failing autocomplete test

#### Ticket Link
N/A

#### Screenshots
![Screen Shot 2022-07-20 at 9 27 08 PM](https://user-images.githubusercontent.com/487991/180130693-b4c4298b-e03c-49de-8500-5ae0332aaa47.png)

#### Release Note
```release-note
NONE
```
