### PR TITLE
MM-41861 : Avoid rendering of ThreadFooter component in Center when typing in center post

### DIFF
--- a/components/dot_menu/index.ts
+++ b/components/dot_menu/index.ts
@@ -9,7 +9,7 @@ import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId, getCurrentTeam, getTeam} from 'mattermost-redux/selectors/entities/teams';
-import {getThreadOrSynthetic} from 'mattermost-redux/selectors/entities/threads';
+import {makeGetThreadOrSynthetic} from 'mattermost-redux/selectors/entities/threads';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
@@ -95,6 +95,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         )
     ) {
         const root = getPost(state, rootId);
+        const getThreadOrSynthetic = makeGetThreadOrSynthetic();
         if (root) {
             const thread = getThreadOrSynthetic(state, root);
             threadReplyCount = thread.reply_count;

--- a/components/rhs_header_post/index.ts
+++ b/components/rhs_header_post/index.ts
@@ -10,7 +10,7 @@ import {getCurrentTeamId, getCurrentRelativeTeamUrl} from 'mattermost-redux/sele
 import {getCurrentUserId, getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
 
 import {setThreadFollow} from 'mattermost-redux/actions/threads';
-import {getThreadOrSynthetic} from 'mattermost-redux/selectors/entities/threads';
+import {makeGetThreadOrSynthetic} from 'mattermost-redux/selectors/entities/threads';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
 import {GlobalState} from 'types/store';
@@ -44,6 +44,7 @@ function mapStateToProps(state: GlobalState, {rootPostId}: OwnProps) {
     const root = getPost(state, rootPostId);
     const currentUserId = getCurrentUserId(state);
     const tipStep = getInt(state, Preferences.CRT_THREAD_PANE_STEP, currentUserId);
+    const getThreadOrSynthetic = makeGetThreadOrSynthetic();
 
     if (root && collapsedThreads) {
         const thread = getThreadOrSynthetic(state, root);

--- a/components/threading/channel_threads/thread_footer/thread_footer.tsx
+++ b/components/threading/channel_threads/thread_footer/thread_footer.tsx
@@ -5,29 +5,28 @@ import React, {memo, useCallback, useEffect, useMemo} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
-import './thread_footer.scss';
-
-import {GlobalState} from 'types/store';
-
 import {Post} from '@mattermost/types/posts';
 import {threadIsSynthetic, UserThread} from '@mattermost/types/threads';
 
 import {setThreadFollow, getThread as fetchThread} from 'mattermost-redux/actions/threads';
-import {selectPost} from 'actions/views/rhs';
-
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getThreadOrSynthetic} from 'mattermost-redux/selectors/entities/threads';
+import {makeGetThreadOrSynthetic} from 'mattermost-redux/selectors/entities/threads';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+
+import {GlobalState} from 'types/store';
+
+import {selectPost} from 'actions/views/rhs';
+import {trackEvent} from 'actions/telemetry_actions';
 
 import Avatars from 'components/widgets/users/avatars';
 import Timestamp from 'components/timestamp';
 import SimpleTooltip from 'components/widgets/simple_tooltip';
 import Button from 'components/threading/common/button';
 import FollowButton from 'components/threading/common/follow_button';
-
 import {THREADING_TIME} from 'components/threading/common/options';
-import {trackEvent} from 'actions/telemetry_actions';
+
+import './thread_footer.scss';
 
 type Props = {
     threadId: UserThread['id'];
@@ -42,6 +41,7 @@ function ThreadFooter({
     const currentTeamId = useSelector(getCurrentTeamId);
     const currentUserId = useSelector(getCurrentUserId);
     const post = useSelector((state: GlobalState) => getPost(state, threadId));
+    const getThreadOrSynthetic = useMemo(makeGetThreadOrSynthetic, [post.id]);
     const thread = useSelector((state: GlobalState) => getThreadOrSynthetic(state, post));
 
     useEffect(() => {

--- a/packages/mattermost-redux/src/selectors/entities/threads.ts
+++ b/packages/mattermost-redux/src/selectors/entities/threads.ts
@@ -75,25 +75,31 @@ export function getThread(state: GlobalState, threadId?: UserThread['id']) {
     return threads[threadId];
 }
 
-export function getThreadOrSynthetic(state: GlobalState, rootPost: Post): UserThread | UserThreadSynthetic {
-    const thread = getThreads(state)[rootPost.id];
+export function makeGetThreadOrSynthetic(): (state: GlobalState, rootPost: Post) => UserThread | UserThreadSynthetic {
+    return createSelector(
+        'getThreadOrSynthetic',
+        (_: GlobalState, rootPost: Post) => rootPost,
+        getThreads,
+        (rootPost, threads) => {
+            const thread = threads[rootPost.id];
+            if (thread?.id) {
+                return thread;
+            }
 
-    if (thread?.id) {
-        return thread;
-    }
-
-    return {
-        id: rootPost.id,
-        type: UserThreadType.Synthetic,
-        reply_count: rootPost.reply_count,
-        participants: rootPost.participants,
-        last_reply_at: rootPost.last_reply_at ?? 0,
-        is_following: thread?.is_following ?? rootPost.is_following ?? null,
-        post: {
-            user_id: rootPost.user_id,
-            channel_id: rootPost.channel_id,
+            return {
+                id: rootPost.id,
+                type: UserThreadType.Synthetic,
+                reply_count: rootPost.reply_count,
+                participants: rootPost.participants,
+                last_reply_at: rootPost.last_reply_at ?? 0,
+                is_following: thread?.is_following ?? rootPost.is_following ?? null,
+                post: {
+                    user_id: rootPost.user_id,
+                    channel_id: rootPost.channel_id,
+                },
+            };
         },
-    };
+    );
 }
 
 export const getThreadOrderInCurrentTeam: (state: GlobalState, selectedThreadIdInTeam?: UserThread['id']) => Array<UserThread['id']> = createSelector(


### PR DESCRIPTION
#### Summary
Created a factory selector for `getThreadOrSynthetic` which is then memoized for postId in footer component.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41861

#### Related Pull Requests
N/A

#### Screenshots
##### Before

![Feb-14-2022 6-45-55 pm](https://user-images.githubusercontent.com/17708702/180146272-61c81d4b-a7ea-46ad-abfe-6c0473bad817.gif)


##### After
![180139954-7de660ee-a2a8-4bee-a8ef-7d8f096d7a61](https://user-images.githubusercontent.com/17708702/180153046-856847bd-a078-49f4-a8d1-a3822be827fb.gif)



### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
