### PR TITLE
Automated cherry pick of #10798

### DIFF
--- a/components/common/hooks/useOpenPricingModal.ts
+++ b/components/common/hooks/useOpenPricingModal.ts
@@ -1,17 +1,26 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 
 import {trackEvent} from 'actions/telemetry_actions';
 import {openModal} from 'actions/views/modals';
 import {ModalIdentifiers} from 'utils/constants';
 import PricingModal from 'components/pricing_modal';
 
+import {isCurrentLicenseCloud} from 'mattermost-redux/selectors/entities/cloud';
+
 export default function useOpenPricingModal() {
     const dispatch = useDispatch();
+    const isCloud = useSelector(isCurrentLicenseCloud);
+    let category;
     return () => {
-        trackEvent('cloud_pricing', 'click_open_pricing_modal');
+        if (isCloud) {
+            category = 'cloud_pricing';
+        } else {
+            category = 'self_hosted_pricing';
+        }
+        trackEvent(category, 'click_open_pricing_modal');
         dispatch(openModal({
             modalId: ModalIdentifiers.PRICING_MODAL,
             dialogType: PricingModal,

--- a/components/global_header/right_controls/plan_upgrade_button/index.tsx
+++ b/components/global_header/right_controls/plan_upgrade_button/index.tsx
@@ -22,7 +22,7 @@ border-radius: 4px;
 border: none;
 box-shadow: none;
 height: 24px;
-width: 67px;
+width: auto;
 font-family: 'Open Sans';
 font-style: normal;
 font-weight: 600;
@@ -54,7 +54,14 @@ const PlanUpgradeButton = (): JSX.Element | null => {
     const config = useSelector(getConfig);
     const license = useSelector(getLicense);
 
+    const buttonTextFeatureFlag = config?.FeatureFlagPlanUpgradeButtonText;
+    let btnText = formatMessage({id: 'pricing_modal.btn.upgrade', defaultMessage: 'Upgrade'});
+    if (isCloud && buttonTextFeatureFlag === 'View plans') {
+        btnText = formatMessage({id: 'pricing_modal.btn.viewPlans', defaultMessage: 'View plans'});
+    }
+
     const isEnterpriseTrial = subscription?.is_free_trial === 'true';
+
     const isStarter = product?.sku === CloudProducts.STARTER;
 
     const isSelfHostedEnterpriseTrial = !isCloud && license.IsTrial === 'true';
@@ -97,7 +104,7 @@ const PlanUpgradeButton = (): JSX.Element | null => {
                 id='UpgradeButton'
                 onClick={openPricingModal}
             >
-                {formatMessage({id: 'pricing_modal.btn.upgrade', defaultMessage: 'Upgrade'})}
+                {btnText}
             </UpgradeButton>
         </OverlayTrigger>);
 };

--- a/components/widgets/menu/menu_items/useWords.test.tsx
+++ b/components/widgets/menu/menu_items/useWords.test.tsx
@@ -188,7 +188,15 @@ describe('useWords', () => {
         },
     ];
 
-    const store = mockStore({});
+    const store = mockStore({
+        entities: {
+            general: {
+                license: {
+                    Cloud: 'true',
+                },
+            },
+        },
+    });
     tests.forEach((t: Test) => {
         test(t.label, () => {
             renderWithIntl(

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4256,6 +4256,7 @@
   "pricing_modal.btn.tooltip": "Only visible to system admins",
   "pricing_modal.btn.tryDays": "Try free for {days} days",
   "pricing_modal.btn.upgrade": "Upgrade",
+  "pricing_modal.btn.viewPlans": "View plans",
   "pricing_modal.extra_briefing.enterprise.playBookAnalytics": "Playbook analytics dashboard",
   "pricing_modal.extra_briefing.professional.guestAccess": "Guest access with MFA enforcement",
   "pricing_modal.extra_briefing.professional.ssoadLdap": "SSO support with AD/LDAP, Google, O365, OpenID",

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -114,6 +114,7 @@ export type ClientConfig = {
     ExperimentalViewArchivedChannels: string;
     FileLevel: string;
     FeatureFlagGraphQL: string;
+    FeatureFlagPlanUpgradeButtonText: string;
     GfycatAPIKey: string;
     GfycatAPISecret: string;
     GoogleDeveloperKey: string;


### PR DESCRIPTION
Cherry pick of #10798 on cloud.

/cc  @AGMETEOR

```release-note
NONE
```