### PR TITLE
bugfix: use filename, if present, when pasting files

### DIFF
--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -451,27 +451,23 @@ export class FileUpload extends PureComponent {
 
             for (let i = 0; i < items.length; i++) {
                 const file = items[i].getAsFile();
+
                 if (!file) {
                     continue;
                 }
 
-                var d = new Date();
-                let hour = d.getHours();
-                hour = hour < 10 ? `0${hour}` : `${hour}`;
+                const now = new Date();
+                const hour = now.getHours().toString().padStart(2, '0');
+                const minute = now.getMinutes().toString().padStart(2, '0');
 
-                let minute = d.getMinutes();
-                minute = minute < 10 ? `0${minute}` : `${minute}`;
-
-                var ext = '';
-                if (file.name) {
-                    if (file.name.includes('.')) {
-                        ext = file.name.substr(file.name.lastIndexOf('.'));
-                    }
+                let ext = '';
+                if (file.name && file.name.includes('.')) {
+                    ext = file.name.substr(file.name.lastIndexOf('.'));
                 } else if (items[i].type.includes('/')) {
                     ext = '.' + items[i].type.split('/')[1].toLowerCase();
                 }
 
-                const name = file.name || formatMessage(holders.pasted) + d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate() + ' ' + hour + '-' + minute + ext;
+                const name = file.name || formatMessage(holders.pasted) + now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + ' ' + hour + '-' + minute + ext;
 
                 const newFile = new Blob([file], {type: file.type});
                 newFile.name = name;

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -471,7 +471,7 @@ export class FileUpload extends PureComponent {
                     ext = '.' + items[i].type.split('/')[1].toLowerCase();
                 }
 
-                const name = formatMessage(holders.pasted) + d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate() + ' ' + hour + '-' + minute + ext;
+                const name = file.name || formatMessage(holders.pasted) + d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate() + ' ' + hour + '-' + minute + ext;
 
                 const newFile = new Blob([file], {type: file.type});
                 newFile.name = name;

--- a/components/file_upload/file_upload.test.jsx
+++ b/components/file_upload/file_upload.test.jsx
@@ -202,7 +202,7 @@ describe('components/FileUpload', () => {
         ['File constructor is supported', true],
         ['File constructor is not supported', false],
     ])('should upload file on paste when %s', (_, fileSupported) => {
-        const expectedFileName = 'Image Pasted at 2000-2-1 01-01';
+        const expectedFileName = 'test';
 
         const event = new Event('paste');
         event.preventDefault = jest.fn();

--- a/components/file_upload/file_upload.test.jsx
+++ b/components/file_upload/file_upload.test.jsx
@@ -198,16 +198,13 @@ describe('components/FileUpload', () => {
         expect(baseProps.onUploadError).toHaveBeenCalledWith(params.err, params.clientId, params.channelId, params.rootId);
     });
 
-    test.each([
-        ['File constructor is supported', true],
-        ['File constructor is not supported', false],
-    ])('should upload file on paste when %s', (_, fileSupported) => {
-        const expectedFileName = 'test';
+    test('should upload file on paste', () => {
+        const expectedFileName = 'test.png';
 
         const event = new Event('paste');
         event.preventDefault = jest.fn();
-        const getAsFile = jest.fn().mockReturnValue(new File(['test'], 'test'));
-        const file = {getAsFile, kind: 'file', name: 'test'};
+        const getAsFile = jest.fn().mockReturnValue(new File(['test'], 'test.png'));
+        const file = {getAsFile, kind: 'file', name: 'test.png'};
         event.clipboardData = {items: [file], types: ['image/png']};
 
         const wrapper = shallowWithIntl(
@@ -215,12 +212,10 @@ describe('components/FileUpload', () => {
                 {...baseProps}
             />,
         );
+
         jest.spyOn(wrapper.instance(), 'containsEventTarget').mockReturnValue(true);
         const spy = jest.spyOn(wrapper.instance(), 'checkPluginHooksAndUploadFiles');
 
-        if (!fileSupported) {
-            global.File = undefined;
-        }
         document.dispatchEvent(event);
         expect(event.preventDefault).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledWith([expect.objectContaining({name: expectedFileName})]);


### PR DESCRIPTION
#### Summary
previously we constructed a `name` property everytime we uploaded a file (or raw image data) via pasting (`CTRL`/`CMD` + `V`). With this we now use the filename if it exists and only construct the name string `Image pasted at xxx` when there is no filename property in the event object.

#### Ticket Link
n/a

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
