### PR TITLE
MM-45859 Disable team sidebar pluggable for products.

### DIFF
--- a/components/team_sidebar/team_sidebar.tsx
+++ b/components/team_sidebar/team_sidebar.tsx
@@ -306,7 +306,8 @@ export default class TeamSidebar extends React.PureComponent<Props, State> {
         }
 
         // Disable team sidebar pluggables in products until proper support can be provided.
-        if (!currentProduct) {
+        const isNonChannelsProduct = !currentProduct;
+        if (isNonChannelsProduct) {
             plugins.push(
                 <div
                     key='team-sidebar-bottom-plugin'

--- a/components/team_sidebar/team_sidebar.tsx
+++ b/components/team_sidebar/team_sidebar.tsx
@@ -305,14 +305,17 @@ export default class TeamSidebar extends React.PureComponent<Props, State> {
             );
         }
 
-        plugins.push(
-            <div
-                key='team-sidebar-bottom-plugin'
-                className='team-sidebar-bottom-plugin is-empty'
-            >
-                <Pluggable pluggableName='BottomTeamSidebar'/>
-            </div>,
-        );
+        // Disable team sidebar pluggables in products until proper support can be provided.
+        if (!currentProduct) {
+            plugins.push(
+                <div
+                    key='team-sidebar-bottom-plugin'
+                    className='team-sidebar-bottom-plugin is-empty'
+                >
+                    <Pluggable pluggableName='BottomTeamSidebar'/>
+                </div>,
+            );
+        }
 
         return (
             <div


### PR DESCRIPTION
#### Summary
Removes the pluggable in the team sidebar when switching to products (boards and playbooks)
This will prevent issues like the GitHub plugin appearing on the LHS for playbooks (and eventually boards) and being inoperative. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45859


#### Release Note
```release-note
NONE
```
