### PR TITLE
MM-46040 enable forced isolatedModules in tsconfig(s)

### DIFF
--- a/components/admin_console/workspace-optimization/dashboard.data.tsx
+++ b/components/admin_console/workspace-optimization/dashboard.data.tsx
@@ -21,7 +21,7 @@ import {GlobalState} from '@mattermost/types/store';
 import {CloudLinks, ConsolePages, DocLinks, LicenseLinks} from 'utils/constants';
 import {daysToLicenseExpire, isEnterpriseOrE20License, getIsStarterLicense} from '../../../utils/license_utils';
 
-type DataModel = {
+export type DataModel = {
     [key: string]: {
         title: string;
         description: string;
@@ -32,7 +32,7 @@ type DataModel = {
     };
 }
 
-enum ItemStatus {
+export enum ItemStatus {
     NONE = 'none',
     OK = 'ok',
     INFO = 'info',
@@ -40,7 +40,7 @@ enum ItemStatus {
     ERROR = 'error',
 }
 
-type ItemModel = {
+export type ItemModel = {
     id: string;
     title: string;
     description: string;
@@ -438,5 +438,4 @@ const useMetricsData = () => {
     return {getAccessData, getConfigurationData, getUpdatesData, getPerformanceData, getDataPrivacyData, getEaseOfManagementData, isLicensed, isEnterpriseLicense};
 };
 
-export {DataModel, ItemModel, ItemStatus};
 export default useMetricsData;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -8,6 +8,7 @@ export {
     DEFAULT_LIMIT_BEFORE,
 } from './client4';
 
-export {TelemetryHandler} from './telemetry';
-
-export {default as WebSocketClient, WebSocketMessage} from './websocket';
+export type {TelemetryHandler} from './telemetry';
+export type {WebSocketMessage} from './websocket';
+// eslint-disable-next-line no-duplicate-imports
+export {default as WebSocketClient} from './websocket';

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -6,6 +6,7 @@
         "declaration": true,
         "strict": true,
         "resolveJsonModule": true,
+        "isolatedModules": true,
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
         "jsx": "react",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -9,6 +9,7 @@
 		"strict": true,
 		"skipLibCheck": true,
 		"strictNullChecks": true,
+        "isolatedModules": true,
 		"noEmit": true,
 		"declaration": true,
 		"outDir": "dist",

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -6,6 +6,7 @@
         "declaration": true,
         "strict": true,
         "resolveJsonModule": true,
+        "isolatedModules": true,
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
         "jsx": "react",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
#### Summary
Added `"isolatedModules": true` to the main tsconfig.json and the package folders as well.
Fixed the few warnings that appeared.

We couldn't update mattermost-webapp ref at playbooks codebase because our tsconfig had it already enabled. Apparently we should have it enabled since we compile through babel (tsc is used more for type-checks).

[Doc reference](https://www.typescriptlang.org/tsconfig#isolatedModules)

[More context at community](https://community.mattermost.com/core/pl/abnr7d4a378gtq3obqfutc5k4y)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46040

#### Related Pull Requests
Not yet

#### Screenshots
No UI changes

#### Release Note
```release-note
NONE
```
