### PR TITLE
MM-46041: only set team unread class in channels

### DIFF
--- a/components/team_sidebar/components/team_button.test.tsx
+++ b/components/team_sidebar/components/team_button.test.tsx
@@ -1,0 +1,104 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {BrowserRouter as Router} from 'react-router-dom';
+
+import TeamButton from 'team_button';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
+
+describe('components/TeamSidebar/TeamButton', () => {
+    const baseProps = {
+        btnClass: '',
+        url: '',
+        displayName: '',
+        tip: '',
+        order: 0,
+        showOrder: false,
+        active: false,
+        disabled: false,
+        unread: false,
+        mentions: 0,
+        placement: 'left',
+        teamIconUrl: null,
+        switchTeam: () => {},
+        isDraggable: false,
+        teamIndex: 0,
+        teamId: '',
+        isInProduct: false,
+    };
+
+    it('should show unread badge and set class when unread in channels', () => {
+        const props = {
+            ...baseProps,
+            active: false,
+            unread: true,
+        };
+
+        const wrapper = mountWithIntl(
+            <Router>
+                <TeamButton {...props}/>
+            </Router>,
+        );
+
+        expect(wrapper.find('.unread-badge').exists()).toBe(true);
+        expect(wrapper.find('.team-container.unread').exists()).toBe(true);
+    });
+
+    it('should hide unread badge and set no class when unread in a product', () => {
+        const props = {
+            ...baseProps,
+            active: false,
+            unread: true,
+            isInProduct: true,
+        };
+
+        const wrapper = mountWithIntl(
+            <Router>
+                <TeamButton {...props}/>
+            </Router>,
+        );
+
+        expect(wrapper.find('.unread-badge').exists()).toBe(false);
+        expect(wrapper.find('.team-container.unread').exists()).toBe(false);
+    });
+
+    it('should show mentions badge and set class when mentions in channels', () => {
+        const props = {
+            ...baseProps,
+            active: false,
+            unread: true,
+            mentions: 1,
+        };
+
+        const wrapper = mountWithIntl(
+            <Router>
+                <TeamButton {...props}/>
+            </Router>,
+        );
+
+        expect(wrapper.find('.badge.badge-max-number').exists()).toBe(true);
+        expect(wrapper.find('.team-container.unread').exists()).toBe(true);
+    });
+
+    it('should hide mentions badge and set no class when mentions in product', () => {
+        const props = {
+            ...baseProps,
+            active: false,
+            unread: true,
+            mentions: 1,
+            isInProduct: true,
+        };
+
+        const wrapper = mountWithIntl(
+            <Router>
+                <TeamButton {...props}/>
+            </Router>,
+        );
+
+        expect(wrapper.find('.badge.badge-max-number').exists()).toBe(false);
+        expect(wrapper.find('.team-container.unread').exists()).toBe(false);
+    });
+});

--- a/components/team_sidebar/components/team_button.test.tsx
+++ b/components/team_sidebar/components/team_button.test.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 
 import {BrowserRouter as Router} from 'react-router-dom';
 
-import TeamButton from 'team_button';
-
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
+
+import TeamButton from './team_button';
 
 describe('components/TeamSidebar/TeamButton', () => {
     const baseProps = {
@@ -21,7 +21,6 @@ describe('components/TeamSidebar/TeamButton', () => {
         disabled: false,
         unread: false,
         mentions: 0,
-        placement: 'left',
         teamIconUrl: null,
         switchTeam: () => {},
         isDraggable: false,

--- a/components/team_sidebar/components/team_button.tsx
+++ b/components/team_sidebar/components/team_button.tsx
@@ -74,7 +74,7 @@ class TeamButton extends React.PureComponent<Props> {
         });
 
         if (!teamClass) {
-            if (unread) {
+            if (unread && !this.props.isInProduct) {
                 teamClass = 'unread';
 
                 badge = (


### PR DESCRIPTION
#### Summary
Avoid spuriously marking Playbooks (and the whole desktop app) as unread:
<img width="524" alt="CleanShot 2022-07-27 at 16 19 40@2x" src="https://user-images.githubusercontent.com/1023171/181354764-3d38af95-b662-47c0-bf71-9bbf7f3afb62.png">

While we were correctly suppressing the mention and unread badge on the team button, we were still setting the class used by desktop to "detect" unreads.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-46041

```release-note
NONE
```
