### PR TITLE
MM-46060 Followup to enabling isolatedModules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,8 @@
     }
   },
   "rules": {
+    "no-duplicate-imports": 0,
+    "import/no-duplicates": 2,
     "max-nested-callbacks": ["error", 10],
     "no-unused-expressions": 0,
     "babel/no-unused-expressions": 2,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,5 +10,4 @@ export {
 
 export type {TelemetryHandler} from './telemetry';
 export type {WebSocketMessage} from './websocket';
-// eslint-disable-next-line no-duplicate-imports
 export {default as WebSocketClient} from './websocket';

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,21 +1,21 @@
 {
-	"compilerOptions": {
-		"target": "esnext",
-		"module": "esnext",
-		"moduleResolution": "node",
-		"jsx": "react",
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"strict": true,
-		"skipLibCheck": true,
-		"strictNullChecks": true,
+    "compilerOptions": {
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "node",
+        "jsx": "react",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "strictNullChecks": true,
         "isolatedModules": true,
-		"noEmit": true,
-		"declaration": true,
-		"outDir": "dist",
-		"paths": {
-			"mattermost-redux/*": ["./node_modules/mattermost-redux/src/*"],
-			"@mattermost/types/*": ["./node_modules/@mattermost/types/src/*"]
-		}
-	}
+        "noEmit": true,
+        "declaration": true,
+        "outDir": "dist",
+        "paths": {
+            "mattermost-redux/*": ["./node_modules/mattermost-redux/src/*"],
+            "@mattermost/types/*": ["./node_modules/@mattermost/types/src/*"]
+        }
+    }
 }

--- a/packages/mattermost-redux/src/selectors/entities/search.ts
+++ b/packages/mattermost-redux/src/selectors/entities/search.ts
@@ -4,12 +4,10 @@
 import {createSelector} from 'reselect';
 
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import {getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserMentionKeys, UserMentionKey} from 'mattermost-redux/selectors/entities/users';
 import {getMyGroupMentionKeys} from 'mattermost-redux/selectors/entities/groups';
 
 import {GlobalState} from '@mattermost/types/store';
-
-import {UserMentionKey} from './users';
 
 export const getCurrentSearchForCurrentTeam: (state: GlobalState) => string = createSelector(
     'getCurrentSearchForCurrentTeam',

--- a/utils/route.test.tsx
+++ b/utils/route.test.tsx
@@ -2,13 +2,11 @@
 // See LICENSE.txt for license information.
 import assert from 'assert';
 
-import {checkIfMFARequired} from 'utils/route';
-
 import {UserProfile} from '@mattermost/types/users';
 
 import {ClientLicense} from '@mattermost/types/config';
 
-import {ConfigOption} from './route';
+import {checkIfMFARequired, ConfigOption} from './route';
 
 describe('Utils.Route', () => {
     describe('checkIfMFARequired', () => {


### PR DESCRIPTION
Two small cleanup things:
1. Changes tabs to spaces in the one tsconfig for consistency (which I'm surprised none of the tooling complained about)
2. Swapping the built-in no-duplicate-imports ESLint rule which isn't aware of TS-specific `import type` and `export type` statements to the no-duplicates rule from eslint-plugin-import which handles those as well as having better support for when a file is imported via two different paths

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46040

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/10848

#### Release Note
```release-note
NONE
```
