### PR TITLE
bugfix: removed white-space: nowrap

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -1964,7 +1964,6 @@
             -webkit-box-orient: vertical;
             -webkit-line-clamp: 4;
             text-overflow: ellipsis;
-            white-space: nowrap;
         }
 
         .post-preview-collapse__show-more-button {


### PR DESCRIPTION
#### Summary
removed a white-space property that introduced a strange bug with permalink previews

#### Ticket Link
n/a

#### Related Pull Requests
n/a

#### Screenshots
|  before  |  after  |
|----|----|
|![Screenshot 2022-07-29 at 07 26 38](https://user-images.githubusercontent.com/32863416/181688799-465611c6-7868-4d2c-b62e-e31159e218f8.png)|![Screenshot 2022-07-29 at 07 26 57](https://user-images.githubusercontent.com/32863416/181688822-eedb8980-28c2-4df4-a092-cc0d1a35cec8.png)|

#### Release Note
```release-note
NONE
```
