### PR TITLE
Fix stretch for custom branding image in Safari

### DIFF
--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -69,7 +69,6 @@
 
                 .login-body-custom-branding-image {
                     max-height: 540px;
-                    flex: 1;
                     align-self: center;
                     margin-bottom: 28px;
                     border-radius: 8px;


### PR DESCRIPTION
#### Summary
Since the redesign of the login page with Mattermost 7.0, the custom branding image has been stretched with the latest version of Safari on both macOS 12.4 and 12.5. The attached screenshots illustrate the issue for our test cloud instance [1] on Safari 15.6 and macOS 12.5 and has been cross-validated on >10 different Apple Mac devices.

Upon further investigation, the issue seems to be especially easy to notice for images used that are much wider than high, e.g. the horizontal Mattermost logo from the official press kit (as png).

The display issue itself can be fixed in a variety of ways. This PR removes a property `flex: 1` that other browsers (like e.g. Firefox) already ignore (grayed out within the investigator) - and that seems to only cause issues in Safari on macOS. Our change has been validated in the latest versions of Firefox, Chrome and Safari.

[1] (has been provided internally)

#### Ticket Link
(pending)

#### Related Pull Requests
(not related to anything else - only a visual change)

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="1428" alt="before" src="https://user-images.githubusercontent.com/15683974/182043213-588dc1e7-fbd3-4aa6-a6dd-bdf0a1e0d546.png"> | <img width="1428" alt="after" src="https://user-images.githubusercontent.com/15683974/182043211-8d65c170-f3a0-4f00-9ea7-020c0af449f7.png"> |


#### Release Note
```release-note
NONE
```
