### PR TITLE
Allowing to affect the current team to go back from other products

### DIFF
--- a/components/global_header/left_controls/product_menu/product_menu.tsx
+++ b/components/global_header/left_controls/product_menu/product_menu.tsx
@@ -5,6 +5,8 @@ import React, {useRef} from 'react';
 import styled from 'styled-components';
 import {useDispatch, useSelector} from 'react-redux';
 
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
 import IconButton from '@mattermost/compass-components/components/icon-button';
 
 import Menu from 'components/widgets/menu/menu';
@@ -57,6 +59,7 @@ const ProductMenu = (): JSX.Element => {
     const products = useProducts();
     const dispatch = useDispatch();
     const switcherOpen = useSelector(isSwitcherOpen);
+    const currentTeam = useSelector(getCurrentTeam);
     const menuRef = useRef<HTMLDivElement>(null);
     const currentProductID = useCurrentProductId(products);
 
@@ -103,7 +106,7 @@ const ProductMenu = (): JSX.Element => {
                     ariaLabel={'switcherOpen'}
                 >
                     <ProductMenuItem
-                        destination={'/'}
+                        destination={currentTeam?.name ? `/${currentTeam.name}` : '/' }
                         icon={'product-channels'}
                         text={'Channels'}
                         active={currentProductID === null}


### PR DESCRIPTION
#### Summary
When you switch to boards, there is not an easy way to affect the current team.
The simplest option is to change the store using the `selectTeam` action from
redux, but that doesn't affect the local storage with the last team. That
implies that when you switch from Channels to Boards in one team, then you
switch to another team, and you go back to Channels again, it use the
"lastTeam" from the localstorage to go to the last viewed team, that is not
the currently selected one (the one that you selected in Boards).

This fix honor the current store information (if it is there) to build the
destination of the "Channels" link, pointing to the right team.

#### Ticket Link
TBD

#### Related Pull Requests
TBD

#### Release Note
```release-note
Fixes navigating back from Boards in a different team.
```