### PR TITLE
Automated cherry pick of #10842

### DIFF
--- a/components/team_sidebar/team_sidebar.tsx
+++ b/components/team_sidebar/team_sidebar.tsx
@@ -305,14 +305,18 @@ export default class TeamSidebar extends React.PureComponent<Props, State> {
             );
         }
 
-        plugins.push(
-            <div
-                key='team-sidebar-bottom-plugin'
-                className='team-sidebar-bottom-plugin is-empty'
-            >
-                <Pluggable pluggableName='BottomTeamSidebar'/>
-            </div>,
-        );
+        // Disable team sidebar pluggables in products until proper support can be provided.
+        const isNonChannelsProduct = !currentProduct;
+        if (isNonChannelsProduct) {
+            plugins.push(
+                <div
+                    key='team-sidebar-bottom-plugin'
+                    className='team-sidebar-bottom-plugin is-empty'
+                >
+                    <Pluggable pluggableName='BottomTeamSidebar'/>
+                </div>,
+            );
+        }
 
         return (
             <div


### PR DESCRIPTION
Cherry pick of #10842 on release-7.2.

/cc  @crspeller

```release-note
NONE
```