### PR TITLE
[chore] Update Node to 16.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: mattermost/mattermost-build-webapp:20210524_node-16
+      - image: mattermost/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d
     resource_class: "xlarge"
 
 aliases:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - trigger
 
 variables:
-  IMAGE_BUILD_WEBAPP: $CI_REGISTRY/mattermost/ci/images/mattermost-build-webapp:20210524_node-16
+  IMAGE_BUILD_WEBAPP: $CI_REGISTRY/mattermost/ci/devops-images/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d
   BUILD: "yes"
   TEST: "yes"
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This updates the build-images used for CI to:
- node: 16.2.0 -> 16.10.0
- npm: 7.13.0 -> 7.24.0



Internal consumed images: 
```
> docker run --platform linux/amd64 -it ${CI_REGISTRY}/mattermost/ci/devops-images/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d node -v
 v16.10.0

> docker run --platform linux/amd64 -it ${$CI_REGISTRY}/mattermost/ci/devops-images/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d npm -v
7.24.0
```

Public consumed images: 
```
> docker run --platform linux/amd64 mattermost/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d  node -v
 v16.10.0

> docker run --platform linux/amd64 mattermost/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d  npm -v
7.24.0
```




#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-3848

