### PR TITLE
Add OIDC to the sign up page

### DIFF
--- a/components/signup/__snapshots__/signup.test.tsx.snap
+++ b/components/signup/__snapshots__/signup.test.tsx.snap
@@ -281,6 +281,19 @@ exports[`components/signup/Signup should match snapshot for all signup options e
             url="/oauth/office365/signup"
           />
           <ExternalLoginButton
+            icon={<LoginOpenIdIcon />}
+            id="openid"
+            key="openid"
+            label="Open ID"
+            style={
+              Object {
+                "borderColor": "",
+                "color": "",
+              }
+            }
+            url="/oauth/openid/signup"
+          />
+          <ExternalLoginButton
             icon={<LockIcon />}
             id="ldap"
             key="ldap"

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -89,6 +89,8 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         CustomDescriptionText,
         GitLabButtonText,
         GitLabButtonColor,
+        OpenIdButtonText,
+        OpenIdButtonColor,
         EnableCustomBrand,
         CustomBrandText,
         TermsOfServiceLink,

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -172,7 +172,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
                 label: formatMessage({id: 'login.office365', defaultMessage: 'Office 365'}),
             });
         }
-        
+
         if (isLicensed && enableSignUpWithOpenId) {
             externalLoginOptions.push({
                 id: 'openid',

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -131,7 +131,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
     const [alertBanner, setAlertBanner] = useState<AlertBannerProps | null>(null);
     const [isMobileView, setIsMobileView] = useState(false);
 
-    const enableExternalSignup = enableSignUpWithGitLab || enableSignUpWithOffice365 || enableSignUpWithGoogle || enableLDAP || enableSAML;
+    const enableExternalSignup = enableSignUpWithGitLab || enableSignUpWithOffice365 || enableSignUpWithGoogle || enableSignUpWithOpenId || enableLDAP || enableSAML;
     const hasError = Boolean(emailError || nameError || passwordError || serverError || alertBanner);
     const canSubmit = Boolean(email && name && password) && !hasError && !loading;
     const {error: passwordInfo} = isValidPassword('', getPasswordConfig(config), intl);
@@ -174,7 +174,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         if (enableSignUpWithOpenId) {
             externalLoginOptions.push({
                 id: 'openid',
-                url: `${Client4.getOAuthRoute()}/openid/login${search}`,
+                url: `${Client4.getOAuthRoute()}/openid/signup${search}`,
                 icon: <LoginOpenIDIcon/>,
                 label: OpenIdButtonText || formatMessage({id: 'login.openid', defaultMessage: 'Open ID'}),
                 style: {color: OpenIdButtonColor, borderColor: OpenIdButtonColor},

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -171,7 +171,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
             });
         }
         
-        if (enableSignUpWithOpenId) {
+        if (isLicensed && enableSignUpWithOpenId) {
             externalLoginOptions.push({
                 id: 'openid',
                 url: `${Client4.getOAuthRoute()}/openid/signup${search}`,

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -28,6 +28,7 @@ import Markdown from 'components/markdown';
 import LockIcon from 'components/widgets/icons/lock_icon';
 import LoginGoogleIcon from 'components/widgets/icons/login_google_icon';
 import LoginGitlabIcon from 'components/widgets/icons/login_gitlab_icon';
+import LoginOpenIDIcon from 'components/widgets/icons/login_openid_icon';
 import LoginOffice365Icon from 'components/widgets/icons/login_office_365_icon';
 import Input, {CustomMessageInputType, SIZE} from 'components/widgets/inputs/input/input';
 import PasswordInput from 'components/widgets/inputs/password_input/password_input';
@@ -79,6 +80,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         EnableSignUpWithGitLab,
         EnableSignUpWithGoogle,
         EnableSignUpWithOffice365,
+        EnableSignUpWithOpenId,
         EnableLdap,
         EnableSaml,
         SamlLoginButtonText,
@@ -108,6 +110,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
     const enableSignUpWithGitLab = EnableSignUpWithGitLab === 'true';
     const enableSignUpWithGoogle = EnableSignUpWithGoogle === 'true';
     const enableSignUpWithOffice365 = EnableSignUpWithOffice365 === 'true';
+    const enableSignUpWithOpenId = EnableSignUpWithOpenId === 'true';
     const enableLDAP = EnableLdap === 'true';
     const enableSAML = EnableSaml === 'true';
     const enableCustomBrand = EnableCustomBrand === 'true';
@@ -165,6 +168,16 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
                 url: `${Client4.getOAuthRoute()}/office365/signup${search}`,
                 icon: <LoginOffice365Icon/>,
                 label: formatMessage({id: 'login.office365', defaultMessage: 'Office 365'}),
+            });
+        }
+        
+        if (enableSignUpWithOpenId) {
+            externalLoginOptions.push({
+                id: 'openid',
+                url: `${Client4.getOAuthRoute()}/openid/login${search}`,
+                icon: <LoginOpenIDIcon/>,
+                label: OpenIdButtonText || formatMessage({id: 'login.openid', defaultMessage: 'Open ID'}),
+                style: {color: OpenIdButtonColor, borderColor: OpenIdButtonColor},
             });
         }
 


### PR DESCRIPTION
#### Summary
Since at least 6.x, the sign up page (where invitation links take new users) does not include an OIDC button despite other openid providers like Google or Gitlab are present. In practice, this will lead to an error page stating "This server doesn’t have any sign-in methods enabled" in case only OIDC is active on a MM server. Since the invitation link generated within the UI leads new users to the sign up page, they will be very confused and contact the administrator (like stated on that page). On the other hand, the login page always displays OIDC correctly as an authentication method.

To restore expected behavior, code is added as part of this PR to make the necessary button available within the `signup.tsx` (based upon similar behavior in `login.tsx`). Test were adapted and all test suites (& linters) are happy.

#### Ticket Link
(pending)

#### Related Pull Requests
None

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="500" alt="before-oidc-on" src="https://user-images.githubusercontent.com/15683974/182589867-9ebd7a40-bbd3-4b40-b1ab-2f450c74154e.png">  | <img width="500" alt="after-oidc" src="https://user-images.githubusercontent.com/15683974/182709535-cf476ed8-1c34-4393-be6a-b9e669787dc7.png"> |

#### Release Note

```release-note
Added the OpenID Connect authentication button to the sign up page
```
