### PR TITLE
MM-45042: Add missing prop.

### DIFF
--- a/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/components/advanced_text_editor/advanced_text_editor.tsx
@@ -414,6 +414,7 @@ const AdvanceTextEditor = ({
                         badConnection={badConnection}
                         listenForMentionKeyClick={true}
                         useChannelMentions={useChannelMentions}
+                        rootId={postId}
                     />
                     {attachmentPreview}
                     <TexteditorActions


### PR DESCRIPTION
#### Summary

Adds missing `rootId` prop to `Textbox` component. Without that prop the `priorityProfiles` prop downstream is always empty:

https://github.com/mattermost/mattermost-webapp/blob/3b0e6a07308ef9e0f6d0a7fd9fef2636f706bd05/components/textbox/index.ts#L57

... and then the `AtMentionProvider` isn't able to include those users in the "priority" results:

https://github.com/mattermost/mattermost-webapp/blob/412b09d3547cdee05dbb84bc5d2345ccea824e87/components/suggestion/at_mention_provider/at_mention_provider.jsx#L217-L257

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45042

#### Release Note

```release-note
NONE
```
