### PR TITLE
Fix RF tests that show landing page

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -266,7 +266,7 @@ export default class Root extends React.PureComponent {
             landing = desktopAppDownloadLink;
         }
 
-        if (landing && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen && !this.props.location.pathname.includes('/landing') && !this.props.location.pathname.includes('.test.mattermost.com') && !UserAgent.isDesktopApp()) {
+        if (landing && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen && !this.props.location.pathname.includes('/landing') && Boolean(!this.props.location.pathname.includes('.test.mattermost.com')) && !UserAgent.isDesktopApp()) {
             this.props.history.push('/landing#' + this.props.location.pathname + this.props.location.search);
             BrowserStore.setLandingPageSeen(true);
         }


### PR DESCRIPTION

#### Summary
After compilation some test servers are still showing the desktop app landing page. My hypothesis is that the RF transpiler does not interpret some conditions as boolean values. Let's test this hypothesis by converting to a boolean.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46232


#### Release Note

-->
```release-note
NONE
```
