### PR TITLE
[MM-45014] - Telemetry: Track how users end up in pricing modal/notify admin for admins and end users

### DIFF
--- a/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
+++ b/components/admin_console/billing/billing_subscriptions/billing_subscriptions.tsx
@@ -102,7 +102,7 @@ export const GrandfatheredPlanBanner = (props: GrandfatheredPlanBannerProps) => 
             }
             actionButtonLeft={
                 <button
-                    onClick={openPricingModal}
+                    onClick={() => openPricingModal({callerInfo: 'grandfathered_plan_banner'})}
                     className='AlertBanner__buttonLeft'
                 >
                     <FormattedMessage

--- a/components/admin_console/billing/billing_subscriptions/index.tsx
+++ b/components/admin_console/billing/billing_subscriptions/index.tsx
@@ -80,7 +80,7 @@ const BillingSubscriptions = () => {
     // show the upgrade section when is a free tier customer
     const onUpgradeMattermostCloud = () => {
         trackEvent('cloud_admin', 'click_upgrade_mattermost_cloud');
-        openPricingModal();
+        openPricingModal({callerInfo: 'admin_console_billing_billing_subscriptions'});
     };
 
     let isFreeTrial = false;
@@ -112,7 +112,7 @@ const BillingSubscriptions = () => {
         }
 
         if (actionQueryParam === 'show_pricing_modal') {
-            openPricingModal();
+            openPricingModal({callerInfo: 'admin_console_billing_billing_subscriptions_action_query_param'});
         }
     }, []);
 

--- a/components/admin_console/billing/billing_subscriptions/limit_reached_banner.tsx
+++ b/components/admin_console/billing/billing_subscriptions/limit_reached_banner.tsx
@@ -69,7 +69,7 @@ const LimitReachedBanner = (props: Props) => {
         defaultMessage: 'View plans',
     };
 
-    let upgradeAction = openPricingModal;
+    let upgradeAction = () => openPricingModal({callerInfo: 'limit_reached_banner'});
 
     if (props.product.sku === CloudProducts.PROFESSIONAL) {
         title = (

--- a/components/admin_console/billing/billing_subscriptions/limits.tsx
+++ b/components/admin_console/billing/billing_subscriptions/limits.tsx
@@ -243,7 +243,7 @@ const Limits = (props: Props): JSX.Element | null => {
                 {subscriptionProduct.sku === CloudProducts.STARTER && (
                     <>
                         <button
-                            onClick={openPricingModal}
+                            onClick={() => openPricingModal({callerInfo: 'admin_console_billing_billing_subscriptions_limits'})}
                             className='btn btn-primary'
                         >
                             {intl.formatMessage({

--- a/components/admin_console/billing/plan_details/plan_details.tsx
+++ b/components/admin_console/billing/plan_details/plan_details.tsx
@@ -100,7 +100,7 @@ export const PlanDetailsTopElements = ({
 
     const viewPlansButton = (
         <button
-            onClick={openPricingModal}
+            onClick={() => openPricingModal({callerInfo: 'admin_console_billing_plan_details_view_plans'})}
             className='btn btn-secondary PlanDetails__viewPlansButton'
         >
             {intl.formatMessage({

--- a/components/announcement_bar/cloud_trial_ended_announcement_bar/index.tsx
+++ b/components/announcement_bar/cloud_trial_ended_announcement_bar/index.tsx
@@ -119,7 +119,7 @@ const CloudTrialEndAnnouncementBar: React.FC = () => {
         <AnnouncementBar
             type={AnnouncementBarTypes.CRITICAL}
             showCloseButton={true}
-            onButtonClick={openPricingModal}
+            onButtonClick={() => openPricingModal({callerInfo: 'cloud_trial_ended_announcement_bar'})}
             modalButtonText={t('more.details')}
             modalButtonDefaultText={'More details'}
             message={<FormattedMessage {...message}/>}

--- a/components/center_message_lock/index.tsx
+++ b/components/center_message_lock/index.tsx
@@ -93,7 +93,7 @@ export default function CenterMessageLock(props: Props) {
     let cta = (
         <button
             className='btn btn-primary'
-            onClick={notifyAdmin}
+            onClick={(e) => notifyAdmin(e, 'center_message_lock')}
         >
             {notifyAdminStatus}
         </button>);
@@ -116,7 +116,7 @@ export default function CenterMessageLock(props: Props) {
                         href='#'
                         onClick={(e: React.MouseEvent) => {
                             e.preventDefault();
-                            openPricingModal();
+                            openPricingModal({callerInfo: 'center_message_lock'});
                         }}
                     >
                         {chunks}
@@ -128,7 +128,7 @@ export default function CenterMessageLock(props: Props) {
         cta = (
             <button
                 className='btn is-admin'
-                onClick={openPricingModal}
+                onClick={() => openPricingModal({callerInfo: 'center_message_lock'})}
             >
                 {
                     intl.formatMessage({

--- a/components/cloud_usage_modal/lhs_nearing_limit_modal.tsx
+++ b/components/cloud_usage_modal/lhs_nearing_limit_modal.tsx
@@ -36,7 +36,7 @@ export default function LHSNearingLimitsModal() {
             id: t('workspace_limits.modals.view_plans'),
             defaultMessage: 'View plans',
         },
-        onClick: openPricingModal,
+        onClick: () => openPricingModal({callerInfo: 'cloud_usage_modal_lhs_nearing_limit_modal'}),
     };
     const secondaryAction = {
         message: {

--- a/components/common/hooks/useOpenPricingModal.ts
+++ b/components/common/hooks/useOpenPricingModal.ts
@@ -10,17 +10,23 @@ import PricingModal from 'components/pricing_modal';
 
 import {isCurrentLicenseCloud} from 'mattermost-redux/selectors/entities/cloud';
 
+export type TelemetryProps = {
+    callerInfo: string;
+}
+
 export default function useOpenPricingModal() {
     const dispatch = useDispatch();
     const isCloud = useSelector(isCurrentLicenseCloud);
     let category;
-    return () => {
+    return (telemetryProps?: TelemetryProps) => {
         if (isCloud) {
             category = 'cloud_pricing';
         } else {
             category = 'self_hosted_pricing';
         }
-        trackEvent(category, 'click_open_pricing_modal');
+        trackEvent(category, 'click_open_pricing_modal', {
+            callerInfo: telemetryProps?.callerInfo,
+        });
         dispatch(openModal({
             modalId: ModalIdentifiers.PRICING_MODAL,
             dialogType: PricingModal,

--- a/components/custom_open_pricing_modal_post_renderer/index.tsx
+++ b/components/custom_open_pricing_modal_post_renderer/index.tsx
@@ -44,7 +44,7 @@ export default function OpenPricingModalPost(props: {post: Post}) {
                     style={style}
                 >
                     <button
-                        onClick={openPricingModal}
+                        onClick={() => openPricingModal({callerInfo: 'system_bot_notify_admin_message_view_upgrade_options'})}
                         style={btnStyle}
                     >
                         {formatMessage({id: 'postypes.custom_open_pricing_modal_post_renderer.view_options', defaultMessage: 'View upgrade options'})}

--- a/components/feature_restricted_modal/feature_restricted_modal.tsx
+++ b/components/feature_restricted_modal/feature_restricted_modal.tsx
@@ -59,7 +59,7 @@ const FeatureRestrictedModal = ({
     };
 
     const handleViewPlansClick = () => {
-        openPricingModal();
+        openPricingModal({callerInfo: 'feature_restricted_modal'});
         dismissAction();
     };
 

--- a/components/file_limit_sticky_banner/index.tsx
+++ b/components/file_limit_sticky_banner/index.tsx
@@ -130,7 +130,7 @@ function FileLimitStickyBanner() {
                                 onClick={
                                     (e) => {
                                         e.preventDefault();
-                                        openPricingModal();
+                                        openPricingModal({callerInfo: 'file_limit_sticky_banner'});
                                     }
                                 }
                             >{chunks}</a>);
@@ -147,7 +147,11 @@ function FileLimitStickyBanner() {
                 defaultMessage: 'Your free plan is limited to {storageGB} of files. New uploads will automatically archive older files. To view them again, <a>notify your admin to upgrade to a paid plan.</a>'},
             {
                 storageGB: asGBString(fileStorageLimit, formatNumber),
-                a: (chunks: React.ReactNode) => <NotifyAdminCTA ctaText={chunks}/>,
+                a: (chunks: React.ReactNode) => (
+                    <NotifyAdminCTA
+                        callerInfo='file_limit_sticky_banner'
+                        ctaText={chunks}
+                    />),
             },
             )}
         </span>

--- a/components/global_header/right_controls/plan_upgrade_button/index.tsx
+++ b/components/global_header/right_controls/plan_upgrade_button/index.tsx
@@ -12,7 +12,7 @@ import {getCloudProducts, getCloudSubscription} from 'mattermost-redux/actions/c
 import {getCloudSubscription as selectCloudSubscription, getSubscriptionProduct as selectSubscriptionProduct, isCurrentLicenseCloud} from 'mattermost-redux/selectors/entities/cloud';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
-import useOpenPricingModal from 'components/common/hooks/useOpenPricingModal';
+import useOpenPricingModal, {TelemetryProps} from 'components/common/hooks/useOpenPricingModal';
 import OverlayTrigger from 'components/overlay_trigger';
 import Tooltip from 'components/tooltip';
 
@@ -32,7 +32,7 @@ letter-spacing: 0.02em;
 color: var(--button-color);
 `;
 
-let openPricingModal: () => void;
+let openPricingModal: (telemetryProps?: TelemetryProps) => void;
 
 const PlanUpgradeButton = (): JSX.Element | null => {
     const dispatch = useDispatch();
@@ -102,7 +102,7 @@ const PlanUpgradeButton = (): JSX.Element | null => {
         >
             <UpgradeButton
                 id='UpgradeButton'
-                onClick={openPricingModal}
+                onClick={() => openPricingModal({callerInfo: 'global_header_plan_upgrade_button'})}
             >
                 {btnText}
             </UpgradeButton>

--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -225,7 +225,7 @@ function Content(props: ContentProps) {
                                     bgColor='var(--center-channel-bg)'
                                     firstSvg={<CheckMarkSvg/>}
                                 />) : undefined}
-                        planExtraInformation={(!isAdmin && (isStarter || isEnterpriseTrial)) ? <NotifyAdminCTA/> : undefined}
+                        planExtraInformation={(!isAdmin && (isStarter || isEnterpriseTrial)) ? <NotifyAdminCTA callerInfo='professional_plan_pricing_modal_card'/> : undefined}
                         buttonDetails={{
                             action: openPurchaseModal,
                             text: formatMessage({id: 'pricing_modal.btn.upgrade', defaultMessage: 'Upgrade'}),
@@ -271,7 +271,12 @@ function Content(props: ContentProps) {
                                     firstSvg={<CheckMarkSvg/>}
                                     renderLastDaysOnTrial={true}
                                 />) : undefined}
-                        planExtraInformation={(!isAdmin && (isStarter || isEnterpriseTrial)) ? <NotifyAdminCTA preTrial={isPreTrial}/> : undefined}
+                        planExtraInformation={(!isAdmin && (isStarter || isEnterpriseTrial)) ? (
+                            <NotifyAdminCTA
+                                callerInfo='enterprise_plan_pricing_modal_card'
+                                preTrial={isPreTrial}
+                            />
+                        ) : undefined}
                         buttonDetails={(isPostTrial || !isAdmin) ? {
                             action: () => {
                                 trackEvent('cloud_pricing', 'click_enterprise_contact_sales');

--- a/components/search_results/search_limits_banner.tsx
+++ b/components/search_results/search_limits_banner.tsx
@@ -92,7 +92,7 @@ function SearchLimitsBanner(props: Props) {
             storage: asGBString(fileStorageLimit, formatNumber),
             a: (chunks: React.ReactNode | React.ReactNodeArray) => (
                 <StyledA
-                    onClick={openPricingModal}
+                    onClick={() => openPricingModal({callerInfo: 'file_search_limits_banner'})}
                 >
                     {chunks}
                 </StyledA>
@@ -111,7 +111,7 @@ function SearchLimitsBanner(props: Props) {
             messages: formatNumber(messagesLimit),
             a: (chunks: React.ReactNode | React.ReactNodeArray) => (
                 <StyledA
-                    onClick={openPricingModal}
+                    onClick={() => openPricingModal({callerInfo: 'messages_search_limits_banner'})}
                 >
                     {chunks}
                 </StyledA>

--- a/components/three_days_left_trial_modal/three_days_left_trial_modal.tsx
+++ b/components/three_days_left_trial_modal/three_days_left_trial_modal.tsx
@@ -50,7 +50,7 @@ function ThreeDaysLeftTrialModal(props: Props): JSX.Element | null {
 
     const handleOpenPricingModal = async () => {
         await dispatch(closeModal(ModalIdentifiers.THREE_DAYS_LEFT_TRIAL_MODAL));
-        openPricingModal();
+        openPricingModal({callerInfo: 'three_days_left_trial_modal'});
     };
 
     const buttonLabel = formatMessage({id: 'three_days_left_trial_modal.learnMore', defaultMessage: 'Learn more'});

--- a/components/widgets/menu/menu_items/menu_cloud_trial.tsx
+++ b/components/widgets/menu/menu_items/menu_cloud_trial.tsx
@@ -93,7 +93,7 @@ const MenuCloudTrial = ({id}: Props): JSX.Element | null => {
                             openModalLink: (msg: string) => (
                                 <a
                                     className='open-trial-benefits-modal style-link'
-                                    onClick={isAdmin ? openTrialBenefitsModal : openPricingModal}
+                                    onClick={isAdmin ? openTrialBenefitsModal : () => openPricingModal({callerInfo: 'menu_cloud_trial'})}
                                 >
                                     {msg}
                                 </a>

--- a/components/widgets/menu/menu_items/menu_item_cloud_limit.tsx
+++ b/components/widgets/menu/menu_items/menu_item_cloud_limit.tsx
@@ -38,7 +38,7 @@ const MenuItemCloudLimit = ({id}: Props) => {
     const [limits] = useGetLimits();
     const usage = useGetUsage();
     const highestLimit = useGetHighestThresholdCloudLimit(usage, limits);
-    const words = useWords(highestLimit, isAdminUser);
+    const words = useWords(highestLimit, isAdminUser, 'menu_item_cloud_limit');
 
     const show = isCloud && !isFreeTrial;
 

--- a/components/widgets/menu/menu_items/useWords.tsx
+++ b/components/widgets/menu/menu_items/useWords.tsx
@@ -18,7 +18,7 @@ interface Words {
     status: React.ReactNode;
 }
 
-export default function useWords(highestLimit: LimitSummary | false, isAdminUser: boolean): Words | false {
+export default function useWords(highestLimit: LimitSummary | false, isAdminUser: boolean, callerInfo: string): Words | false {
     const intl = useIntl();
     const openPricingModal = useOpenPricingModal();
     if (!highestLimit) {
@@ -42,7 +42,7 @@ export default function useWords(highestLimit: LimitSummary | false, isAdminUser
         callToAction,
         a: (chunks: React.ReactNode | React.ReactNodeArray) => (
             <a
-                onClick={openPricingModal}
+                onClick={() => openPricingModal({callerInfo})}
             >
                 {chunks}
             </a>),
@@ -54,7 +54,12 @@ export default function useWords(highestLimit: LimitSummary | false, isAdminUser
             id: 'workspace_limits.menu_limit.notify_admin',
             defaultMessage: 'Notify admin',
         });
-        values.a = (chunks: React.ReactNode | React.ReactNodeArray) => <NotifyAdminCTA ctaText={chunks}/>;
+        values.a = (chunks: React.ReactNode | React.ReactNodeArray) => (
+            <NotifyAdminCTA
+                callerInfo={callerInfo}
+                ctaText={chunks}
+            />
+        );
     }
 
     switch (highestLimit.id) {


### PR DESCRIPTION
#### Summary
This PR adds a way to track where the pricing modal or notify admin cta are called from. This information is then passed to the respective telemetry events

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45014

#### Release Note

```release-note
NONE
```
