### PR TITLE
MM-46293 : Increase eslint file lines limit warning to 800

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,7 +71,8 @@
       "paths": [
         {"name": "react-bootstrap", "importNames": ["OverlayTrigger"], "message": "Please use OverlayTrigger from '/components/overlay_trigger' instead"}
       ]
-    }]
+    }],
+    "max-lines": ["warn", {"max": 800, "skipBlankLines": true, "skipComments": true}]
   },
   "overrides": [
     {

--- a/actions/views/rhs.ts
+++ b/actions/views/rhs.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
-
 import debounce from 'lodash/debounce';
 import {AnyAction} from 'redux';
 import {batchActions} from 'redux-batched-actions';

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 /* eslint-disable max-lines */
 
 import {batchActions} from 'redux-batched-actions';

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 /* eslint-disable max-lines */
 
 import React from 'react';

--- a/components/admin_console/license_settings/license_settings.tsx
+++ b/components/admin_console/license_settings/license_settings.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable react/no-string-refs */
 /* eslint-disable header/header */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable max-lines */
 import React from 'react';
 
 import {ClientConfig, ClientLicense} from '@mattermost/types/config';

--- a/components/common/svg_images_components/laptop_alert_svg.tsx
+++ b/components/common/svg_images_components/laptop_alert_svg.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
 import React from 'react';
 
 type SvgProps = {

--- a/components/common/svg_images_components/man_with_laptop_svg.tsx
+++ b/components/common/svg_images_components/man_with_laptop_svg.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
 import React from 'react';
 
 type SvgProps = {

--- a/components/common/svg_images_components/man_with_mailbox_svg.tsx
+++ b/components/common/svg_images_components/man_with_mailbox_svg.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
 import React from 'react';
 
 type SvgProps = {

--- a/components/create_post/create_post.tsx
+++ b/components/create_post/create_post.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 /* eslint-disable max-lines */
 
 import React, {CSSProperties, SyntheticEvent} from 'react';

--- a/components/integrations/bots/add_bot/add_bot.tsx
+++ b/components/integrations/bots/add_bot/add_bot.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable max-lines */
 
 import React, {ChangeEvent, FormEvent} from 'react';
 import {Link} from 'react-router-dom';

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
 import React, {useState, useEffect, useRef, useCallback} from 'react';
 import {useIntl} from 'react-intl';
 import {Link, useLocation, useHistory} from 'react-router-dom';

--- a/components/main_menu/main_menu.tsx
+++ b/components/main_menu/main_menu.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
 import React from 'react';
 import {injectIntl, IntlShape} from 'react-intl';
 

--- a/components/post_view/post_list_virtualized/post_list_virtualized.tsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 /* eslint-disable max-lines */
+
 import React from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {DynamicSizeList, OnItemsRenderedArgs} from 'dynamic-virtualized-list';

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
-
 import React, {ReactNode} from 'react';
 import {FormattedMessage, injectIntl, IntlShape} from 'react-intl';
 

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
 import deepEqual from 'fast-deep-equal';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
 import React, {useState, useEffect, useRef, useCallback} from 'react';
 import {useIntl} from 'react-intl';
 import {useLocation, useHistory} from 'react-router-dom';

--- a/components/suggestion/command_provider/app_command_parser/app_command_parser.test.ts
+++ b/components/suggestion/command_provider/app_command_parser/app_command_parser.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
-
 import mockStore from 'tests/test_store';
 
 import {

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 /* eslint-disable max-lines */
 
 import React from 'react';

--- a/components/threading/thread_viewer/thread_viewer.tsx
+++ b/components/threading/thread_viewer/thread_viewer.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
-
 import React, {HTMLAttributes} from 'react';
 import classNames from 'classnames';
 

--- a/components/user_settings/advanced/user_settings_advanced.tsx
+++ b/components/user_settings/advanced/user_settings_advanced.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable react/no-string-refs */
+
 /* eslint-disable max-lines */
 
 import React, {ReactNode} from 'react';
@@ -780,6 +780,7 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
                     </button>
                     <h4
                         className='modal-title'
+                        // eslint-disable-next-line react/no-string-refs
                         ref='title'
                     >
                         <div className='modal-back'>

--- a/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/components/user_settings/notifications/user_settings_notifications.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 /* eslint-disable max-lines */
 
 import React, {ChangeEvent, RefObject} from 'react';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "mattermost-webapp",
       "version": "7.0.0",
       "hasInstallScript": true,
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "mattermost-webapp",
       "version": "7.0.0",
       "hasInstallScript": true,
       "workspaces": [

--- a/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
-
 import {createSelector} from 'reselect';
 
 import {Posts, Preferences} from 'mattermost-redux/constants';

--- a/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable max-lines */
-
 import {createSelector} from 'reselect';
 
 import {

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint max-lines: 0 */
-
 import React from 'react';
 
 import reducerRegistry from 'mattermost-redux/store/reducer_registry';

--- a/utils/post_utils.test.jsx
+++ b/utils/post_utils.test.jsx
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable max-lines */
 
 import assert from 'assert';
 


### PR DESCRIPTION
#### Summary
Added the rule for increasing the default file lines limit to 800. Removed the disable eslint rule for file lines in few files after the new rule. Conversation here https://community.mattermost.com/core/pl/7fbbyid14fr9xdgbwirakjc4cy

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46293

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
