### PR TITLE
MM-46242 : Move "gfycat-sdk" type defination to webapp

### DIFF
--- a/packages/mattermost-redux/src/utils/gfycat_sdk.ts
+++ b/packages/mattermost-redux/src/utils/gfycat_sdk.ts
@@ -1,12 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import Gfycat from 'gfycat-sdk';
+
 const defaultKey = '2_KtH_W5';
 const defaultSecret = '3wLVZPiswc3DnaiaFoLkDvB4X0IV6CpMkj4tf2inJRsBY6-FnkT08zGmppWFgeof';
 let activeKey: string|null = null;
 let activeSecret: string | null = null;
-
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let instance: any = null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function gfycatSdk(key: string, secret: string): any {
     if (instance && activeKey === key && activeSecret === secret) {
         return instance;

--- a/types/external/gfycat-sdk.d.ts
+++ b/types/external/gfycat-sdk.d.ts
@@ -1,3 +1,4 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 declare module 'gfycat-sdk';


### PR DESCRIPTION

#### Summary

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46242

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
