### PR TITLE
Show new version bar when build hash changes

### DIFF
--- a/components/announcement_bar/version_bar/__snapshots__/version_bar.test.tsx.snap
+++ b/components/announcement_bar/version_bar/__snapshots__/version_bar.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/VersionBar should match snapshot - bar rendered after server version change 1`] = `""`;
+exports[`components/VersionBar should match snapshot - bar rendered after build hash change 1`] = `""`;
 
-exports[`components/VersionBar should match snapshot - bar rendered after server version change 2`] = `
+exports[`components/VersionBar should match snapshot - bar rendered after build hash change 2`] = `
 <Connect(AnnouncementBar)
   message={
     <React.Fragment>

--- a/components/announcement_bar/version_bar/index.ts
+++ b/components/announcement_bar/version_bar/index.ts
@@ -9,7 +9,7 @@ import VersionBar from './version_bar';
 
 function mapStateToProps(state: GlobalState) {
     return {
-        serverVersion: state.entities.general.serverVersion,
+        buildHash: state.entities.general.config.BuildHash,
     };
 }
 

--- a/components/announcement_bar/version_bar/version_bar.test.tsx
+++ b/components/announcement_bar/version_bar/version_bar.test.tsx
@@ -8,14 +8,14 @@ import VersionBar from 'components/announcement_bar/version_bar/version_bar';
 import AnnouncementBar from 'components/announcement_bar/default_announcement_bar';
 
 describe('components/VersionBar', () => {
-    test('should match snapshot - bar rendered after server version change', () => {
+    test('should match snapshot - bar rendered after build hash change', () => {
         const wrapper = shallow(
-            <VersionBar serverVersion='5.11.0.5.11.0.844f70a08ead47f06232ecb6fcad63d2.true'/>,
+            <VersionBar buildHash='844f70a08ead47f06232ecb6fcad63d2'/>,
         );
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find(AnnouncementBar).exists()).toBe(false);
 
-        wrapper.setProps({serverVersion: '5.12.0.dev.83ea110da12da84442f92b4634a1e0e2.true'});
+        wrapper.setProps({buildHash: '83ea110da12da84442f92b4634a1e0e2'});
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find(AnnouncementBar).exists()).toBe(true);
     });

--- a/components/announcement_bar/version_bar/version_bar.tsx
+++ b/components/announcement_bar/version_bar/version_bar.tsx
@@ -10,11 +10,11 @@ import {AnnouncementBarTypes} from 'utils/constants';
 import AnnouncementBar from '../default_announcement_bar';
 
 interface Props {
-    buildHash: string | undefined;
+    buildHash?: string;
 }
 
 interface State {
-    buildHashOnAppLoad: string | undefined;
+    buildHashOnAppLoad?: string;
 }
 
 export default class VersionBar extends React.PureComponent <Props, State> {

--- a/components/announcement_bar/version_bar/version_bar.tsx
+++ b/components/announcement_bar/version_bar/version_bar.tsx
@@ -5,17 +5,16 @@ import React from 'react';
 
 import {FormattedMessage} from 'react-intl';
 
-import {equalServerVersions} from 'utils/server_version';
 import {AnnouncementBarTypes} from 'utils/constants';
 
 import AnnouncementBar from '../default_announcement_bar';
 
 interface Props {
-    serverVersion: string;
+    buildHash: string | undefined;
 }
 
 interface State {
-    serverVersionOnAppLoad: string;
+    buildHashOnAppLoad: string | undefined;
 }
 
 export default class VersionBar extends React.PureComponent <Props, State> {
@@ -23,14 +22,14 @@ export default class VersionBar extends React.PureComponent <Props, State> {
         super(props);
 
         this.state = {
-            serverVersionOnAppLoad: props.serverVersion,
+            buildHashOnAppLoad: props.buildHash,
         };
     }
 
     static getDerivedStateFromProps(props: Props, state: State) {
-        if (!state.serverVersionOnAppLoad && props.serverVersion) {
+        if (!state.buildHashOnAppLoad && props.buildHash) {
             return {
-                serverVersionOnAppLoad: props.serverVersion,
+                buildHashOnAppLoad: props.buildHash,
             };
         }
 
@@ -42,14 +41,14 @@ export default class VersionBar extends React.PureComponent <Props, State> {
     }
 
     render() {
-        const {serverVersionOnAppLoad} = this.state;
-        const {serverVersion} = this.props;
+        const {buildHashOnAppLoad} = this.state;
+        const {buildHash} = this.props;
 
-        if (!serverVersionOnAppLoad) {
+        if (!buildHashOnAppLoad) {
             return null;
         }
 
-        if (!equalServerVersions(serverVersionOnAppLoad, serverVersion)) {
+        if (buildHashOnAppLoad !== buildHash) {
             return (
                 <AnnouncementBar
                     type={AnnouncementBarTypes.ANNOUNCEMENT}

--- a/utils/server_version.test.tsx
+++ b/utils/server_version.test.tsx
@@ -1,63 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {equalServerVersions, isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
-
-describe('utils/server_version/equalServerVersions', () => {
-    test('should consider two empty versions as equal', () => {
-        const a = '';
-        const b = '';
-        expect(equalServerVersions(a, b)).toEqual(true);
-    });
-
-    test('should consider different strings without components as equal', () => {
-        const a = 'not a server version';
-        const b = 'also not a server version';
-        expect(equalServerVersions(a, b)).toEqual(true);
-    });
-
-    test('should consider different malformed versions as equal ignoring the last two components', () => {
-        const a = '1.2.3';
-        const b = '1.2.4';
-        expect(equalServerVersions(a, b)).toEqual(true);
-    });
-
-    test('should consider an empty version different from a non-empty one', () => {
-        const a = '';
-        const b = '4.7.1.dev.c51676437bc02ada78f3a0a0a2203c60.true';
-        expect(equalServerVersions(a, b)).toEqual(false);
-    });
-
-    test('should consider the same versions equal', () => {
-        const a = '4.7.1.dev.c51676437bc02ada78f3a0a0a2203c60.true';
-        const b = '4.7.1.dev.c51676437bc02ada78f3a0a0a2203c60.true';
-        expect(equalServerVersions(a, b)).toEqual(true);
-    });
-
-    test('should consider different release versions unequal', () => {
-        const a = '4.7.0.12.c51676437bc02ada78f3a0a0a2203c60.true';
-        const b = '4.7.1.12.c51676437bc02ada78f3a0a0a2203c60.true';
-        expect(equalServerVersions(a, b)).toEqual(false);
-    });
-
-    test('should consider different build numbers unequal', () => {
-        const a = '4.7.1.12.c51676437bc02ada78f3a0a0a2203c60.true';
-        const b = '4.7.1.13.c51676437bc02ada78f3a0a0a2203c60.true';
-        expect(equalServerVersions(a, b)).toEqual(false);
-    });
-
-    test('should ignore different config hashes', () => {
-        const a = '4.7.1.12.c51676437bc02ada78f3a0a0a2203c60.true';
-        const b = '4.7.1.12.c51676437bc02ada78f3a0a0a2203c61.true';
-        expect(equalServerVersions(a, b)).toEqual(true);
-    });
-
-    test('should ignore different licensed statuses', () => {
-        const a = '4.7.1.12.c51676437bc02ada78f3a0a0a2203c60.false';
-        const b = '4.7.1.12.c51676437bc02ada78f3a0a0a2203c60.true';
-        expect(equalServerVersions(a, b)).toEqual(true);
-    });
-});
+import {isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
 
 describe('utils/server_version/isServerVersionGreaterThanOrEqualTo', () => {
     test('should consider two empty versions as equal', () => {

--- a/utils/server_version.tsx
+++ b/utils/server_version.tsx
@@ -2,32 +2,6 @@
 // See LICENSE.txt for license information.
 
 /**
- * Compare server versions, ignoring the configuration hash and licensed status.
- *
- * For example, the following two server versions are considered equal:
- *     4.7.1.dev.3034fbc5fd566195d1b53e03890e35ff.true
- *     4.7.1.dev.d131dd02c5e6eec4693d9a0698aff95c.false
- *
- * but the following two are not
- *     4.7.0.dev.3034fbc5fd566195d1b53e03890e35ff.true
- *     4.7.1.dev.d131dd02c5e6eec4693d9a0698aff95c.true
- */
-export function equalServerVersions(a: string, b: string): boolean {
-    if (a === b) {
-        return true;
-    }
-
-    const ignoredComponents = 2;
-    const aIgnoringComponents = (a || '').split('.').slice(0, -ignoredComponents).join('.');
-    const bIgnoringComponents = (b || '').split('.').slice(0, -ignoredComponents).join('.');
-    if (aIgnoringComponents === bIgnoringComponents) {
-        return true;
-    }
-
-    return false;
-}
-
-/**
  * Boolean function to check if a server version is greater than another.
  *
  * currentVersion: The server version being checked


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull requests switches displaying the "new version available" announcement when the config's `BuildHash` changes instead of the server version.

This change is needed for community the current check of server version takes into account MAJOR.MINOR.PATCH.BUILDNUMBER parts of the server version, and BUILDNUMBER for community is always master, so the announcement bar is not displayed as it should.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-45934

#### Release Note
```
NONE
```
