### PR TITLE
remove mime-db import and unused code

### DIFF
--- a/packages/mattermost-redux/src/utils/file_utils.test.js
+++ b/packages/mattermost-redux/src/utils/file_utils.test.js
@@ -51,13 +51,4 @@ describe('FileUtils', () => {
             assert.deepEqual(FileUtils.sortFileInfos(testCase.inputFileInfos), testCase.outputFileInfos);
         });
     });
-
-    it('lookupMimeType', () => {
-        const jpgFilePaths = ['file://aaa.jpg', 'file://bbb.JPG'];
-        const mimeType = 'image/jpeg';
-
-        jpgFilePaths.forEach((filePath) => {
-            assert.equal(FileUtils.lookupMimeType(filePath), mimeType);
-        });
-    });
 });

--- a/packages/mattermost-redux/src/utils/file_utils.ts
+++ b/packages/mattermost-redux/src/utils/file_utils.ts
@@ -5,8 +5,6 @@ import {Files, General} from '../constants';
 import {Client4} from 'mattermost-redux/client';
 import {FileInfo} from '@mattermost/types/files';
 
-const mimeDB = require('mime-db');
-
 export function getFormattedFileSize(file: FileInfo): string {
     const bytes = file.size;
     const fileSizes = [
@@ -50,28 +48,6 @@ export function getFileType(file: FileInfo): string {
         const fileTypeExts = Files[constForFileTypeExtList];
         return fileTypeExts.indexOf(fileExt) > -1;
     }) || 'other';
-}
-
-let extToMime: Record<string, string>;
-function buildExtToMime() {
-    extToMime = {};
-    Object.keys(mimeDB).forEach((key) => {
-        const mime = mimeDB[key];
-        if (mime.extensions) {
-            mime.extensions.forEach((ext: string) => {
-                extToMime[ext] = key;
-            });
-        }
-    });
-}
-
-export function lookupMimeType(filename: string): string {
-    if (!extToMime) {
-        buildExtToMime();
-    }
-
-    const ext = filename.split('.').pop()!.toLowerCase();
-    return extToMime[ext] || 'application/octet-stream';
 }
 
 export function getFileUrl(fileId: string): string {


### PR DESCRIPTION
#### Summary
Remove `mime-db` usage webapp. This function was not used internally; the only mattermost related code I could find using it, was 100% duplicated code in mattermost-mobile that doesn't reference *this* code; its a full on copy of the code here. Because we don't currently export the mattermost-redux package, and the exported version is older and not tied to *this* code, it shouldn't affect any plugins, either. In the unlikely event some plugin uses the function in the old mattermost-redux package, and we do start exporting our newer version of mattermost redux as an npm package, and they need an upgrade path, we could either make a single purpose library, or point them to the code and tell them how to make their own. This saves 19.61KB, gzipped, from a bundle that we always load.

#### Ticket Link
None/OSF contribution

```release-note
NONE
```
