### PR TITLE
MM-20393: Migrate 'components/channel_header' module and associated tests to TypeScript

### DIFF
--- a/components/channel_header/__snapshots__/channel_header.test.tsx.snap
+++ b/components/channel_header/__snapshots__/channel_header.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -38,12 +38,14 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
-                    <span />
+                    <span>
+                      name
+                    </span>
                   </strong>
                   <span
                     aria-label="dropdown icon"
@@ -91,7 +93,8 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -140,46 +143,120 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -188,10 +265,21 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -207,7 +295,7 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -237,12 +325,14 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
-                    <span />
+                    <span>
+                      name
+                    </span>
                   </strong>
                   <span
                     aria-label="dropdown icon"
@@ -290,7 +380,8 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -339,46 +430,120 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -387,10 +552,21 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -406,7 +582,7 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -436,12 +612,14 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
-                    <span />
+                    <span>
+                      name
+                    </span>
                   </strong>
                   <span
                     aria-label="dropdown icon"
@@ -489,7 +667,8 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -538,46 +717,120 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -586,10 +839,21 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -605,7 +869,7 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -635,12 +899,14 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
-                    <span />
+                    <span>
+                      name
+                    </span>
                   </strong>
                   <span
                     aria-label="dropdown icon"
@@ -688,7 +954,8 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -737,46 +1004,120 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -785,10 +1126,21 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -804,7 +1156,7 @@ exports[`components/ChannelHeader should render archived view 1`] = `
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -834,7 +1186,7 @@ exports[`components/ChannelHeader should render archived view 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
@@ -843,6 +1195,7 @@ exports[`components/ChannelHeader should render archived view 1`] = `
                       <ArchiveIcon
                         className="icon icon__archive icon channel-header-archived-icon svg-text-color"
                       />
+                      name
                     </span>
                   </strong>
                   <span
@@ -857,7 +1210,8 @@ exports[`components/ChannelHeader should render archived view 1`] = `
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -906,21 +1260,120 @@ exports[`components/ChannelHeader should render archived view 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
+          <div
+            className="header-popover-text-measurer"
+          >
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
+            >
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
+              >
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 1234,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -929,10 +1382,21 @@ exports[`components/ChannelHeader should render archived view 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 1234,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -948,7 +1412,7 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -978,12 +1442,14 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
-                    <span />
+                    <span>
+                      name
+                    </span>
                   </strong>
                   <span
                     aria-label="dropdown icon"
@@ -1063,7 +1529,8 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
           </OverlayTrigger>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -1112,46 +1579,120 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -1160,10 +1701,21 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -1179,7 +1731,7 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -1209,12 +1761,14 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
-                    <span />
+                    <span>
+                      name
+                    </span>
                   </strong>
                   <span
                     aria-label="dropdown icon"
@@ -1262,7 +1816,8 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -1288,7 +1843,7 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
           />
           <HeaderIconWrapper
             ariaLabel={true}
-            buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left"
+            buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left channel-header__icon--active"
             buttonId="channelHeaderPinButton"
             iconComponent={
               <i
@@ -1311,46 +1866,120 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -1359,10 +1988,21 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -1375,10 +2015,10 @@ exports[`components/ChannelHeader should render properly when custom status is e
   aria-label="channel header region"
   className="channel-header alt a11y__region"
   data-a11y-sort-order="8"
-  data-channelid="undefined"
+  data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -1408,21 +2048,18 @@ exports[`components/ChannelHeader should render properly when custom status is e
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
                     <span>
-                      <ArchiveIcon
-                        className="icon icon__archive icon channel-header-archived-icon svg-text-color"
-                      />
                       <MemoizedFormattedMessage
                         defaultMessage="{displayname} (you) "
                         id="channel_header.directchannel.you"
                         values={
                           Object {
-                            "displayname": undefined,
+                            "displayname": "some-user",
                           }
                         }
                       />
@@ -1441,6 +2078,40 @@ exports[`components/ChannelHeader should render properly when custom status is e
               </div>
               <ChannelHeaderDropdown />
             </MenuWrapper>
+            <OverlayTrigger
+              defaultOverlayShown={false}
+              delayShow={400}
+              key="isFavorite-undefined"
+              onEntering={[Function]}
+              overlay={
+                <Tooltip
+                  id="favoriteTooltip"
+                >
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Add to Favorites"
+                    id="channelHeader.addToFavorites"
+                  />
+                </Tooltip>
+              }
+              placement="bottom"
+              trigger={
+                Array [
+                  "hover",
+                  "focus",
+                ]
+              }
+            >
+              <button
+                aria-label="add to favorites"
+                className="style--none color--link channel-header__favorites inactive"
+                id="toggleFavorite"
+                onClick={[Function]}
+              >
+                <i
+                  className="icon icon-star-outline"
+                />
+              </button>
+            </OverlayTrigger>
           </div>
         </div>
         <div
@@ -1564,14 +2235,43 @@ exports[`components/ChannelHeader should render properly when custom status is e
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
+          "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
           "header": "not the bot description",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
+          "name": "DN",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "status": "offline",
+          "team_id": "team_id",
           "type": "D",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -1580,9 +2280,22 @@ exports[`components/ChannelHeader should render properly when custom status is e
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
+          "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
           "header": "not the bot description",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
+          "name": "DN",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "status": "offline",
+          "team_id": "team_id",
           "type": "D",
+          "update_at": 0,
         }
       }
     />
@@ -1595,10 +2308,10 @@ exports[`components/ChannelHeader should render properly when custom status is s
   aria-label="channel header region"
   className="channel-header alt a11y__region"
   data-a11y-sort-order="8"
-  data-channelid="undefined"
+  data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -1628,21 +2341,18 @@ exports[`components/ChannelHeader should render properly when custom status is s
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
                     <span>
-                      <ArchiveIcon
-                        className="icon icon__archive icon channel-header-archived-icon svg-text-color"
-                      />
                       <MemoizedFormattedMessage
                         defaultMessage="{displayname} (you) "
                         id="channel_header.directchannel.you"
                         values={
                           Object {
-                            "displayname": undefined,
+                            "displayname": "some-user",
                           }
                         }
                       />
@@ -1661,6 +2371,40 @@ exports[`components/ChannelHeader should render properly when custom status is s
               </div>
               <ChannelHeaderDropdown />
             </MenuWrapper>
+            <OverlayTrigger
+              defaultOverlayShown={false}
+              delayShow={400}
+              key="isFavorite-undefined"
+              onEntering={[Function]}
+              overlay={
+                <Tooltip
+                  id="favoriteTooltip"
+                >
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Add to Favorites"
+                    id="channelHeader.addToFavorites"
+                  />
+                </Tooltip>
+              }
+              placement="bottom"
+              trigger={
+                Array [
+                  "hover",
+                  "focus",
+                ]
+              }
+            >
+              <button
+                aria-label="add to favorites"
+                className="style--none color--link channel-header__favorites inactive"
+                id="toggleFavorite"
+                onClick={[Function]}
+              >
+                <i
+                  className="icon icon-star-outline"
+                />
+              </button>
+            </OverlayTrigger>
           </div>
         </div>
         <div
@@ -1800,14 +2544,43 @@ exports[`components/ChannelHeader should render properly when custom status is s
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
+          "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
           "header": "not the bot description",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
+          "name": "DN",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "status": "offline",
+          "team_id": "team_id",
           "type": "D",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -1816,9 +2589,22 @@ exports[`components/ChannelHeader should render properly when custom status is s
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
+          "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
           "header": "not the bot description",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
+          "name": "DN",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "status": "offline",
+          "team_id": "team_id",
           "type": "D",
+          "update_at": 0,
         }
       }
     />
@@ -1828,19 +2614,13 @@ exports[`components/ChannelHeader should render properly when custom status is s
 
 exports[`components/ChannelHeader should render properly when empty 1`] = `
 <div
-  className="channel-header"
-/>
-`;
-
-exports[`components/ChannelHeader should render properly when populated 1`] = `
-<div
   aria-label="channel header region"
   className="channel-header alt a11y__region"
   data-a11y-sort-order="8"
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -1870,12 +2650,14 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
-                    <span />
+                    <span>
+                      name
+                    </span>
                   </strong>
                   <span
                     aria-label="dropdown icon"
@@ -1923,7 +2705,8 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -1972,46 +2755,120 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
-          "name": "Test",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
+          "name": "DN",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -2020,10 +2877,21 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
-          "name": "Test",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
+          "name": "DN",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -2031,7 +2899,7 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
 </div>
 `;
 
-exports[`components/ChannelHeader should render properly when populated with channel props 1`] = `
+exports[`components/ChannelHeader should render properly when populated 1`] = `
 <div
   aria-label="channel header region"
   className="channel-header alt a11y__region"
@@ -2039,7 +2907,7 @@ exports[`components/ChannelHeader should render properly when populated with cha
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -2069,15 +2937,13 @@ exports[`components/ChannelHeader should render properly when populated with cha
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
                     <span>
-                      <ArchiveIcon
-                        className="icon icon__archive icon channel-header-archived-icon svg-text-color"
-                      />
+                      name
                     </span>
                   </strong>
                   <span
@@ -2089,6 +2955,327 @@ exports[`components/ChannelHeader should render properly when populated with cha
               </div>
               <ChannelHeaderDropdown />
             </MenuWrapper>
+            <OverlayTrigger
+              defaultOverlayShown={false}
+              delayShow={400}
+              key="isFavorite-undefined"
+              onEntering={[Function]}
+              overlay={
+                <Tooltip
+                  id="favoriteTooltip"
+                >
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Add to Favorites"
+                    id="channelHeader.addToFavorites"
+                  />
+                </Tooltip>
+              }
+              placement="bottom"
+              trigger={
+                Array [
+                  "hover",
+                  "focus",
+                ]
+              }
+            >
+              <button
+                aria-label="add to favorites"
+                className="style--none color--link channel-header__favorites inactive"
+                id="toggleFavorite"
+                onClick={[Function]}
+              >
+                <i
+                  className="icon icon-star-outline"
+                />
+              </button>
+            </OverlayTrigger>
+          </div>
+        </div>
+        <div
+          className="channel-header__description"
+          dir="auto"
+          id="channelHeaderDescription"
+        >
+          <HeaderIconWrapper
+            ariaLabel={true}
+            buttonClass="member-rhs__trigger channel-header__icon channel-header__icon--left channel-header__icon--wide"
+            buttonId="member_rhs"
+            iconComponent={
+              <React.Fragment>
+                <i
+                  aria-hidden="true"
+                  className="icon icon-account-outline channel-header__members"
+                />
+                <span
+                  className="icon__text"
+                  id="channelMemberCountText"
+                >
+                  -
+                </span>
+              </React.Fragment>
+            }
+            onClick={[Function]}
+            tooltipKey="channelMembers"
+          />
+          <HeaderIconWrapper
+            ariaLabel={true}
+            buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left"
+            buttonId="channelHeaderPinButton"
+            iconComponent={
+              <i
+                aria-hidden="true"
+                className="icon icon-pin-outline channel-header__pin"
+              />
+            }
+            onClick={[Function]}
+            tooltipKey="pinnedPosts"
+          />
+          <HeaderIconWrapper
+            ariaLabel={true}
+            buttonClass="channel-header__icon channel-header__icon--wide channel-header__icon--left"
+            buttonId="channelHeaderFilesButton"
+            iconComponent={
+              <i
+                className="icon icon-file-text-outline"
+              />
+            }
+            onClick={[Function]}
+            tooltipKey="channelFiles"
+          />
+          <div
+            className="header-popover-text-measurer"
+          >
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
+            >
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
+              >
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+    <Connect(injectIntl(ChannelHeaderPlug))
+      channel={
+        Object {
+          "create_at": 0,
+          "creator_id": "id",
+          "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
+          "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
+          "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
+        }
+      }
+      channelMember={
+        Object {
+          "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
+          "user_id": "user_id",
+        }
+      }
+    />
+    <Connect(CallButton) />
+    <ChannelInfoButton
+      channel={
+        Object {
+          "create_at": 0,
+          "creator_id": "id",
+          "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
+          "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
+          "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
+          "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`components/ChannelHeader should render properly when populated with channel props 1`] = `
+<div
+  aria-label="channel header region"
+  className="channel-header alt a11y__region"
+  data-a11y-sort-order="8"
+  data-channelid="channel_id"
+  id="channel-header"
+  role="banner"
+  tabIndex={-1}
+>
+  <div
+    className="flex-parent"
+  >
+    <div
+      className="flex-child"
+    >
+      <div
+        className="channel-header__info"
+        id="channelHeaderInfo"
+      >
+        <div
+          className="channel-header__title dropdown"
+        >
+          <div>
+            <MenuWrapper
+              animationComponent={[Function]}
+              className=""
+              onToggle={[Function]}
+            >
+              <div
+                className="channel-header__top"
+                id="channelHeaderDropdownButton"
+              >
+                <button
+                  aria-label="channel menu"
+                  className="channel-header__trigger style--none "
+                >
+                  <strong
+                    aria-level={2}
+                    className="heading"
+                    id="channelHeaderTitle"
+                    role="heading"
+                  >
+                    <span>
+                      name
+                    </span>
+                  </strong>
+                  <span
+                    aria-label="dropdown icon"
+                    className="icon icon-chevron-down header-dropdown-chevron-icon"
+                    id="channelHeaderDropdownIcon"
+                  />
+                </button>
+              </div>
+              <ChannelHeaderDropdown />
+            </MenuWrapper>
+            <OverlayTrigger
+              defaultOverlayShown={false}
+              delayShow={400}
+              key="isFavorite-undefined"
+              onEntering={[Function]}
+              overlay={
+                <Tooltip
+                  id="favoriteTooltip"
+                >
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Add to Favorites"
+                    id="channelHeader.addToFavorites"
+                  />
+                </Tooltip>
+              }
+              placement="bottom"
+              trigger={
+                Array [
+                  "hover",
+                  "focus",
+                ]
+              }
+            >
+              <button
+                aria-label="add to favorites"
+                className="style--none color--link channel-header__favorites inactive"
+                id="toggleFavorite"
+                onClick={[Function]}
+              >
+                <i
+                  className="icon icon-star-outline"
+                />
+              </button>
+            </OverlayTrigger>
           </div>
         </div>
         <div
@@ -2232,8 +3419,15 @@ exports[`components/ChannelHeader should render properly when populated with cha
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
+          "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
           "header": "See ~test",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
           "props": Object {
             "channel_mentions": Object {
@@ -2242,12 +3436,32 @@ exports[`components/ChannelHeader should render properly when populated with cha
               },
             },
           },
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -2256,8 +3470,15 @@ exports[`components/ChannelHeader should render properly when populated with cha
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
+          "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
           "header": "See ~test",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
           "props": Object {
             "channel_mentions": Object {
@@ -2266,7 +3487,11 @@ exports[`components/ChannelHeader should render properly when populated with cha
               },
             },
           },
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -2282,7 +3507,7 @@ exports[`components/ChannelHeader should render shared view 1`] = `
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -2312,12 +3537,13 @@ exports[`components/ChannelHeader should render shared view 1`] = `
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
                     <span>
+                      name
                       <SharedChannelIndicator
                         channelType="O"
                         className="shared-channel-icon"
@@ -2371,7 +3597,8 @@ exports[`components/ChannelHeader should render shared view 1`] = `
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -2420,48 +3647,121 @@ exports[`components/ChannelHeader should render shared view 1`] = `
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "shared": true,
           "team_id": "team_id",
           "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -2470,12 +3770,22 @@ exports[`components/ChannelHeader should render shared view 1`] = `
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "shared": true,
           "team_id": "team_id",
           "type": "O",
+          "update_at": 0,
         }
       }
     />
@@ -2491,7 +3801,7 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
   data-channelid="channel_id"
   id="channel-header"
   role="banner"
-  tabIndex="-1"
+  tabIndex={-1}
 >
   <div
     className="flex-parent"
@@ -2521,12 +3831,14 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
                   className="channel-header__trigger style--none "
                 >
                   <strong
-                    aria-level="2"
+                    aria-level={2}
                     className="heading"
                     id="channelHeaderTitle"
                     role="heading"
                   >
-                    <span />
+                    <span>
+                      name
+                    </span>
                   </strong>
                   <span
                     aria-label="dropdown icon"
@@ -2574,7 +3886,8 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
           </div>
         </div>
         <div
-          className="channel-header__description light"
+          className="channel-header__description"
+          dir="auto"
           id="channelHeaderDescription"
         >
           <HeaderIconWrapper
@@ -2631,46 +3944,120 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
             onClick={[Function]}
             tooltipKey="channelFiles"
           />
-          <Connect(ChannelPermissionGate)
-            channelId="channel_id"
-            permissions={
-              Array [
-                "manage_public_channel_properties",
-              ]
-            }
-            teamId="team_id"
+          <div
+            className="header-popover-text-measurer"
           >
-            <button
-              className="header-placeholder style--none"
-              onClick={[Function]}
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </div>
+          <span
+            className="header-description__text"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <Overlay
+              animation={[Function]}
+              onEnter={[Function]}
+              onHide={[Function]}
+              placement="bottom"
+              rootClose={true}
+              show={false}
+              target={null}
             >
-              <MemoizedFormattedMessage
-                defaultMessage="Add a channel header"
-                id="channel_header.addChannelHeader"
-              />
-              <MemoizedFormattedMessage
-                defaultMessage="Edit"
-                id="channel_header.editLink"
+              <Popover
+                className="channel-header__popover"
+                id="header-popover"
+                placement="bottom"
+                popoverSize="lg"
+                popoverStyle="info"
+                style={
+                  Object {
+                    "maxWidth": "0px",
+                    "transform": "translate(0px, 0px)",
+                  }
+                }
               >
-                <Component />
-              </MemoizedFormattedMessage>
-            </button>
-          </Connect(ChannelPermissionGate)>
+                <span
+                  onClick={[Function]}
+                >
+                  <Connect(Markdown)
+                    message="header"
+                    options={
+                      Object {
+                        "atMentions": true,
+                        "channelNamesMap": undefined,
+                        "mentionHighlight": false,
+                        "singleline": false,
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </Overlay>
+            <Connect(Markdown)
+              message="header"
+              options={
+                Object {
+                  "atMentions": true,
+                  "channelNamesMap": undefined,
+                  "mentionHighlight": false,
+                  "singleline": true,
+                }
+              }
+            />
+          </span>
         </div>
       </div>
     </div>
     <Connect(injectIntl(ChannelHeaderPlug))
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
       channelMember={
         Object {
           "channel_id": "channel_id",
+          "last_update_at": 0,
+          "last_viewed_at": 0,
+          "mention_count": 0,
+          "mention_count_root": 0,
+          "msg_count": 0,
+          "msg_count_root": 0,
+          "notify_props": Object {
+            "desktop": "default",
+            "email": "default",
+            "ignore_channel_mentions": "default",
+            "mark_unread": "all",
+            "push": "default",
+          },
+          "roles": "channel_user",
+          "scheme_admin": false,
+          "scheme_user": true,
           "user_id": "user_id",
         }
       }
@@ -2679,10 +4066,21 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
     <ChannelInfoButton
       channel={
         Object {
+          "create_at": 0,
+          "creator_id": "id",
           "delete_at": 0,
+          "display_name": "name",
+          "group_constrained": false,
+          "header": "header",
           "id": "channel_id",
+          "last_post_at": 0,
+          "last_root_post_at": 0,
           "name": "Test",
+          "purpose": "purpose",
+          "scheme_id": "id",
           "team_id": "team_id",
+          "type": "O",
+          "update_at": 0,
         }
       }
     />

--- a/components/channel_header/channel_header.test.tsx
+++ b/components/channel_header/channel_header.test.tsx
@@ -18,10 +18,8 @@ describe('components/ChannelHeader', () => {
         actions: {
             favoriteChannel: jest.fn(),
             unfavoriteChannel: jest.fn(),
-            showFlaggedPosts: jest.fn(),
             showPinnedPosts: jest.fn(),
             showChannelFiles: jest.fn(),
-            showMentions: jest.fn(),
             closeRightHandSide: jest.fn(),
             openModal: jest.fn(),
             closeModal: jest.fn(),
@@ -30,6 +28,7 @@ describe('components/ChannelHeader', () => {
             goToLastViewedChannel: jest.fn(),
             showChannelMembers: jest.fn(),
         },
+        announcementBarCount: 1,
         teamId: 'team_id',
         channel: TestHelper.getChannelMock({}),
         channelMember: TestHelper.getChannelMembershipMock({}),

--- a/components/channel_header/channel_header.test.tsx
+++ b/components/channel_header/channel_header.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {ComponentProps} from 'react';
 
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import ChannelHeader from 'components/channel_header/channel_header';
@@ -9,18 +9,19 @@ import ChannelInfoButton from 'components/channel_header/channel_info_button';
 import Markdown from 'components/markdown';
 import GuestBadge from 'components/widgets/badges/guest_badge';
 import Constants, {RHSStates} from 'utils/constants';
+import {TestHelper} from '../../utils/test_helper';
+import {ChannelType} from '@mattermost/types/channels';
+import {UserCustomStatus} from '@mattermost/types/users';
 
 describe('components/ChannelHeader', () => {
-    const baseProps = {
+    const baseProps: ComponentProps<typeof ChannelHeader> = {
         actions: {
-            leaveChannel: jest.fn(),
             favoriteChannel: jest.fn(),
             unfavoriteChannel: jest.fn(),
             showFlaggedPosts: jest.fn(),
             showPinnedPosts: jest.fn(),
             showChannelFiles: jest.fn(),
             showMentions: jest.fn(),
-            openRHSSearch: jest.fn(),
             closeRightHandSide: jest.fn(),
             openModal: jest.fn(),
             closeModal: jest.fn(),
@@ -29,14 +30,10 @@ describe('components/ChannelHeader', () => {
             goToLastViewedChannel: jest.fn(),
             showChannelMembers: jest.fn(),
         },
-        showChannelFilesButton: false,
-        teamUrl: 'team_url',
         teamId: 'team_id',
-        channel: {},
-        channelMember: {},
-        currentUser: {},
-        lastViewedChannelName: '',
-        penultimateViewedChannelName: '',
+        channel: TestHelper.getChannelMock({}),
+        channelMember: TestHelper.getChannelMembershipMock({}),
+        currentUser: TestHelper.getUserMock({}),
         teammateNameDisplaySetting: '',
         currentRelativeTeamUrl: '',
         isCustomStatusEnabled: false,
@@ -46,19 +43,19 @@ describe('components/ChannelHeader', () => {
 
     const populatedProps = {
         ...baseProps,
-        channel: {
+        channel: TestHelper.getChannelMock({
             id: 'channel_id',
             team_id: 'team_id',
             name: 'Test',
             delete_at: 0,
-        },
-        channelMember: {
+        }),
+        channelMember: TestHelper.getChannelMembershipMock({
             channel_id: 'channel_id',
             user_id: 'user_id',
-        },
-        currentUser: {
+        }),
+        currentUser: TestHelper.getUserMock({
             id: 'user_id',
-        },
+        }),
     };
 
     test('should render properly when empty', () => {
@@ -78,7 +75,7 @@ describe('components/ChannelHeader', () => {
     test('should render properly when populated with channel props', () => {
         const props = {
             ...baseProps,
-            channel: {
+            channel: TestHelper.getChannelMock({
                 id: 'channel_id',
                 team_id: 'team_id',
                 name: 'Test',
@@ -90,14 +87,14 @@ describe('components/ChannelHeader', () => {
                         },
                     },
                 },
-            },
-            channelMember: {
+            }),
+            channelMember: TestHelper.getChannelMembershipMock({
                 channel_id: 'channel_id',
                 user_id: 'user_id',
-            },
-            currentUser: {
+            }),
+            currentUser: TestHelper.getUserMock({
                 id: 'user_id',
-            },
+            }),
         };
 
         const wrapper = shallowWithIntl(
@@ -121,11 +118,11 @@ describe('components/ChannelHeader', () => {
     test('should render shared view', () => {
         const props = {
             ...populatedProps,
-            channel: {
+            channel: TestHelper.getChannelMock({
                 ...populatedProps.channel,
                 shared: true,
-                type: Constants.OPEN_CHANNEL,
-            },
+                type: Constants.OPEN_CHANNEL as ChannelType,
+            }),
         };
 
         const wrapper = shallowWithIntl(
@@ -190,7 +187,7 @@ describe('components/ChannelHeader', () => {
     test('should render not active channel files', () => {
         const props = {
             ...populatedProps,
-            rhsState: RHSStates.CHANNEL_PIN,
+            rhsState: RHSStates.PIN,
             showChannelFilesButton: true,
         };
 
@@ -227,15 +224,15 @@ describe('components/ChannelHeader', () => {
     test('should render bot description', () => {
         const props = {
             ...populatedProps,
-            channel: {
+            channel: TestHelper.getChannelMock({
                 header: 'not the bot description',
-                type: Constants.DM_CHANNEL,
-            },
-            dmUser: {
+                type: Constants.DM_CHANNEL as ChannelType,
+            }),
+            dmUser: TestHelper.getUserMock({
                 id: 'user_id',
                 is_bot: true,
                 bot_description: 'the bot description',
-            },
+            }),
         };
 
         const wrapper = shallowWithIntl(
@@ -262,22 +259,22 @@ describe('components/ChannelHeader', () => {
     test('should render the guest badges on gms', () => {
         const props = {
             ...populatedProps,
-            channel: {
+            channel: TestHelper.getChannelMock({
                 header: 'test',
                 display_name: 'regular_user, guest_user',
-                type: Constants.GM_CHANNEL,
-            },
+                type: Constants.GM_CHANNEL as ChannelType,
+            }),
             gmMembers: [
-                {
+                TestHelper.getUserMock({
                     id: 'user_id',
                     username: 'regular_user',
                     roles: 'system_user',
-                },
-                {
+                }),
+                TestHelper.getUserMock({
                     id: 'guest_id',
                     username: 'guest_user',
                     roles: 'system_guest',
-                },
+                }),
             ],
         };
 
@@ -292,20 +289,20 @@ describe('components/ChannelHeader', () => {
     test('should render properly when custom status is set', () => {
         const props = {
             ...populatedProps,
-            channel: {
+            channel: TestHelper.getChannelMock({
                 header: 'not the bot description',
-                type: Constants.DM_CHANNEL,
+                type: Constants.DM_CHANNEL as ChannelType,
                 status: 'offline',
-            },
-            dmUser: {
+            }),
+            dmUser: TestHelper.getUserMock({
                 id: 'user_id',
                 is_bot: false,
-            },
+            }),
             isCustomStatusEnabled: true,
             customStatus: {
                 emoji: 'calender',
                 text: 'In a meeting',
-            },
+            } as UserCustomStatus,
         };
 
         const wrapper = shallowWithIntl(
@@ -317,21 +314,21 @@ describe('components/ChannelHeader', () => {
     test('should render properly when custom status is expired', () => {
         const props = {
             ...populatedProps,
-            channel: {
+            channel: TestHelper.getChannelMock({
                 header: 'not the bot description',
-                type: Constants.DM_CHANNEL,
+                type: Constants.DM_CHANNEL as ChannelType,
                 status: 'offline',
-            },
-            dmUser: {
+            }),
+            dmUser: TestHelper.getUserMock({
                 id: 'user_id',
                 is_bot: false,
-            },
+            }),
             isCustomStatusEnabled: true,
             isCustomStatusExpired: true,
             customStatus: {
                 emoji: 'calender',
                 text: 'In a meeting',
-            },
+            } as UserCustomStatus,
         };
 
         const wrapper = shallowWithIntl(

--- a/components/channel_header/channel_header.test.tsx
+++ b/components/channel_header/channel_header.test.tsx
@@ -11,7 +11,7 @@ import GuestBadge from 'components/widgets/badges/guest_badge';
 import Constants, {RHSStates} from 'utils/constants';
 import {TestHelper} from '../../utils/test_helper';
 import {ChannelType} from '@mattermost/types/channels';
-import {UserCustomStatus, UserProfile} from '@mattermost/types/users';
+import {UserCustomStatus} from '@mattermost/types/users';
 
 describe('components/ChannelHeader', () => {
     const baseProps: ComponentProps<typeof ChannelHeader> = {
@@ -52,9 +52,10 @@ describe('components/ChannelHeader', () => {
             channel_id: 'channel_id',
             user_id: 'user_id',
         }),
-        currentUser: {
+        currentUser: TestHelper.getUserMock({
             id: 'user_id',
-        } as UserProfile,
+            bot_description: 'the bot description',
+        }),
     };
 
     test('should render properly when empty', () => {

--- a/components/channel_header/channel_header.test.tsx
+++ b/components/channel_header/channel_header.test.tsx
@@ -11,7 +11,7 @@ import GuestBadge from 'components/widgets/badges/guest_badge';
 import Constants, {RHSStates} from 'utils/constants';
 import {TestHelper} from '../../utils/test_helper';
 import {ChannelType} from '@mattermost/types/channels';
-import {UserCustomStatus} from '@mattermost/types/users';
+import {UserCustomStatus, UserProfile} from '@mattermost/types/users';
 
 describe('components/ChannelHeader', () => {
     const baseProps: ComponentProps<typeof ChannelHeader> = {
@@ -53,9 +53,9 @@ describe('components/ChannelHeader', () => {
             channel_id: 'channel_id',
             user_id: 'user_id',
         }),
-        currentUser: TestHelper.getUserMock({
+        currentUser: {
             id: 'user_id',
-        }),
+        } as UserProfile,
     };
 
     test('should render properly when empty', () => {

--- a/components/channel_header/channel_header.tsx
+++ b/components/channel_header/channel_header.tsx
@@ -242,7 +242,7 @@ class ChannelHeader extends React.PureComponent<Props, State> {
     setPopoverOverlayWidth = () => {
         const headerDescriptionRect = this.headerDescriptionRef.current?.getBoundingClientRect();
         const ellipsisWidthAdjustment = 10;
-        this.setState({popoverOverlayWidth: (headerDescriptionRect?.width || 0) + ellipsisWidthAdjustment});
+        this.setState({popoverOverlayWidth: (headerDescriptionRect?.width ?? 0) + ellipsisWidthAdjustment});
     }
 
     handleFormattedTextClick = (e: MouseEvent<HTMLSpanElement>) => handleFormattedTextClick(e, this.props.currentRelativeTeamUrl);

--- a/components/channel_header/channel_header.tsx
+++ b/components/channel_header/channel_header.tsx
@@ -352,7 +352,7 @@ class ChannelHeader extends React.PureComponent<Props, State> {
             channelTitle = (
                 <React.Fragment>
                     {channelTitle}
-                    <GuestBadge show={isGuest(dmUser?.roles || '')}/>
+                    <GuestBadge show={isGuest(dmUser?.roles ?? '')}/>
                 </React.Fragment>
             );
         }

--- a/components/channel_header/channel_header.tsx
+++ b/components/channel_header/channel_header.tsx
@@ -35,12 +35,15 @@ import {
     RHSStates,
 } from 'utils/constants';
 import {handleFormattedTextClick, localizeMessage, isEmptyObject, toTitleCase} from 'utils/utils';
+import {t} from 'utils/i18n';
 
 import {UserCustomStatus, UserProfile} from '@mattermost/types/users';
 import {Channel, ChannelMembership, ChannelNotifyProps} from '@mattermost/types/channels';
 import {RhsState} from 'types/store/rhs';
 
 import {ModalData} from 'types/actions';
+
+import LocalizedIcon from 'components/localized_icon';
 
 import ChannelInfoButton from './channel_info_button';
 import HeaderIconWrapper from './components/header_icon_wrapper';
@@ -81,7 +84,7 @@ export type Props = {
     };
     teammateNameDisplaySetting: string;
     currentRelativeTeamUrl: string;
-    announcementBarCount?: number;
+    announcementBarCount: number;
     customStatus?: UserCustomStatus;
     isCustomStatusEnabled: boolean;
     isCustomStatusExpired: boolean;
@@ -223,7 +226,7 @@ class ChannelHeader extends React.PureComponent<Props, State> {
         }
 
         // add 40px to take the global header into account
-        const topOffset = (announcementBarSize * (this.props.announcementBarCount || 1)) + 40;
+        const topOffset = (announcementBarSize * this.props.announcementBarCount) + 40;
 
         this.setState({topOffset});
     }
@@ -591,17 +594,10 @@ class ChannelHeader extends React.PureComponent<Props, State> {
                                     id='channel_header.addChannelHeader'
                                     defaultMessage='Add a channel header'
                                 />
-                                <FormattedMessage
-                                    id='channel_header.editLink'
-                                    defaultMessage='Edit'
-                                >
-                                    {(message: string[]) => (
-                                        <i
-                                            aria-label={message[0]}
-                                            className='icon icon-pencil-outline edit-icon'
-                                        />
-                                    )}
-                                </FormattedMessage>
+                                <LocalizedIcon
+                                    className='icon icon-pencil-outline edit-icon'
+                                    ariaLabel={{id: t('channel_header.editLink'), defaultMessage: 'Edit'}}
+                                />
                             </button>
                         );
                     }
@@ -620,17 +616,10 @@ class ChannelHeader extends React.PureComponent<Props, State> {
                                     id='channel_header.addChannelHeader'
                                     defaultMessage='Add a channel header'
                                 />
-                                <FormattedMessage
-                                    id='channel_header.editLink'
-                                    defaultMessage='Edit'
-                                >
-                                    {(message: string[]) => (
-                                        <i
-                                            aria-label={message[0]}
-                                            className='icon icon-pencil-outline edit-icon'
-                                        />
-                                    )}
-                                </FormattedMessage>
+                                <LocalizedIcon
+                                    className='icon icon-pencil-outline edit-icon'
+                                    ariaLabel={{id: t('channel_header.editLink'), defaultMessage: 'Edit'}}
+                                />
                             </button>
                         </ChannelPermissionGate>
                     );

--- a/components/channel_header/channel_header.tsx
+++ b/components/channel_header/channel_header.tsx
@@ -69,10 +69,8 @@ export type Props = {
     actions: {
         favoriteChannel: (channelId: string) => void;
         unfavoriteChannel: (channelId: string) => void;
-        showFlaggedPosts: () => void; // check if it is used somewhere
         showPinnedPosts: (channelId?: string) => void;
         showChannelFiles: (channelId: string) => void;
-        showMentions: () => void; // check if it is used somewhere
         closeRightHandSide: () => void;
         getCustomEmojisInText: (text: string) => void;
         updateChannelNotifyProps: (userId: string, channelId: string, props: Partial<ChannelNotifyProps>) => void;

--- a/components/channel_header/channel_header.tsx
+++ b/components/channel_header/channel_header.tsx
@@ -48,7 +48,7 @@ import HeaderIconWrapper from './components/header_icon_wrapper';
 const headerMarkdownOptions = {singleline: true, mentionHighlight: false, atMentions: true};
 const popoverMarkdownOptions = {singleline: false, mentionHighlight: false, atMentions: true};
 
-type Props = {
+export type Props = {
     teamId: string;
     currentUser: UserProfile;
     channel: Channel;

--- a/components/channel_header/channel_header.tsx
+++ b/components/channel_header/channel_header.tsx
@@ -388,7 +388,7 @@ class ChannelHeader extends React.PureComponent<Props, State> {
                     <React.Fragment key={user?.id}>
                         {index > 0 && ', '}
                         {displayName}
-                        <GuestBadge show={isGuest(user?.roles || '')}/>
+                        <GuestBadge show={isGuest(user?.roles ?? '')}/>
                     </React.Fragment>
                 );
             });

--- a/components/channel_header/index.ts
+++ b/components/channel_header/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {bindActionCreators} from 'redux';
+import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
 import {withRouter} from 'react-router-dom';
 
@@ -46,7 +46,11 @@ import {getAnnouncementBarCount} from 'selectors/views/announcement_bar';
 import {ModalIdentifiers} from 'utils/constants';
 import {isFileAttachmentsEnabled} from 'utils/file_utils';
 
-import ChannelHeader from './channel_header';
+import {GlobalState} from 'types/store';
+
+import {Action} from 'mattermost-redux/types/actions';
+
+import ChannelHeader, {Props} from './channel_header';
 
 const EMPTY_CHANNEL = {};
 const EMPTY_CHANNEL_STATS = {member_count: 0, guest_count: 0, pinnedpost_count: 0, files_count: 0};
@@ -55,7 +59,7 @@ function makeMapStateToProps() {
     const doGetProfilesInChannel = makeGetProfilesInChannel();
     const getCustomStatus = makeGetCustomStatus();
 
-    return function mapStateToProps(state) {
+    return function mapStateToProps(state: GlobalState) {
         const channel = getCurrentChannel(state) || EMPTY_CHANNEL;
         const user = getCurrentUser(state);
         const teams = getMyTeams(state);
@@ -102,8 +106,8 @@ function makeMapStateToProps() {
     };
 }
 
-const mapDispatchToProps = (dispatch) => ({
-    actions: bindActionCreators({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+    actions: bindActionCreators<ActionCreatorsMapObject<Action>, Props['actions']>({
         favoriteChannel,
         unfavoriteChannel,
         showFlaggedPosts,
@@ -120,4 +124,4 @@ const mapDispatchToProps = (dispatch) => ({
     }, dispatch),
 });
 
-export default withRouter(connect(makeMapStateToProps, mapDispatchToProps)(ChannelHeader));
+export default withRouter<any, any>(connect(makeMapStateToProps, mapDispatchToProps)(ChannelHeader));

--- a/components/channel_header/index.ts
+++ b/components/channel_header/index.ts
@@ -32,10 +32,8 @@ import {getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
 import {goToLastViewedChannel} from 'actions/views/channel';
 import {openModal, closeModal} from 'actions/views/modals';
 import {
-    showFlaggedPosts,
     showPinnedPosts,
     showChannelFiles,
-    showMentions,
     closeRightHandSide,
     showChannelMembers,
 } from 'actions/views/rhs';

--- a/components/channel_header/index.ts
+++ b/components/channel_header/index.ts
@@ -110,10 +110,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     actions: bindActionCreators<ActionCreatorsMapObject<Action>, Props['actions']>({
         favoriteChannel,
         unfavoriteChannel,
-        showFlaggedPosts,
         showPinnedPosts,
         showChannelFiles,
-        showMentions,
         closeRightHandSide,
         getCustomEmojisInText,
         updateChannelNotifyProps,

--- a/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/components/user_settings/notifications/user_settings_notifications.tsx
@@ -8,16 +8,18 @@ import {FormattedMessage} from 'react-intl';
 
 import semver from 'semver';
 
-import Constants, {NotificationLevels} from 'utils/constants';
-import {localizeMessage, moveCursorToEnd} from 'utils/utils';
-import {isDesktopApp} from 'utils/user_agent';
-
-import SettingItemMax from 'components/setting_item_max.jsx';
-import SettingItemMin from 'components/setting_item_min';
-
 import {UserNotifyProps, UserProfile} from '@mattermost/types/users';
 
 import {ActionResult} from 'mattermost-redux/types/actions';
+
+import Constants, {NotificationLevels} from 'utils/constants';
+import {localizeMessage, moveCursorToEnd} from 'utils/utils';
+import {isDesktopApp} from 'utils/user_agent';
+import {t} from 'utils/i18n';
+
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min';
+import LocalizedIcon from 'components/localized_icon';
 
 import DesktopNotificationSettings from './desktop_notification_setting/desktop_notification_settings';
 import EmailNotificationSetting from './email_notification_setting';
@@ -963,18 +965,14 @@ export default class NotificationsTab extends React.PureComponent<Props, State> 
                         ref={this.drawerRef}
                     >
                         <div className='modal-back'>
-                            <FormattedMessage
-                                id='generic_icons.collapse'
-                                defaultMessage='Collapse Icon'
-                            >
-                                {(title: string[]) => (
-                                    <i
-                                        className='fa fa-angle-left'
-                                        title={title[0]}
-                                        onClick={this.props.collapseModal}
-                                    />
-                                )}
-                            </FormattedMessage>
+                            <LocalizedIcon
+                                className='fa fa-angle-left'
+                                ariaLabel={{
+                                    id: t('generic_icons.collapse'),
+                                    defaultMessage: 'Collapse Icon',
+                                }}
+                                onClick={this.props.collapseModal}
+                            />
                         </div>
                         <FormattedMessage
                             id='user.settings.notifications.title'

--- a/plugins/channel_header_plug/channel_header_plug.tsx
+++ b/plugins/channel_header_plug/channel_header_plug.tsx
@@ -100,7 +100,7 @@ type ChannelHeaderPlugProps = {
     appBindings?: AppBinding[];
     appsEnabled: boolean;
     channel: Channel;
-    channelMember: ChannelMembership;
+    channelMember?: ChannelMembership;
     theme: Theme;
     sidebarOpen: boolean;
     shouldShowAppBar: boolean;
@@ -148,7 +148,7 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
         this.toggleDropdown(false);
     }
 
-    fireAction = (action: (channel: Channel, channelMember: ChannelMembership) => void) => {
+    fireAction = (action: (channel: Channel, channelMember?: ChannelMembership) => void) => {
         if (this.disableButtonsClosingRHS) {
             return;
         }
@@ -156,7 +156,7 @@ class ChannelHeaderPlug extends React.PureComponent<ChannelHeaderPlugProps, Chan
         action(this.props.channel, this.props.channelMember);
     }
 
-    fireActionAndClose = (action: (channel: Channel, channelMember: ChannelMembership) => void) => {
+    fireActionAndClose = (action: (channel: Channel, channelMember?: ChannelMembership) => void) => {
         action(this.props.channel, this.props.channelMember);
         this.onClose();
     }


### PR DESCRIPTION
#### Summary
This PR migrates 'components/channel_header' module and associated tests to TypeScript

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/16713
JIRA: https://mattermost.atlassian.net/browse/MM-20393

#### Release Note
```release-note
NONE
```
