### PR TITLE
separate out preparing_workspace

### DIFF
--- a/components/onboarding_tasks/onboarding_tasks_manager.tsx
+++ b/components/onboarding_tasks/onboarding_tasks_manager.tsx
@@ -34,8 +34,7 @@ import {
     switchToChannels,
 } from 'actions/views/onboarding_tasks';
 
-import {Constants, ModalIdentifiers, TELEMETRY_CATEGORIES} from 'utils/constants';
-import {OnboardingPreferences} from 'components/preparing_workspace/preparing_workspace';
+import {Constants, ModalIdentifiers, TELEMETRY_CATEGORIES, Preferences} from 'utils/constants';
 
 import {generateTelemetryTag} from './utils';
 import {OnboardingTaskCategory, OnboardingTaskList, OnboardingTasksName, TaskNameMapToSteps} from './constants';
@@ -115,7 +114,7 @@ export const useTasksList = () => {
     const showStartTrialTask = selfHostedTrialCondition || cloudTrialCondition;
 
     const list: Record<string, string> = {...OnboardingTasksName};
-    const pluginsPreferenceState = useSelector((state: GlobalState) => get(state, Constants.Preferences.ONBOARDING, OnboardingPreferences.USE_CASE));
+    const pluginsPreferenceState = useSelector((state: GlobalState) => get(state, Constants.Preferences.ONBOARDING, Preferences.USE_CASE));
     const pluginsPreference = pluginsPreferenceState && JSON.parse(pluginsPreferenceState);
     if ((pluginsPreference && !pluginsPreference.boards) || !pluginsList.focalboard) {
         delete list.BOARDS_TOUR;

--- a/components/preparing_workspace/preparing_workspace.tsx
+++ b/components/preparing_workspace/preparing_workspace.tsx
@@ -60,10 +60,6 @@ import UseCase from './use_case';
 
 import './preparing_workspace.scss';
 
-export const OnboardingPreferences = {
-    USE_CASE: 'use_case',
-};
-
 const SubmissionStates = {
     Presubmit: 'Presubmit',
     UserRequested: 'UserRequested',
@@ -247,7 +243,7 @@ export default function PreparingWorkspace(props: Props) {
             dispatch(savePreferences(user.id, [
                 {
                     category: Constants.Preferences.ONBOARDING,
-                    name: OnboardingPreferences.USE_CASE,
+                    name: Preferences.USE_CASE,
                     user_id: user.id,
                     value: JSON.stringify(form.useCase),
                 },

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -148,6 +148,7 @@ export const Preferences = {
     ADVANCED_TEXT_EDITOR: 'advanced_text_editor',
 
     FORWARD_POST_VIEWED: 'forward_post_viewed',
+    USE_CASE: 'use_case',
 };
 
 // For one off things that have a special, attention-grabbing UI until you interact with them


### PR DESCRIPTION
#### Summary
The preparing_workspace module defined its own const which was being imported, breaking its laziness. Fixed by defining the const in `utils/constants.tsx` and importing from there. Saves everyone not loading that page 216KB, gzipped (which is everyone except admins on their very first app load).

#### Ticket Link
OSF effort, no ticket

#### Screenshots
before (notice it in one of the main bundles, in the top left):
![before](https://user-images.githubusercontent.com/13738432/184448255-b2c748e7-f2cb-4697-a541-e5b721cc23f8.png)

after (notice it is now in its own bundle, on the right):
![after](https://user-images.githubusercontent.com/13738432/184448274-576d2dd0-9ad5-4291-81f7-859fdf31989c.png)

#### Release Note
```release-note
NONE
```
