### PR TITLE
Correctly import React Router elements

### DIFF
--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {RouteComponentProps} from 'react-router';
+import {RouteComponentProps} from 'react-router-dom';
 
 import {PermissionsScope, ModalIdentifiers} from 'utils/constants';
 import {localizeMessage} from 'utils/utils';

--- a/components/admin_console/permission_schemes_settings/permissions_scheme_summary/index.tsx
+++ b/components/admin_console/permission_schemes_settings/permissions_scheme_summary/index.tsx
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
-import {RouteComponentProps} from 'react-router';
+import {RouteComponentProps} from 'react-router-dom';
 
 import {deleteScheme} from 'mattermost-redux/actions/schemes';
 

--- a/components/global_header/hooks.tsx
+++ b/components/global_header/hooks.tsx
@@ -3,7 +3,7 @@
 
 import {MutableRefObject, useEffect, useRef} from 'react';
 import {useSelector} from 'react-redux';
-import {useLocation} from 'react-router';
+import {useLocation} from 'react-router-dom';
 
 import {getCurrentUser, isFirstAdmin, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {UserProfile} from '@mattermost/types/users';

--- a/components/logged_in/logged_in.tsx
+++ b/components/logged_in/logged_in.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {Redirect} from 'react-router';
+import {Redirect} from 'react-router-dom';
 
 import semver from 'semver';
 

--- a/components/password_reset_send_link/password_reset_send_link.test.tsx
+++ b/components/password_reset_send_link/password_reset_send_link.test.tsx
@@ -3,7 +3,7 @@
 
 import {shallow} from 'enzyme';
 import React from 'react';
-import {MemoryRouter} from 'react-router';
+import {MemoryRouter} from 'react-router-dom';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 

--- a/components/permalink_view/permalink_view.test.tsx
+++ b/components/permalink_view/permalink_view.test.tsx
@@ -4,7 +4,7 @@
 import {ReactWrapper, shallow} from 'enzyme';
 import React, {ComponentProps} from 'react';
 import nock from 'nock';
-import {match} from 'react-router';
+import {match} from 'react-router-dom';
 
 import {act} from 'react-dom/test-utils';
 

--- a/components/permalink_view/permalink_view.tsx
+++ b/components/permalink_view/permalink_view.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useState, useEffect, useCallback, memo} from 'react';
-import {match} from 'react-router';
+import {match} from 'react-router-dom';
 
 type Props = {
     channelId: string;


### PR DESCRIPTION
We shouldn't need to access react-router directly since everything is re-exported by react-router-dom. I found this while working on module federation because I managed somehow to have different versions of react-router and react-router-dom loaded at once so everything broke.

CC @mgdelacroix on this too. I think you mentioned something about Focalboard having issues importing React Router from the web app, so perhaps this was the issue? The error I got was around a call to `getContext` returning undefined in `useLocation` and other React Router hooks.

#### Release Note
```release-note
NONE
```
