### PR TITLE
MM-46432 Fix file attachment modal not closing properly

### DIFF
--- a/components/file_preview_modal/index.ts
+++ b/components/file_preview_modal/index.ts
@@ -16,9 +16,6 @@ import {GlobalState} from 'types/store';
 import {FilePreviewComponent} from 'types/store/plugins';
 
 import {canDownloadFiles} from 'utils/file_utils';
-import {ModalIdentifiers} from 'utils/constants';
-
-import {closeModal} from 'actions/views/modals';
 
 import type {Props} from './file_preview_modal';
 
@@ -38,9 +35,6 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         isMobileView: getIsMobileView(state),
         pluginFilePreviewComponents: state.plugins.components.FilePreview as unknown as FilePreviewComponent[],
         post: ownProps.post || getPost(state, ownProps.postId || ''),
-        onExited: () => {
-            closeModal(ModalIdentifiers.FILE_PREVIEW_MODAL);
-        },
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "mattermost-webapp",
       "version": "7.0.0",
       "hasInstallScript": true,
       "workspaces": [


### PR DESCRIPTION
Modals mounted by the ModalController (ie by using `openModal`) have an `onExited` prop added automatically that removes them from the DOM. Since we overrode this one's in the `mapStateToProps`, it caused the modal to be hidden but not actually unmounted. Since the first FilePreviewModal that wasn't unmounted (it was just invisible), a new one couldn't be added when you try to view another file.

Also, I don't know why that line in package-lock.json keeps changing, but I'm going to keep changing it back because NPM keeps changing it back.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46432

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/10904

#### Release Note
```release-note
NONE
```
