### PR TITLE
Finally create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Web Platform should be assigned to review all PRs that involve changing dependencies in the app, either intentional or accidental.
+package.json @mattermost/web-platform
+*/package.json @mattermost/web-platform
+package-lock.json @mattermost/web-platform


### PR DESCRIPTION
We've talked about adding this for a while, and using it to make sure Web Platform knows what's up with dependency changes seems like a good use for it.

#### Release Note
```release-note
NONE
```
