### PR TITLE
MM-41823/MM-41824 Count requests made during channel_switch and team_switch

### DIFF
--- a/components/post_view/post_list/post_list.tsx
+++ b/components/post_view/post_list/post_list.tsx
@@ -21,8 +21,8 @@ export const MAX_EXTRA_PAGES_LOADED = 10;
 function markAndMeasureChannelSwitchEnd(fresh = false) {
     mark('PostList#component');
 
-    const [dur1] = measure('SidebarChannelLink#click', 'PostList#component');
-    const [dur2] = measure('TeamLink#click', 'PostList#component');
+    const {duration: dur1, requestCount: requestCount1} = measure('SidebarChannelLink#click', 'PostList#component');
+    const {duration: dur2, requestCount: requestCount2} = measure('TeamLink#click', 'PostList#component');
 
     clearMarks([
         'SidebarChannelLink#click',
@@ -31,10 +31,18 @@ function markAndMeasureChannelSwitchEnd(fresh = false) {
     ]);
 
     if (dur1 !== -1) {
-        trackEvent('performance', 'channel_switch', {duration: Math.round(dur1), fresh});
+        trackEvent('performance', 'channel_switch', {
+            duration: Math.round(dur1),
+            fresh,
+            requestCount: requestCount1,
+        });
     }
     if (dur2 !== -1) {
-        trackEvent('performance', 'team_switch', {duration: Math.round(dur2), fresh});
+        trackEvent('performance', 'team_switch', {
+            duration: Math.round(dur2),
+            fresh,
+            requestCount: requestCount2,
+        });
     }
 }
 


### PR DESCRIPTION
More specifically, it's supposed to count all HTTP requests made using fetch or XMLHttpRequest during that period that go to the API. Unfortunately, it seems to only count requests completed by the time `markAndMeasureChannelSwitchEnd` occurs which happens as soon as any posts in the channel have been loaded. That matches with the time period captured by channel_switch and team_switch events though, so it might still be reasonable.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41823
https://mattermost.atlassian.net/browse/MM-41824

#### Release Note
```release-note
Add telemetry for counting network requests made while switching channels or teams
```
