### PR TITLE
[MM-46196] allow tabbing through dot menu items

### DIFF
--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -386,8 +386,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
             [Constants.KeyCodes.U, this.handleMarkPostAsUnread, null],
         ];
 
-        for (const shortcut of shortcuts) {
-            const [keyCode, func, condition] = shortcut;
+        for (const [keyCode, func, condition] of shortcuts) {
             const conditionMet = (condition === null) || (condition !== null && condition);
             if (Utils.isKeyPressed(e, keyCode) && conditionMet) {
                 this.handleShortCut(e, func);

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -28,6 +28,7 @@ import Badge from '../widgets/badges/badge';
 import {ChangeEvent, trackDotMenuEvent} from './utils';
 import './dot_menu.scss';
 
+type ShortcutFunc = (e: KeyboardEvent) => void
 type ShortcutKeyProps = {
     shortcutKey: string;
 };
@@ -360,73 +361,41 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         return (e).getModifierState !== undefined;
     }
 
-    onShortcutKeyDown = (e: KeyboardEvent): void => {
+    handleShortCut = (e: KeyboardEvent, f: ShortcutFunc) => {
         e.preventDefault();
+        f(e);
+        this.props.handleDropdownOpened(false);
+    }
+
+    onShortcutKeyDown = (e: KeyboardEvent): void => {
         if (!this.isKeyboardEvent(e)) {
             return;
         }
 
         const isShiftKeyPressed = e.shiftKey;
+        const shortcuts: Array<[[string, number], (e: KeyboardEvent) => void, null | boolean]> = [
+            [Constants.KeyCodes.R, this.handleCommentClick, null],
+            [Constants.KeyCodes.E, this.handleEditMenuItemActivated, null],
+            [Constants.KeyCodes.F, this.handleSetThreadFollow, !isShiftKeyPressed],
+            [Constants.KeyCodes.F, this.handleForwardMenuItemActivated, isShiftKeyPressed],
+            [Constants.KeyCodes.K, this.copyLink, null],
+            [Constants.KeyCodes.C, this.copyText, null],
+            [Constants.KeyCodes.DELETE, this.handleDeleteMenuItemActivated, null],
+            [Constants.KeyCodes.P, this.handlePinMenuItemActivated, null],
+            [Constants.KeyCodes.S, this.handleFlagMenuItemActivated, null],
+            [Constants.KeyCodes.U, this.handleMarkPostAsUnread, null],
+        ];
 
-        switch (true) {
-        case Utils.isKeyPressed(e, Constants.KeyCodes.R):
-            this.handleCommentClick(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // edit post
-        case Utils.isKeyPressed(e, Constants.KeyCodes.E):
-            this.handleEditMenuItemActivated(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // follow thread
-        case Utils.isKeyPressed(e, Constants.KeyCodes.F) && !isShiftKeyPressed:
-            this.handleSetThreadFollow(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // forward post
-        case Utils.isKeyPressed(e, Constants.KeyCodes.F) && isShiftKeyPressed:
-            this.handleForwardMenuItemActivated(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // copy link
-        case Utils.isKeyPressed(e, Constants.KeyCodes.K):
-            this.copyLink(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // copy text
-        case Utils.isKeyPressed(e, Constants.KeyCodes.C):
-            this.copyText(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // delete post
-        case Utils.isKeyPressed(e, Constants.KeyCodes.DELETE):
-            this.handleDeleteMenuItemActivated(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // pin / unpin
-        case Utils.isKeyPressed(e, Constants.KeyCodes.P):
-            this.handlePinMenuItemActivated(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // save / unsave
-        case Utils.isKeyPressed(e, Constants.KeyCodes.S):
-            this.handleFlagMenuItemActivated(e);
-            this.props.handleDropdownOpened(false);
-            break;
-
-        // mark as unread
-        case Utils.isKeyPressed(e, Constants.KeyCodes.U):
-            this.handleMarkPostAsUnread(e);
-            this.props.handleDropdownOpened(false);
-            break;
+        for (const shortcut of shortcuts) {
+            const [keyCode, func, condition] = shortcut;
+            if (Utils.isKeyPressed(e, keyCode) && condition === null) {
+                this.handleShortCut(e, func);
+                break;
+            }
+            if (Utils.isKeyPressed(e, keyCode) && condition !== null && condition) {
+                this.handleShortCut(e, func);
+                break;
+            }
         }
     }
 

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -374,14 +374,14 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
 
         const isShiftKeyPressed = e.shiftKey;
         const shortcuts: Array<[[string, number], (e: KeyboardEvent) => void, null | boolean]> = [
-            [Constants.KeyCodes.R, this.handleCommentClick, null],
-            [Constants.KeyCodes.E, this.handleEditMenuItemActivated, null],
-            [Constants.KeyCodes.F, this.handleSetThreadFollow, !isShiftKeyPressed],
-            [Constants.KeyCodes.F, this.handleForwardMenuItemActivated, isShiftKeyPressed],
-            [Constants.KeyCodes.K, this.copyLink, null],
             [Constants.KeyCodes.C, this.copyText, null],
             [Constants.KeyCodes.DELETE, this.handleDeleteMenuItemActivated, null],
+            [Constants.KeyCodes.E, this.handleEditMenuItemActivated, null],
+            [Constants.KeyCodes.F, this.handleForwardMenuItemActivated, isShiftKeyPressed],
+            [Constants.KeyCodes.F, this.handleSetThreadFollow, !isShiftKeyPressed],
+            [Constants.KeyCodes.K, this.copyLink, null],
             [Constants.KeyCodes.P, this.handlePinMenuItemActivated, null],
+            [Constants.KeyCodes.R, this.handleCommentClick, null],
             [Constants.KeyCodes.S, this.handleFlagMenuItemActivated, null],
             [Constants.KeyCodes.U, this.handleMarkPostAsUnread, null],
         ];

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -388,11 +388,8 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
 
         for (const shortcut of shortcuts) {
             const [keyCode, func, condition] = shortcut;
-            if (Utils.isKeyPressed(e, keyCode) && condition === null) {
-                this.handleShortCut(e, func);
-                break;
-            }
-            if (Utils.isKeyPressed(e, keyCode) && condition !== null && condition) {
+            const conditionMet = (condition === null) || (condition !== null && condition);
+            if (Utils.isKeyPressed(e, keyCode) && conditionMet) {
                 this.handleShortCut(e, func);
                 break;
             }

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -28,7 +28,6 @@ import Badge from '../widgets/badges/badge';
 import {ChangeEvent, trackDotMenuEvent} from './utils';
 import './dot_menu.scss';
 
-type ShortcutFunc = (e: KeyboardEvent) => void
 type ShortcutKeyProps = {
     shortcutKey: string;
 };
@@ -361,12 +360,6 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         return (e).getModifierState !== undefined;
     }
 
-    handleShortCut = (e: KeyboardEvent, f: ShortcutFunc) => {
-        e.preventDefault();
-        f(e);
-        this.props.handleDropdownOpened(false);
-    }
-
     onShortcutKeyDown = (e: KeyboardEvent): void => {
         if (!this.isKeyboardEvent(e)) {
             return;
@@ -389,7 +382,9 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         for (const [keyCode, func, condition] of shortcuts) {
             const conditionMet = (typeof condition === 'undefined') || (typeof condition === 'boolean' && condition);
             if (Utils.isKeyPressed(e, keyCode) && conditionMet) {
-                this.handleShortCut(e, func);
+                e.preventDefault();
+                func(e);
+                this.props.handleDropdownOpened(false);
                 break;
             }
         }

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -387,7 +387,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         ];
 
         for (const [keyCode, func, condition] of shortcuts) {
-            const conditionMet = (!condition) || (typeof condition === 'boolean' && condition);
+            const conditionMet = (typeof condition === 'undefined') || (typeof condition === 'boolean' && condition);
             if (Utils.isKeyPressed(e, keyCode) && conditionMet) {
                 this.handleShortCut(e, func);
                 break;

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -373,7 +373,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         }
 
         const isShiftKeyPressed = e.shiftKey;
-        const shortcuts: Array<[[string, number], (e: KeyboardEvent) => void, (undefined | boolean)?]> = [
+        const shortcuts: Array<[[string, number], (e: KeyboardEvent) => void, boolean?]> = [
             [Constants.KeyCodes.C, this.copyText],
             [Constants.KeyCodes.DELETE, this.handleDeleteMenuItemActivated],
             [Constants.KeyCodes.E, this.handleEditMenuItemActivated],

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -360,13 +360,8 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         return (e).getModifierState !== undefined;
     }
 
-    onShortcutKeyDown = (e: KeyboardEvent): void => {
-        if (!this.isKeyboardEvent(e)) {
-            return;
-        }
-
-        const isShiftKeyPressed = e.shiftKey;
-        const shortcuts: Array<[[string, number], (e: KeyboardEvent) => void, boolean?]> = [
+    getShortcuts = (isShiftKeyPressed: boolean): Array<[[string, number], (e: KeyboardEvent) => void, boolean?]> => {
+        return [
             [Constants.KeyCodes.C, this.copyText],
             [Constants.KeyCodes.DELETE, this.handleDeleteMenuItemActivated],
             [Constants.KeyCodes.E, this.handleEditMenuItemActivated],
@@ -378,6 +373,21 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
             [Constants.KeyCodes.S, this.handleFlagMenuItemActivated],
             [Constants.KeyCodes.U, this.handleMarkPostAsUnread],
         ];
+    }
+
+    onShortcutKeyDown = (e: KeyboardEvent): void => {
+        if (!this.isKeyboardEvent(e)) {
+            return;
+        }
+
+        // disable non shortcut keys to prevent typing in post input
+        // allow Tab key to tab through the menu items
+        if (!Utils.isKeyPressed(e, Constants.KeyCodes.TAB)) {
+            e.preventDefault();
+        }
+
+        const isShiftKeyPressed = e.shiftKey;
+        const shortcuts = this.getShortcuts(isShiftKeyPressed);
 
         for (const [keyCode, func, condition] of shortcuts) {
             const conditionMet = (typeof condition === 'undefined') || (typeof condition === 'boolean' && condition);

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -373,21 +373,21 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
         }
 
         const isShiftKeyPressed = e.shiftKey;
-        const shortcuts: Array<[[string, number], (e: KeyboardEvent) => void, null | boolean]> = [
-            [Constants.KeyCodes.C, this.copyText, null],
-            [Constants.KeyCodes.DELETE, this.handleDeleteMenuItemActivated, null],
-            [Constants.KeyCodes.E, this.handleEditMenuItemActivated, null],
+        const shortcuts: Array<[[string, number], (e: KeyboardEvent) => void, (undefined | boolean)?]> = [
+            [Constants.KeyCodes.C, this.copyText],
+            [Constants.KeyCodes.DELETE, this.handleDeleteMenuItemActivated],
+            [Constants.KeyCodes.E, this.handleEditMenuItemActivated],
             [Constants.KeyCodes.F, this.handleForwardMenuItemActivated, isShiftKeyPressed],
             [Constants.KeyCodes.F, this.handleSetThreadFollow, !isShiftKeyPressed],
-            [Constants.KeyCodes.K, this.copyLink, null],
-            [Constants.KeyCodes.P, this.handlePinMenuItemActivated, null],
-            [Constants.KeyCodes.R, this.handleCommentClick, null],
-            [Constants.KeyCodes.S, this.handleFlagMenuItemActivated, null],
-            [Constants.KeyCodes.U, this.handleMarkPostAsUnread, null],
+            [Constants.KeyCodes.K, this.copyLink],
+            [Constants.KeyCodes.P, this.handlePinMenuItemActivated],
+            [Constants.KeyCodes.R, this.handleCommentClick],
+            [Constants.KeyCodes.S, this.handleFlagMenuItemActivated],
+            [Constants.KeyCodes.U, this.handleMarkPostAsUnread],
         ];
 
         for (const [keyCode, func, condition] of shortcuts) {
-            const conditionMet = (condition === null) || (condition !== null && condition);
+            const conditionMet = (!condition) || (typeof condition === 'boolean' && condition);
             if (Utils.isKeyPressed(e, keyCode) && conditionMet) {
                 this.handleShortCut(e, func);
                 break;


### PR DESCRIPTION
#### Summary
This PR allows a user to tab through the dot menu items when the menu is open. I tested that all shortuts work as expected and the user can tab to a menu item and <return> will execute that action.

I also refactored the code to reduce code duplication. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46196

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
