### PR TITLE
Prevent thundering herd on websocket reconnect

### DIFF
--- a/packages/client/src/websocket.ts
+++ b/packages/client/src/websocket.ts
@@ -144,7 +144,7 @@ export default class WebSocketClient {
             }
 
             // Applying jitter to avoid thundering herd problems.
-            retryTime += Math.floor(Math.random() * JITTER_RANGE);
+            retryTime += Math.random() * JITTER_RANGE;
 
             setTimeout(
                 () => {

--- a/packages/client/src/websocket.ts
+++ b/packages/client/src/websocket.ts
@@ -4,6 +4,7 @@
 const MAX_WEBSOCKET_FAILS = 7;
 const MIN_WEBSOCKET_RETRY_TIME = 3000; // 3 sec
 const MAX_WEBSOCKET_RETRY_TIME = 300000; // 5 mins
+const JITTER_RANGE = 2000; // 2 sec
 
 const WEBSOCKET_HELLO = 'hello';
 
@@ -141,6 +142,9 @@ export default class WebSocketClient {
                     retryTime = MAX_WEBSOCKET_RETRY_TIME;
                 }
             }
+
+            // Applying jitter to avoid thundering herd problems.
+            retryTime += Math.floor(Math.random() * JITTER_RANGE);
 
             setTimeout(
                 () => {


### PR DESCRIPTION
On large installations, sometimes a proxy server can restart
or a network blip can happen which can disconnect a large
number of websocket connections. When this happens,
all of those clients will simultaneously try to reconnect,
putting the server under immense pressure.

This is fondly termed as thundering herd. And the solution
is to add a random time interval to spread out the reconnects.

We observed this happening on community, where a large number
of websocket reconnects causes the webapp to freeze due to
spikes in CPU and goroutines on the server side.
