### PR TITLE
[MM-46473]: removed onExited action from modal

### DIFF
--- a/components/file_preview_modal/index.ts
+++ b/components/file_preview_modal/index.ts
@@ -16,9 +16,6 @@ import {GlobalState} from 'types/store';
 import {FilePreviewComponent} from 'types/store/plugins';
 
 import {canDownloadFiles} from 'utils/file_utils';
-import {ModalIdentifiers} from 'utils/constants';
-
-import {closeModal} from 'actions/views/modals';
 
 import type {Props} from './file_preview_modal';
 
@@ -38,9 +35,6 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         isMobileView: getIsMobileView(state),
         pluginFilePreviewComponents: state.plugins.components.FilePreview as unknown as FilePreviewComponent[],
         post: ownProps.post || getPost(state, ownProps.postId || ''),
-        onExited: () => {
-            closeModal(ModalIdentifiers.FILE_PREVIEW_MODAL);
-        },
     };
 }
 


### PR DESCRIPTION
#### Summary
#10904 introduced a regression with image preview modals. This PR intends to fix that.
The problem was that a `onExited` prop was passed manually to the preview modal component. This collided with the `ModalController` component which handles the mounting/unmounting of modals.

#### Ticket Link
[MM-46473](https://mattermost.atlassian.net/browse/MM-46473)

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
