### PR TITLE
MM-46496 : Seperate bundle for ActivityAndInsights and ChannelHeaderMobile

### DIFF
--- a/components/channel_layout/center_channel/center_channel.test.tsx
+++ b/components/channel_layout/center_channel/center_channel.test.tsx
@@ -6,22 +6,23 @@ import {shallow} from 'enzyme';
 
 import CenterChannel from './center_channel';
 
+import type {OwnProps} from './index';
+
 describe('components/channel_layout/CenterChannel', () => {
     const props = {
         location: {
             pathname: '/some',
-        },
+        } as OwnProps['location'],
+        match: {
+            url: '/url',
+        } as OwnProps['match'],
+        history: {} as OwnProps['history'],
         lastChannelPath: '',
         lhsOpen: true,
         rhsOpen: true,
         rhsMenuOpen: true,
         isCollapsedThreadsEnabled: true,
-        match: {
-            url: '/url',
-        },
         currentUserId: 'testUserId',
-        isOnboardingHidden: true,
-        enableTipsViewRoute: false,
         insightsAreEnabled: true,
         isMobileView: false,
         actions: {

--- a/components/channel_layout/center_channel/center_channel.tsx
+++ b/components/channel_layout/center_channel/center_channel.tsx
@@ -5,15 +5,18 @@ import React from 'react';
 import {Route, Switch, Redirect} from 'react-router-dom';
 import classNames from 'classnames';
 
-import {ActionFunc} from 'mattermost-redux/types/actions';
-
 import LoadingScreen from 'components/loading_screen';
 import PermalinkView from 'components/permalink_view';
-import ChannelHeaderMobile from 'components/channel_header_mobile';
 import ChannelIdentifierRouter from 'components/channel_layout/channel_identifier_router';
 import PlaybookRunner from 'components/channel_layout/playbook_runner';
-import ActivityAndInsights from 'components/activity_and_insights/activity_and_insights';
 import {makeAsyncComponent} from 'components/async_load';
+
+import type {OwnProps, PropsFromRedux} from './index';
+
+const LazyChannelHeaderMobile = makeAsyncComponent(
+    'LazyChannelHeaderMobile',
+    React.lazy(() => import('components/channel_header_mobile')),
+);
 
 const LazyGlobalThreads = makeAsyncComponent(
     'LazyGlobalThreads',
@@ -25,25 +28,17 @@ const LazyGlobalThreads = makeAsyncComponent(
     ),
 );
 
-type Props = {
-    match: {
-        url: string;
-    };
-    location: {
-        pathname: string;
-    };
-    lastChannelPath: string;
-    lhsOpen: boolean;
-    rhsOpen: boolean;
-    rhsMenuOpen: boolean;
-    isCollapsedThreadsEnabled: boolean;
-    currentUserId: string;
-    insightsAreEnabled: boolean;
-    isMobileView: boolean;
-    actions: {
-        getProfiles: (page?: number, perPage?: number, options?: Record<string, string | boolean>) => ActionFunc;
-    };
-};
+const LazyActivityAndInsights = makeAsyncComponent(
+    'LazyActivityAndInsights',
+    React.lazy(() => import('components/activity_and_insights/activity_and_insights')),
+    (
+        <div className='app__content'>
+            <LoadingScreen/>
+        </div>
+    ),
+);
+
+type Props = PropsFromRedux & OwnProps;
 
 type State = {
     returnTo: string;
@@ -90,7 +85,7 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
                 {isMobileView && (
                     <div className='row header'>
                         <div id='navbar_wrapper'>
-                            <ChannelHeaderMobile/>
+                            <LazyChannelHeaderMobile/>
                         </div>
                     </div>
                 )}
@@ -123,7 +118,7 @@ export default class CenterChannel extends React.PureComponent<Props, State> {
                         {insightsAreEnabled ? (
                             <Route
                                 path='/:team/activity-and-insights'
-                                component={ActivityAndInsights}
+                                component={LazyActivityAndInsights}
                             />
                         ) : null}
                         <Redirect to={lastChannelPath}/>

--- a/components/channel_layout/center_channel/index.ts
+++ b/components/channel_layout/center_channel/index.ts
@@ -1,8 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {connect} from 'react-redux';
+import {connect, ConnectedProps} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
+import {RouteComponentProps} from 'react-router-dom';
 
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
 import {getProfiles} from 'mattermost-redux/actions/users';
@@ -22,16 +23,13 @@ import {PreviousViewedTypes} from 'utils/constants';
 
 import CenterChannel from './center_channel';
 
-type Props = {
-    match: {
-        url: string;
-        params: {
-            team: string;
-        };
-    };
-};
+type Params = {
+    team: string;
+}
 
-const mapStateToProps = (state: GlobalState, ownProps: Props) => {
+export type OwnProps = RouteComponentProps<Params>;
+
+const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
     const lastViewedType = getLastViewedTypeByTeamName(state, ownProps.match.params.team);
     let channelName = getLastViewedChannelNameByTeamName(state, ownProps.match.params.team);
 
@@ -71,15 +69,19 @@ const mapStateToProps = (state: GlobalState, ownProps: Props) => {
 
 type Actions = {
     getProfiles: (page?: number, perPage?: number, options?: Record<string, string | boolean>) => ActionFunc;
-}
+};
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
-        actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc|GenericAction>, Actions>({
+        actions: bindActionCreators<ActionCreatorsMapObject, Actions>({
             getProfiles,
         }, dispatch),
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CenterChannel);
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+export type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(CenterChannel);
 


### PR DESCRIPTION
#### Summary
- Lazy loaded ActivityAndInsights (since it depends if it is enabled on the server)
- Lazy loaded ChannelHeaderMobile (since it depends if its open in mobile view
- Prop rearrangement for components/channel_layout/center_channel/center_channel.tsx

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46496

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
