### PR TITLE
Fix stretch for custom branding image in Safari on sign up page

### DIFF
--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -95,7 +95,6 @@
 
                 .signup-body-custom-branding-image {
                     max-height: 540px;
-                    flex: 1;
                     align-self: center;
                     margin-bottom: 28px;
                     border-radius: 8px;


### PR DESCRIPTION
#### Summary
This PR applies the fix known from https://github.com/mattermost/mattermost-webapp/pull/10862 (login page) now also for the sign up page.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46522

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="1428" alt="before" src="https://user-images.githubusercontent.com/15683974/182043213-588dc1e7-fbd3-4aa6-a6dd-bdf0a1e0d546.png"> | <img width="1428" alt="after" src="https://user-images.githubusercontent.com/15683974/182043211-8d65c170-f3a0-4f00-9ea7-020c0af449f7.png"> |

#### Release Note
```release-note
NONE
```
