### PR TITLE
Disable desktop promp in cloud context

### DIFF
--- a/components/root/index.js
+++ b/components/root/index.js
@@ -4,6 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
+import {isCurrentLicenseCloud} from 'mattermost-redux/selectors/entities/cloud';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {shouldShowTermsOfService, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getTeam} from 'mattermost-redux/selectors/entities/teams';
@@ -42,6 +43,7 @@ function mapStateToProps(state) {
         plugins,
         products,
         showLaunchingWorkspace: getShowLaunchingWorkspace(state),
+        isCloud: isCurrentLicenseCloud(state),
     };
 }
 

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -113,6 +113,7 @@ export default class Root extends React.PureComponent {
         noAccounts: PropTypes.bool,
         showTermsOfService: PropTypes.bool,
         permalinkRedirectTeamName: PropTypes.string,
+        isCloud: PropTypes.bool,
         actions: PropTypes.shape({
             emitBrowserWindowResized: PropTypes.func.isRequired,
             getFirstAdminSetupComplete: PropTypes.func.isRequired,
@@ -265,7 +266,7 @@ export default class Root extends React.PureComponent {
             landing = desktopAppDownloadLink;
         }
 
-        if (landing && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen && !this.props.location.pathname.includes('/landing') && !window.location.hostname?.endsWith('.test.mattermost.com') && !UserAgent.isDesktopApp()) {
+        if (landing && !this.props.isCloud && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen && !this.props.location.pathname.includes('/landing') && !window.location.hostname?.endsWith('.test.mattermost.com') && !UserAgent.isDesktopApp()) {
             this.props.history.push('/landing#' + this.props.location.pathname + this.props.location.search);
             BrowserStore.setLandingPageSeen(true);
         }


### PR DESCRIPTION

#### Summary
The desktop app prompt was breaking the cloud workspace flow for new users. This PR disables it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46490

#### Release Note

```release-note
NONE
```
