### PR TITLE
[MM-46495]: fixed whitespace bug on paste

### DIFF
--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -901,7 +901,11 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft);
     }
 
-    handleUploadError = (err: string | ServerError, clientId = '', channelId = '') => {
+    handleUploadError = (err: string | ServerError, clientId?: string, channelId?: string) => {
+        if (!channelId || !clientId) {
+            return;
+        }
+
         const draft = {...this.draftsForChannel[channelId]!};
 
         let serverError = err;


### PR DESCRIPTION
#### Summary
ixes the parameter definitions in the `handleUploadError` function and instead added a guard with an early return

#### Ticket Link
[MM-46495](https://mattermost.atlassian.net/browse/MM-46495)

#### Related Pull Requests
bug got introduced by #10858 

#### Screenshots
n/a 

#### Release Note
```release-note
NONE
```
