### PR TITLE
Automated cherry pick of #10964

### DIFF
--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -231,7 +231,7 @@ function Content(props: ContentProps) {
                         buttonDetails={{
                             action: () => openPurchaseModal('click_pricing_modal_professional_card_upgrade_button'),
                             text: formatMessage({id: 'pricing_modal.btn.upgrade', defaultMessage: 'Upgrade'}),
-                            disabled: !isAdmin || isProfessional || isEnterprise,
+                            disabled: !isAdmin || isProfessional || (isEnterprise && !isEnterpriseTrial),
                             customClass: isPostTrial ? ButtonCustomiserClasses.special : ButtonCustomiserClasses.active,
                         }}
                         briefing={{

--- a/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.js
@@ -272,8 +272,8 @@ describe('Pricing modal', () => {
         // *Check that starter Downgrade card  button exists
         cy.get('#pricingModal').get('#starter').get('#starter_action').contains('Downgrade');
 
-        // *Check that professsional card Upgrade button is disabled while on enterprise
-        cy.get('#pricingModal').get('#professional').get('#professional_action').should('be.disabled');
+        // *Check that professsional card Upgrade button is not disabled while on enterprise trial
+        cy.get('#pricingModal').get('#professional').get('#professional_action').should('not.be.disabled');
 
         // *Check that enterprise card action button is disabled
         cy.get('#pricingModal').get('#enterprise').get('#start_cloud_trial_btn').contains('Try free for 30 days');
@@ -429,6 +429,9 @@ describe('Pricing modal', () => {
 
         // *Check that starter card Downgrade button is disabled
         cy.get('#pricingModal').get('#starter').get('#starter_action').should('be.disabled').contains('Downgrade');
+
+        // *Check that professsional card Upgrade button is disabled while on non trial enterprise
+        cy.get('#pricingModal').get('#professional').get('#professional_action').should('be.disabled');
 
         // *Check that Trial button is disabled on enterprise trial
         cy.get('#pricingModal').get('#enterprise').get('#start_cloud_trial_btn').should('be.disabled');


### PR DESCRIPTION
Cherry pick of #10964 on cloud.

/cc  @AGMETEOR

```release-note
NONE
```