### PR TITLE
[MM-46239] Remove target=_blank from support packet link

### DIFF
--- a/components/commercial_support_modal/__snapshots__/commercial_support_modal.test.tsx.snap
+++ b/components/commercial_support_modal/__snapshots__/commercial_support_modal.test.tsx.snap
@@ -68,7 +68,6 @@ We recommend that you download additional environment details about your Matterm
         className="btn btn-primary DownloadSupportPacket"
         href="/api/v4/system/support_packet"
         rel="noopener noreferrer"
-        target="_blank"
       >
         <MemoizedFormattedMessage
           defaultMessage="Download Support Packet"

--- a/components/commercial_support_modal/commercial_support_modal.tsx
+++ b/components/commercial_support_modal/commercial_support_modal.tsx
@@ -94,7 +94,6 @@ export default class CommercialSupportModal extends React.PureComponent<Props, S
                         <a
                             className='btn btn-primary DownloadSupportPacket'
                             href={`${Client4.getBaseRoute()}/system/support_packet`}
-                            target='_blank'
                             rel='noopener noreferrer'
                         >
                             <FormattedMessage


### PR DESCRIPTION
#### Summary
In the Desktop App, the support was unable to be downloaded because the app expected the link to be opened in a new window, which is only handled by the Desktop App for certain links.

It didn't really seem to make sense to make an exception for the support packet, so I've removed the `target=_blank` from the link since it doesn't really need to open in a new window as far I can tell anyways.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46239

```release-note
NONE
```
