### PR TITLE
Fix URLs in translations string for personal access tokens

### DIFF
--- a/components/user_settings/security/user_access_token_section/user_access_token_section.tsx
+++ b/components/user_settings/security/user_access_token_section/user_access_token_section.tsx
@@ -478,7 +478,7 @@ export default class UserAccessTokenSection extends React.PureComponent<Props, S
                                     {msg}
                                 </a>
                             ),
-                            linkApi: (msg: React.ReactNode) => (
+                            linkAPI: (msg: React.ReactNode) => (
                                 <a
                                     href='https://api.mattermost.com/#tag/authentication'
                                     target='_blank'

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1357,7 +1357,7 @@
   "admin.manage_teams.makeMemberError": "Unable to make user a member.",
   "admin.manage_teams.removeError": "Unable to remove user from team.",
   "admin.manage_tokens.manageTokensTitle": "Manage Personal Access Tokens",
-  "admin.manage_tokens.userAccessTokensDescription": "Personal access tokens function similarly to session tokens and can be used by integrations to <linkAuthtentication>interact with this Mattermost server</linkAuthtentication>. Tokens are disabled if the user is deactivated. Learn more about <linkPersonalAccessTokens>personal access tokens</linkPersonalAccessTokens>.",
+  "admin.manage_tokens.userAccessTokensDescription": "Personal access tokens function similarly to session tokens and can be used by integrations to <linkAuthentication>interact with this Mattermost server</linkAuthentication>. Tokens are disabled if the user is deactivated. Learn more about <linkPersonalAccessTokens>personal access tokens</linkPersonalAccessTokens>.",
   "admin.manage_tokens.userAccessTokensIdLabel": "Token ID: ",
   "admin.manage_tokens.userAccessTokensNameLabel": "Token Description: ",
   "admin.manage_tokens.userAccessTokensNone": "No personal access tokens.",


### PR DESCRIPTION
There's some typos in these strings as discussed here: https://community.mattermost.com/core/pl/unwdybmhy3baiygmrfbshydp8o

#### Release Note
```release-note
Fixed typos in some translations that caused links to be broken
```
