### PR TITLE
[MM-46557] Adding user to channel on RHS causes an error

### DIFF
--- a/packages/mattermost-redux/src/actions/threads.ts
+++ b/packages/mattermost-redux/src/actions/threads.ts
@@ -348,7 +348,7 @@ export function handleReadChanged(
                 newUnreadMentions,
                 prevUnreadReplies,
                 newUnreadReplies,
-                channelType: channel.type,
+                channelType: channel?.type,
             },
         });
     };


### PR DESCRIPTION
#### Summary
Adding a user to the channel on RHS causes an error

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-46557


#### Related Pull Requests
NONE

#### Screenshots


#### Release Note
```release-note
* Adding user to channel on RHS causes an error
```
