### PR TITLE
MM-46526 - add telemetry event for initial show of tasklist and add event to dismiss

### DIFF
--- a/components/onboarding_tasklist/onboarding_tasklist.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist.tsx
@@ -219,6 +219,12 @@ const OnBoardingTaskList = (): JSX.Element | null => {
         }
     }, [firstTimeOnboarding]);
 
+    useEffect(() => {
+        if (firstTimeOnboarding && showTaskList && isEnableOnboardingFlow) {
+            trackEvent(OnboardingTaskCategory, OnboardingTaskList.ONBOARDING_TASK_LIST_SHOW);
+        }
+    }, [firstTimeOnboarding, showTaskList, isEnableOnboardingFlow]);
+
     // Done to show task done animation in closed state as well
     useEffect(() => {
         const newCCount = tasksList.filter((task) => task.status).length;
@@ -252,7 +258,7 @@ const OnBoardingTaskList = (): JSX.Element | null => {
             value: 'false',
         }];
         dispatch(savePreferences(currentUserId, preferences));
-        trackEvent(OnboardingTaskCategory, OnboardingTaskList.ONBOARDING_TASK_LIST_SHOW);
+        trackEvent(OnboardingTaskCategory, OnboardingTaskList.DECLINED_ONBOARDING_TASK_LIST);
     }, [currentUserId]);
 
     const toggleTaskList = useCallback(() => {

--- a/components/onboarding_tasks/constants.ts
+++ b/components/onboarding_tasks/constants.ts
@@ -22,6 +22,7 @@ export const OnboardingTaskList = {
     ONBOARDING_TASK_LIST_OPEN: 'onboarding_task_list_open',
     ONBOARDING_TASK_LIST_SHOW: 'onboarding_task_list_show',
     ONBOARDING_VIDEO_MODAL: 'onboarding_video_modal',
+    DECLINED_ONBOARDING_TASK_LIST: 'declined_onboarding_task_list',
 };
 
 export const GenericTaskSteps = {


### PR DESCRIPTION
#### Summary
this PR adds a telemetry event for initial show of the onboarding tasklist and and also add event when the tasklist dismissed

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46526

#### Related Pull Requests
n/a

#### Screenshots


#### Release Note
```release-note
NONE
```
