### PR TITLE
MM-46642 : Skip bundlesize CI for forked repositories PR

### DIFF
--- a/.github/workflows/bundle-size-analysis.yml
+++ b/.github/workflows/bundle-size-analysis.yml
@@ -53,7 +53,7 @@ jobs:
 
   # Build current PR and upload it's bundle stats file
   build-pr:
-    name: "Pull request"
+    name: "branch"
     runs-on: ubuntu-latest
       
     needs: [build-main]
@@ -82,7 +82,7 @@ jobs:
 
   # Compare bundle stats of main branch and current PR
   compare-bundle:
-    name: "Compare"
+    name: "compare"
     runs-on: ubuntu-latest
     
     # Since we dont want to block the PR when we are not able to show the bundle size

--- a/.github/workflows/bundle-size-analysis.yml
+++ b/.github/workflows/bundle-size-analysis.yml
@@ -85,9 +85,6 @@ jobs:
     name: "compare"
     runs-on: ubuntu-latest
     
-    # Since we dont want to block the PR when we are not able to show the bundle size
-    continue-on-error: true
-    
     needs: [build-pr, build-main]
     
     permissions:

--- a/.github/workflows/bundle-size-analysis.yml
+++ b/.github/workflows/bundle-size-analysis.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           name: main-bundle-stats
           path: ./dist/bundlestats.json
+          retention-days: 3
 
   # Build current PR and upload it's bundle stats file
   build-pr:
@@ -76,6 +77,7 @@ jobs:
       with:
         name: pr-bundle-stats
         path: ./dist/bundlestats.json
+        retention-days: 3
 
   # Compare bundle stats of main branch and current PR
   compare-bundle:

--- a/.github/workflows/bundle-size-analysis.yml
+++ b/.github/workflows/bundle-size-analysis.yml
@@ -22,17 +22,19 @@ jobs:
 
     steps:
       - name: Checkout master branch 
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3.0.2
         with:
+          repository: mattermost/mattermost-webapp
           ref: master
 
-      - name: Setting up Node v16.10.0
+      - name: Setting up Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 16.10.0
+          node-version-file: '.nvmrc'
+          cache: "npm"
           
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1.6.0
+        run: npm ci
       
       - name: Build app
         run: npm run build
@@ -50,22 +52,21 @@ jobs:
 
     permissions:
       contents: read
+      
+    needs: [build-main]
     
     steps:
     - name: Checkout PR branch 
-      uses: actions/checkout@v3.0.0
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
+      uses: actions/checkout@v3.0.2
     
-    - name: Setting up Node v16.10.0
+    - name: Setting up Node.js
       uses: actions/setup-node@v3.4.1
       with:
-        node-version: 16.10.0
+        node-version-file: '.nvmrc'
+        cache: "npm"
 
     - name: Install dependencies
-      uses: bahmutov/npm-install@v1.6.0
-      with:
-       install-command: npm install --force
+      run: npm ci 
       
     - name: Build app
       run: npm run build
@@ -88,11 +89,6 @@ jobs:
     needs: [build-pr, build-main]
     
     steps:
-      - name: Setting up Node v16.10.0
-        uses: actions/setup-node@v3.4.1
-        with:
-          node-version: 16.10.0
-      
       - name: Downloading Main bundle stats
         uses: actions/download-artifact@v3.0.0
         with:
@@ -102,14 +98,9 @@ jobs:
         uses: actions/download-artifact@v3.0.0
         with:
           name: pr-bundle-stats
-      
-      - name: Checkout action repository
-        uses: actions/checkout@v3.0.0
-        with:
-          repository: github/webpack-bundlesize-compare-action
-    
+          
       - name: Bundlesize compare
-        uses: github/webpack-bundlesize-compare-action@v1.4.0
+        uses: github/webpack-bundlesize-compare-action@v1.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           current-stats-json-path: ./pr-bundle-stats/bundlestats.json

--- a/.github/workflows/bundle-size-analysis.yml
+++ b/.github/workflows/bundle-size-analysis.yml
@@ -6,19 +6,25 @@ on:
       - master
     paths-ignore:
       - "e2e/**"
-      - "**.snap"
       - "**/*.test.jsx?"
       - "**/*.test.tsx?"
+      - "**.snap"
       - "**.yml"
+      - "**.md"
+      - "**.txt"
+      
+permissions: 
+  contents: read
 
 jobs:  
   # Build main branch and upload its's bundle stats file
   build-main:
-    name: "Building master"
+    name: "Master"
     runs-on: ubuntu-latest
-  
-    permissions:
-      contents: read
+    
+    # Only run on prs within the same repository, and not from forks.
+    # as forked prs do not have write permission
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout master branch 
@@ -30,7 +36,7 @@ jobs:
       - name: Setting up Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           cache: "npm"
           
       - name: Install dependencies
@@ -44,15 +50,11 @@ jobs:
         with:
           name: main-bundle-stats
           path: ./dist/bundlestats.json
-          retention-days: 3
 
   # Build current PR and upload it's bundle stats file
   build-pr:
-    name: "Building pr"
+    name: "Pull request"
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
       
     needs: [build-main]
     
@@ -63,7 +65,7 @@ jobs:
     - name: Setting up Node.js
       uses: actions/setup-node@v3.4.1
       with:
-        node-version-file: '.nvmrc'
+        node-version-file: ".nvmrc"
         cache: "npm"
 
     - name: Install dependencies
@@ -77,18 +79,20 @@ jobs:
       with:
         name: pr-bundle-stats
         path: ./dist/bundlestats.json
-        retention-days: 3
 
   # Compare bundle stats of main branch and current PR
   compare-bundle:
-    name: "Compare sizes"
+    name: "Compare"
     runs-on: ubuntu-latest
+    
+    # Since we dont want to block the PR when we are not able to show the bundle size
+    continue-on-error: true
+    
+    needs: [build-pr, build-main]
     
     permissions:
       contents: read
       pull-requests: write
-    
-    needs: [build-pr, build-main]
     
     steps:
       - name: Downloading Main bundle stats
@@ -102,7 +106,7 @@ jobs:
           name: pr-bundle-stats
           
       - name: Bundlesize compare
-        uses: github/webpack-bundlesize-compare-action@v1.5.0
+        uses: github/webpack-bundlesize-compare-action@v1.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           current-stats-json-path: ./pr-bundle-stats/bundlestats.json

--- a/.github/workflows/bundle-size-analysis.yml
+++ b/.github/workflows/bundle-size-analysis.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:  
   # Build main branch and upload its's bundle stats file
   build-main:
-    name: "Master"
+    name: "master"
     runs-on: ubuntu-latest
     
     # Only run on prs within the same repository, and not from forks.

--- a/components/actions_menu/actions_menu.tsx
+++ b/components/actions_menu/actions_menu.tsx
@@ -6,8 +6,6 @@ import classNames from 'classnames';
 import {FormattedMessage, injectIntl, IntlShape} from 'react-intl';
 import './actions_menu.scss';
 
-//sdsd
-
 import {Tooltip} from 'react-bootstrap';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';

--- a/components/actions_menu/actions_menu.tsx
+++ b/components/actions_menu/actions_menu.tsx
@@ -6,6 +6,8 @@ import classNames from 'classnames';
 import {FormattedMessage, injectIntl, IntlShape} from 'react-intl';
 import './actions_menu.scss';
 
+//sdsd
+
 import {Tooltip} from 'react-bootstrap';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';


### PR DESCRIPTION
#### Summary
As per [permissions of github actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) forked prs cannot have write permissions. Hence adding this skipping this CI

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46642

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
