### PR TITLE
[MM-45349] Fix for visible html line breaks in code blocks

### DIFF
--- a/utils/text_formatting.test.jsx
+++ b/utils/text_formatting.test.jsx
@@ -20,6 +20,16 @@ describe('formatText', () => {
             expect(output).toBe(`<span class="all-emoji"><p>${spaces}<span data-emoticon="slightly_smiling_face">${emoji}</span></p></span>`);
         }
     });
+
+    test('code blocks newlines are not converted into <br/> with inline markdown image in the post', () => {
+        const output = formatText('```\nsome text\nsecond line\n```\n ![](https://example.com/image.png)');
+        expect(output).not.toContain('<br/>');
+    });
+
+    test('newlines in post text are converted into <br/> with inline markdown image in the post', () => {
+        const output = formatText('some text\nand some more ![](https://example.com/image.png)');
+        expect(output).toContain('<br/>');
+    });
 });
 
 describe('autolinkAtMentions', () => {

--- a/utils/text_formatting.tsx
+++ b/utils/text_formatting.tsx
@@ -239,9 +239,16 @@ export function formatText(
              * the Markdown.format function removes all duplicate line-breaks beforehand, so it is safe to just
              * replace occurrences which are not followed by opening <p> tags to prevent duplicate line-breaks
              *
-             * @link to regex101.com: https://regex101.com/r/iPZ02c/1
+             * The data-codeblock-code part is a fix for MM-45349 - do not replace newlines with `<br/>`
+             * in code blocks, as they become visible in the message
              */
-            output = output.replace(/[\r\n]+(?!(<p>))/g, '<br/>');
+            output = output.replace(/data-codeblock-code="[^"]+"|[\r\n]+(?!(<p>))/g, (match: string) => {
+                if (match.includes('data-codeblock-code')) {
+                    return match;
+                }
+
+                return '<br/>';
+            });
 
             /*
              * the replacer is not ideal, since it replaces every occurence with a new div


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When a post has a markdown image in it and a code block, all new lines in the code block are converted into `<br/>` and are visible in the code block.

This pull request excludes code blocks from conversion of newlines into `<br/>`.
Relevant unit tests have been added in the text formatting util, too.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-45349

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
