### PR TITLE
Automated cherry pick of #10838

### DIFF
--- a/components/dot_menu/dot_menu.test.tsx
+++ b/components/dot_menu/dot_menu.test.tsx
@@ -49,7 +49,6 @@ describe('components/dot_menu/DotMenu', () => {
         threadReplyCount: 0,
         userId: 'user_id_1',
         showForwardPostNewLabel: false,
-        isPostForwardingEnabled: true,
     };
 
     test('should match snapshot, on Center', () => {

--- a/components/dot_menu/dot_menu.tsx
+++ b/components/dot_menu/dot_menu.tsx
@@ -121,7 +121,6 @@ type Props = {
     userId: string;
     threadId: UserThread['id'];
     isCollapsedThreadsEnabled: boolean;
-    isPostForwardingEnabled?: boolean;
     isFollowingThread?: boolean;
     isMentionedInRootPost?: boolean;
     threadReplyCount?: number;
@@ -467,7 +466,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
 
         const fromWebhook = this.props.post.props?.from_webhook === 'true';
         const fromBot = this.props.post.props?.from_bot === 'true';
-        this.canPostBeForwarded = Boolean(this.props.isPostForwardingEnabled && !(fromWebhook || fromBot || isSystemMessage));
+        this.canPostBeForwarded = !(fromWebhook || fromBot || isSystemMessage);
 
         const forwardPostItemText = (
             <span className={'title-with-new-badge'}>

--- a/components/dot_menu/index.ts
+++ b/components/dot_menu/index.ts
@@ -11,7 +11,7 @@ import {getCurrentUserId, getCurrentUserMentionKeys} from 'mattermost-redux/sele
 import {getCurrentTeamId, getCurrentTeam, getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {makeGetThreadOrSynthetic} from 'mattermost-redux/selectors/entities/threads';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
-import {getIsPostForwardingEnabled, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
@@ -110,7 +110,6 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         }
     }
 
-    const isPostForwardingEnabled = getIsPostForwardingEnabled(state);
     const showForwardPostNewLabel = getGlobalItem(state, Preferences.FORWARD_POST_VIEWED, true);
 
     return {
@@ -128,7 +127,6 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         isFollowingThread,
         isMentionedInRootPost,
         isCollapsedThreadsEnabled: collapsedThreads,
-        isPostForwardingEnabled,
         threadReplyCount,
         isMobileView: getIsMobileView(state),
         showForwardPostNewLabel,

--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -240,10 +240,6 @@ export function isCollapsedThreadsEnabled(state: GlobalState): boolean {
     return isAllowed && (userPreference === Preferences.COLLAPSED_REPLY_THREADS_ON || getConfig(state).CollapsedThreads === CollapsedThreads.ALWAYS_ON);
 }
 
-export function getIsPostForwardingEnabled(state: GlobalState): boolean {
-    return getFeatureFlagValue(state, 'PostForwarding') === 'true';
-}
-
 export function isGroupChannelManuallyVisible(state: GlobalState, channelId: string): boolean {
     return getBool(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channelId, false);
 }


### PR DESCRIPTION
Cherry pick of #10838 on cloud.

/cc  @michelengelen

```release-note
NONE
```