### PR TITLE
Fix error in error handling

### DIFF
--- a/packages/mattermost-redux/src/actions/errors.ts
+++ b/packages/mattermost-redux/src/actions/errors.ts
@@ -5,7 +5,6 @@ import {serializeError, ErrorObject} from 'serialize-error';
 
 import {ErrorTypes} from 'mattermost-redux/action_types';
 import {Client4} from 'mattermost-redux/client';
-import EventEmitter from 'mattermost-redux/utils/event_emitter';
 import {DispatchFunc, ActionFunc} from 'mattermost-redux/types/actions';
 import {LogLevel} from '@mattermost/types/client4';
 import {ServerError} from '@mattermost/types/errors';
@@ -45,8 +44,7 @@ export function logError(error: ServerError, displayable = false, consoleError =
 
         let sendToServer = true;
 
-        const err = error as any;
-        const message = err.stack?.stack || err.stack || '';
+        const message = error.stack || '';
 
         if (message.includes('TypeError: Failed to fetch')) {
             sendToServer = false;
@@ -69,7 +67,6 @@ export function logError(error: ServerError, displayable = false, consoleError =
             serializedError.message = 'A JavaScript error has occurred. Please use the JavaScript console to capture and report the error';
         }
 
-        EventEmitter.emit(ErrorTypes.LOG_ERROR, error);
         dispatch(getLogErrorAction(serializedError, displayable));
 
         return {data: true};

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 export type ServerError = {
+    type?: string;
     server_error_id?: string;
     stack?: string;
     message: string;

--- a/root.tsx
+++ b/root.tsx
@@ -22,7 +22,7 @@ import App from 'components/app';
 // This is for anything that needs to be done for ALL react components.
 // This runs before we start to render anything.
 function preRenderSetup(callwhendone: () => void) {
-    window.onerror = (msg, url, line, column, stack) => {
+    window.onerror = (msg, url, line, column, error) => {
         if (msg === 'ResizeObserver loop limit exceeded') {
             return;
         }
@@ -33,14 +33,15 @@ function preRenderSetup(callwhendone: () => void) {
         }
 
         store.dispatch(
-            logError({
-                type: AnnouncementBarTypes.DEVELOPER,
-                message: 'A JavaScript error in the webapp client has occurred. (msg: ' + msg + ', row: ' + line + ', col: ' + column + ').',
-                stack: stack as any,
-                url,
-            } as any,
-            displayable,
-            true,
+            logError(
+                {
+                    type: AnnouncementBarTypes.DEVELOPER,
+                    message: 'A JavaScript error in the webapp client has occurred. (msg: ' + msg + ', row: ' + line + ', col: ' + column + ').',
+                    stack: error?.stack,
+                    url,
+                },
+                displayable,
+                true,
             ),
         );
     };


### PR DESCRIPTION
This typo was introduced in #9891 and attemptedly fixed in #10095. The first PR confused the type of the 5th parameter to `window.onerror` which caused us to pass an `Error` instead of the `stack` string. The second PR stopped the error that the first PR caused, but we thought that it happened because of inconsistent behaviour between browsers when it was actually just our own code that was a bit messed up.

#### Related Pull Requests
#9891
#10095

#### Release Note
```release-note
NONE
```
