### PR TITLE
[MM-46663] Only enable marketplace command execution when config allows it and user has permission

### DIFF
--- a/actions/command.ts
+++ b/actions/command.ts
@@ -37,6 +37,10 @@ import {GlobalState} from 'types/store';
 import {t} from 'utils/i18n';
 import MarketplaceModal from 'components/plugin_marketplace';
 
+import {haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
+import {Permissions} from 'mattermost-redux/constants';
+import {isMarketplaceEnabled} from 'mattermost-redux/selectors/entities/general';
+
 import {doAppSubmit, openAppsModal, postEphemeralCallResponseForCommandArgs} from './apps';
 
 export function executeCommand(message: string, args: CommandArgs): ActionFunc {
@@ -111,6 +115,16 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
             dispatch(openModal({modalId: ModalIdentifiers.USER_SETTINGS, dialogType: UserSettingsModal, dialogProps: {isContentProductSettings: true}}));
             return {data: true};
         case '/marketplace':
+            // check if user has permissions to access the read plugins
+            if (!haveICurrentTeamPermission(state, Permissions.SYSCONSOLE_READ_PLUGINS)) {
+                return {error: {message: localizeMessage('marketplace_command.no_permission', 'You do not have the appropriate permissions to access the marketplace')}};
+            }
+
+            // check config to see if marketplace is enabled
+            if (!isMarketplaceEnabled(state)) {
+                return {error: {message: localizeMessage('marketplace_command.disabled', 'The marketplace is disabled. Please contact your System Administrator for details.')}};
+            }
+
             dispatch(openModal({modalId: ModalIdentifiers.PLUGIN_MARKETPLACE, dialogType: MarketplaceModal}));
             return {data: true};
         case '/collapse':

--- a/actions/command.ts
+++ b/actions/command.ts
@@ -117,7 +117,7 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
         case '/marketplace':
             // check if user has permissions to access the read plugins
             if (!haveICurrentTeamPermission(state, Permissions.SYSCONSOLE_READ_PLUGINS)) {
-                return {error: {message: localizeMessage('marketplace_command.no_permission', 'You do not have the appropriate permissions to access the marketplace')}};
+                return {error: {message: localizeMessage('marketplace_command.no_permission', 'You do not have the appropriate permissions to access the marketplace.')}};
             }
 
             // check config to see if marketplace is enabled

--- a/components/global_header/left_controls/product_menu/product_menu_list/index.ts
+++ b/components/global_header/left_controls/product_menu/product_menu_list/index.ts
@@ -15,6 +15,7 @@ import {
     getConfig,
     getFirstAdminVisitMarketplaceStatus,
     getLicense,
+    isMarketplaceEnabled,
 } from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
@@ -44,7 +45,7 @@ function mapStateToProps(state: GlobalState) {
     const enableIncomingWebhooks = config.EnableIncomingWebhooks === 'true';
     const enableOAuthServiceProvider = config.EnableOAuthServiceProvider === 'true';
     const enableOutgoingWebhooks = config.EnableOutgoingWebhooks === 'true';
-    const enablePluginMarketplace = config.PluginsEnabled === 'true' && config.EnableMarketplace === 'true';
+    const enablePluginMarketplace = isMarketplaceEnabled(state);
     const canManageTeamIntegrations = (haveICurrentTeamPermission(state, Permissions.MANAGE_SLASH_COMMANDS) || haveICurrentTeamPermission(state, Permissions.MANAGE_OAUTH) || haveICurrentTeamPermission(state, Permissions.MANAGE_INCOMING_WEBHOOKS) || haveICurrentTeamPermission(state, Permissions.MANAGE_OUTGOING_WEBHOOKS));
     const canManageSystemBots = (haveISystemPermission(state, {permission: Permissions.MANAGE_BOTS}) || haveISystemPermission(state, {permission: Permissions.MANAGE_OTHERS_BOTS}));
     const canManageIntegrations = canManageTeamIntegrations || canManageSystemBots;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3883,6 +3883,8 @@
   "login.verified": " Email Verified",
   "manage_channel_groups_modal.search_placeholder": "Search groups",
   "manage_team_groups_modal.search_placeholder": "Search groups",
+  "marketplace_command.disabled": "The marketplace is disabled. Please contact your System Administrator for details.",
+  "marketplace_command.no_permission": "You do not have the appropriate permissions to access the marketplace",
   "marketplace_list.count_total_page": "{startCount, number} - {endCount, number} {total, plural, one {plugin} other {plugins}} of {total, number} total",
   "marketplace_modal.install_plugins": "Install Plugins",
   "marketplace_modal.installing": "Installing...",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3884,7 +3884,7 @@
   "manage_channel_groups_modal.search_placeholder": "Search groups",
   "manage_team_groups_modal.search_placeholder": "Search groups",
   "marketplace_command.disabled": "The marketplace is disabled. Please contact your System Administrator for details.",
-  "marketplace_command.no_permission": "You do not have the appropriate permissions to access the marketplace",
+  "marketplace_command.no_permission": "You do not have the appropriate permissions to access the marketplace.",
   "marketplace_list.count_total_page": "{startCount, number} - {endCount, number} {total, plural, one {plugin} other {plugins}} of {total, number} total",
   "marketplace_modal.install_plugins": "Install Plugins",
   "marketplace_modal.installing": "Installing...",

--- a/packages/mattermost-redux/src/selectors/entities/general.ts
+++ b/packages/mattermost-redux/src/selectors/entities/general.ts
@@ -105,3 +105,11 @@ export function getFirstAdminSetupComplete(state: GlobalState): boolean {
 export function isPerformanceDebuggingEnabled(state: GlobalState): boolean {
     return state.entities.general.config.EnableClientPerformanceDebugging === 'true';
 }
+
+export const isMarketplaceEnabled: (state: GlobalState) => boolean = createSelector(
+    'isMarketplaceEnabled',
+    getConfig,
+    (config) => {
+        return config.PluginsEnabled === 'true' && config.EnableMarketplace === 'true';
+    },
+);


### PR DESCRIPTION
#### Summary
Add checks on the `/marketplace` command to only allow its execution when: 

- the user has the appropriate permission (`sysconsole_read_plugins` - [got it from the server side permission](https://github.com/mattermost/mattermost-server/blob/a5ea445bf9b173515f09a4b71a15c911cf9f35cb/api4/plugin.go#L291))
- the server config has plugins and marketplace enabled


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46663

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- [Has server changes](https://github.com/mattermost/mattermost-server/pull/20919)

#### Screenshots
As a user without permission:
![image](https://user-images.githubusercontent.com/785518/187524298-885cf937-9987-4561-8f84-ce44c3be49a9.png)

When marketplace is disabled in the config:
![image](https://user-images.githubusercontent.com/785518/187524386-90983786-b0f3-41ba-8c98-0a7fe6221f21.png)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
