### PR TITLE
[MM-45597]: made RhsSuggestionList default in ATE

### DIFF
--- a/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/components/advanced_text_editor/advanced_text_editor.tsx
@@ -28,6 +28,7 @@ import KeyboardShortcutSequence, {KEYBOARD_SHORTCUTS} from 'components/keyboard_
 import * as Utils from 'utils/utils';
 import {ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
 import Constants, {Locations} from 'utils/constants';
+import RhsSuggestionList from '../suggestion/rhs_suggestion_list';
 import Tooltip from '../tooltip';
 
 import TexteditorActions from './texteditor_actions';
@@ -392,6 +393,7 @@ const AdvanceTextEditor = ({
                     className='AdvancedTextEditor__cell a11y__region'
                 >
                     <Textbox
+                        suggestionList={RhsSuggestionList}
                         onChange={handleChange}
                         onKeyPress={postMsgKeyPress}
                         onKeyDown={handleKeyDown}


### PR DESCRIPTION
#### Summary
the `RhsSuggestionList` component measures the correct position for itself and therefor is being used as the default suggestionList component for the ATE now.

#### Ticket Link
[MM-45597](https://mattermost.atlassian.net/browse/MM-45597)

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
