### PR TITLE
Hide Top Playbooks Insights widget (temporarily for cloud).

### DIFF
--- a/components/activity_and_insights/activity_and_insights.scss
+++ b/components/activity_and_insights/activity_and_insights.scss
@@ -94,6 +94,10 @@
             }
         }
 
+        .top-playbooks-card {
+            visibility: hidden;
+        }
+
         .top-playbooks-card,
         .top-boards-card {
             .Card__body {


### PR DESCRIPTION
#### Summary

Hiding the Top Playbooks widget, temporarily for the Cloud release. This merge into master will be used for a `cloud` branch cherry-pick and then will be undone on `master`.

#### Ticket Link

n/a


```release-note
NONE
```
