### PR TITLE
updated version for compass-icons package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@floating-ui/react-dom": "0.7.2",
         "@floating-ui/react-dom-interactions": "0.9.1",
         "@mattermost/compass-components": "^0.2.12",
-        "@mattermost/compass-icons": "0.1.24",
+        "@mattermost/compass-icons": "0.1.25",
         "@stripe/react-stripe-js": "1.6.0",
         "@stripe/stripe-js": "1.20.3",
         "@tippyjs/react": "4.2.6",
@@ -4117,9 +4117,9 @@
       }
     },
     "node_modules/@mattermost/compass-icons": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.24.tgz",
-      "integrity": "sha512-UhLFbRPrgHvt2+lUwUq17Ecs6ag+NUtIH0T/zX6agYngvt+tUJZJ3Y2hTu+Dj4/3zeCTKCHkIhacWv6qGleU/A==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.25.tgz",
+      "integrity": "sha512-1fjw3kPUXZL0dfmzz2XJUIXhXcJKFvBEw9QljjYUKiyXgK3EpA1w4TsZqJ3az/7kKq9K8qi8zLBtHw5AXr1HDA==",
       "dependencies": {
         "esm": "3.2.25",
         "fontello-batch-cli": "4.0.0",
@@ -31808,9 +31808,9 @@
       }
     },
     "@mattermost/compass-icons": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.24.tgz",
-      "integrity": "sha512-UhLFbRPrgHvt2+lUwUq17Ecs6ag+NUtIH0T/zX6agYngvt+tUJZJ3Y2hTu+Dj4/3zeCTKCHkIhacWv6qGleU/A==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.25.tgz",
+      "integrity": "sha512-1fjw3kPUXZL0dfmzz2XJUIXhXcJKFvBEw9QljjYUKiyXgK3EpA1w4TsZqJ3az/7kKq9K8qi8zLBtHw5AXr1HDA==",
       "requires": {
         "esm": "3.2.25",
         "fontello-batch-cli": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@floating-ui/react-dom": "0.7.2",
     "@floating-ui/react-dom-interactions": "0.9.1",
     "@mattermost/compass-components": "^0.2.12",
-    "@mattermost/compass-icons": "0.1.24",
+    "@mattermost/compass-icons": "0.1.25",
     "@stripe/react-stripe-js": "1.6.0",
     "@stripe/stripe-js": "1.20.3",
     "@tippyjs/react": "4.2.6",


### PR DESCRIPTION
#### Summary
update the compass-icon package version to the latest release

#### Ticket Link
n/a

#### Related Pull Requests
https://github.com/mattermost/compass-icons/pull/46

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
