### PR TITLE
MM-40387 fix highlighting of reply posts on RHS

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -672,7 +672,9 @@
     word-wrap: break-word;
 
     &:not(.post--editing):not(.post--editing):hover {
-        background-color: rgba(v(center-channel-color-rgb), 0.04);
+        &:not(.post--highlight) {
+            background-color: rgba(v(center-channel-color-rgb), 0.04);
+        }
 
         .PostAttachmentOpenGraph .remove-button {
             display: flex;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR fixes a bug, where clicking on the timestamp of a reply post (when CRT is enabled) does not show it highlighted, but shows the styling applied on hover.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40387

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| ![Screenshot from 2022-09-02 17-50-23](https://user-images.githubusercontent.com/812886/188176062-c46eddec-e8a1-41c8-8812-d2e3ee8485cd.png) | ![Screenshot from 2022-09-02 17-49-38](https://user-images.githubusercontent.com/812886/188176081-846ab301-cdc6-49ea-8bd7-9668487de148.png) |

-->


|  before  |  after  |
|----|----|
| ![Screenshot from 2022-09-02 17-50-23](https://user-images.githubusercontent.com/812886/188176062-c46eddec-e8a1-41c8-8812-d2e3ee8485cd.png) | ![Screenshot from 2022-09-02 17-49-38](https://user-images.githubusercontent.com/812886/188176081-846ab301-cdc6-49ea-8bd7-9668487de148.png) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
