### PR TITLE
invite member modal fits on screen for small screen

### DIFF
--- a/components/invitation_modal/invitation_modal.scss
+++ b/components/invitation_modal/invitation_modal.scss
@@ -1,6 +1,9 @@
 .InvitationModal {
     .modal-dialog {
-        position: absolute;
+        @media screen and (min-width: 640px) {
+            position: absolute;
+        }
+
         top: 50%;
         left: 50%;
         margin: auto;

--- a/components/invitation_modal/invitation_modal.scss
+++ b/components/invitation_modal/invitation_modal.scss
@@ -6,6 +6,9 @@
 
         top: 50%;
         left: 50%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
         margin: auto;
         transform: translate(-50%, -50%) !important;
     }

--- a/components/invitation_modal/invitation_modal.scss
+++ b/components/invitation_modal/invitation_modal.scss
@@ -2,6 +2,7 @@
     .modal-dialog {
         @media screen and (min-width: 640px) {
             position: absolute;
+            width: 600px;
         }
 
         top: 50%;


### PR DESCRIPTION
#### Summary

The PR fixes the squashed invite member modal which happens on smaller screens.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-44799

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.
-->
|  before  |  after  |
|----|----|
| ![Screenshot 2022-09-05 at 10 58 12](https://user-images.githubusercontent.com/841955/188398427-1038e256-a7a6-4840-a3a5-26c1130fca6c.png) | ![Screenshot 2022-09-05 at 10 54 34](https://user-images.githubusercontent.com/841955/188397799-c2aae89e-b86b-4c15-9984-5b47d013fbc4.png) |


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
