### PR TITLE
MM-46865 : Improve return type of 'ActionFunc' of 'mattermost-redux/types/actions'

### DIFF
--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -1276,7 +1276,7 @@ export default class Client4 {
     };
 
     getTeamMembers = (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT, options: GetTeamMembersOpts) => {
-        return this.doFetch<TeamMembership>(
+        return this.doFetch<TeamMembership[]>(
             `${this.getTeamMembersRoute(teamId)}${buildQueryString({page, per_page: perPage, ...options})}`,
             {method: 'get'},
         );

--- a/packages/mattermost-redux/src/actions/groups.ts
+++ b/packages/mattermost-redux/src/actions/groups.ts
@@ -158,7 +158,7 @@ export function getGroup(id: string, includeMemberCount = false): ActionFunc {
     });
 }
 
-export function getGroups(filterAllowReference: false, page = 0, perPage = 10, includeMemberCount = false): ActionFunc {
+export function getGroups(filterAllowReference = false, page = 0, perPage = 10, includeMemberCount = false): ActionFunc {
     return bindClientFunc({
         clientFunc: async (param1, param2, param3, param4) => {
             const result = await Client4.getGroups(param1, param2, param3, param4);
@@ -203,7 +203,7 @@ export function getGroupsNotAssociatedToChannel(channelID: string, q = '', page 
     });
 }
 
-export function getAllGroupsAssociatedToTeam(teamID: string, filterAllowReference: false, includeMemberCount: false): ActionFunc {
+export function getAllGroupsAssociatedToTeam(teamID: string, filterAllowReference = false, includeMemberCount = false): ActionFunc {
     return bindClientFunc({
         clientFunc: async (param1, param2, param3) => {
             const result = await Client4.getAllGroupsAssociatedToTeam(param1, param2, param3);
@@ -219,7 +219,7 @@ export function getAllGroupsAssociatedToTeam(teamID: string, filterAllowReferenc
     });
 }
 
-export function getAllGroupsAssociatedToChannelsInTeam(teamID: string, filterAllowReference: false): ActionFunc {
+export function getAllGroupsAssociatedToChannelsInTeam(teamID: string, filterAllowReference = false): ActionFunc {
     return bindClientFunc({
         clientFunc: async (param1, param2) => {
             const result = await Client4.getAllGroupsAssociatedToChannelsInTeam(param1, param2);
@@ -233,7 +233,7 @@ export function getAllGroupsAssociatedToChannelsInTeam(teamID: string, filterAll
     });
 }
 
-export function getAllGroupsAssociatedToChannel(channelID: string, filterAllowReference: false, includeMemberCount: false): ActionFunc {
+export function getAllGroupsAssociatedToChannel(channelID: string, filterAllowReference = false, includeMemberCount = false): ActionFunc {
     return bindClientFunc({
         clientFunc: async (param1, param2, param3) => {
             const result = await Client4.getAllGroupsAssociatedToChannel(param1, param2, param3);
@@ -249,7 +249,7 @@ export function getAllGroupsAssociatedToChannel(channelID: string, filterAllowRe
     });
 }
 
-export function getGroupsAssociatedToTeam(teamID: string, q = '', page = 0, perPage: number = General.PAGE_SIZE_DEFAULT, filterAllowReference: false): ActionFunc {
+export function getGroupsAssociatedToTeam(teamID: string, q = '', page = 0, perPage: number = General.PAGE_SIZE_DEFAULT, filterAllowReference = false): ActionFunc {
     return bindClientFunc({
         clientFunc: async (param1, param2, param3, param4, param5) => {
             const result = await Client4.getGroupsAssociatedToTeam(param1, param2, param3, param4, param5);

--- a/packages/mattermost-redux/src/actions/teams.ts
+++ b/packages/mattermost-redux/src/actions/teams.ts
@@ -4,30 +4,28 @@
 import {AnyAction} from 'redux';
 import {batchActions} from 'redux-batched-actions';
 
+import {ServerError} from '@mattermost/types/errors';
+import {UserProfile} from '@mattermost/types/users';
+import {Team, TeamMembership, TeamMemberWithError, GetTeamMembersOpts, TeamsWithCount, TeamSearchOpts} from '@mattermost/types/teams';
+
 import {Client4} from 'mattermost-redux/client';
-import {General} from '../constants';
+
+import {General} from 'mattermost-redux/constants';
 import {ChannelTypes, TeamTypes, UserTypes} from 'mattermost-redux/action_types';
+import {GetStateFunc, DispatchFunc, ActionFunc, ActionResult} from 'mattermost-redux/types/actions';
+
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {isCompatibleWithJoinViewTeamPermissions} from 'mattermost-redux/selectors/entities/general';
-
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
-import {GetStateFunc, DispatchFunc, ActionFunc, ActionResult} from 'mattermost-redux/types/actions';
-
-import {Team, TeamMembership, TeamMemberWithError, GetTeamMembersOpts, TeamsWithCount, TeamSearchOpts} from '@mattermost/types/teams';
-
-import {UserProfile} from '@mattermost/types/users';
-
-import {isCollapsedThreadsEnabled} from '../selectors/entities/preferences';
-
-import {selectChannel} from './channels';
-import {logError} from './errors';
-import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
-import {getProfilesByIds, getStatusesByIds} from './users';
-import {loadRolesIfNeeded} from './roles';
+import {getProfilesByIds, getStatusesByIds} from 'mattermost-redux/actions/users';
+import {logError} from 'mattermost-redux/actions/errors';
+import {selectChannel} from 'mattermost-redux/actions/channels';
+import {bindClientFunc, forceLogoutIfNecessary} from 'mattermost-redux/actions/helpers';
+import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
 
 async function getProfilesAndStatusesForMembers(userIds: string[], dispatch: DispatchFunc, getState: GetStateFunc) {
     const {
@@ -111,7 +109,7 @@ export function getMyTeamUnreads(collapsedThreads: boolean, skipCurrentTeam = fa
     };
 }
 
-export function getTeam(teamId: string): ActionFunc {
+export function getTeam(teamId: string): ActionFunc<Team, ServerError> {
     return bindClientFunc({
         clientFunc: Client4.getTeam,
         onSuccess: TeamTypes.RECEIVED_TEAM,
@@ -121,7 +119,7 @@ export function getTeam(teamId: string): ActionFunc {
     });
 }
 
-export function getTeamByName(teamName: string): ActionFunc {
+export function getTeamByName(teamName: string): ActionFunc<Team, ServerError> {
     return bindClientFunc({
         clientFunc: Client4.getTeamByName,
         onSuccess: TeamTypes.RECEIVED_TEAM,
@@ -366,7 +364,7 @@ export function getMyTeamMembers(): ActionFunc {
     };
 }
 
-export function getTeamMembers(teamId: string, page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, options: GetTeamMembersOpts): ActionFunc {
+export function getTeamMembers(teamId: string, page = 0, perPage: number = General.TEAMS_CHUNK_SIZE, options: GetTeamMembersOpts): ActionFunc<TeamMembership[], ServerError> {
     return bindClientFunc({
         clientFunc: Client4.getTeamMembers,
         onRequest: TeamTypes.GET_TEAM_MEMBERS_REQUEST,

--- a/packages/mattermost-redux/src/types/actions.ts
+++ b/packages/mattermost-redux/src/types/actions.ts
@@ -12,10 +12,22 @@ export type Thunk = (b: DispatchFunc, a: GetStateFunc) => Promise<ActionResult> 
 
 export type Action = GenericAction | Thunk | BatchAction | ActionFunc;
 
-export type ActionResult = {
-    data?: any;
-    error?: any;
+export type ActionResult<Data = any, Error = any> = {
+    data?: Data;
+    error?: Error;
 };
 
 export type DispatchFunc = (action: Action, getState?: GetStateFunc | null) => Promise<ActionResult>;
-export type ActionFunc = (dispatch: DispatchFunc, getState: GetStateFunc) => Promise<ActionResult|ActionResult[]> | ActionResult;
+
+/**
+ * Return type of a redux action.
+ * @usage
+ * ActionFunc<ReturnTypeOfData, ErrorTypeReturnedFromServer>
+ */
+export type ActionFunc<Data = any, Error = any> = (
+    dispatch: DispatchFunc,
+    getState: GetStateFunc
+) => Promise<Data extends any[]
+    ? Array<ActionResult<Data, Error>>
+    : ActionResult<Data, Error>>
+| ActionResult<Data, Error>;

--- a/packages/mattermost-redux/src/types/actions.ts
+++ b/packages/mattermost-redux/src/types/actions.ts
@@ -17,17 +17,14 @@ export type ActionResult<Data = any, Error = any> = {
     error?: Error;
 };
 
-export type DispatchFunc = (action: Action, getState?: GetStateFunc | null) => Promise<ActionResult>;
+export type DispatchFunc<Data = any, Error = any> = (action: Action, getState?: GetStateFunc | null) => Promise<ActionResult<Data, Error>>;
 
 /**
  * Return type of a redux action.
  * @usage
- * ActionFunc<ReturnTypeOfData, ErrorTypeReturnedFromServer>
+ * ActionFunc<ReturnTypeOfData, ErrorType>
  */
 export type ActionFunc<Data = any, Error = any> = (
-    dispatch: DispatchFunc,
+    dispatch: DispatchFunc<Data, Error>,
     getState: GetStateFunc
-) => Promise<Data extends any[]
-    ? Array<ActionResult<Data, Error>>
-    : ActionResult<Data, Error>>
-| ActionResult<Data, Error>;
+) => Promise<ActionResult<Data, Error> | Array<ActionResult<Data, Error>>> | ActionResult<Data, Error>;


### PR DESCRIPTION
#### Summary
Adds support to specify Return data and error type of an action using 'ActionFunc' as its return type by use of generics and conditional typing.

🔗 This is part of effort for adding graphQL to channels

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46865

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
