### PR TITLE
improved alternate link placement on login and signup page

### DIFF
--- a/components/login/__snapshots__/login.test.tsx.snap
+++ b/components/login/__snapshots__/login.test.tsx.snap
@@ -44,50 +44,54 @@ exports[`components/login/Login should match snapshot with base login 1`] = `
       </div>
     </div>
     <div
-      className="login-body-card"
+      className="login-body-action"
     >
       <div
-        className="login-body-card-content"
-        onKeyDown={[Function]}
-        tabIndex={0}
+        className="login-body-card"
       >
-        <p
-          className="login-body-card-title"
-        >
-          Log in
-        </p>
         <div
-          className="login-body-card-form"
+          className="login-body-card-content"
+          onKeyDown={[Function]}
+          tabIndex={0}
         >
-          <ForwardRef
-            autoFocus={true}
-            containerClassName="login-body-card-form-input"
-            disabled={false}
-            hasError={false}
-            inputSize="large"
-            name="loginId"
-            onChange={[Function]}
-            placeholder="Email"
-            type="text"
-            value=""
-          />
-          <ForwardRef
-            className="login-body-card-form-password-input"
-            disabled={false}
-            hasError={false}
-            inputSize="large"
-            onChange={[Function]}
-            value=""
-          />
-          <SaveButton
-            btnClass="btn-primary"
-            defaultMessage="Log in"
-            disabled={false}
-            extraClasses="login-body-card-form-button-submit large"
-            onClick={[Function]}
-            saving={false}
-            savingMessage="Logging in…"
-          />
+          <p
+            className="login-body-card-title"
+          >
+            Log in
+          </p>
+          <div
+            className="login-body-card-form"
+          >
+            <ForwardRef
+              autoFocus={true}
+              containerClassName="login-body-card-form-input"
+              disabled={false}
+              hasError={false}
+              inputSize="large"
+              name="loginId"
+              onChange={[Function]}
+              placeholder="Email"
+              type="text"
+              value=""
+            />
+            <ForwardRef
+              className="login-body-card-form-password-input"
+              disabled={false}
+              hasError={false}
+              inputSize="large"
+              onChange={[Function]}
+              value=""
+            />
+            <SaveButton
+              btnClass="btn-primary"
+              defaultMessage="Log in"
+              disabled={false}
+              extraClasses="login-body-card-form-button-submit large"
+              onClick={[Function]}
+              saving={false}
+              savingMessage="Logging in…"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -12,11 +12,14 @@
         display: flex;
         flex-direction: column;
         align-items: flex-end;
+
+        @media (max-width: 700px) {
+            width: 100%;
+        }
     }
 
     .login-body-alternate-link {
         margin-bottom: 18px;
-        margin-left: 60px;
     }
 
     .login-body-content {
@@ -38,6 +41,7 @@
             width: 540px;
             flex-flow: column;
             align-self: flex-start;
+            margin-top: 40px;
 
             .login-body-message-title {
                 padding-right: 60px;

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -8,8 +8,15 @@
     flex-direction: column;
     margin: auto;
 
+    .login-body-action {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+    }
+
     .login-body-alternate-link {
         margin-bottom: 18px;
+        margin-left: 60px;
     }
 
     .login-body-content {

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -41,7 +41,6 @@
             width: 540px;
             flex-flow: column;
             align-self: flex-start;
-            margin-top: 40px;
 
             .login-body-message-title {
                 padding-right: 60px;
@@ -84,6 +83,10 @@
                     margin-bottom: 28px;
                     border-radius: 8px;
                 }
+            }
+
+            &.with-alternate-link {
+                margin-top: 40px;
             }
         }
 

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -736,82 +736,85 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
                         </div>
                     )}
                 </div>
-                <div className={classNames('login-body-card', {'custom-branding': enableCustomBrand, 'with-error': hasError})}>
-                    <div
-                        className='login-body-card-content'
-                        onKeyDown={onEnterKeyDown}
-                        tabIndex={0}
-                    >
-                        <p className='login-body-card-title'>
-                            {getCardTitle()}
-                        </p>
-                        {enableCustomBrand && getMessageSubtitle()}
-                        {alertBanner && (
-                            <AlertBanner
-                                className='login-body-card-banner'
-                                mode={alertBanner.mode}
-                                title={alertBanner.title}
-                                onDismiss={alertBanner.onDismiss ?? dismissAlert}
-                            />
-                        )}
-                        {enableBaseLogin && (
-                            <div className='login-body-card-form'>
-                                <Input
-                                    ref={loginIdInput}
-                                    name='loginId'
-                                    containerClassName='login-body-card-form-input'
-                                    type='text'
-                                    inputSize={SIZE.LARGE}
-                                    value={loginId}
-                                    onChange={handleInputOnChange}
-                                    hasError={hasError}
-                                    placeholder={getInputPlaceholder()}
-                                    disabled={isWaiting}
-                                    autoFocus={true}
+                <div className='login-body-action'>
+                    {!isMobileView && getAlternateLink()}
+                    <div className={classNames('login-body-card', {'custom-branding': enableCustomBrand, 'with-error': hasError})}>
+                        <div
+                            className='login-body-card-content'
+                            onKeyDown={onEnterKeyDown}
+                            tabIndex={0}
+                        >
+                            <p className='login-body-card-title'>
+                                {getCardTitle()}
+                            </p>
+                            {enableCustomBrand && getMessageSubtitle()}
+                            {alertBanner && (
+                                <AlertBanner
+                                    className='login-body-card-banner'
+                                    mode={alertBanner.mode}
+                                    title={alertBanner.title}
+                                    onDismiss={alertBanner.onDismiss ?? dismissAlert}
                                 />
-                                <PasswordInput
-                                    ref={passwordInput}
-                                    className='login-body-card-form-password-input'
-                                    value={password}
-                                    inputSize={SIZE.LARGE}
-                                    onChange={handlePasswordInputOnChange}
-                                    hasError={hasError}
-                                    disabled={isWaiting}
-                                />
-                                {(enableSignInWithUsername || enableSignUpWithEmail) && (
-                                    <div className='login-body-card-form-link'>
-                                        <Link to='/reset_password'>
-                                            {formatMessage({id: 'login.forgot', defaultMessage: 'Forgot your password?'})}
-                                        </Link>
-                                    </div>
-                                )}
-                                <SaveButton
-                                    extraClasses='login-body-card-form-button-submit large'
-                                    saving={isWaiting}
-                                    onClick={preSubmit}
-                                    defaultMessage={formatMessage({id: 'login.logIn', defaultMessage: 'Log in'})}
-                                    savingMessage={formatMessage({id: 'login.logingIn', defaultMessage: 'Logging in…'})}
-                                />
-                            </div>
-                        )}
-                        {enableBaseLogin && enableExternalSignup && (
-                            <div className='login-body-card-form-divider'>
-                                <span className='login-body-card-form-divider-label'>
-                                    {formatMessage({id: 'login.or', defaultMessage: 'or log in with'})}
-                                </span>
-                            </div>
-                        )}
-                        {enableExternalSignup && (
-                            <div className={classNames('login-body-card-form-login-options', {column: !enableBaseLogin})}>
-                                {getExternalLoginOptions().map((option) => (
-                                    <ExternalLoginButton
-                                        key={option.id}
-                                        direction={enableBaseLogin ? undefined : 'column'}
-                                        {...option}
+                            )}
+                            {enableBaseLogin && (
+                                <div className='login-body-card-form'>
+                                    <Input
+                                        ref={loginIdInput}
+                                        name='loginId'
+                                        containerClassName='login-body-card-form-input'
+                                        type='text'
+                                        inputSize={SIZE.LARGE}
+                                        value={loginId}
+                                        onChange={handleInputOnChange}
+                                        hasError={hasError}
+                                        placeholder={getInputPlaceholder()}
+                                        disabled={isWaiting}
+                                        autoFocus={true}
                                     />
-                                ))}
-                            </div>
-                        )}
+                                    <PasswordInput
+                                        ref={passwordInput}
+                                        className='login-body-card-form-password-input'
+                                        value={password}
+                                        inputSize={SIZE.LARGE}
+                                        onChange={handlePasswordInputOnChange}
+                                        hasError={hasError}
+                                        disabled={isWaiting}
+                                    />
+                                    {(enableSignInWithUsername || enableSignUpWithEmail) && (
+                                        <div className='login-body-card-form-link'>
+                                            <Link to='/reset_password'>
+                                                {formatMessage({id: 'login.forgot', defaultMessage: 'Forgot your password?'})}
+                                            </Link>
+                                        </div>
+                                    )}
+                                    <SaveButton
+                                        extraClasses='login-body-card-form-button-submit large'
+                                        saving={isWaiting}
+                                        onClick={preSubmit}
+                                        defaultMessage={formatMessage({id: 'login.logIn', defaultMessage: 'Log in'})}
+                                        savingMessage={formatMessage({id: 'login.logingIn', defaultMessage: 'Logging in…'})}
+                                    />
+                                </div>
+                            )}
+                            {enableBaseLogin && enableExternalSignup && (
+                                <div className='login-body-card-form-divider'>
+                                    <span className='login-body-card-form-divider-label'>
+                                        {formatMessage({id: 'login.or', defaultMessage: 'or log in with'})}
+                                    </span>
+                                </div>
+                            )}
+                            {enableExternalSignup && (
+                                <div className={classNames('login-body-card-form-login-options', {column: !enableBaseLogin})}>
+                                    {getExternalLoginOptions().map((option) => (
+                                        <ExternalLoginButton
+                                            key={option.id}
+                                            direction={enableBaseLogin ? undefined : 'column'}
+                                            {...option}
+                                        />
+                                    ))}
+                                </div>
+                            )}
+                        </div>
                     </div>
                 </div>
             </>
@@ -820,7 +823,6 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
 
     return (
         <div className='login-body'>
-            {!isMobileView && getAlternateLink()}
             <div className='login-body-content'>
                 {getContent()}
             </div>

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -716,7 +716,7 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
 
         return (
             <>
-                <div className={classNames('login-body-message', {'custom-branding': enableCustomBrand, 'with-brand-image': enableCustomBrand && !brandImageError})}>
+                <div className={classNames('login-body-message', {'custom-branding': enableCustomBrand, 'with-brand-image': enableCustomBrand && !brandImageError}, {'with-alternate-link': showSignup})}>
                     {enableCustomBrand && !brandImageError ? (
                         <img
                             className={classNames('login-body-custom-branding-image')}

--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -716,7 +716,16 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
 
         return (
             <>
-                <div className={classNames('login-body-message', {'custom-branding': enableCustomBrand, 'with-brand-image': enableCustomBrand && !brandImageError}, {'with-alternate-link': showSignup})}>
+                <div
+                    className={classNames(
+                        'login-body-message',
+                        {
+                            'custom-branding': enableCustomBrand,
+                            'with-brand-image': enableCustomBrand && !brandImageError,
+                            'with-alternate-link': showSignup && !isMobileView,
+                        },
+                    )}
+                >
                     {enableCustomBrand && !brandImageError ? (
                         <img
                             className={classNames('login-body-custom-branding-image')}

--- a/components/signup/__snapshots__/signup.test.tsx.snap
+++ b/components/signup/__snapshots__/signup.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
     className="signup-body-content"
   >
     <div
-      className="signup-body-message"
+      className="signup-body-message with-alternate-link"
     >
       <h1
         className="signup-body-message-title"
@@ -156,7 +156,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
     className="signup-body-content"
   >
     <div
-      className="signup-body-message"
+      className="signup-body-message with-alternate-link"
     >
       <h1
         className="signup-body-message-title"

--- a/components/signup/__snapshots__/signup.test.tsx.snap
+++ b/components/signup/__snapshots__/signup.test.tsx.snap
@@ -4,12 +4,6 @@ exports[`components/signup/Signup should match snapshot for all signup options e
 <div
   className="signup-body"
 >
-  <AlternateLink
-    alternateLinkLabel="Log in"
-    alternateLinkPath="/login"
-    alternateMessage="Already have an account?"
-    className="signup-body-alternate-link"
-  />
   <div
     className="signup-body-content"
   >
@@ -33,111 +27,121 @@ exports[`components/signup/Signup should match snapshot for all signup options e
       </div>
     </div>
     <div
-      className="signup-body-card"
+      className="signup-body-action"
     >
+      <AlternateLink
+        alternateLinkLabel="Log in"
+        alternateLinkPath="/login"
+        alternateMessage="Already have an account?"
+        className="signup-body-alternate-link"
+      />
       <div
-        className="signup-body-card-content"
-        onKeyDown={[Function]}
-        tabIndex={0}
+        className="signup-body-card"
       >
-        <p
-          className="signup-body-card-title"
-        >
-          Create your account
-        </p>
         <div
-          className="signup-body-card-form"
+          className="signup-body-card-content"
+          onKeyDown={[Function]}
+          tabIndex={0}
         >
-          <ForwardRef
-            autoFocus={true}
-            className="signup-body-card-form-email-input"
-            customMessage={null}
-            disabled={false}
-            inputSize="large"
-            name="email"
-            onChange={[Function]}
-            placeholder="Email address"
-            type="text"
-            value=""
-          />
-          <ForwardRef
-            autoFocus={false}
-            className="signup-body-card-form-name-input"
-            customMessage={
-              Object {
-                "type": "info",
-                "value": "You can use lowercase letters, numbers, periods, dashes, and underscores.",
-              }
-            }
-            disabled={false}
-            inputSize="large"
-            name="name"
-            onChange={[Function]}
-            placeholder="Choose a Username"
-            type="text"
-            value=""
-          />
-          <ForwardRef
-            className="signup-body-card-form-password-input"
-            createMode={true}
-            disabled={false}
-            error=""
-            info="Must be 5-64 characters long."
-            inputSize="large"
-            onChange={[Function]}
-            value=""
-          />
-          <SaveButton
-            btnClass="btn-primary"
-            defaultMessage="Create account"
-            disabled={true}
-            extraClasses="signup-body-card-form-button-submit large"
-            onClick={[Function]}
-            saving={false}
-            savingMessage="Creating account…"
-          />
-        </div>
-        <div
-          className="signup-body-card-form-divider"
-        >
-          <span
-            className="signup-body-card-form-divider-label"
+          <p
+            className="signup-body-card-title"
           >
-            or create an account with
-          </span>
-        </div>
-        <div
-          className="signup-body-card-form-login-options"
-        >
-          <ExternalLoginButton
-            icon={<LoginGitlabIcon />}
-            id="gitlab"
-            key="gitlab"
-            label="GitLab"
-            style={
-              Object {
-                "borderColor": "",
-                "color": "",
+            Create your account
+          </p>
+          <div
+            className="signup-body-card-form"
+          >
+            <ForwardRef
+              autoFocus={true}
+              className="signup-body-card-form-email-input"
+              customMessage={null}
+              disabled={false}
+              inputSize="large"
+              name="email"
+              onChange={[Function]}
+              placeholder="Email address"
+              type="text"
+              value=""
+            />
+            <ForwardRef
+              autoFocus={false}
+              className="signup-body-card-form-name-input"
+              customMessage={
+                Object {
+                  "type": "info",
+                  "value": "You can use lowercase letters, numbers, periods, dashes, and underscores.",
+                }
               }
-            }
-            url="/oauth/gitlab/signup"
-          />
-        </div>
-        <p
-          className="signup-body-card-agreement"
-        >
-          <FormattedMarkdownMessage
-            defaultMessage="By proceeding to create your account and use {siteName}, you agree to our [Terms of Use]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}."
-            id="create_team.agreement"
-            values={
-              Object {
-                "PrivacyPolicyLink": "!undefined",
-                "TermsOfServiceLink": "!undefined",
-                "siteName": "Mattermost",
+              disabled={false}
+              inputSize="large"
+              name="name"
+              onChange={[Function]}
+              placeholder="Choose a Username"
+              type="text"
+              value=""
+            />
+            <ForwardRef
+              className="signup-body-card-form-password-input"
+              createMode={true}
+              disabled={false}
+              error=""
+              info="Must be 5-64 characters long."
+              inputSize="large"
+              onChange={[Function]}
+              value=""
+            />
+            <SaveButton
+              btnClass="btn-primary"
+              defaultMessage="Create account"
+              disabled={true}
+              extraClasses="signup-body-card-form-button-submit large"
+              onClick={[Function]}
+              saving={false}
+              savingMessage="Creating account…"
+            />
+          </div>
+          <div
+            className="signup-body-card-form-divider"
+          >
+            <span
+              className="signup-body-card-form-divider-label"
+            >
+              or create an account with
+            </span>
+          </div>
+          <div
+            className="signup-body-card-form-login-options"
+          >
+            <ExternalLoginButton
+              icon={<LoginGitlabIcon />}
+              id="gitlab"
+              key="gitlab"
+              label="GitLab"
+              style={
+                Object {
+                  "borderColor": "",
+                  "color": "",
+                }
               }
-            }
-          />
-        </p>
+              url="/oauth/gitlab/signup"
+            />
+          </div>
+          <p
+            className="signup-body-card-agreement"
+          >
+            <FormattedMarkdownMessage
+              defaultMessage="By proceeding to create your account and use {siteName}, you agree to our [Terms of Use]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}."
+              id="create_team.agreement"
+              values={
+                Object {
+                  "PrivacyPolicyLink": "!undefined",
+                  "TermsOfServiceLink": "!undefined",
+                  "siteName": "Mattermost",
+                }
+              }
+            />
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -148,12 +152,6 @@ exports[`components/signup/Signup should match snapshot for all signup options e
 <div
   className="signup-body"
 >
-  <AlternateLink
-    alternateLinkLabel="Log in"
-    alternateLinkPath="/login"
-    alternateMessage="Already have an account?"
-    className="signup-body-alternate-link"
-  />
   <div
     className="signup-body-content"
   >
@@ -177,152 +175,162 @@ exports[`components/signup/Signup should match snapshot for all signup options e
       </div>
     </div>
     <div
-      className="signup-body-card"
+      className="signup-body-action"
     >
+      <AlternateLink
+        alternateLinkLabel="Log in"
+        alternateLinkPath="/login"
+        alternateMessage="Already have an account?"
+        className="signup-body-alternate-link"
+      />
       <div
-        className="signup-body-card-content"
-        onKeyDown={[Function]}
-        tabIndex={0}
+        className="signup-body-card"
       >
-        <p
-          className="signup-body-card-title"
-        >
-          Create your account
-        </p>
         <div
-          className="signup-body-card-form"
+          className="signup-body-card-content"
+          onKeyDown={[Function]}
+          tabIndex={0}
         >
-          <ForwardRef
-            autoFocus={true}
-            className="signup-body-card-form-email-input"
-            customMessage={null}
-            disabled={false}
-            inputSize="large"
-            name="email"
-            onChange={[Function]}
-            placeholder="Email address"
-            type="text"
-            value=""
-          />
-          <ForwardRef
-            autoFocus={false}
-            className="signup-body-card-form-name-input"
-            customMessage={
-              Object {
-                "type": "info",
-                "value": "You can use lowercase letters, numbers, periods, dashes, and underscores.",
-              }
-            }
-            disabled={false}
-            inputSize="large"
-            name="name"
-            onChange={[Function]}
-            placeholder="Choose a Username"
-            type="text"
-            value=""
-          />
-          <ForwardRef
-            className="signup-body-card-form-password-input"
-            createMode={true}
-            disabled={false}
-            error=""
-            info="Must be 5-64 characters long."
-            inputSize="large"
-            onChange={[Function]}
-            value=""
-          />
-          <SaveButton
-            btnClass="btn-primary"
-            defaultMessage="Create account"
-            disabled={true}
-            extraClasses="signup-body-card-form-button-submit large"
-            onClick={[Function]}
-            saving={false}
-            savingMessage="Creating account…"
-          />
-        </div>
-        <div
-          className="signup-body-card-form-divider"
-        >
-          <span
-            className="signup-body-card-form-divider-label"
+          <p
+            className="signup-body-card-title"
           >
-            or create an account with
-          </span>
+            Create your account
+          </p>
+          <div
+            className="signup-body-card-form"
+          >
+            <ForwardRef
+              autoFocus={true}
+              className="signup-body-card-form-email-input"
+              customMessage={null}
+              disabled={false}
+              inputSize="large"
+              name="email"
+              onChange={[Function]}
+              placeholder="Email address"
+              type="text"
+              value=""
+            />
+            <ForwardRef
+              autoFocus={false}
+              className="signup-body-card-form-name-input"
+              customMessage={
+                Object {
+                  "type": "info",
+                  "value": "You can use lowercase letters, numbers, periods, dashes, and underscores.",
+                }
+              }
+              disabled={false}
+              inputSize="large"
+              name="name"
+              onChange={[Function]}
+              placeholder="Choose a Username"
+              type="text"
+              value=""
+            />
+            <ForwardRef
+              className="signup-body-card-form-password-input"
+              createMode={true}
+              disabled={false}
+              error=""
+              info="Must be 5-64 characters long."
+              inputSize="large"
+              onChange={[Function]}
+              value=""
+            />
+            <SaveButton
+              btnClass="btn-primary"
+              defaultMessage="Create account"
+              disabled={true}
+              extraClasses="signup-body-card-form-button-submit large"
+              onClick={[Function]}
+              saving={false}
+              savingMessage="Creating account…"
+            />
+          </div>
+          <div
+            className="signup-body-card-form-divider"
+          >
+            <span
+              className="signup-body-card-form-divider-label"
+            >
+              or create an account with
+            </span>
+          </div>
+          <div
+            className="signup-body-card-form-login-options"
+          >
+            <ExternalLoginButton
+              icon={<LoginGitlabIcon />}
+              id="gitlab"
+              key="gitlab"
+              label="GitLab"
+              style={
+                Object {
+                  "borderColor": "",
+                  "color": "",
+                }
+              }
+              url="/oauth/gitlab/signup"
+            />
+            <ExternalLoginButton
+              icon={<LoginGoggleIcon />}
+              id="google"
+              key="google"
+              label="Google"
+              url="/oauth/google/signup"
+            />
+            <ExternalLoginButton
+              icon={<LoginOffice365Icon />}
+              id="office365"
+              key="office365"
+              label="Office 365"
+              url="/oauth/office365/signup"
+            />
+            <ExternalLoginButton
+              icon={<LoginOpenIdIcon />}
+              id="openid"
+              key="openid"
+              label="Open ID"
+              style={
+                Object {
+                  "borderColor": "",
+                  "color": "",
+                }
+              }
+              url="/oauth/openid/signup"
+            />
+            <ExternalLoginButton
+              icon={<LockIcon />}
+              id="ldap"
+              key="ldap"
+              label="AD/LDAP Credentials"
+              url="/login?extra=create_ldap"
+            />
+            <ExternalLoginButton
+              icon={<LockIcon />}
+              id="saml"
+              key="saml"
+              label="SAML"
+              url="/login/sso/saml?action=signup"
+            />
+          </div>
+          <p
+            className="signup-body-card-agreement"
+          >
+            <FormattedMarkdownMessage
+              defaultMessage="By proceeding to create your account and use {siteName}, you agree to our [Terms of Use]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}."
+              id="create_team.agreement"
+              values={
+                Object {
+                  "PrivacyPolicyLink": "!undefined",
+                  "TermsOfServiceLink": "!undefined",
+                  "siteName": "Mattermost",
+                }
+              }
+            />
+          </p>
         </div>
-        <div
-          className="signup-body-card-form-login-options"
-        >
-          <ExternalLoginButton
-            icon={<LoginGitlabIcon />}
-            id="gitlab"
-            key="gitlab"
-            label="GitLab"
-            style={
-              Object {
-                "borderColor": "",
-                "color": "",
-              }
-            }
-            url="/oauth/gitlab/signup"
-          />
-          <ExternalLoginButton
-            icon={<LoginGoggleIcon />}
-            id="google"
-            key="google"
-            label="Google"
-            url="/oauth/google/signup"
-          />
-          <ExternalLoginButton
-            icon={<LoginOffice365Icon />}
-            id="office365"
-            key="office365"
-            label="Office 365"
-            url="/oauth/office365/signup"
-          />
-          <ExternalLoginButton
-            icon={<LoginOpenIdIcon />}
-            id="openid"
-            key="openid"
-            label="Open ID"
-            style={
-              Object {
-                "borderColor": "",
-                "color": "",
-              }
-            }
-            url="/oauth/openid/signup"
-          />
-          <ExternalLoginButton
-            icon={<LockIcon />}
-            id="ldap"
-            key="ldap"
-            label="AD/LDAP Credentials"
-            url="/login?extra=create_ldap"
-          />
-          <ExternalLoginButton
-            icon={<LockIcon />}
-            id="saml"
-            key="saml"
-            label="SAML"
-            url="/login/sso/saml?action=signup"
-          />
-        </div>
-        <p
-          className="signup-body-card-agreement"
-        >
-          <FormattedMarkdownMessage
-            defaultMessage="By proceeding to create your account and use {siteName}, you agree to our [Terms of Use]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}."
-            id="create_team.agreement"
-            values={
-              Object {
-                "PrivacyPolicyLink": "!undefined",
-                "TermsOfServiceLink": "!undefined",
-                "siteName": "Mattermost",
-              }
-            }
-          />
-        </p>
       </div>
     </div>
   </div>

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -67,7 +67,6 @@
             width: 540px;
             flex-flow: column;
             align-self: flex-start;
-            margin-top: 40px;
 
             .signup-body-message-title {
                 padding-right: 60px;
@@ -104,12 +103,20 @@
                     }
                 }
 
+                .signup-body-message-subtitle {
+                    padding-right: 0;
+                }
+
                 .signup-body-custom-branding-image {
                     max-height: 540px;
                     align-self: center;
                     margin-bottom: 28px;
                     border-radius: 8px;
                 }
+            }
+
+            &.with-alternate-link {
+                margin-top: 40px;
             }
         }
 

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -8,8 +8,15 @@
     flex-direction: column;
     margin: auto;
 
+    .signup-body-action {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+    }
+
     .signup-body-alternate-link {
         margin-bottom: 18px;
+        margin-left: 60px;
     }
 
     .signup-body-content {

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -12,11 +12,14 @@
         display: flex;
         flex-direction: column;
         align-items: flex-end;
+
+        @media (max-width: 700px) {
+            width: 100%;
+        }
     }
 
     .signup-body-alternate-link {
         margin-bottom: 18px;
-        margin-left: 60px;
     }
 
     .signup-body-content {
@@ -64,6 +67,7 @@
             width: 540px;
             flex-flow: column;
             align-self: flex-start;
+            margin-top: 40px;
 
             .signup-body-message-title {
                 padding-right: 60px;

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -605,7 +605,16 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
         return (
             <>
-                <div className={classNames('signup-body-message', {'custom-branding': enableCustomBrand, 'with-brand-image': enableCustomBrand && !brandImageError})}>
+                <div
+                    className={classNames(
+                        'signup-body-message',
+                        {
+                            'custom-branding': enableCustomBrand,
+                            'with-brand-image': enableCustomBrand && !brandImageError,
+                            'with-alternate-link': !isMobileView,
+                        },
+                    )}
+                >
                     {enableCustomBrand && !brandImageError ? (
                         <img
                             className={classNames('signup-body-custom-branding-image')}

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -625,115 +625,118 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
                         </div>
                     )}
                 </div>
-                <div className={classNames('signup-body-card', {'custom-branding': enableCustomBrand, 'with-error': hasError})}>
-                    <div
-                        className='signup-body-card-content'
-                        onKeyDown={onEnterKeyDown}
-                        tabIndex={0}
-                    >
-                        <p className='signup-body-card-title'>
-                            {getCardTitle()}
-                        </p>
-                        {enableCustomBrand && getMessageSubtitle()}
-                        {alertBanner && (
-                            <AlertBanner
-                                className='login-body-card-banner'
-                                mode={alertBanner.mode}
-                                title={alertBanner.title}
-                                onDismiss={alertBanner.onDismiss}
-                            />
-                        )}
-                        {enableSignUpWithEmail && (
-                            <div className='signup-body-card-form'>
-                                <Input
-                                    ref={emailInput}
-                                    name='email'
-                                    className='signup-body-card-form-email-input'
-                                    type='text'
-                                    inputSize={SIZE.LARGE}
-                                    value={email}
-                                    onChange={handleEmailOnChange}
-                                    placeholder={formatMessage({
-                                        id: 'signup_user_completed.emailLabel',
-                                        defaultMessage: 'Email address',
-                                    })}
-                                    disabled={isWaiting || Boolean(parsedEmail)}
-                                    autoFocus={true}
-                                    customMessage={emailCustomLabelForInput}
-                                />
-                                <Input
-                                    ref={nameInput}
-                                    name='name'
-                                    className='signup-body-card-form-name-input'
-                                    type='text'
-                                    inputSize={SIZE.LARGE}
-                                    value={name}
-                                    onChange={handleNameOnChange}
-                                    placeholder={formatMessage({
-                                        id: 'signup_user_completed.chooseUser',
-                                        defaultMessage: 'Choose a Username',
-                                    })}
-                                    disabled={isWaiting}
-                                    autoFocus={Boolean(parsedEmail)}
-                                    customMessage={
-                                        nameError ? {type: ItemStatus.ERROR, value: nameError} : {
-                                            type: ItemStatus.INFO,
-                                            value: formatMessage({id: 'signup_user_completed.userHelp', defaultMessage: 'You can use lowercase letters, numbers, periods, dashes, and underscores.'}),
-                                        }
-                                    }
-                                />
-                                <PasswordInput
-                                    ref={passwordInput}
-                                    className='signup-body-card-form-password-input'
-                                    value={password}
-                                    inputSize={SIZE.LARGE}
-                                    onChange={handlePasswordInputOnChange}
-                                    disabled={isWaiting}
-                                    createMode={true}
-                                    info={passwordInfo as string}
-                                    error={passwordError}
-                                />
-                                <SaveButton
-                                    extraClasses='signup-body-card-form-button-submit large'
-                                    saving={isWaiting}
-                                    disabled={!canSubmit}
-                                    onClick={handleSubmit}
-                                    defaultMessage={formatMessage({id: 'signup_user_completed.create', defaultMessage: 'Create account'})}
-                                    savingMessage={formatMessage({id: 'signup_user_completed.saving', defaultMessage: 'Creating account…'})}
-                                />
-                            </div>
-                        )}
-                        {enableSignUpWithEmail && enableExternalSignup && (
-                            <div className='signup-body-card-form-divider'>
-                                <span className='signup-body-card-form-divider-label'>
-                                    {formatMessage({id: 'signup_user_completed.or', defaultMessage: 'or create an account with'})}
-                                </span>
-                            </div>
-                        )}
-                        {enableExternalSignup && (
-                            <div className={classNames('signup-body-card-form-login-options', {column: !enableSignUpWithEmail})}>
-                                {getExternalSignupOptions().map((option) => (
-                                    <ExternalLoginButton
-                                        key={option.id}
-                                        direction={enableSignUpWithEmail ? undefined : 'column'}
-                                        {...option}
-                                    />
-                                ))}
-                            </div>
-                        )}
-                        {enableSignUpWithEmail && !serverError && (
-                            <p className='signup-body-card-agreement'>
-                                <FormattedMarkdownMessage
-                                    id='create_team.agreement'
-                                    defaultMessage='By proceeding to create your account and use {siteName}, you agree to our [Terms of Use]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}.'
-                                    values={{
-                                        siteName: SiteName,
-                                        TermsOfServiceLink: `!${TermsOfServiceLink}`,
-                                        PrivacyPolicyLink: `!${PrivacyPolicyLink}`,
-                                    }}
-                                />
+                <div className='signup-body-action'>
+                    {!isMobileView && getAlternateLink()}
+                    <div className={classNames('signup-body-card', {'custom-branding': enableCustomBrand, 'with-error': hasError})}>
+                        <div
+                            className='signup-body-card-content'
+                            onKeyDown={onEnterKeyDown}
+                            tabIndex={0}
+                        >
+                            <p className='signup-body-card-title'>
+                                {getCardTitle()}
                             </p>
-                        )}
+                            {enableCustomBrand && getMessageSubtitle()}
+                            {alertBanner && (
+                                <AlertBanner
+                                    className='login-body-card-banner'
+                                    mode={alertBanner.mode}
+                                    title={alertBanner.title}
+                                    onDismiss={alertBanner.onDismiss}
+                                />
+                            )}
+                            {enableSignUpWithEmail && (
+                                <div className='signup-body-card-form'>
+                                    <Input
+                                        ref={emailInput}
+                                        name='email'
+                                        className='signup-body-card-form-email-input'
+                                        type='text'
+                                        inputSize={SIZE.LARGE}
+                                        value={email}
+                                        onChange={handleEmailOnChange}
+                                        placeholder={formatMessage({
+                                            id: 'signup_user_completed.emailLabel',
+                                            defaultMessage: 'Email address',
+                                        })}
+                                        disabled={isWaiting || Boolean(parsedEmail)}
+                                        autoFocus={true}
+                                        customMessage={emailCustomLabelForInput}
+                                    />
+                                    <Input
+                                        ref={nameInput}
+                                        name='name'
+                                        className='signup-body-card-form-name-input'
+                                        type='text'
+                                        inputSize={SIZE.LARGE}
+                                        value={name}
+                                        onChange={handleNameOnChange}
+                                        placeholder={formatMessage({
+                                            id: 'signup_user_completed.chooseUser',
+                                            defaultMessage: 'Choose a Username',
+                                        })}
+                                        disabled={isWaiting}
+                                        autoFocus={Boolean(parsedEmail)}
+                                        customMessage={
+                                            nameError ? {type: ItemStatus.ERROR, value: nameError} : {
+                                                type: ItemStatus.INFO,
+                                                value: formatMessage({id: 'signup_user_completed.userHelp', defaultMessage: 'You can use lowercase letters, numbers, periods, dashes, and underscores.'}),
+                                            }
+                                        }
+                                    />
+                                    <PasswordInput
+                                        ref={passwordInput}
+                                        className='signup-body-card-form-password-input'
+                                        value={password}
+                                        inputSize={SIZE.LARGE}
+                                        onChange={handlePasswordInputOnChange}
+                                        disabled={isWaiting}
+                                        createMode={true}
+                                        info={passwordInfo as string}
+                                        error={passwordError}
+                                    />
+                                    <SaveButton
+                                        extraClasses='signup-body-card-form-button-submit large'
+                                        saving={isWaiting}
+                                        disabled={!canSubmit}
+                                        onClick={handleSubmit}
+                                        defaultMessage={formatMessage({id: 'signup_user_completed.create', defaultMessage: 'Create account'})}
+                                        savingMessage={formatMessage({id: 'signup_user_completed.saving', defaultMessage: 'Creating account…'})}
+                                    />
+                                </div>
+                            )}
+                            {enableSignUpWithEmail && enableExternalSignup && (
+                                <div className='signup-body-card-form-divider'>
+                                    <span className='signup-body-card-form-divider-label'>
+                                        {formatMessage({id: 'signup_user_completed.or', defaultMessage: 'or create an account with'})}
+                                    </span>
+                                </div>
+                            )}
+                            {enableExternalSignup && (
+                                <div className={classNames('signup-body-card-form-login-options', {column: !enableSignUpWithEmail})}>
+                                    {getExternalSignupOptions().map((option) => (
+                                        <ExternalLoginButton
+                                            key={option.id}
+                                            direction={enableSignUpWithEmail ? undefined : 'column'}
+                                            {...option}
+                                        />
+                                    ))}
+                                </div>
+                            )}
+                            {enableSignUpWithEmail && !serverError && (
+                                <p className='signup-body-card-agreement'>
+                                    <FormattedMarkdownMessage
+                                        id='create_team.agreement'
+                                        defaultMessage='By proceeding to create your account and use {siteName}, you agree to our [Terms of Use]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}.'
+                                        values={{
+                                            siteName: SiteName,
+                                            TermsOfServiceLink: `!${TermsOfServiceLink}`,
+                                            PrivacyPolicyLink: `!${PrivacyPolicyLink}`,
+                                        }}
+                                    />
+                                </p>
+                            )}
+                        </div>
                     </div>
                 </div>
             </>
@@ -742,7 +745,6 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
     return (
         <div className='signup-body'>
-            {!isMobileView && getAlternateLink()}
             <div className='signup-body-content'>
                 {getContent()}
             </div>


### PR DESCRIPTION
#### Summary

Currently, the alternate link anchors away from the login and signup form if the brand description or brand image occupies alot of space. This PR fixes it so the alternate link remains in its place

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45803

#### Screenshots

|  before  |  after  |
|----|----|
| ![login-before](https://user-images.githubusercontent.com/841955/188657549-876cc31b-de76-40e3-a269-2cd5144ff2d0.png) | ![login-after](https://user-images.githubusercontent.com/841955/188657593-fd9b54b6-d030-4faf-b9e4-6e95faa2eb87.png) |

#### Release Note
```release-note
NONE
```
