### PR TITLE
Fix plugin ChannelHeaderMenu component shouldRender function check

### DIFF
--- a/selectors/plugins.ts
+++ b/selectors/plugins.ts
@@ -47,7 +47,13 @@ const getChannelHeaderMenuPluginComponentsShouldRender = createSelector(
     (state: GlobalState) => state,
     (state: GlobalState) => state.plugins.components.ChannelHeader,
     (state, channelHeaderMenuComponents = []) => {
-        return channelHeaderMenuComponents.map((component) => !component.shouldRender || component.shouldRender(state));
+        return channelHeaderMenuComponents.map((component) => {
+            if (typeof component.shouldRender === 'function') {
+                return component.shouldRender(state);
+            }
+
+            return true;
+        });
     },
 );
 


### PR DESCRIPTION
#### Summary

This PR adds a check to ensure the `shouldRender` argument is a function before attempting to call it. More info is in the linked ticket.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46695

#### Related Pull Requests

- https://github.com/mattermost/mattermost-webapp/pull/10400

#### Release Note

```release-note
NONE
```
