### PR TITLE
MM-44921_First admin signup in new server briefly flashes error screen

### DIFF
--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -560,7 +560,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
             );
         }
 
-        if (noOpenServer || serverError || usedBefore) {
+        if (!isWaiting && (noOpenServer || serverError || usedBefore)) {
             const titleColumn = noOpenServer ? (
                 formatMessage({id: 'signup_user_completed.no_open_server.title', defaultMessage: 'This server doesn’t allow open signups'})
             ) : (


### PR DESCRIPTION
#### Summary
In a brand new server with no users, after the signup completes and before redirecting to the create team screen, there should not be a brief flash of an error of “No signups allowed”.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44921

#### Screenshots
##### Before
https://user-images.githubusercontent.com/79058848/188735314-bc9f51cb-d76f-479e-874e-d3f285a1b983.mp4

##### After
https://user-images.githubusercontent.com/79058848/188728681-c5cd1de0-69f0-46cf-a55b-0ed6405ae9bf.mp4

#### Release Note
```release-note
NONE
```
