### PR TITLE
[MM-46903] Fix synching of plugin enabled state in redux store

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -1266,6 +1266,7 @@ function handleChannelViewedEvent(msg) {
 
 export function handlePluginEnabled(msg) {
     const manifest = msg.data.manifest;
+    dispatch({type: ActionTypes.RECEIVED_WEBAPP_PLUGIN, data: manifest});
 
     loadPlugin(manifest).catch((error) => {
         console.error(error.message); //eslint-disable-line no-console

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -838,18 +838,30 @@ describe('handlePluginEnabled/handlePluginDisabled', () => {
             const mockComponent = 'mockRootComponent';
             registery.registerRootComponent(mockComponent);
 
-            const dispatchArg = store.dispatch.mock.calls[0][0];
+            let dispatchArg = store.dispatch.mock.calls[0][0];
+            expect(dispatchArg.type).toBe(ActionTypes.RECEIVED_WEBAPP_PLUGIN);
+            expect(dispatchArg.data).toBe(manifest);
+
+            dispatchArg = store.dispatch.mock.calls[1][0];
+
             expect(dispatchArg.type).toBe(ActionTypes.RECEIVED_PLUGIN_COMPONENT);
             expect(dispatchArg.name).toBe('Root');
             expect(dispatchArg.data.component).toBe(mockComponent);
             expect(dispatchArg.data.pluginId).toBe(manifest.id);
+
+            expect(store.dispatch).toHaveBeenCalledTimes(2);
 
             // Assert handlePluginEnabled is idempotent
             mockScript.onload = undefined;
             handlePluginEnabled({data: {manifest}});
             expect(mockScript.onload).toBeUndefined();
 
-            expect(store.dispatch).toHaveBeenCalledTimes(1);
+            dispatchArg = store.dispatch.mock.calls[2][0];
+            expect(dispatchArg.type).toBe(ActionTypes.RECEIVED_WEBAPP_PLUGIN);
+            expect(dispatchArg.data).toBe(manifest);
+
+            expect(store.dispatch).toHaveBeenCalledTimes(3);
+
             expect(console.error).toHaveBeenCalledTimes(0);
         });
 
@@ -867,6 +879,7 @@ describe('handlePluginEnabled/handlePluginDisabled', () => {
 
             const manifestv2 = {
                 ...manifest,
+                version: '0.2.1',
                 webapp: {
                     bundle_path: 'webapp/dist/main2.0.js',
                 },
@@ -890,11 +903,15 @@ describe('handlePluginEnabled/handlePluginDisabled', () => {
             const mockComponent = 'mockRootComponent';
             registry.registerRootComponent(mockComponent);
 
-            const dispatchReceivedArg = store.dispatch.mock.calls[0][0];
-            expect(dispatchReceivedArg.type).toBe(ActionTypes.RECEIVED_PLUGIN_COMPONENT);
-            expect(dispatchReceivedArg.name).toBe('Root');
-            expect(dispatchReceivedArg.data.component).toBe(mockComponent);
-            expect(dispatchReceivedArg.data.pluginId).toBe(manifest.id);
+            let dispatchArg = store.dispatch.mock.calls[0][0];
+            expect(dispatchArg.type).toBe(ActionTypes.RECEIVED_WEBAPP_PLUGIN);
+            expect(dispatchArg.data).toBe(manifest);
+
+            dispatchArg = store.dispatch.mock.calls[1][0];
+            expect(dispatchArg.type).toBe(ActionTypes.RECEIVED_PLUGIN_COMPONENT);
+            expect(dispatchArg.name).toBe('Root');
+            expect(dispatchArg.data.component).toBe(mockComponent);
+            expect(dispatchArg.data.pluginId).toBe(manifest.id);
 
             // Upgrade plugin
             mockScript.onload = undefined;
@@ -913,19 +930,28 @@ describe('handlePluginEnabled/handlePluginDisabled', () => {
             const mockComponent2 = 'mockRootComponent2';
             registry2.registerRootComponent(mockComponent2);
 
-            expect(store.dispatch).toHaveBeenCalledTimes(3);
-            const dispatchRemovedArg = store.dispatch.mock.calls[1][0];
+            dispatchArg = store.dispatch.mock.calls[2][0];
+            expect(dispatchArg.type).toBe(ActionTypes.RECEIVED_WEBAPP_PLUGIN);
+            expect(dispatchArg.data).toBe(manifestv2);
+
+            expect(store.dispatch).toHaveBeenCalledTimes(6);
+            const dispatchRemovedArg = store.dispatch.mock.calls[3][0];
             expect(typeof dispatchRemovedArg).toBe('function');
             dispatchRemovedArg(store.dispatch);
 
-            const dispatchReceivedArg2 = store.dispatch.mock.calls[2][0];
+            dispatchArg = store.dispatch.mock.calls[4][0];
+            expect(dispatchArg.type).toBe(ActionTypes.RECEIVED_WEBAPP_PLUGIN);
+            expect(dispatchArg.data).toBe(manifestv2);
+
+            const dispatchReceivedArg2 = store.dispatch.mock.calls[5][0];
             expect(dispatchReceivedArg2.type).toBe(ActionTypes.RECEIVED_PLUGIN_COMPONENT);
             expect(dispatchReceivedArg2.name).toBe('Root');
             expect(dispatchReceivedArg2.data.component).toBe(mockComponent2);
             expect(dispatchReceivedArg2.data.pluginId).toBe(manifest.id);
 
-            expect(store.dispatch).toHaveBeenCalledTimes(5);
-            const dispatchReceivedArg4 = store.dispatch.mock.calls[4][0];
+            expect(store.dispatch).toHaveBeenCalledTimes(8);
+            const dispatchReceivedArg4 = store.dispatch.mock.calls[7][0];
+
             expect(dispatchReceivedArg4.type).toBe(ActionTypes.REMOVED_WEBAPP_PLUGIN);
             expect(dispatchReceivedArg4.data).toBe(manifestv2);
 
@@ -991,13 +1017,19 @@ describe('handlePluginEnabled/handlePluginDisabled', () => {
             // Assert handlePluginDisabled is idempotent
             handlePluginDisabled({data: {manifest}});
 
-            expect(store.dispatch).toHaveBeenCalledTimes(2);
-            const dispatchRemovedArg = store.dispatch.mock.calls[0][0];
+            expect(store.dispatch).toHaveBeenCalledTimes(3);
+
+            const dispatchArg = store.dispatch.mock.calls[0][0];
+            expect(dispatchArg.type).toBe(ActionTypes.RECEIVED_WEBAPP_PLUGIN);
+            expect(dispatchArg.data).toBe(manifest);
+
+            const dispatchRemovedArg = store.dispatch.mock.calls[1][0];
+
             expect(typeof dispatchRemovedArg).toBe('function');
             dispatchRemovedArg(store.dispatch);
 
-            expect(store.dispatch).toHaveBeenCalledTimes(4);
-            const dispatchReceivedArg3 = store.dispatch.mock.calls[3][0];
+            expect(store.dispatch).toHaveBeenCalledTimes(5);
+            const dispatchReceivedArg3 = store.dispatch.mock.calls[4][0];
             expect(dispatchReceivedArg3.type).toBe(ActionTypes.REMOVED_WEBAPP_PLUGIN);
             expect(dispatchReceivedArg3.data).toBe(manifest);
 

--- a/reducers/plugins/index.ts
+++ b/reducers/plugins/index.ts
@@ -165,7 +165,6 @@ function plugins(state: IDMappedObjects<ClientPluginManifest> = {}, action: Gene
         }
         return state;
     }
-
     case UserTypes.LOGOUT_SUCCESS:
         return {};
     default:
@@ -215,7 +214,6 @@ function components(state: PluginsState['components'] = initialComponents, actio
     }
     case ActionTypes.REMOVED_PLUGIN_COMPONENT:
         return removePluginComponent(state, action);
-    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
     case ActionTypes.REMOVED_WEBAPP_PLUGIN:
         return removePluginComponents(state, action);
 
@@ -245,7 +243,6 @@ function postTypes(state: PluginsState['postTypes'] = {}, action: GenericAction)
     }
     case ActionTypes.REMOVED_PLUGIN_POST_COMPONENT:
         return removePostPluginComponent(state, action);
-    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
     case ActionTypes.REMOVED_WEBAPP_PLUGIN:
         return removePostPluginComponents(state, action);
 
@@ -275,7 +272,6 @@ function postCardTypes(state: PluginsState['postTypes'] = {}, action: GenericAct
     }
     case ActionTypes.REMOVED_PLUGIN_POST_CARD_COMPONENT:
         return removePostPluginComponent(state, action);
-    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
     case ActionTypes.REMOVED_WEBAPP_PLUGIN:
         return removePostPluginComponents(state, action);
 
@@ -304,7 +300,6 @@ function adminConsoleReducers(state: {[pluginId: string]: any} = {}, action: Gen
         }
         return state;
     }
-    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
     case ActionTypes.REMOVED_WEBAPP_PLUGIN:
         if (action.data && state[action.data.id]) {
             const nextState = {...state};
@@ -340,7 +335,6 @@ function adminConsoleCustomComponents(state: {[pluginId: string]: Record<string,
 
         return nextState;
     }
-    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
     case ActionTypes.REMOVED_WEBAPP_PLUGIN: {
         if (!action.data || !state[action.data.id]) {
             return state;
@@ -369,7 +363,6 @@ function siteStatsHandlers(state: PluginsState['siteStatsHandlers'] = {}, action
         }
         return state;
 
-    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
     case ActionTypes.REMOVED_WEBAPP_PLUGIN:
         if (action.data) {
             const nextState = {...state};
@@ -394,7 +387,6 @@ function insightsHandlers(state: PluginsState['insightsHandlers'] = {}, action: 
             return nextState;
         }
         return state;
-    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
     case ActionTypes.REMOVED_WEBAPP_PLUGIN:
         if (action.data) {
             const nextState = {...state};


### PR DESCRIPTION
#### Summary

PR partially reverts https://github.com/mattermost/mattermost-webapp/pull/10152 in order to keep the plugins state properly synched. This makes it easy to figure out whether a plugin is enable or disabled without addition logic (see https://github.com/mattermost/mattermost-webapp/commit/73c617764f3818c7134286684530205472b108bd for an example).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46903

#### Release Note

```release-note
NONE
```
