### PR TITLE
[MM-34595] Provide a way for plugins to force the team sidebar to be visible

### DIFF
--- a/components/team_sidebar/index.ts
+++ b/components/team_sidebar/index.ts
@@ -29,15 +29,19 @@ import {switchTeam, updateTeamsOrderForUser} from 'actions/team_actions.jsx';
 
 import {Preferences} from 'utils/constants';
 
+import {getForceTeamSidebarToBeVisible} from '../../selectors/views/team_sidebar';
+
 import TeamSidebar from './team_sidebar';
 
 function mapStateToProps(state: GlobalState) {
     const config: Partial<ClientConfig> = getConfig(state);
 
-    const experimentalPrimaryTeam: string | undefined = config.ExperimentalPrimaryTeam;
+    const experimentalPrimaryTeam: string | undefined =
+        config.ExperimentalPrimaryTeam;
     const joinableTeams: string[] = getJoinableTeamIds(state);
     const moreTeamsToJoin: boolean = joinableTeams && joinableTeams.length > 0;
     const products = state.plugins.components.Product || [];
+    const forceTeamSidebarToBeVisible = getForceTeamSidebarToBeVisible(state);
 
     const [unreadTeamsSet, mentionsInTeamMap] = getTeamsUnreadStatuses(state);
 
@@ -52,6 +56,7 @@ function mapStateToProps(state: GlobalState) {
         products,
         unreadTeamsSet,
         mentionsInTeamMap,
+        forceTeamSidebarToBeVisible,
     };
 }
 

--- a/components/team_sidebar/index.ts
+++ b/components/team_sidebar/index.ts
@@ -24,24 +24,22 @@ import {GlobalState} from 'types/store';
 
 import {getCurrentLocale} from 'selectors/i18n';
 import {getIsLhsOpen} from 'selectors/lhs';
+import {getTeamSidebarVisible} from 'selectors/views/team_sidebar';
 
 import {switchTeam, updateTeamsOrderForUser} from 'actions/team_actions.jsx';
 
 import {Preferences} from 'utils/constants';
-
-import {getForceTeamSidebarToBeVisible} from '../../selectors/views/team_sidebar';
 
 import TeamSidebar from './team_sidebar';
 
 function mapStateToProps(state: GlobalState) {
     const config: Partial<ClientConfig> = getConfig(state);
 
-    const experimentalPrimaryTeam: string | undefined =
-        config.ExperimentalPrimaryTeam;
+    const experimentalPrimaryTeam: string | undefined = config.ExperimentalPrimaryTeam;
     const joinableTeams: string[] = getJoinableTeamIds(state);
     const moreTeamsToJoin: boolean = joinableTeams && joinableTeams.length > 0;
     const products = state.plugins.components.Product || [];
-    const forceTeamSidebarToBeVisible = getForceTeamSidebarToBeVisible(state);
+    const teamSidebarVisible = getTeamSidebarVisible(state);
 
     const [unreadTeamsSet, mentionsInTeamMap] = getTeamsUnreadStatuses(state);
 
@@ -56,7 +54,7 @@ function mapStateToProps(state: GlobalState) {
         products,
         unreadTeamsSet,
         mentionsInTeamMap,
-        forceTeamSidebarToBeVisible,
+        teamSidebarVisible,
     };
 }
 

--- a/components/team_sidebar/team_sidebar.tsx
+++ b/components/team_sidebar/team_sidebar.tsx
@@ -192,7 +192,9 @@ export default class TeamSidebar extends React.PureComponent<Props, State> {
 
     render() {
         const root: Element | null = document.querySelector('#root');
-        if (this.props.myTeams.length <= 1) {
+        const forceTeamSidebarToBeVisible = this.props.forceTeamSidebarToBeVisible;
+
+        if (this.props.myTeams.length <= 1 && !forceTeamSidebarToBeVisible) {
             root!.classList.remove('multi-teams');
             return null;
         }

--- a/components/team_sidebar/team_sidebar.tsx
+++ b/components/team_sidebar/team_sidebar.tsx
@@ -192,9 +192,9 @@ export default class TeamSidebar extends React.PureComponent<Props, State> {
 
     render() {
         const root: Element | null = document.querySelector('#root');
-        const forceTeamSidebarToBeVisible = this.props.forceTeamSidebarToBeVisible;
+        const teamSidebarVisible = this.props.teamSidebarVisible;
 
-        if (this.props.myTeams.length <= 1 && !forceTeamSidebarToBeVisible) {
+        if (this.props.myTeams.length <= 1 && !teamSidebarVisible) {
             root!.classList.remove('multi-teams');
             return null;
         }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -905,9 +905,9 @@ export default class PluginRegistry {
         });
     }
 
-    forceTeamSidebarToBeVisible(showSidebar) {
+    setTeamSidebarVisible(showSidebar) {
         store.dispatch({
-            type: ActionTypes.FORCE_TEAM_SIDEBAR_TO_BE_VISIBLE,
+            type: ActionTypes.SET_TEAM_SIDEBAR_VISIBLE,
             showSidebar,
         });
     }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -904,4 +904,11 @@ export default class PluginRegistry {
             },
         });
     }
+
+    forceTeamSidebarToBeVisible(showSidebar) {
+        store.dispatch({
+            type: ActionTypes.FORCE_TEAM_SIDEBAR_TO_BE_VISIBLE,
+            showSidebar,
+        });
+    }
 }

--- a/reducers/plugins/index.ts
+++ b/reducers/plugins/index.ts
@@ -418,11 +418,11 @@ export default combineReducers({
     // components wrapped in an object that contains an id and plugin id
     components,
 
-    // object where every key is a post type and the values are components wrapped in an
+    // object where every key is a post type and the values are components wrapped in
     // an object that contains a plugin id
     postTypes,
 
-    // object where every key is a post type and the values are components wrapped in an
+    // object where every key is a post type and the values are components wrapped in
     // an object that contains a plugin id
     postCardTypes,
 

--- a/reducers/plugins/index.ts
+++ b/reducers/plugins/index.ts
@@ -418,11 +418,11 @@ export default combineReducers({
     // components wrapped in an object that contains an id and plugin id
     components,
 
-    // object where every key is a post type and the values are components wrapped in
+    // object where every key is a post type and the values are components wrapped in an
     // an object that contains a plugin id
     postTypes,
 
-    // object where every key is a post type and the values are components wrapped in
+    // object where every key is a post type and the values are components wrapped in an
     // an object that contains a plugin id
     postCardTypes,
 

--- a/reducers/views/index.ts
+++ b/reducers/views/index.ts
@@ -21,6 +21,7 @@ import channelSelectorModal from './channel_selector_modal';
 import settings from './settings';
 import marketplace from './marketplace';
 import channelSidebar from './channel_sidebar';
+import teamSidebar from './team_sidebar';
 import productMenu from './product_menu';
 import textbox from './textbox';
 import statusDropdown from './status_dropdown';
@@ -53,4 +54,5 @@ export default combineReducers({
     onboardingTasks,
     threads,
     productMenu,
+    teamSidebar,
 });

--- a/reducers/views/team_sidebar.ts
+++ b/reducers/views/team_sidebar.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {combineReducers} from 'redux';
+
+import {GenericAction} from 'mattermost-redux/types/actions';
+
+import {ActionTypes} from 'utils/constants';
+
+export function forceTeamSidebarToBeVisible(state = false, action: GenericAction): boolean {
+    switch (action.type) {
+    case ActionTypes.FORCE_TEAM_SIDEBAR_TO_BE_VISIBLE:
+        return action.showSidebar;
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+    forceTeamSidebarToBeVisible,
+});

--- a/reducers/views/team_sidebar.ts
+++ b/reducers/views/team_sidebar.ts
@@ -7,9 +7,9 @@ import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {ActionTypes} from 'utils/constants';
 
-export function forceTeamSidebarToBeVisible(state = false, action: GenericAction): boolean {
+export function setTeamSidebarVisible(state = false, action: GenericAction): boolean {
     switch (action.type) {
-    case ActionTypes.FORCE_TEAM_SIDEBAR_TO_BE_VISIBLE:
+    case ActionTypes.SET_TEAM_SIDEBAR_VISIBLE:
         return action.showSidebar;
     default:
         return state;
@@ -17,5 +17,5 @@ export function forceTeamSidebarToBeVisible(state = false, action: GenericAction
 }
 
 export default combineReducers({
-    forceTeamSidebarToBeVisible,
+    setTeamSidebarVisible,
 });

--- a/selectors/views/team_sidebar.ts
+++ b/selectors/views/team_sidebar.ts
@@ -3,6 +3,6 @@
 
 import {GlobalState} from 'types/store';
 
-export function getForceTeamSidebarToBeVisible(state: GlobalState): boolean {
-    return state.views.teamSidebar.forceTeamSidebarToBeVisible;
+export function getTeamSidebarVisible(state: GlobalState): boolean {
+    return state.views.teamSidebar.setTeamSidebarVisible;
 }

--- a/selectors/views/team_sidebar.ts
+++ b/selectors/views/team_sidebar.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {GlobalState} from 'types/store';
+
+export function getForceTeamSidebarToBeVisible(state: GlobalState): boolean {
+    return state.views.teamSidebar.forceTeamSidebarToBeVisible;
+}

--- a/types/store/views.ts
+++ b/types/store/views.ts
@@ -170,6 +170,11 @@ export type ViewsState = {
         multiSelectedChannelIds: string[];
         lastSelectedChannel: string;
         firstChannelName: string;
+        forceTeamSidebarToBeVisible: boolean;
+    };
+
+    teamSidebar: {
+        forceTeamSidebarToBeVisible: boolean;
     };
 
     statusDropdown: {

--- a/types/store/views.ts
+++ b/types/store/views.ts
@@ -170,11 +170,10 @@ export type ViewsState = {
         multiSelectedChannelIds: string[];
         lastSelectedChannel: string;
         firstChannelName: string;
-        forceTeamSidebarToBeVisible: boolean;
     };
 
     teamSidebar: {
-        forceTeamSidebarToBeVisible: boolean;
+        setTeamSidebarVisible: boolean;
     };
 
     statusDropdown: {

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -308,7 +308,7 @@ export const ActionTypes = keyMirror({
     SET_EDIT_CHANNEL_MEMBERS: null,
     NEEDS_LOGGED_IN_LIMIT_REACHED_CHECK: null,
 
-    FORCE_TEAM_SIDEBAR_TO_BE_VISIBLE: null,
+    SET_TEAM_SIDEBAR_VISIBLE: null,
 });
 
 export const PostRequestTypes = keyMirror({

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -307,6 +307,8 @@ export const ActionTypes = keyMirror({
     RECEIVED_PLUGIN_INSIGHT: null,
     SET_EDIT_CHANNEL_MEMBERS: null,
     NEEDS_LOGGED_IN_LIMIT_REACHED_CHECK: null,
+
+    FORCE_TEAM_SIDEBAR_TO_BE_VISIBLE: null,
 });
 
 export const PostRequestTypes = keyMirror({


### PR DESCRIPTION
#### Summary
Provide a method in PluginRegistry, that forces team sidebar to be visible. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34595

#### Related Pull Requests

#### Screenshots

#### Release Note
```release-note
Provided a method in PluginRegistry, that forces team sidebar to be visible. 
```
