### PR TITLE
Downgrade Bulgarian/Български to Beta

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -354,7 +354,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 13,
-                  "text": "Български",
+                  "text": "Български (Beta)",
                   "value": "bg",
                 },
                 Object {
@@ -485,7 +485,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 13,
-                  "text": "Български",
+                  "text": "Български (Beta)",
                   "value": "bg",
                 },
                 Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -109,7 +109,7 @@ const languages = {
     },
     bg: {
         value: 'bg',
-        name: 'Български',
+        name: 'Български (Beta)',
         order: 13,
         url: bg,
     },


### PR DESCRIPTION
#### Summary
Bulgarian product translations haven't been actively maintained, and with this reduction in translation quality, this language is being downgraded to Beta.

#### Release Note
```release-note
Downgraded Bulgarian language support to Beta.
```
