### PR TITLE
MM-45848: fix mention badge update

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/channels.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/channels.test.js
@@ -1091,6 +1091,7 @@ describe('myMembers', () => {
                 [channelId]: {
                     ...TestHelper.fakeChannelMember(userId, channelId),
                     last_viewed_at: 20000,
+                    last_update_at: 10000,
                     msg_count: 10,
                 },
             });
@@ -1098,6 +1099,7 @@ describe('myMembers', () => {
             const channelMember = {
                 ...TestHelper.fakeChannelMember(userId, channelId),
                 last_viewed_at: 10000,
+                last_update_at: 10000,
                 msg_count: 15,
             };
 
@@ -1160,6 +1162,7 @@ describe('myMembers', () => {
                 [channelId]: {
                     ...TestHelper.fakeChannelMember(userId, channelId),
                     last_viewed_at: 20000,
+                    last_update_at: 10000,
                     msg_count: 10,
                 },
             });
@@ -1167,6 +1170,7 @@ describe('myMembers', () => {
             const channelMember = {
                 ...TestHelper.fakeChannelMember(userId, channelId),
                 last_viewed_at: 10000,
+                last_update_at: 10000,
                 msg_count: 15,
             };
 

--- a/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -516,8 +516,8 @@ function receiveChannelMember(state: RelationOneToOne<Channel, ChannelMembership
             last_viewed_at: Math.max(existingChannelMember.last_viewed_at, received.last_viewed_at),
             msg_count: Math.max(existingChannelMember.msg_count, received.msg_count),
             msg_count_root: Math.max(existingChannelMember.msg_count_root, received.msg_count_root),
-            mention_count: Math.min(existingChannelMember.mention_count, received.mention_count),
-            mention_count_root: Math.min(existingChannelMember.mention_count_root, received.mention_count_root),
+            mention_count: Math.max(existingChannelMember.mention_count, received.mention_count),
+            mention_count_root: Math.max(existingChannelMember.mention_count_root, received.mention_count_root),
         };
     }
 

--- a/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -508,16 +508,21 @@ function receiveChannelMember(state: RelationOneToOne<Channel, ChannelMembership
         return state;
     }
 
-    if (existingChannelMember && updatedChannelMember.last_viewed_at < existingChannelMember.last_viewed_at) {
+    // https://github.com/mattermost/mattermost-webapp/pull/10589 and
+    // https://github.com/mattermost/mattermost-webapp/pull/11094
+    if (existingChannelMember &&
+        updatedChannelMember.last_viewed_at < existingChannelMember.last_viewed_at &&
+        updatedChannelMember.last_update_at <= existingChannelMember.last_update_at) {
         // The last_viewed_at should almost never decrease upon receiving a member, so if it does, assume that the
         // unread state of the existing channel member is correct. See MM-44900 for more information.
         updatedChannelMember = {
             ...received,
             last_viewed_at: Math.max(existingChannelMember.last_viewed_at, received.last_viewed_at),
+            last_update_at: Math.max(existingChannelMember.last_update_at, received.last_update_at),
             msg_count: Math.max(existingChannelMember.msg_count, received.msg_count),
             msg_count_root: Math.max(existingChannelMember.msg_count_root, received.msg_count_root),
-            mention_count: Math.max(existingChannelMember.mention_count, received.mention_count),
-            mention_count_root: Math.max(existingChannelMember.mention_count_root, received.mention_count_root),
+            mention_count: Math.min(existingChannelMember.mention_count, received.mention_count),
+            mention_count_root: Math.min(existingChannelMember.mention_count_root, received.mention_count_root),
         };
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
On a websocket reconnect, under certain circumstances, a DM was marked as unread, but mention badges were not appearing. 
This appears to be a result of the change introduced in [#10589](https://github.com/mattermost/mattermost-webapp/pull/10589/files?diff=split&w=0#diff-7e2d5cd0fc248e2dd23906616bad90b0c819b2070ef84e8fc5138760b7d56d90R480). 

If the DM is read, then the mention count is 0. The count in the newly fetched membership is ignored because `math.min(0, updated_count)` is 0.



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-45848

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fix display of mention counts in unread channels
```
