### PR TITLE
Intro-link button fix

### DIFF
--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -510,9 +510,9 @@
 
     .intro-links {
         display: flex;
+        align-items: center;
         padding: 8px 16px;
         margin-bottom: 10px;
-        align-items: center;
 
         .fa,
         i {

--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -509,9 +509,10 @@
     }
 
     .intro-links {
-        display: inline-block;
         padding: 8px 16px;
         margin-bottom: 10px;
+        display: flex;
+        align-items: center;
 
         .fa,
         i {

--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -36,7 +36,7 @@
             }
         }
 
-        .heading>span {
+        .heading > span {
             overflow: hidden;
             line-height: 20px;
             text-overflow: ellipsis;
@@ -317,13 +317,13 @@
             opacity: 0.5;
         }
 
-        >div {
+        > div {
             display: flex;
             min-width: 0;
             flex: 0 1 auto;
         }
 
-        >a {
+        > a {
             display: inline-block;
             width: calc(100% - 65px);
             text-decoration: none;
@@ -510,9 +510,9 @@
 
     .intro-links {
         display: flex;
-        align-items: center;
         padding: 8px 16px;
         margin-bottom: 10px;
+        align-items: center;
 
         .fa,
         i {
@@ -565,7 +565,7 @@
     .divider {
         border-top: 1px solid transparent;
 
-        &+.divider {
+        & + .divider {
             display: none;
         }
     }
@@ -771,7 +771,7 @@
                 height: 16px;
             }
 
-            &-emoji>span:first-child {
+            &-emoji > span:first-child {
                 width: 16px;
                 min-width: 16px;
                 height: 16px;
@@ -832,7 +832,7 @@
             right: -400px;
         }
 
-        >a {
+        > a {
             color: inherit;
             opacity: 0.6;
             text-decoration: none;

--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -509,9 +509,9 @@
     }
 
     .intro-links {
+        display: flex;
         padding: 8px 16px;
         margin-bottom: 10px;
-        display: flex;
         align-items: center;
 
         .fa,

--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -36,7 +36,7 @@
             }
         }
 
-        .heading > span {
+        .heading>span {
             overflow: hidden;
             line-height: 20px;
             text-overflow: ellipsis;
@@ -317,13 +317,13 @@
             opacity: 0.5;
         }
 
-        > div {
+        >div {
             display: flex;
             min-width: 0;
             flex: 0 1 auto;
         }
 
-        > a {
+        >a {
             display: inline-block;
             width: calc(100% - 65px);
             text-decoration: none;
@@ -467,7 +467,7 @@
             position: relative;
             top: 1px;
             margin: 0 2px 0 5px;
-            content: '\2022';
+            content: "\2022";
         }
     }
 
@@ -510,9 +510,9 @@
 
     .intro-links {
         display: flex;
+        align-items: center;
         padding: 8px 16px;
         margin-bottom: 10px;
-        align-items: center;
 
         .fa,
         i {
@@ -565,7 +565,7 @@
     .divider {
         border-top: 1px solid transparent;
 
-        & + .divider {
+        &+.divider {
             display: none;
         }
     }
@@ -588,7 +588,7 @@
             width: 100%;
             height: 100%;
             background: none;
-            content: '';
+            content: "";
             transition: all $transition-quick ease-in-out;
         }
 
@@ -771,7 +771,7 @@
                 height: 16px;
             }
 
-            &-emoji > span:first-child {
+            &-emoji>span:first-child {
                 width: 16px;
                 min-width: 16px;
                 height: 16px;
@@ -813,7 +813,7 @@
         width: 30px;
         height: 30px;
         margin-right: 1px;
-        font-family: 'Open Sans', sans-serif;
+        font-family: "Open Sans", sans-serif;
         font-size: 22px;
         line-height: 26px;
         text-align: center;
@@ -832,7 +832,7 @@
             right: -400px;
         }
 
-        > a {
+        >a {
             color: inherit;
             opacity: 0.6;
             text-decoration: none;


### PR DESCRIPTION
#### Summary
Intro-link button fix
The buttons don't force the icon to be inline (if it isn't already). The compassIcon component has certain styles that make it take display flex styling instead of inline, so the button forcing a display flex layout would be a much better way of fixing this.

#### Screenshots
<img width="636" alt="Screenshot 2022-09-08 at 9 54 57 PM" src="https://user-images.githubusercontent.com/11034289/189181575-fb636d57-1278-45d5-9b36-18f02f302fae.png">

```release-note
NONE
```