### PR TITLE
[MM-42341] Reset password error message

### DIFF
--- a/components/password_reset_form/password_reset_form.tsx
+++ b/components/password_reset_form/password_reset_form.tsx
@@ -33,9 +33,10 @@ const PasswordResetForm = ({location, siteName, actions}: Props) => {
             setError(
                 <FormattedMessage
                     id='password_form.error'
-                    defaultMessage='Please enter at least {chars} characters.'
+                    defaultMessage='Your password must contain between {min} and {max} characters.'
                     values={{
-                        chars: Constants.MIN_PASSWORD_LENGTH,
+                        min: Constants.MIN_PASSWORD_LENGTH,
+                        max: Constants.MAX_PASSWORD_LENGTH,
                     }}
                 />,
             );

--- a/components/password_reset_form/password_reset_form.tsx
+++ b/components/password_reset_form/password_reset_form.tsx
@@ -22,13 +22,13 @@ interface Props {
 
 const PasswordResetForm = ({location, siteName, actions}: Props) => {
     const [error, setError] = useState<React.ReactNode>(null);
-    const [password, setPassword] = useState<string>("");
+    const [password, setPassword] = useState<string>('');
 
     const passwordInput = useRef<HTMLInputElement>(null);
 
     const updatePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
         setPassword(e.target.value);
-    }
+    };
 
     const handlePasswordReset = async (e: React.FormEvent) => {
         e.preventDefault();

--- a/components/password_reset_form/password_reset_form.tsx
+++ b/components/password_reset_form/password_reset_form.tsx
@@ -22,17 +22,13 @@ interface Props {
 
 const PasswordResetForm = ({location, siteName, actions}: Props) => {
     const [error, setError] = useState<React.ReactNode>(null);
-    const [password, setPassword] = useState<string>('');
 
     const passwordInput = useRef<HTMLInputElement>(null);
-
-    const updatePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setPassword(e.target.value);
-    };
 
     const handlePasswordReset = async (e: React.FormEvent) => {
         e.preventDefault();
 
+        const password = passwordInput.current!.value;
         const token = (new URLSearchParams(location.search)).get('token');
 
         if (typeof token !== 'string') {
@@ -83,7 +79,6 @@ const PasswordResetForm = ({location, siteName, actions}: Props) => {
                             placeholder={{id: t('password_form.pwd'), defaultMessage: 'Password'}}
                             spellCheck='false'
                             autoFocus={true}
-                            onChange={updatePassword}
                         />
                     </div>
                     {errorElement}
@@ -91,7 +86,6 @@ const PasswordResetForm = ({location, siteName, actions}: Props) => {
                         id='resetPasswordButton'
                         type='submit'
                         className='btn btn-primary'
-                        disabled={!password || password.length < Constants.MIN_PASSWORD_LENGTH}
                     >
                         <FormattedMessage
                             id='password_form.change'

--- a/components/password_reset_form/password_reset_form.tsx
+++ b/components/password_reset_form/password_reset_form.tsx
@@ -33,11 +33,8 @@ const PasswordResetForm = ({location, siteName, actions}: Props) => {
             setError(
                 <FormattedMessage
                     id='password_form.error'
-                    defaultMessage='Your password must contain between {min} and {max} characters.'
-                    values={{
-                        min: Constants.MIN_PASSWORD_LENGTH,
-                        max: Constants.MAX_PASSWORD_LENGTH,
-                    }}
+                    defaultMessage='Your password must contain at least 10 characters made up of at 
+                    least one lowercase letter, at least one uppercase letter, at least one number, and at least one symbol (e.g. "~!@#$%^&*()").'
                 />,
             );
             return;

--- a/components/password_reset_form/password_reset_form.tsx
+++ b/components/password_reset_form/password_reset_form.tsx
@@ -22,23 +22,16 @@ interface Props {
 
 const PasswordResetForm = ({location, siteName, actions}: Props) => {
     const [error, setError] = useState<React.ReactNode>(null);
+    const [password, setPassword] = useState<string>("");
 
     const passwordInput = useRef<HTMLInputElement>(null);
 
+    const updatePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setPassword(e.target.value);
+    }
+
     const handlePasswordReset = async (e: React.FormEvent) => {
         e.preventDefault();
-
-        const password = passwordInput.current!.value;
-        if (!password || password.length < Constants.MIN_PASSWORD_LENGTH) {
-            setError(
-                <FormattedMessage
-                    id='password_form.error'
-                    defaultMessage='Your password must contain at least 10 characters made up of at 
-                    least one lowercase letter, at least one uppercase letter, at least one number, and at least one symbol (e.g. "~!@#$%^&*()").'
-                />,
-            );
-            return;
-        }
 
         const token = (new URLSearchParams(location.search)).get('token');
 
@@ -90,6 +83,7 @@ const PasswordResetForm = ({location, siteName, actions}: Props) => {
                             placeholder={{id: t('password_form.pwd'), defaultMessage: 'Password'}}
                             spellCheck='false'
                             autoFocus={true}
+                            onChange={updatePassword}
                         />
                     </div>
                     {errorElement}
@@ -97,6 +91,7 @@ const PasswordResetForm = ({location, siteName, actions}: Props) => {
                         id='resetPasswordButton'
                         type='submit'
                         className='btn btn-primary'
+                        disabled={!password || password.length < Constants.MIN_PASSWORD_LENGTH}
                     >
                         <FormattedMessage
                             id='password_form.change'

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4144,7 +4144,6 @@
   "onboardingTour.sendMessage.title": "Send messages",
   "password_form.change": "Change my password",
   "password_form.enter": "Enter a new password for your {siteName} account.",
-  "password_form.error": "Please enter at least {chars} characters.",
   "password_form.pwd": "Password",
   "password_form.title": "Password Reset",
   "password_send.checkInbox": "Please check your inbox.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4144,7 +4144,7 @@
   "onboardingTour.sendMessage.title": "Send messages",
   "password_form.change": "Change my password",
   "password_form.enter": "Enter a new password for your {siteName} account.",
-  "password_form.error": "Your password must contain between {min} and {max} characters.",
+  "password_form.error": "Your password must contain at least 10 characters made up of at least one lowercase letter, at least one uppercase letter, at least one number, and at least one symbol (e.g. '~!@#$%^&*()').",
   "password_form.pwd": "Password",
   "password_form.title": "Password Reset",
   "password_send.checkInbox": "Please check your inbox.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4144,7 +4144,7 @@
   "onboardingTour.sendMessage.title": "Send messages",
   "password_form.change": "Change my password",
   "password_form.enter": "Enter a new password for your {siteName} account.",
-  "password_form.error": "Your password must contain at least 10 characters made up of at least one lowercase letter, at least one uppercase letter, at least one number, and at least one symbol (e.g. '~!@#$%^&*()').",
+  "password_form.error": "Please enter at least {chars} characters.",
   "password_form.pwd": "Password",
   "password_form.title": "Password Reset",
   "password_send.checkInbox": "Please check your inbox.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4144,7 +4144,7 @@
   "onboardingTour.sendMessage.title": "Send messages",
   "password_form.change": "Change my password",
   "password_form.enter": "Enter a new password for your {siteName} account.",
-  "password_form.error": "Please enter at least {chars} characters.",
+  "password_form.error": "Your password must contain between {min} and {max} characters.",
   "password_form.pwd": "Password",
   "password_form.title": "Password Reset",
   "password_send.checkInbox": "Please check your inbox.",


### PR DESCRIPTION
#### Summary
Remove the error message that displays when the inputted password is less than 5 characters so it only relies on the backend error message.

#### Ticket Link
[MM-42341
](https://mattermost.atlassian.net/browse/MM-42341)

#### Screenshots

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/44761757/189185127-1af0e675-054a-4c32-ae8f-2ce7ee43cdfd.png) |![image](https://user-images.githubusercontent.com/44761757/189210401-205f44b2-2570-452d-99b0-1372b5aabc63.png)|


#### Release Note

```release-note
Remove the error message on the Reset Password page that appears when the inputted password is fewer than 5 characters .
```
