### PR TITLE
MM-46410: adds urgency on mention counts

### DIFF
--- a/actions/new_post.ts
+++ b/actions/new_post.ts
@@ -129,7 +129,7 @@ export function setChannelReadAndViewed(dispatch: DispatchFunc, getState: GetSta
         ];
     }
 
-    return actionsToMarkChannelAsUnread(getState, websocketMessageProps.team_id, post.channel_id, websocketMessageProps.mentions, fetchedChannelMember, post.root_id === '');
+    return actionsToMarkChannelAsUnread(getState, websocketMessageProps.team_id, post.channel_id, websocketMessageProps.mentions, fetchedChannelMember, post.root_id === '', post?.props?.priority);
 }
 
 export function setThreadRead(post: Post) {

--- a/components/post_priority/post_priority_badge.tsx
+++ b/components/post_priority/post_priority_badge.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import styled from 'styled-components';
+
+import {AlertOutlineIcon, AlertCircleOutlineIcon} from '@mattermost/compass-icons/components';
+
+import {PostPriority} from '@mattermost/types/posts';
+
+type Props = {
+    priority?: PostPriority;
+}
+
+const Badge = styled.span`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 20px;
+    width: 20px;
+    margin-right: 10px;
+    border-radius: 10px;
+    color: #fff;
+
+    background-color: ${(props: {priority: PostPriority}) => {
+        return props.priority === PostPriority.URGENT ?
+            'rgb(var(--semantic-color-danger))' :
+            'rgb(var(--semantic-color-info))';
+    }}
+`;
+
+export default function PriorityLabel({priority}: Props) {
+    if (priority !== PostPriority.URGENT && priority !== PostPriority.IMPORTANT) {
+        return null;
+    }
+
+    return (
+        <Badge priority={priority}>
+            {priority === PostPriority.URGENT ? (
+                <AlertOutlineIcon
+                    color={'currentColor'}
+                    size={14}
+                />
+            ) : (
+                <AlertCircleOutlineIcon
+                    color={'currentColor'}
+                    size={14}
+                />
+            )}
+        </Badge>
+    );
+}
+

--- a/components/post_priority/post_priority_label.tsx
+++ b/components/post_priority/post_priority_label.tsx
@@ -69,7 +69,7 @@ export default function PriorityLabel({
                 icon={(
                     <AlertCircleOutlineIcon
                         color={'currentColor'}
-                        size={12}
+                        size={iconSize}
                     />
                 )}
             >

--- a/components/sidebar/sidebar_channel/channel_mention_badge.tsx
+++ b/components/sidebar/sidebar_channel/channel_mention_badge.tsx
@@ -2,17 +2,19 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import classNames from 'classnames';
 
 type Props = {
     unreadMentions: number;
+    hasUrgent?: boolean;
 };
 
-export default function ChannelMentionBadge({unreadMentions}: Props) {
+export default function ChannelMentionBadge({unreadMentions, hasUrgent}: Props) {
     if (unreadMentions > 0) {
         return (
             <span
                 id='unreadMentions'
-                className='badge'
+                className={classNames({badge: true, urgent: hasUrgent})}
             >
                 {unreadMentions}
             </span>

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/index.ts
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/index.ts
@@ -50,6 +50,7 @@ function makeMapStateToProps() {
             unreadMsgs: unreadCount.messages,
             isUnread: unreadCount.showUnread,
             isMuted: isChannelMuted(member),
+            hasUrgent: unreadCount.hasUrgent,
             isChannelSelected: isChannelSelected(state, ownProps.channel.id),
             firstChannelName: showChannelsTutorialStep ? firstChannelName : '',
             showChannelsTutorialStep,

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -62,6 +62,8 @@ type Props = {
 
     showChannelsTutorialStep: boolean;
 
+    hasUrgent: boolean;
+
     actions: {
         clearChannelSelection: () => void;
         multiSelectChannelTo: (channelId: string) => void;
@@ -170,6 +172,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
             unreadMentions,
             firstChannelName,
             showChannelsTutorialStep,
+            hasUrgent,
         } = this.props;
 
         let channelsTutorialTip: JSX.Element | null = null;
@@ -243,6 +246,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                 </div>
                 <ChannelMentionBadge
                     unreadMentions={unreadMentions}
+                    hasUrgent={hasUrgent}
                 />
                 <SidebarChannelMenu
                     channel={channel}

--- a/components/team_sidebar/components/team_button.tsx
+++ b/components/team_sidebar/components/team_button.tsx
@@ -39,6 +39,7 @@ interface Props {
     teamIndex?: number;
     teamId?: string;
     isInProduct?: boolean;
+    hasUrgent?: boolean;
 }
 
 // eslint-disable-next-line react/require-optimization
@@ -104,7 +105,7 @@ class TeamButton extends React.PureComponent<Props> {
                 });
 
                 badge = (
-                    <span className={'badge badge-max-number pull-right small'}>{mentions > 99 ? '99+' : mentions}</span>
+                    <span className={classNames('badge badge-max-number pull-right small', {urgent: this.props.hasUrgent})}>{mentions > 99 ? '99+' : mentions}</span>
                 );
             }
         }

--- a/components/team_sidebar/index.ts
+++ b/components/team_sidebar/index.ts
@@ -39,7 +39,7 @@ function mapStateToProps(state: GlobalState) {
     const moreTeamsToJoin: boolean = joinableTeams && joinableTeams.length > 0;
     const products = state.plugins.components.Product || [];
 
-    const [unreadTeamsSet, mentionsInTeamMap] = getTeamsUnreadStatuses(state);
+    const [unreadTeamsSet, mentionsInTeamMap, teamHasUrgentMap] = getTeamsUnreadStatuses(state);
 
     return {
         currentTeamId: getCurrentTeamId(state),
@@ -52,6 +52,7 @@ function mapStateToProps(state: GlobalState) {
         products,
         unreadTeamsSet,
         mentionsInTeamMap,
+        teamHasUrgentMap,
     };
 }
 

--- a/components/team_sidebar/team_sidebar.tsx
+++ b/components/team_sidebar/team_sidebar.tsx
@@ -218,6 +218,7 @@ export default class TeamSidebar extends React.PureComponent<Props, State> {
                     showOrder={this.state.showOrder}
                     unread={this.props.unreadTeamsSet.has(team.id)}
                     mentions={this.props.mentionsInTeamMap.has(team.id) ? this.props.mentionsInTeamMap.get(team.id) : 0}
+                    hasUrgent={this.props.teamHasUrgentMap.has(team.id) ? this.props.teamHasUrgentMap.get(team.id) : false}
                     teamIconUrl={Utils.imageURLForTeam(team)}
                     switchTeam={(url: string) => this.props.actions.switchTeam(url, currentProduct ? team : undefined)}
                     isDraggable={true}

--- a/components/threading/global_threads/thread_item/index.ts
+++ b/components/threading/global_threads/thread_item/index.ts
@@ -5,7 +5,7 @@ import {memo} from 'react';
 import {compose} from 'redux';
 import {connect} from 'react-redux';
 
-import {getPost, makeGetPostsForThread} from 'mattermost-redux/selectors/entities/posts';
+import {getPost, isPostPriorityEnabled, makeGetPostsForThread} from 'mattermost-redux/selectors/entities/posts';
 import {makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetDisplayName} from 'mattermost-redux/selectors/entities/users';
 import {getThread} from 'mattermost-redux/selectors/entities/threads';
@@ -32,6 +32,7 @@ function makeMapStateToProps() {
             displayName: getDisplayName(state, post.user_id, true),
             postsInThread: getPostsForThread(state, post.id),
             thread: getThread(state, threadId),
+            isPostPriorityEnabled: isPostPriorityEnabled(state),
         };
     };
 }

--- a/components/threading/global_threads/thread_item/thread_item.scss
+++ b/components/threading/global_threads/thread_item/thread_item.scss
@@ -29,6 +29,17 @@
         }
     }
 
+    &__author {
+        @include clearfix;
+
+        text-align: left;
+        text-overflow: ellipsis;
+        -moz-user-select: all; /* Firefox all */
+        white-space: nowrap;
+        min-width: 0;
+        overflow: hidden;
+    }
+
     &.is-selected {
         background: rgba(var(--button-bg-rgb), 0.04);
 
@@ -96,7 +107,7 @@
         font-family: 'Open Sans', sans-serif;
         font-size: 14px;
         font-weight: 600;
-        grid-template-columns: min-content 1fr min-content;
+        grid-template-columns: minmax(0, min-content) 1fr min-content;
         line-height: 20px;
         white-space: nowrap;
     }

--- a/components/threading/global_threads/thread_item/thread_item.tsx
+++ b/components/threading/global_threads/thread_item/thread_item.tsx
@@ -28,6 +28,7 @@ import SimpleTooltip from 'components/widgets/simple_tooltip';
 import CRTListTutorialTip from 'components/crt_tour/crt_list_tutorial_tip/crt_list_tutorial_tip';
 import Markdown from 'components/markdown';
 import {manuallyMarkThreadAsUnread} from 'actions/views/threads';
+import PriorityBadge from 'components/post_priority/post_priority_badge';
 
 import {THREADING_TIME} from '../../common/options';
 import {useThreadRouting} from '../../hooks';
@@ -51,6 +52,7 @@ type Props = {
     post: Post;
     postsInThread: Post[];
     thread: UserThread;
+    isPostPriorityEnabled: boolean;
 };
 
 const markdownPreviewOptions = {
@@ -70,6 +72,7 @@ function ThreadItem({
     thread,
     threadId,
     isFirstThreadInList,
+    isPostPriorityEnabled,
 }: Props & OwnProps): React.ReactElement|null {
     const dispatch = useDispatch();
     const {select, goToInChannel, currentTeamId} = useThreadRouting();
@@ -186,17 +189,22 @@ function ThreadItem({
                         )}
                     </div>
                 )}
-                <span>{postAuthor}</span>
-                {Boolean(channel) && (
-                    <Badge
-                        className={classNames({
-                            Badge__hidden: postAuthor === channel?.display_name,
-                        })}
-                        onClick={goToInChannelHandler}
-                    >
-                        {channel?.display_name}
-                    </Badge>
-                )}
+                <div className='ThreadItem__author'>{postAuthor}</div>
+                <div className='d-flex align-items-center'>
+                    {Boolean(channel) && (
+                        <Badge
+                            className={classNames({
+                                Badge__hidden: postAuthor === channel?.display_name,
+                            })}
+                            onClick={goToInChannelHandler}
+                        >
+                            {channel?.display_name}
+                        </Badge>
+                    )}
+                    {isPostPriorityEnabled && (
+                        post?.props?.priority && <PriorityBadge priority={post.props.priority}/>
+                    )}
+                </div>
                 <Timestamp
                     {...THREADING_TIME}
                     className='alt-hidden'

--- a/components/threading/global_threads_link/global_threads_link.tsx
+++ b/components/threading/global_threads_link/global_threads_link.tsx
@@ -110,7 +110,10 @@ const GlobalThreadsLink = () => {
                         </span>
                     </div>
                     {counts?.total_unread_mentions > 0 && (
-                        <ChannelMentionBadge unreadMentions={counts.total_unread_mentions}/>
+                        <ChannelMentionBadge
+                            unreadMentions={counts.total_unread_mentions}
+                            hasUrgent={counts?.total_unread_urgent_mentions > 0}
+                        />
                     )}
                     {showTutorialTrigger && <PulsatingDot/>}
                 </Link>

--- a/packages/mattermost-redux/src/actions/channels.ts
+++ b/packages/mattermost-redux/src/actions/channels.ts
@@ -1297,6 +1297,7 @@ export function actionsToMarkChannelAsRead(getState: GetStateFunc, channelId: st
                 channelId,
                 amount: channelMember.mention_count,
                 amountRoot: channelMember.mention_count_root,
+                amountUrgent: channelMember.urgent_mention_count,
             },
         });
     }
@@ -1326,6 +1327,7 @@ export function actionsToMarkChannelAsRead(getState: GetStateFunc, channelId: st
                 channelId: prevChannelId,
                 amount: prevChannelMember.mention_count,
                 amountRoot: prevChannelMember.mention_count_root,
+                amountUrgent: prevChannelMember.urgent_mention_count,
             },
         });
     }
@@ -1383,7 +1385,7 @@ export function markChannelAsUnread(teamId: string, channelId: string, mentions:
     };
 }
 
-export function actionsToMarkChannelAsUnread(getState: GetStateFunc, teamId: string, channelId: string, mentions: string[], fetchedChannelMember = false, isRoot = false) {
+export function actionsToMarkChannelAsUnread(getState: GetStateFunc, teamId: string, channelId: string, mentions: string[], fetchedChannelMember = false, isRoot = false, priority = '') {
     const state = getState();
     const {myMembers} = state.entities.channels;
     const {currentUserId} = state.entities.users;
@@ -1420,6 +1422,7 @@ export function actionsToMarkChannelAsUnread(getState: GetStateFunc, teamId: str
                 channelId,
                 amountRoot: isRoot ? 1 : 0,
                 amount: 1,
+                amountUrgent: priority === 'urgent' ? 1 : 0,
                 fetchedChannelMember,
             },
         });

--- a/packages/mattermost-redux/src/actions/posts.ts
+++ b/packages/mattermost-redux/src/actions/posts.ts
@@ -452,6 +452,7 @@ function getUnreadPostData(unreadChan: ChannelUnread, state: GlobalState) {
         mentionCount: unreadChan.mention_count,
         msgCountRoot: unreadChan.msg_count_root,
         mentionCountRoot: unreadChan.mention_count_root,
+        urgentMentionCount: unreadChan.urgent_mention_count,
         lastViewedAt: unreadChan.last_viewed_at,
         deltaMsgs: delta,
         deltaMsgsRoot: deltaRoot,

--- a/packages/mattermost-redux/src/actions/threads.ts
+++ b/packages/mattermost-redux/src/actions/threads.ts
@@ -15,7 +15,7 @@ import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
 import {getMissingFilesByPosts} from 'mattermost-redux/actions/files';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import {getThreadsInChannel, getThread as getThreadSelector} from 'mattermost-redux/selectors/entities/threads';
+import {getThreadsInChannel, getThread as getThreadSelector, getThreadItemsInChannel} from 'mattermost-redux/selectors/entities/threads';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {makeGetPostsForThread} from 'mattermost-redux/selectors/entities/posts';
@@ -96,6 +96,7 @@ export function getThreadCounts(userId: string, teamId: string) {
             total: counts.total,
             total_unread_threads: counts.total_unread_threads,
             total_unread_mentions: counts.total_unread_mentions,
+            total_unread_urgent_mentions: counts.total_unread_urgent_mentions,
         };
 
         dispatch({
@@ -145,6 +146,7 @@ export function getCountsAndThreadsSince(userId: string, teamId: string, since?:
             total: userThreadList.total,
             total_unread_threads: userThreadList.total_unread_threads,
             total_unread_mentions: userThreadList.total_unread_mentions,
+            total_unread_urgent_mentions: userThreadList.total_unread_urgent_mentions,
         };
 
         actions.push({
@@ -336,6 +338,7 @@ export function handleReadChanged(
     return (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const channel = getChannel(state, channelId);
+        const thread = getThreadSelector(state, threadId);
 
         return dispatch({
             type: ThreadTypes.READ_CHANGED_THREAD,
@@ -349,6 +352,7 @@ export function handleReadChanged(
                 prevUnreadReplies,
                 newUnreadReplies,
                 channelType: channel?.type,
+                isUrgent: thread?.is_urgent,
             },
         });
     };
@@ -382,7 +386,7 @@ export function setThreadFollow(userId: string, teamId: string, threadId: string
 
 export function handleAllThreadsInChannelMarkedRead(dispatch: DispatchFunc, getState: GetStateFunc, channelId: string, lastViewedAt: number) {
     const state = getState();
-    const threadsInChannel = getThreadsInChannel(state, channelId);
+    const threadsInChannel = getThreadItemsInChannel(state, channelId);
     const channel = getChannel(state, channelId);
     if (channel == null) {
         return;
@@ -390,16 +394,17 @@ export function handleAllThreadsInChannelMarkedRead(dispatch: DispatchFunc, getS
     const teamId = channel.team_id;
     const actions = [];
 
-    for (const id of threadsInChannel) {
+    for (const thread of threadsInChannel) {
         actions.push({
             type: ThreadTypes.READ_CHANGED_THREAD,
             data: {
-                id,
+                id: thread.id,
                 channelId,
                 teamId,
                 lastViewedAt,
                 newUnreadMentions: 0,
                 newUnreadReplies: 0,
+                isUrgent: thread.is_urgent,
             },
         });
     }

--- a/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -391,6 +391,7 @@ export function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = 
             channelId,
             amount,
             amountRoot,
+            amountUrgent,
             fetchedChannelMember,
         } = action.data;
 
@@ -416,11 +417,13 @@ export function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = 
                 ...member,
                 mention_count: member.mention_count + amount,
                 mention_count_root: member.mention_count_root + amountRoot,
+                urgent_mention_count: member.urgent_mention_count + amountUrgent,
+
             },
         };
     }
     case ChannelTypes.DECREMENT_UNREAD_MENTION_COUNT: {
-        const {channelId, amount, amountRoot} = action.data;
+        const {channelId, amount, amountRoot, amountUrgent} = action.data;
 
         if (amount === 0 && amountRoot === 0) {
             return state;
@@ -439,6 +442,7 @@ export function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = 
                 ...member,
                 mention_count: Math.max(member.mention_count - amount, 0),
                 mention_count_root: Math.max(member.mention_count_root - amountRoot, 0),
+                urgent_mention_count: Math.max(member.urgent_mention_count - amountUrgent, 0),
             },
         };
     }
@@ -488,6 +492,7 @@ export function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = 
                 mention_count: data.mentionCount,
                 msg_count_root: data.msgCountRoot,
                 mention_count_root: data.mentionCountRoot,
+                urgent_mention_count: data.urgentMentionCount,
                 last_viewed_at: data.lastViewedAt,
             },
         };
@@ -517,6 +522,7 @@ function receiveChannelMember(state: RelationOneToOne<Channel, ChannelMembership
             msg_count: Math.max(existingChannelMember.msg_count, received.msg_count),
             msg_count_root: Math.max(existingChannelMember.msg_count_root, received.msg_count_root),
             mention_count: Math.min(existingChannelMember.mention_count, received.mention_count),
+            urgent_mention_count: Math.min(existingChannelMember.urgent_mention_count, received.urgent_mention_count),
             mention_count_root: Math.min(existingChannelMember.mention_count_root, received.mention_count_root),
         };
     }

--- a/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
@@ -23,6 +23,7 @@ function handleAllTeamThreadsRead(state: ThreadsState['counts'], action: Generic
             ...counts,
             total_unread_mentions: 0,
             total_unread_threads: 0,
+            total_unread_urgent_mentions: 0,
         },
     };
 }
@@ -34,11 +35,13 @@ function isEqual(state: ThreadsState['counts'], action: GenericAction, unreads: 
         total,
         total_unread_threads: totalUnreadThreads,
         total_unread_mentions: totalUnreadMentions,
+        total_unread_urgent_mentions: totalUnreadUrgentMentions,
     } = action.data;
 
     if (
         totalUnreadMentions !== counts.total_unread_mentions ||
-        totalUnreadThreads !== counts.total_unread_threads
+        totalUnreadThreads !== counts.total_unread_threads ||
+        totalUnreadUrgentMentions !== counts.total_unread_urgent_mentions
     ) {
         return false;
     }
@@ -53,7 +56,7 @@ function isEqual(state: ThreadsState['counts'], action: GenericAction, unreads: 
     return true;
 }
 
-function handleReadChangedThread(state: ThreadsState['counts'], action: GenericAction, teamId: string): ThreadsState['counts'] {
+function handleReadChangedThread(state: ThreadsState['counts'], action: GenericAction, teamId: string, isUrgent: boolean): ThreadsState['counts'] {
     const {
         prevUnreadMentions = 0,
         newUnreadMentions = 0,
@@ -66,11 +69,15 @@ function handleReadChangedThread(state: ThreadsState['counts'], action: GenericA
         total_unread_threads: prevUnreadReplies,
         total: 0,
         total_unread_mentions: prevUnreadMentions,
+        total_unread_urgent_mentions: isUrgent ? prevUnreadMentions : 0,
     };
 
     const unreadMentionDiff = newUnreadMentions - prevUnreadMentions;
 
     counts.total_unread_mentions = Math.max(counts.total_unread_mentions + unreadMentionDiff, 0);
+    counts.total_unread_urgent_mentions = isUrgent ?
+        Math.max(counts.total_unread_urgent_mentions + unreadMentionDiff, 0) :
+        0;
 
     if (newUnreadReplies > 0 && prevUnreadReplies === 0) {
         counts.total_unread_threads += 1;
@@ -108,13 +115,14 @@ function handleLeaveChannel(state: ThreadsState['counts'] = {}, action: GenericA
         return state;
     }
 
-    const {unreadMentions, unreadThreads} = extra.threadsToDelete.reduce((curr, item: UserThread) => {
+    const {unreadMentions, unreadThreads, unreadUrgentMentions} = extra.threadsToDelete.reduce((curr, item: UserThread) => {
         curr.unreadMentions += item.unread_mentions;
         curr.unreadThreads = item.unread_replies > 0 ? curr.unreadThreads + 1 : curr.unreadThreads;
+        curr.unreadUrgentMentions = item.is_urgent ? curr.unreadUrgentMentions + item.unread_mentions : curr.unreadUrgentMentions;
         return curr;
-    }, {unreadMentions: 0, unreadThreads: 0});
+    }, {unreadMentions: 0, unreadThreads: 0, unreadUrgentMentions: 0});
 
-    const {total, total_unread_mentions: totalUnreadMentions, total_unread_threads: totalUnreadThreads} = state[teamId];
+    const {total, total_unread_mentions: totalUnreadMentions, total_unread_threads: totalUnreadThreads, total_unread_urgent_mentions: totalUnreadUrgentMentions} = state[teamId];
 
     return {
         ...state,
@@ -122,6 +130,7 @@ function handleLeaveChannel(state: ThreadsState['counts'] = {}, action: GenericA
             total: Math.max(total - extra.threadsToDelete.length, 0),
             total_unread_mentions: Math.max(totalUnreadMentions - unreadMentions, 0),
             total_unread_threads: Math.max(totalUnreadThreads - unreadThreads, 0),
+            total_unread_urgent_mentions: Math.max((totalUnreadUrgentMentions || 0) - unreadUrgentMentions, 0),
         },
     };
 }
@@ -148,7 +157,7 @@ export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {},
     case ThreadTypes.ALL_TEAM_THREADS_READ:
         return handleAllTeamThreadsRead(state, action);
     case ThreadTypes.READ_CHANGED_THREAD: {
-        const {teamId, channelType} = action.data;
+        const {teamId, channelType, isUrgent} = action.data;
         if (isDmGmChannel(channelType)) {
             const teamIds = new Set(Object.keys(state));
 
@@ -159,13 +168,13 @@ export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {},
 
             let newState = {...state};
             teamIds.forEach((id) => {
-                newState = handleReadChangedThread(newState, action, id);
+                newState = handleReadChangedThread(newState, action, id, isUrgent);
             });
 
             return newState;
         }
 
-        return handleReadChangedThread(state, action, teamId);
+        return handleReadChangedThread(state, action, teamId, isUrgent);
     }
     case ThreadTypes.FOLLOW_CHANGED_THREAD: {
         const {team_id: teamId, following} = action.data;
@@ -199,6 +208,7 @@ export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {},
                 total: action.data.total,
                 total_unread_threads: action.data.total_unread_threads,
                 total_unread_mentions: action.data.total_unread_mentions,
+                total_unread_urgent_mentions: action.data.total_unread_urgent_mentions,
             },
         };
     case ThreadTypes.DECREMENT_THREAD_COUNTS:
@@ -217,7 +227,7 @@ export function countsReducer(state: ThreadsState['counts'] = {}, action: Generi
         if (isDmGmChannel(action.data.channelType)) {
             return state;
         }
-        return handleReadChangedThread(state, action, action.data.teamId);
+        return handleReadChangedThread(state, action, action.data.teamId, action.data.isUrgent);
     case TeamTypes.LEAVE_TEAM:
         return handleLeaveTeam(state, action);
     case UserTypes.LOGOUT_SUCCESS:
@@ -234,6 +244,7 @@ export function countsReducer(state: ThreadsState['counts'] = {}, action: Generi
                     ...state[member.team_id],
                     total_unread_threads: member.thread_count || 0,
                     total_unread_mentions: member.thread_mention_count || 0,
+                    total_unread_urgent_mentions: member.thread_urgent_mention_count || 0,
                 };
 
                 return result;

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -70,6 +70,7 @@ import {createIdsSelector} from 'mattermost-redux/utils/helpers';
 import {createSelector} from 'reselect';
 
 import {getThreadCounts, getThreadCountsIncludingDirect} from './threads';
+import {isPostPriorityEnabled} from './posts';
 
 export {getCurrentChannelId, getMyChannelMemberships, getMyCurrentChannelMembership};
 export function getAllChannels(state: GlobalState): IDMappedObjects<Channel> {
@@ -672,7 +673,7 @@ export const getUnreadStatus: (state: GlobalState) => BasicUnreadStatus = create
  * - Set of team IDs that have unread messages
  * - Map with team IDs as keys and unread mentions counts as values
  */
-export const getTeamsUnreadStatuses: (state: GlobalState) => [Set<Team['id']>, Map<Team['id'], number>] = createSelector(
+export const getTeamsUnreadStatuses: (state: GlobalState) => [Set<Team['id']>, Map<Team['id'], number>, Map<Team['id'], boolean>] = createSelector(
     'getTeamsUnreadStatuses',
     getAllChannels,
     getMyChannelMemberships,
@@ -692,6 +693,7 @@ export const getTeamsUnreadStatuses: (state: GlobalState) => [Set<Team['id']>, M
     ) => {
         const teamUnreadsSet = new Set<Team['id']>();
         const teamMentionsMap = new Map<Team['id'], number>();
+        const teamHasUrgentMap = new Map<Team['id'], boolean>();
 
         for (const [channelId, channelMembership] of Object.entries(channelMemberships)) {
             const channel = channels[channelId];
@@ -735,6 +737,14 @@ export const getTeamsUnreadStatuses: (state: GlobalState) => [Set<Team['id']>, M
                     teamMentionsMap.set(channel.team_id, unreadCountObjectForChannel.mentions + previousMentionsInTeam);
                 }
             }
+
+            // Add has urgent mentions count from channel membership
+            if (unreadCountObjectForChannel.hasUrgent) {
+                const previousHasUrgetInTeam = teamHasUrgentMap.has(channel.team_id) ? teamHasUrgentMap.get(channel.team_id) as boolean : false;
+                if (!previousHasUrgetInTeam) {
+                    teamHasUrgentMap.set(channel.team_id, unreadCountObjectForChannel.hasUrgent);
+                }
+            }
         }
 
         if (collapsedThreadsEnabled) {
@@ -755,10 +765,18 @@ export const getTeamsUnreadStatuses: (state: GlobalState) => [Set<Team['id']>, M
                         teamMentionsMap.set(teamId, threadCountsObjectForTeam.total_unread_mentions + previousMentionsInTeam);
                     }
                 }
+
+                // Add mentions count from global threads view for team
+                if (threadCountsObjectForTeam.total_unread_urgent_mentions) {
+                    const previousHasUrgetInTeam = teamHasUrgentMap.has(teamId) ? teamHasUrgentMap.get(teamId) as boolean : false;
+                    if (!previousHasUrgetInTeam) {
+                        teamHasUrgentMap.set(teamId, Boolean(threadCountsObjectForTeam.total_unread_urgent_mentions));
+                    }
+                }
             }
         }
 
-        return [teamUnreadsSet, teamMentionsMap];
+        return [teamUnreadsSet, teamMentionsMap, teamHasUrgentMap];
     },
 );
 
@@ -773,6 +791,7 @@ export const getUnreadStatusInCurrentTeam: (state: GlobalState) => BasicUnreadSt
     getCurrentTeamId,
     isCollapsedThreadsEnabled,
     getThreadCountsIncludingDirect,
+    isPostPriorityEnabled,
     (
         currentChannelId,
         channels,
@@ -783,6 +802,7 @@ export const getUnreadStatusInCurrentTeam: (state: GlobalState) => BasicUnreadSt
         currentTeamId,
         collapsedThreadsEnabled,
         threadCounts,
+        postPriorityEnabled,
     ) => {
         const {
             messages: currentTeamUnreadMessages,
@@ -804,6 +824,10 @@ export const getUnreadStatusInCurrentTeam: (state: GlobalState) => BasicUnreadSt
                 counts.mentions += mentions;
             }
 
+            if (postPriorityEnabled) {
+                counts.urgentMentions += m.urgent_mention_count;
+            }
+
             const unreadCount = calculateUnreadCount(messageCounts[channel.id], m, collapsedThreadsEnabled);
             if (unreadCount.showUnread) {
                 counts.messages += unreadCount.messages;
@@ -813,6 +837,7 @@ export const getUnreadStatusInCurrentTeam: (state: GlobalState) => BasicUnreadSt
         }, {
             messages: 0,
             mentions: 0,
+            urgentMentions: 0,
         });
 
         let totalUnreadMentions = currentTeamUnreadMentions;

--- a/packages/mattermost-redux/src/selectors/entities/threads.ts
+++ b/packages/mattermost-redux/src/selectors/entities/threads.ts
@@ -182,3 +182,17 @@ export const getThreadsInChannel: (
         return Object.keys(allThreads).filter((id) => allThreads[id].post.channel_id === channelID);
     },
 );
+
+export const getThreadItemsInChannel: (
+    state: GlobalState,
+    channelID: string,
+) => UserThread[] = createSelector(
+    'getThreadItemsInChannel',
+    getThreads,
+    (state: GlobalState, channelID: string) => channelID,
+    (allThreads: IDMappedObjects<UserThread>, channelID: string) => {
+        return Object.keys(allThreads).
+            map((id) => allThreads[id]).
+            filter((item) => item.post.channel_id === channelID);
+    },
+);

--- a/packages/mattermost-redux/src/utils/channel_utils.ts
+++ b/packages/mattermost-redux/src/utils/channel_utils.ts
@@ -366,10 +366,11 @@ export function calculateUnreadCount(
     messageCount: ChannelMessageCount | undefined,
     member: ChannelMembership | null | undefined,
     crtEnabled: boolean,
-): {showUnread: boolean; mentions: number; messages: number} {
+): {showUnread: boolean; mentions: number; messages: number; hasUrgent: boolean} {
     if (!member || !messageCount) {
         return {
             showUnread: false,
+            hasUrgent: false,
             mentions: 0,
             messages: 0,
         };
@@ -377,6 +378,7 @@ export function calculateUnreadCount(
 
     let messages;
     let mentions;
+    let hasUrgent = false;
     if (crtEnabled) {
         messages = messageCount.root - member.msg_count_root;
         mentions = member.mention_count_root;
@@ -384,10 +386,14 @@ export function calculateUnreadCount(
         mentions = member.mention_count;
         messages = messageCount.total - member.msg_count;
     }
+    if (member.urgent_mention_count) {
+        hasUrgent = true;
+    }
 
     return {
         showUnread: mentions > 0 || (!isChannelMuted(member) && messages > 0),
         messages,
         mentions,
+        hasUrgent,
     };
 }

--- a/packages/types/src/channels.ts
+++ b/packages/types/src/channels.ts
@@ -105,6 +105,9 @@ export type ChannelMembership = {
     /** The number of unread mentions in root posts in this channel */
     mention_count_root: number;
 
+    /** The number of unread urgent mentions in this channel */
+    urgent_mention_count: number;
+
     notify_props: Partial<ChannelNotifyProps>;
     last_update_at: number;
     scheme_user: boolean;
@@ -125,6 +128,9 @@ export type ChannelUnread = {
 
     /** The number of unread mentions in this channel */
     mention_count: number;
+
+    /** The number of unread urgent mentions in this channel */
+    urgent_mention_count: number;
 
     /** The number of unread mentions in root posts in this channel */
     mention_count_root: number;

--- a/packages/types/src/teams.ts
+++ b/packages/types/src/teams.ts
@@ -78,6 +78,7 @@ export type TeamUnread = {
 
     thread_count?: number;
     thread_mention_count?: number;
+    thread_urgent_mention_count?: number;
 };
 
 export type GetTeamMembersOpts = {

--- a/packages/types/src/threads.ts
+++ b/packages/types/src/threads.ts
@@ -20,6 +20,7 @@ export type UserThread = {
     unread_replies: number;
     unread_mentions: number;
     is_following: boolean;
+    is_urgent?: boolean;
     type?: UserThreadType;
 
     // TODO consider flattening, removing post from UserThreads in-store
@@ -48,6 +49,7 @@ export type UserThreadList = {
     total: number;
     total_unread_threads: number;
     total_unread_mentions: number;
+    total_unread_urgent_mentions?: number;
     threads: UserThreadWithPost[];
 }
 
@@ -59,10 +61,12 @@ export type ThreadsState = {
         total: number;
         total_unread_threads: number;
         total_unread_mentions: number;
+        total_unread_urgent_mentions?: number;
     }>;
     countsIncludingDirect: RelationOneToOne<Team, {
         total: number;
         total_unread_threads: number;
         total_unread_mentions: number;
+        total_unread_urgent_mentions?: number;
     }>;
 };

--- a/sass/components/_badge.scss
+++ b/sass/components/_badge.scss
@@ -19,6 +19,11 @@
         .badge {
             background: var(--mention-bg);
             color: var(--mention-color);
+
+            &.urgent {
+                background-color: var(--dnd-indicator);
+                color: #fff;
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary

We have introduced priority for posts in
mattermost/mattermost-webapp#10951. We do need to color the mention badges in the webapp with a prominent color when a mention is posted in an urgent message. A thread has urgent mentions if the root post is marked as urgent, and the replies contain mentions to the user viewing the thread.

This PR incorporates the newly added `total_unread_urgent_mentions`, and `urgent_mention_count` properties in the responese for thread counts, and channel members respectively.
The team's icon in the sidebar, threads link, and channel sidebar link, are all shown with an urgent mention count (red background) when they contain an mention in an urgent post.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46410

#### Related Pull Requests

- Has server changes ([please link here](https://github.com/mattermost/mattermost-server/pull/20999))


#### Screenshots


#### Release Note

```release-note

```
