### PR TITLE
MM-44114 : Announcing of channel interface language dropdown correctly

### DIFF
--- a/components/user_settings/display/__snapshots__/user_settings_display.test.tsx.snap
+++ b/components/user_settings/display/__snapshots__/user_settings_display.test.tsx.snap
@@ -1379,7 +1379,7 @@ exports[`components/user_settings/display/UserSettingsDisplay should match snaps
       />
     </div>
     <div>
-      <Connect(ManageLanguage)
+      <Connect(injectIntl(ManageLanguage))
         locale="en"
         updateSection={[Function]}
         user={

--- a/components/user_settings/display/manage_languages/manage_languages.test.tsx
+++ b/components/user_settings/display/manage_languages/manage_languages.test.tsx
@@ -2,11 +2,12 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
 
 import {UserProfile} from '@mattermost/types/users';
 
-import ManageLanguages from './manage_languages';
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
+
+import ManageLanguages, {ManageLanguage as ManageLanguageClass} from './manage_languages';
 
 describe('components/user_settings/display/manage_languages/manage_languages', () => {
     const user = {
@@ -25,8 +26,8 @@ describe('components/user_settings/display/manage_languages/manage_languages', (
     test('submitUser() should have called updateMe', async () => {
         const updateMe = jest.fn(() => Promise.resolve({data: true}));
         const props = {...requiredProps, actions: {...requiredProps.actions, updateMe}};
-        const wrapper = shallow(<ManageLanguages {...props}/>);
-        const instance = wrapper.instance() as ManageLanguages;
+        const wrapper = shallowWithIntl(<ManageLanguages {...props}/>);
+        const instance = wrapper.instance() as ManageLanguageClass;
 
         await instance.submitUser(requiredProps.user);
 

--- a/components/user_settings/display/manage_languages/manage_languages.tsx
+++ b/components/user_settings/display/manage_languages/manage_languages.tsx
@@ -181,7 +181,7 @@ export class ManageLanguage extends React.PureComponent<Props, State> {
                 zIndex: 9999,
             }),
         };
-        const interfaceLanguageLabelAria = intl.formatMessage({id: 'user.settings.languages.dropdown.arialabel', defaultMessage: 'dropdown selector to change the interface language'});
+        const interfaceLanguageLabelAria = intl.formatMessage({id: 'user.settings.languages.dropdown.arialabel', defaultMessage: 'Dropdown selector to change the interface language'});
 
         const input = (
             <div key='changeLanguage'>

--- a/components/user_settings/display/manage_languages/manage_languages.tsx
+++ b/components/user_settings/display/manage_languages/manage_languages.tsx
@@ -38,7 +38,7 @@ type State = {
     selectedOption: SelectedOption;
 };
 
-class ManageLanguage extends React.PureComponent<Props, State> {
+export class ManageLanguage extends React.PureComponent<Props, State> {
     reactSelectContainer: React.RefObject<HTMLDivElement>;
     constructor(props: Props) {
         super(props);

--- a/components/user_settings/display/manage_languages/manage_languages.tsx
+++ b/components/user_settings/display/manage_languages/manage_languages.tsx
@@ -181,13 +181,13 @@ class ManageLanguage extends React.PureComponent<Props, State> {
                 zIndex: 9999,
             }),
         };
-        const aria = intl.formatMessage({id: 'user.settings.languages.dropdown', defaultMessage: 'drop down selector to change the interface language'});
+        const interfaceLanguageLabelAria = intl.formatMessage({id: 'user.settings.languages.dropdown.arialabel', defaultMessage: 'dropdown selector to change the interface language'});
 
         const input = (
             <div key='changeLanguage'>
                 <br/>
                 <label
-                    aria-label={aria}
+                    aria-label={interfaceLanguageLabelAria}
                     className='control-label'
                     id='changeInterfaceLanguageLabel'
                 >

--- a/components/user_settings/display/manage_languages/manage_languages.tsx
+++ b/components/user_settings/display/manage_languages/manage_languages.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, injectIntl, IntlShape} from 'react-intl';
 import ReactSelect, {ValueType} from 'react-select';
 
 import {ActionResult} from 'mattermost-redux/types/actions';
@@ -18,6 +18,7 @@ type Actions = {
 };
 
 type Props = {
+    intl: IntlShape;
     user: UserProfile;
     locale: string;
     updateSection: (section: string) => void;
@@ -37,7 +38,7 @@ type State = {
     selectedOption: SelectedOption;
 };
 
-export default class ManageLanguage extends React.PureComponent<Props, State> {
+class ManageLanguage extends React.PureComponent<Props, State> {
     reactSelectContainer: React.RefObject<HTMLDivElement>;
     constructor(props: Props) {
         super(props);
@@ -149,6 +150,7 @@ export default class ManageLanguage extends React.PureComponent<Props, State> {
     };
 
     render() {
+        const {intl} = this.props;
         let serverError;
         if (this.state.serverError) {
             serverError = (
@@ -179,11 +181,13 @@ export default class ManageLanguage extends React.PureComponent<Props, State> {
                 zIndex: 9999,
             }),
         };
+        const aria = intl.formatMessage({id: 'user.settings.languages.dropdown', defaultMessage: 'drop down selector to change the interface language'});
 
         const input = (
             <div key='changeLanguage'>
                 <br/>
                 <label
+                    aria-label={aria}
                     className='control-label'
                     id='changeInterfaceLanguageLabel'
                 >
@@ -257,3 +261,4 @@ export default class ManageLanguage extends React.PureComponent<Props, State> {
         );
     }
 }
+export default injectIntl(ManageLanguage);

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5085,7 +5085,7 @@
   "user.settings.import_theme.submit": "Submit",
   "user.settings.import_theme.submitError": "Invalid format, please try copying and pasting in again.",
   "user.settings.languages.change": "Change interface language",
-  "user.settings.languages.dropdown": "drop down selector to change the interface language",
+  "user.settings.languages.dropdown.arialabel": "dropdown selector to change the interface language",
   "user.settings.languages.promote1": "Select which language Mattermost displays in the user interface.",
   "user.settings.languages.promote2": "Would you like to help with translations? Join the <link>Mattermost Translation Server</link> to contribute.",
   "user.settings.mfa.add": "Add MFA to Account",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5085,7 +5085,7 @@
   "user.settings.import_theme.submit": "Submit",
   "user.settings.import_theme.submitError": "Invalid format, please try copying and pasting in again.",
   "user.settings.languages.change": "Change interface language",
-  "user.settings.languages.dropdown.arialabel": "dropdown selector to change the interface language",
+  "user.settings.languages.dropdown.arialabel": "Dropdown selector to change the interface language",
   "user.settings.languages.promote1": "Select which language Mattermost displays in the user interface.",
   "user.settings.languages.promote2": "Would you like to help with translations? Join the <link>Mattermost Translation Server</link> to contribute.",
   "user.settings.mfa.add": "Add MFA to Account",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5085,6 +5085,7 @@
   "user.settings.import_theme.submit": "Submit",
   "user.settings.import_theme.submitError": "Invalid format, please try copying and pasting in again.",
   "user.settings.languages.change": "Change interface language",
+  "user.settings.languages.dropdown": "drop down selector to change the interface language",
   "user.settings.languages.promote1": "Select which language Mattermost displays in the user interface.",
   "user.settings.languages.promote2": "Would you like to help with translations? Join the <link>Mattermost Translation Server</link> to contribute.",
   "user.settings.mfa.add": "Add MFA to Account",


### PR DESCRIPTION
#### Summary
Announcing of Settings > Display > Language > Change interface language field dropdown correctly 

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-44114
Fixes https://github.com/mattermost/mattermost-server/issues/21159


#### Related Pull Requests
none
#### Screenshots

|  before | 

https://user-images.githubusercontent.com/102028591/189839616-ae976aa3-87eb-4d5b-8750-166a67e1af0b.mp4

|  after  |

https://user-images.githubusercontent.com/102028591/189838983-b1e9fb1a-0917-45eb-bf0f-776a95b64a02.mp4


```release-note

Channel interface language dropdown in  Settings > Display > Language > Change interface language field not announcing that it was a dropdown by ScreenReader. Now by giving Aria-label to it makes it announcing properly by ScreenReader.

```
