### PR TITLE
[MM-46974]: Insights: Fix activity time display when lastactivityat = 0

### DIFF
--- a/components/activity_and_insights/insights/least_active_channels/least_active_channels.test.tsx
+++ b/components/activity_and_insights/insights/least_active_channels/least_active_channels.test.tsx
@@ -59,6 +59,14 @@ jest.mock('mattermost-redux/actions/insights', () => ({
                     last_activity_at: 1660175775169,
                     participants: [],
                 },
+                {
+                    id: 'uziynciroprq4g6ohhnednoeuw',
+                    type: 'O',
+                    display_name: 'dolor',
+                    name: 'aut-9',
+                    last_activity_at: 0,
+                    participants: [],
+                },
             ],
         }}),
 }));
@@ -111,6 +119,14 @@ describe('components/activity_and_insights/insights/top_boards', () => {
                         last_activity_at: 1660175775169,
                         team_id: 'team_id1',
                     },
+                    uziynciroprq4g6ohhnednoeuw: {
+                        id: 'uziynciroprq4g6ohhnednoeuw',
+                        type: 'O',
+                        display_name: 'dolor',
+                        name: 'aut-9',
+                        last_activity_at: 0,
+                        participants: [],
+                    },
                 },
                 myMembers: {},
             },
@@ -141,7 +157,7 @@ describe('components/activity_and_insights/insights/top_boards', () => {
         },
     };
 
-    test('check if 3 channels render', async () => {
+    test('check if 4 channels render', async () => {
         const store = await mockStore(initialState);
         const wrapper = mountWithIntl(
             <Provider store={store}>
@@ -154,7 +170,7 @@ describe('components/activity_and_insights/insights/top_boards', () => {
         );
         await actImmediate(wrapper);
 
-        expect(wrapper.find('a.channel-row').length).toEqual(3);
+        expect(wrapper.find('a.channel-row').length).toEqual(4);
     });
 
     test('check if 0 channels render', async () => {

--- a/components/activity_and_insights/insights/least_active_channels/least_active_channels_item/least_active_channels_item.tsx
+++ b/components/activity_and_insights/insights/least_active_channels/least_active_channels_item/least_active_channels_item.tsx
@@ -43,6 +43,45 @@ const LeastActiveChannelsItem = ({channel, actionCallback}: Props) => {
         return iconToDisplay;
     }, [channel]);
 
+    let timeMessage = (
+        <FormattedMessage
+            id='insights.leastActiveChannels.lastActivity'
+            defaultMessage='Last activity: {time}'
+            values={{
+                time:
+                (
+                    <Timestamp
+                        value={channel.last_activity_at}
+                        units={[
+                            'now',
+                            'minute',
+                            'hour',
+                            'day',
+                            'week',
+                            'month',
+                        ]}
+                        useTime={false}
+                    />
+                ),
+            }}
+        />
+    );
+    if (channel.last_activity_at === 0) {
+        timeMessage = (
+            <FormattedMessage
+                id='insights.leastActiveChannels.lastActivityNone'
+                defaultMessage='{time}'
+                values={{
+                    time:
+                    (
+                        <span>
+                            {'No activity'}
+                        </span>
+                    ),
+                }}
+            />
+        );
+    }
     return (
         <Link
             className='channel-row'
@@ -57,26 +96,7 @@ const LeastActiveChannelsItem = ({channel, actionCallback}: Props) => {
                     <span className='display-name'>{channel.display_name}</span>
                 </div>
                 <span className='last-activity'>
-                    <FormattedMessage
-                        id='insights.leastActiveChannels.lastActivity'
-                        defaultMessage='Last activity: {time}'
-                        values={{
-                            time: (
-                                <Timestamp
-                                    value={channel.last_activity_at}
-                                    units={[
-                                        'now',
-                                        'minute',
-                                        'hour',
-                                        'day',
-                                        'week',
-                                        'month',
-                                    ]}
-                                    useTime={false}
-                                />
-                            ),
-                        }}
-                    />
+                    {timeMessage}
                 </span>
             </div>
             <Avatars

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3565,6 +3565,7 @@
   "insights.leastActiveChannels.copyLink": "Copy link",
   "insights.leastActiveChannels.lastActivity": "Last activity: {time}",
   "insights.leastActiveChannels.lastActivityCell": "Last activity",
+  "insights.leastActiveChannels.lastActivityNone": "{time}",
   "insights.leastActiveChannels.leaveChannel": "Leave channel",
   "insights.leastActiveChannels.members": "Members",
   "insights.leastActiveChannels.menuAriaLabel": "Manage channel menu",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR changes time label to display 'No Activity' when lastactivityat in a channel is 0 due to coalesce/

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-46974

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| 
<img width="639" alt="Screenshot 2022-09-13 at 3 24 19 PM" src="https://user-images.githubusercontent.com/22407757/189881286-bb75d2ca-2e29-4d90-8a39-de6480be5b3a.png">
 | 
<img width="561" alt="Screenshot 2022-09-13 at 4 24 37 PM" src="https://user-images.githubusercontent.com/22407757/189883499-e3eb6abd-6ae2-4913-87ab-5154dce791b9.png">
 |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
