### PR TITLE
MM-46977: fixes post priority menu

### DIFF
--- a/components/post_priority/post_priority_picker_item.tsx
+++ b/components/post_priority/post_priority_picker_item.tsx
@@ -28,6 +28,11 @@ const StyledCheckIcon = styled(CheckIcon)`
 `;
 
 const Menu = styled.ul`
+    display: block;
+    position: relative;
+    box-shadow: none;
+    border-radius: 0;
+    border: 0;
     padding: 8px 0;
     margin: 0;
     color: var(--center-channel-text-rgb);


### PR DESCRIPTION
#### Summary

Boards is adding inline styles that change the `.Menu` class, 
which have the effect of not showing the "post priority" picker items.

This PR negates those changes, by styles in the styled-component used as the Menu in the picker.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46977

#### Release Note

```release-note
NONE
```
