### PR TITLE
[MM-46886] Fix responsive issue for insights

### DIFF
--- a/components/activity_and_insights/activity_and_insights.scss
+++ b/components/activity_and_insights/activity_and_insights.scss
@@ -101,6 +101,15 @@
         }
 
         .top-playbooks-card,
+        .least-active-channels-card {
+            &.medium {
+                @media screen and (max-width: 1279px) and (min-width: 769px) {
+                    width: calc(100% - 16px);
+                }
+            }
+        }
+
+        .top-playbooks-card,
         .top-dms-card {
             .Card__body {
                 padding: 0 12px 12px;

--- a/sass/responsive/_desktop.scss
+++ b/sass/responsive/_desktop.scss
@@ -1,5 +1,19 @@
 @charset "utf-8";
 
+@media screen and (min-width: 1680px) and (max-width: 2135px) {
+    .inner-wrap {
+        &.move--left {
+            .ActivityAndInsights {
+                .insights-card {
+                    &.large {
+                        align-self: flex-start;
+                    }
+                }
+            }
+        }
+    }
+}
+
 @media screen and (min-width: 1680px) {
     .sidebar--right {
         width: 500px;


### PR DESCRIPTION
#### Summary
Fixing responsive of insights when threads are open. On larger screens the large cards were being pushed to the side

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46886

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
