### PR TITLE
MM-46992 : Migrate "actions/channel_actions" to ts

### DIFF
--- a/actions/channel_actions.test.ts
+++ b/actions/channel_actions.test.ts
@@ -98,7 +98,7 @@ const initialState = {
 const realDateNow = Date.now;
 
 jest.mock('mattermost-redux/actions/channels', () => ({
-    fetchMyChannelsAndMembers: (...args) => ({type: 'MOCK_FETCH_CHANNELS_AND_MEMBERS', args}),
+    fetchMyChannelsAndMembers: (...args: any) => ({type: 'MOCK_FETCH_CHANNELS_AND_MEMBERS', args}),
     searchChannels: () => {
         return {
             type: 'MOCK_SEARCH_CHANNELS',
@@ -111,9 +111,9 @@ jest.mock('mattermost-redux/actions/channels', () => ({
             }],
         };
     },
-    addChannelMember: (...args) => ({type: 'MOCK_ADD_CHANNEL_MEMBER', args}),
-    createDirectChannel: (...args) => ({type: 'MOCK_CREATE_DIRECT_CHANNEL', args}),
-    createGroupChannel: (...args) => ({type: 'MOCK_CREATE_GROUP_CHANNEL', args}),
+    addChannelMember: (...args: any) => ({type: 'MOCK_ADD_CHANNEL_MEMBER', args}),
+    createDirectChannel: (...args: any) => ({type: 'MOCK_CREATE_DIRECT_CHANNEL', args}),
+    createGroupChannel: (...args: any) => ({type: 'MOCK_CREATE_GROUP_CHANNEL', args}),
 }));
 
 jest.mock('actions/user_actions', () => ({
@@ -150,7 +150,7 @@ describe('Actions.Channel', () => {
             }],
         }];
 
-        await testStore.dispatch(Actions.searchMoreChannels());
+        await testStore.dispatch(Actions.searchMoreChannels('', false));
         expect(testStore.getActions()).toEqual(expectedActions);
     });
 

--- a/actions/channel_actions.ts
+++ b/actions/channel_actions.ts
@@ -3,9 +3,14 @@
 
 import {batchActions} from 'redux-batched-actions';
 
+import {UserProfile} from '@mattermost/types/users';
+import {Channel, ChannelNotifyProps} from '@mattermost/types/channels';
+import {ServerError} from '@mattermost/types/errors';
+
 import {PreferenceTypes} from 'mattermost-redux/action_types';
 import * as ChannelActions from 'mattermost-redux/actions/channels';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {ActionFunc} from 'mattermost-redux/types/actions';
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
 import {getChannelByName, getUnreadChannelIds, getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
@@ -13,11 +18,12 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded, loadProfilesForSidebar} from 'actions/user_actions';
+
 import {browserHistory} from 'utils/browser_history';
 import {Constants, Preferences, NotificationLevels} from 'utils/constants';
 import {getDirectChannelName} from 'utils/utils';
 
-export function openDirectChannelToUserId(userId) {
+export function openDirectChannelToUserId(userId: UserProfile['id']): ActionFunc {
     return async (dispatch, getState) => {
         const state = getState();
         const currentUserId = getCurrentUserId(state);
@@ -58,7 +64,7 @@ export function openDirectChannelToUserId(userId) {
     };
 }
 
-export function openGroupChannelToUserIds(userIds) {
+export function openGroupChannelToUserIds(userIds: Array<UserProfile['id']>): ActionFunc {
     return async (dispatch, getState) => {
         const result = await dispatch(ChannelActions.createGroupChannel(userIds));
 
@@ -70,7 +76,7 @@ export function openGroupChannelToUserIds(userIds) {
     };
 }
 
-export function loadChannelsForCurrentUser() {
+export function loadChannelsForCurrentUser(): ActionFunc {
     return async (dispatch, getState) => {
         const state = getState();
         const unreads = getUnreadChannelIds(state);
@@ -90,7 +96,7 @@ export function loadChannelsForCurrentUser() {
     };
 }
 
-export function searchMoreChannels(term, showArchivedChannels) {
+export function searchMoreChannels(term: string, showArchivedChannels: boolean): ActionFunc<Channel[], ServerError> {
     return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);
@@ -104,7 +110,7 @@ export function searchMoreChannels(term, showArchivedChannels) {
             const myMembers = getMyChannelMemberships(state);
 
             // When searching public channels, only get channels user is not a member of
-            const channels = showArchivedChannels ? data : data.filter((c) => !myMembers[c.id]);
+            const channels = showArchivedChannels ? data : (data as Channel[]).filter((c) => !myMembers[c.id]);
             return {data: channels};
         }
 
@@ -112,7 +118,7 @@ export function searchMoreChannels(term, showArchivedChannels) {
     };
 }
 
-export function autocompleteChannels(term, success, error) {
+export function autocompleteChannels(term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void): ActionFunc {
     return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);
@@ -131,7 +137,7 @@ export function autocompleteChannels(term, success, error) {
     };
 }
 
-export function autocompleteChannelsForSearch(term, success, error) {
+export function autocompleteChannelsForSearch(term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void): ActionFunc {
     return async (dispatch, getState) => {
         const state = getState();
         const teamId = getCurrentTeamId(state);
@@ -150,7 +156,7 @@ export function autocompleteChannelsForSearch(term, success, error) {
     };
 }
 
-export function addUsersToChannel(channelId, userIds) {
+export function addUsersToChannel(channelId: Channel['id'], userIds: Array<UserProfile['id']>): ActionFunc {
     return async (dispatch) => {
         try {
             const requests = userIds.map((uId) => dispatch(ChannelActions.addChannelMember(channelId, uId)));
@@ -162,14 +168,14 @@ export function addUsersToChannel(channelId, userIds) {
     };
 }
 
-export function unmuteChannel(userId, channelId) {
+export function unmuteChannel(userId: UserProfile['id'], channelId: Channel['id']) {
     return ChannelActions.updateChannelNotifyProps(userId, channelId, {
         mark_unread: NotificationLevels.ALL,
-    });
+    } as ChannelNotifyProps);
 }
 
-export function muteChannel(userId, channelId) {
+export function muteChannel(userId: UserProfile['id'], channelId: Channel['id']) {
     return ChannelActions.updateChannelNotifyProps(userId, channelId, {
         mark_unread: NotificationLevels.MENTION,
-    });
+    } as ChannelNotifyProps);
 }

--- a/actions/channel_actions.ts
+++ b/actions/channel_actions.ts
@@ -4,7 +4,7 @@
 import {batchActions} from 'redux-batched-actions';
 
 import {UserProfile} from '@mattermost/types/users';
-import {Channel, ChannelNotifyProps} from '@mattermost/types/channels';
+import {Channel} from '@mattermost/types/channels';
 import {ServerError} from '@mattermost/types/errors';
 
 import {PreferenceTypes} from 'mattermost-redux/action_types';
@@ -171,11 +171,11 @@ export function addUsersToChannel(channelId: Channel['id'], userIds: Array<UserP
 export function unmuteChannel(userId: UserProfile['id'], channelId: Channel['id']) {
     return ChannelActions.updateChannelNotifyProps(userId, channelId, {
         mark_unread: NotificationLevels.ALL,
-    } as ChannelNotifyProps);
+    });
 }
 
 export function muteChannel(userId: UserProfile['id'], channelId: Channel['id']) {
     return ChannelActions.updateChannelNotifyProps(userId, channelId, {
         mark_unread: NotificationLevels.MENTION,
-    } as ChannelNotifyProps);
+    });
 }

--- a/actions/views/channel.ts
+++ b/actions/views/channel.ts
@@ -47,7 +47,7 @@ import {getChannelByName} from 'mattermost-redux/utils/channel_utils';
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {closeRightHandSide} from 'actions/views/rhs';
-import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
+import {openDirectChannelToUserId} from 'actions/channel_actions';
 import {loadCustomStatusEmojisForPostList} from 'actions/emoji_actions';
 import {getLastViewedChannelName} from 'selectors/local_storage';
 import {getLastPostsApiTimeForChannel} from 'selectors/views/channel';

--- a/actions/views/create_comment.test.jsx
+++ b/actions/views/create_comment.test.jsx
@@ -305,7 +305,7 @@ describe('rhs view actions', () => {
         });
 
         test('it calls submitPost on error.sendMessage', async () => {
-            jest.mock('actions/channel_actions.jsx', () => ({
+            jest.mock('actions/channel_actions', () => ({
                 executeCommand: jest.fn((message, _args, resolve, reject) => reject({sendMessage: 'test'})),
             }));
 

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -95,7 +95,7 @@ import {syncPostsInChannel} from 'actions/views/channel';
 import {updateThreadLastOpened} from 'actions/views/threads';
 
 import {browserHistory} from 'utils/browser_history';
-import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
+import {loadChannelsForCurrentUser} from 'actions/channel_actions';
 import {loadCustomEmojisIfNeeded} from 'actions/emoji_actions';
 import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import {handleNewPost} from 'actions/post_actions';

--- a/components/advanced_create_post/advanced_create_post.test.jsx
+++ b/components/advanced_create_post/advanced_create_post.test.jsx
@@ -687,7 +687,7 @@ describe('components/advanced_create_post', () => {
     });
 
     it('onSubmit test for "/unknown" message ', async () => {
-        jest.mock('actions/channel_actions.jsx', () => ({
+        jest.mock('actions/channel_actions', () => ({
             executeCommand: jest.fn((message, _args, resolve) => resolve()),
         }));
 

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -657,7 +657,7 @@ describe('components/create_post', () => {
     });
 
     it('onSubmit test for "/unknown" message ', async () => {
-        jest.mock('actions/channel_actions.jsx', () => ({
+        jest.mock('actions/channel_actions', () => ({
             executeCommand: jest.fn((message, _args, resolve) => resolve()),
         }));
 

--- a/components/more_channels/index.ts
+++ b/components/more_channels/index.ts
@@ -15,7 +15,7 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getChannels, getArchivedChannels, joinChannel} from 'mattermost-redux/actions/channels';
 import {getOtherChannels, getChannelsInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
 
-import {searchMoreChannels} from 'actions/channel_actions.jsx';
+import {searchMoreChannels} from 'actions/channel_actions';
 import {openModal, closeModal} from 'actions/views/modals';
 
 import {ModalData} from 'types/actions';

--- a/components/permalink_view/actions.ts
+++ b/components/permalink_view/actions.ts
@@ -14,7 +14,7 @@ import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import {Post} from '@mattermost/types/posts';
 import {Channel} from '@mattermost/types/channels';
 
-import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
+import {loadChannelsForCurrentUser} from 'actions/channel_actions';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions';
 import {selectPostAndHighlight} from 'actions/views/rhs';
 

--- a/components/permalink_view/permalink_view.test.tsx
+++ b/components/permalink_view/permalink_view.test.tsx
@@ -28,7 +28,7 @@ jest.mock('utils/browser_history', () => ({
     },
 }));
 
-jest.mock('actions/channel_actions.jsx', () => ({
+jest.mock('actions/channel_actions', () => ({
     loadChannelsForCurrentUser: jest.fn(() => {
         return {type: 'MOCK_LOAD_CHANNELS_FOR_CURRENT_USER'};
     }),

--- a/components/post_view/message_attachments/action_menu/action_menu.test.tsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.test.tsx
@@ -24,11 +24,10 @@ describe('components/post_view/message_attachments/ActionMenu', () => {
             id: 'id',
             cookie: 'cookie',
         },
-        actions: {
-            autocompleteChannels: jest.fn(),
-            autocompleteUsers: jest.fn(),
-            selectAttachmentMenuAction: jest.fn(),
-        },
+        selected: undefined,
+        autocompleteChannels: jest.fn(),
+        autocompleteUsers: jest.fn(),
+        selectAttachmentMenuAction: jest.fn(),
     };
 
     test('should start with nothing selected', () => {

--- a/components/post_view/message_attachments/action_menu/action_menu.tsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.tsx
@@ -3,11 +3,8 @@
 
 import React from 'react';
 
-import {ActionResult, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
-import {PostAction} from '@mattermost/types/integration_actions';
 import {UserProfile} from '@mattermost/types/users';
 import {Channel} from '@mattermost/types/channels';
-import {ServerError} from '@mattermost/types/errors';
 
 import MenuActionProvider from 'components/suggestion/menu_action_provider';
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
@@ -15,25 +12,7 @@ import GenericChannelProvider from 'components/suggestion/generic_channel_provid
 import AutocompleteSelector from 'components/autocomplete_selector';
 import PostContext from 'components/post_view/post_context';
 
-type Error = ServerError & {id: string};
-
-type AutocompleteUsersAction =
-    (username: string) => (doDispatch: DispatchFunc) => Promise<UserProfile[]>;
-
-type AutocompleteChannelsAction = (
-    term: string,
-    success: (channels: Channel[]) => void,
-    error: (error: Error) => void
-) => (dispatch: DispatchFunc, getState: GetStateFunc) => Promise<ActionResult>;
-
-type SelectAttachmentMenuAction = (
-    postId: string,
-    actionId: string,
-    cookie: string,
-    dataSource: string | undefined,
-    text: string,
-    value: string
-) => (dispatch: DispatchFunc) => Promise<ActionResult>;
+import type {OwnProps, PropsFromRedux} from './index';
 
 type Option = {
     text: string;
@@ -44,17 +23,7 @@ type Provider = GenericUserProvider | GenericChannelProvider | MenuActionProvide
 
 type Selected = Option | UserProfile | Channel;
 
-export type Props = {
-    postId: string;
-    action: PostAction;
-    selected?: Selected;
-    disabled?: boolean;
-    actions: {
-        autocompleteChannels: AutocompleteChannelsAction;
-        selectAttachmentMenuAction: SelectAttachmentMenuAction;
-        autocompleteUsers: AutocompleteUsersAction;
-    };
-};
+export type Props = OwnProps & PropsFromRedux;
 
 type State = {
     selected?: Selected;
@@ -71,9 +40,9 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
         this.providers = [];
         if (action) {
             if (action.data_source === 'users') {
-                this.providers = [new GenericUserProvider(props.actions.autocompleteUsers)];
+                this.providers = [new GenericUserProvider(props.autocompleteUsers)];
             } else if (action.data_source === 'channels') {
-                this.providers = [new GenericChannelProvider(props.actions.autocompleteChannels)];
+                this.providers = [new GenericChannelProvider(props.autocompleteChannels)];
             } else if (action.options) {
                 this.providers = [new MenuActionProvider(action.options)];
             }
@@ -128,7 +97,7 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
             value = option.value;
         }
 
-        this.props.actions.selectAttachmentMenuAction(
+        this.props.selectAttachmentMenuAction(
             this.props.postId, this.props.action.id || '', this.props.action.cookie || '', this.props.action?.data_source, text, value);
 
         this.setState({value: text});

--- a/components/post_view/message_attachments/action_menu/index.ts
+++ b/components/post_view/message_attachments/action_menu/index.ts
@@ -1,10 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {connect} from 'react-redux';
-import {bindActionCreators, Dispatch} from 'redux';
+import {connect, ConnectedProps} from 'react-redux';
 
-import {GenericAction} from 'mattermost-redux/types/actions';
 import {PostAction} from '@mattermost/types/integration_actions';
 
 import {GlobalState} from 'types/store';
@@ -14,9 +12,10 @@ import {selectAttachmentMenuAction} from 'actions/views/posts';
 
 import ActionMenu from './action_menu';
 
-type OwnProps = {
+export type OwnProps = {
     postId: string;
     action: PostAction;
+    disabled?: boolean;
 }
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
@@ -28,14 +27,14 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
-    return {
-        actions: bindActionCreators({
-            selectAttachmentMenuAction,
-            autocompleteChannels,
-            autocompleteUsers,
-        }, dispatch),
-    };
-}
+const mapDispatchToProps = {
+    selectAttachmentMenuAction,
+    autocompleteChannels,
+    autocompleteUsers,
+};
 
-export default connect(mapStateToProps, mapDispatchToProps)(ActionMenu);
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+export type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(ActionMenu);

--- a/components/profile_popover/index.ts
+++ b/components/profile_popover/index.ts
@@ -16,7 +16,7 @@ import {
     getCurrentChannelId,
 } from 'mattermost-redux/selectors/entities/channels';
 
-import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
+import {openDirectChannelToUserId} from 'actions/channel_actions';
 import {getMembershipForEntities} from 'actions/views/profile_popover';
 import {closeModal, openModal} from 'actions/views/modals';
 

--- a/packages/mattermost-redux/src/actions/channels.ts
+++ b/packages/mattermost-redux/src/actions/channels.ts
@@ -336,7 +336,7 @@ export function updateChannelPrivacy(channelId: string, privacy: string): Action
     };
 }
 
-export function updateChannelNotifyProps(userId: string, channelId: string, props: ChannelNotifyProps): ActionFunc {
+export function updateChannelNotifyProps(userId: string, channelId: string, props: Partial<ChannelNotifyProps>): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const notifyProps = {
             user_id: userId,


### PR DESCRIPTION
#### Summary
This is where the new graphql actions related to channels are , so it was important it to be converted to ts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46992

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
