### PR TITLE
[MM-46884] Load custom emojis in top reactions components

### DIFF
--- a/components/activity_and_insights/insights/top_reactions/top_reactions.tsx
+++ b/components/activity_and_insights/insights/top_reactions/top_reactions.tsx
@@ -9,6 +9,7 @@ import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {GlobalState} from '@mattermost/types/store';
 import {TopReaction} from '@mattermost/types/insights';
 
+import {loadCustomEmojisIfNeeded} from 'actions/emoji_actions';
 import {InsightsScopes} from 'utils/constants';
 
 import BarChartLoader from '../skeleton_loader/bar_chart_loader/bar_chart_loader';
@@ -31,11 +32,9 @@ const TopReactions = (props: WidgetHocProps) => {
     const myTopReactions = useSelector((state: GlobalState) => getMyTopReactionsForCurrentTeam(state, props.timeFrame, 5), shallowEqual);
 
     useEffect(() => {
-        if (props.filterType === InsightsScopes.TEAM) {
-            setTopReactions(teamTopReactions);
-        } else {
-            setTopReactions(myTopReactions);
-        }
+        const reactions = props.filterType === InsightsScopes.TEAM ? teamTopReactions : myTopReactions;
+        setTopReactions(reactions);
+        dispatch(loadCustomEmojisIfNeeded(reactions.map((reaction) => reaction.emoji_name)));
     }, [props.filterType, teamTopReactions, myTopReactions]);
 
     const currentTeamId = useSelector(getCurrentTeamId);

--- a/components/activity_and_insights/insights/top_reactions/top_reactions_table/top_reactions_table.test.tsx
+++ b/components/activity_and_insights/insights/top_reactions/top_reactions_table/top_reactions_table.test.tsx
@@ -34,6 +34,7 @@ describe('components/activity_and_insights/insights/top_reactions/top_reactions_
 
     const initialState = {
         entities: {
+            general: {config: {}},
             teams: {
                 currentTeamId: 'team_id1',
                 teams: {

--- a/components/activity_and_insights/insights/top_reactions/top_reactions_table/top_reactions_table.tsx
+++ b/components/activity_and_insights/insights/top_reactions/top_reactions_table/top_reactions_table.tsx
@@ -8,6 +8,7 @@ import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 
 import {TimeFrame} from '@mattermost/types/insights';
 
+import {loadCustomEmojisIfNeeded} from 'actions/emoji_actions';
 import DataGrid, {Row, Column} from 'components/admin_console/data_grid/data_grid';
 import RenderEmoji from 'components/emoji/render_emoji';
 
@@ -57,6 +58,11 @@ const TopReactionsTable = (props: Props) => {
     useEffect(() => {
         getMyTeamReactions();
     }, [getMyTeamReactions]);
+
+    useEffect(() => {
+        const reactions = props.filterType === InsightsScopes.TEAM ? teamTopReactions : myTopReactions;
+        dispatch(loadCustomEmojisIfNeeded(reactions.map((reaction) => reaction.emoji_name)));
+    }, [props.filterType, teamTopReactions, myTopReactions]);
 
     const getColumns = useMemo((): Column[] => {
         const columns: Column[] = [


### PR DESCRIPTION
#### Summary

Load custom emojis in the top reactions table and top reactions chart components, so that they are shown.

#### Ticket Link

[Jira ticket](https://mattermost.atlassian.net/browse/MM-46884)

Steps to reproduce bug:
- Switch to insights, make sure top reactions chart and/or top reactions table contains some custom emojis 
- Switch to a channel that doesn't have custom emojis in use
- Log out of user then log back in
- Switch to insights 
- You should see that the custom emojis in the top reactions chart/table do not render

The bug may also occur in other cases but the above is the easiest way for me to reproduce it.

#### Release Note

```release-note
NONE
```
