### PR TITLE
[MM-45488] Adding insights to the channel switcher

### DIFF
--- a/actions/views/channel.ts
+++ b/actions/views/channel.ts
@@ -121,6 +121,8 @@ export function switchToChannel(channel: Channel & {userId?: string}) {
             browserHistory.push(`${teamUrl}/channels/${gmChannel.name}`);
         } else if (channel.type === Constants.THREADS) {
             browserHistory.push(`${teamUrl}/${channel.name}`);
+        } else if (channel.type === Constants.INSIGHTS) {
+            browserHistory.push(`${teamUrl}/${channel.name}`);
         } else {
             browserHistory.push(`${teamUrl}/channels/${channel.name}`);
         }

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -738,7 +738,7 @@ export default class SwitchChannelProvider extends Provider {
         const insightsEnabled = insightsAreEnabled(state);
 
         // adding last viewed at equal to Date.now() to push it to the top of the list
-        let insightsItem = {
+        const insightsItem = {
             channel: InsightsChannel,
             name: InsightsChannel.name,
             unread_mentions: 0,

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -20,7 +20,7 @@ import {
     getAllTeamsUnreadChannelIds,
 } from 'mattermost-redux/selectors/entities/channels';
 import ProfilePicture from '../profile_picture';
-import {getMyPreferences, isGroupChannelManuallyVisible, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {getMyPreferences, isGroupChannelManuallyVisible, isCollapsedThreadsEnabled, insightsAreEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {
     getCurrentTeamId,
@@ -61,6 +61,14 @@ const ThreadsChannel = {
     name: 'threads',
     display_name: 'Threads',
     type: Constants.THREADS,
+    delete_at: 0,
+};
+
+const InsightsChannel = {
+    id: 'insights',
+    name: 'activity-and-insights',
+    display_name: 'Insights',
+    type: Constants.INSIGHTS,
     delete_at: 0,
 };
 
@@ -139,6 +147,12 @@ class SwitchChannelSuggestion extends Suggestion {
             icon = (
                 <span className='suggestion-list__icon suggestion-list__icon--large'>
                     <i className='icon icon-message-text-outline'/>
+                </span>
+            );
+        } else if (channel.type === Constants.INSIGHTS) {
+            icon = (
+                <span className='suggestion-list__icon suggestion-list__icon--large'>
+                    <i className='icon icon-chart-line'/>
                 </span>
             );
         } else if (channel.type === Constants.GM_CHANNEL) {
@@ -414,7 +428,7 @@ export default class SwitchChannelProvider extends Provider {
             // Dispatch suggestions for local data
             const channels = getChannelsInAllTeams(getState()).concat(getDirectAndGroupChannels(getState()));
             const users = Object.assign([], searchProfilesMatchingWithTerm(getState(), channelPrefix, false));
-            const formattedData = this.formatList(channelPrefix, [ThreadsChannel, ...channels], users, true, true);
+            const formattedData = this.formatList(channelPrefix, [ThreadsChannel, InsightsChannel, ...channels], users, true, true);
             if (formattedData) {
                 resultsCallback(formattedData);
             }
@@ -464,7 +478,7 @@ export default class SwitchChannelProvider extends Provider {
         const currentUserId = getCurrentUserId(state);
         const localChannelData = getChannelsInAllTeams(state).concat(getDirectAndGroupChannels(state)) || [];
         const localUserData = Object.assign([], searchProfilesMatchingWithTerm(state, channelPrefix, false)) || [];
-        const localFormattedData = this.formatList(channelPrefix, [ThreadsChannel, ...localChannelData], localUserData);
+        const localFormattedData = this.formatList(channelPrefix, [ThreadsChannel, InsightsChannel, ...localChannelData], localUserData);
         const remoteChannelData = channelsFromServer.concat(getGroupChannels(state)) || [];
         const remoteUserData = Object.assign([], usersFromServer.users) || [];
         const remoteFormattedData = this.formatList(channelPrefix, remoteChannelData, remoteUserData, false);
@@ -551,7 +565,7 @@ export default class SwitchChannelProvider extends Provider {
                 let wrappedChannel = {channel: newChannel, name: newChannel.name, deactivated: false};
                 if (members[channel.id]) {
                     wrappedChannel.last_viewed_at = members[channel.id].last_viewed_at;
-                } else if (skipNotMember && newChannel.type !== Constants.THREADS) {
+                } else if (skipNotMember && (newChannel.type !== Constants.THREADS && newChannel.type !== Constants.INSIGHTS)) {
                     continue;
                 }
 
@@ -569,6 +583,13 @@ export default class SwitchChannelProvider extends Provider {
                     const threadItem = this.getThreadsItem('total');
                     if (threadItem) {
                         wrappedChannel = threadItem;
+                    } else {
+                        continue;
+                    }
+                } else if (newChannel.type === Constants.INSIGHTS) {
+                    const insightsItem = this.getInsightsItem();
+                    if (insightsItem) {
+                        wrappedChannel = insightsItem;
                     } else {
                         continue;
                     }
@@ -707,6 +728,26 @@ export default class SwitchChannelProvider extends Provider {
         }
         if (collapsedThreads && ((countType === 'unread' && counts?.total_unread_threads) || (countType === 'total'))) {
             return threadsItem;
+        }
+
+        return null;
+    }
+
+    getInsightsItem() {
+        const state = getState();
+        const insightsEnabled = insightsAreEnabled(state);
+
+        // adding last viewed at equal to Date.now() to push it to the top of the list
+        let insightsItem = {
+            channel: InsightsChannel,
+            name: InsightsChannel.name,
+            unread_mentions: 0,
+            deactivated: false,
+            last_viewed_at: Date.now(),
+        };
+
+        if (insightsEnabled) {
+            return insightsItem;
         }
 
         return null;

--- a/components/suggestion/switch_channel_provider.test.jsx
+++ b/components/suggestion/switch_channel_provider.test.jsx
@@ -915,4 +915,98 @@ describe('components/SwitchChannelProvider', () => {
             terms: expectedOrder,
         }));
     });
+
+    it('Should show insights as the first item in the list if search term matches', async () => {
+        const modifiedState = {
+            ...defaultState,
+            entities: {
+                ...defaultState.entities,
+                general: {
+                    config: {
+                        FeatureFlagCollapsedThreads: 'true',
+                        CollapsedThreads: 'default_off',
+                        FeatureFlagInsightsEnabled: 'true',
+                        InsightsEnabled: 'true',
+                    },
+                },
+                threads: {
+                    countsIncludingDirect: {
+                        currentTeamId: {
+                            total: 0,
+                            total_unread_threads: 0,
+                            total_unread_mentions: 0,
+                        },
+                    },
+                    counts: {
+                        currentTeamId: {
+                            total: 0,
+                            total_unread_threads: 0,
+                            total_unread_mentions: 0,
+                        },
+                    },
+                },
+                preferences: {
+                    ...defaultState.entities.preferences,
+                    myPreferences: {
+                        ...defaultState.entities.preferences.myPreferences,
+                        [`${Preferences.CATEGORY_DISPLAY_SETTINGS}--${Preferences.COLLAPSED_REPLY_THREADS}`]: {
+                            value: 'on',
+                        },
+                    },
+                },
+                channels: {
+                    ...defaultState.entities.channels,
+                    myMembers: {
+                        current_channel_id: {
+                            channel_id: 'current_channel_id',
+                            user_id: 'current_user_id',
+                            roles: 'channel_role',
+                            mention_count: 1,
+                            msg_count: 9,
+                        },
+                        insight_gm_channel: {
+                            channel_id: 'insight_gm_channel',
+                            msg_count: 1,
+                            last_viewed_at: 3,
+                        },
+                        thread_user1: {},
+                    },
+                    channels: {
+                        insight_gm_channel: {
+                            id: 'insight_gm_channel',
+                            msg_count: 1,
+                            last_viewed_at: 3,
+                            type: 'G',
+                            name: 'insight_gm_channel',
+                            delete_at: 0,
+                            display_name: 'insight_gm_channel',
+                        },
+                    },
+                    channelsInTeam: {
+                        '': ['insight_gm_channel'],
+                    },
+                },
+            },
+        };
+
+        getState.mockClear();
+
+        const switchProvider = new SwitchChannelProvider();
+        const store = mockStore(modifiedState);
+
+        getState.mockImplementation(store.getState);
+        const searchText = 'insight';
+        const resultsCallback = jest.fn();
+
+        switchProvider.startNewRequest(searchText);
+        await switchProvider.fetchUsersAndChannels(searchText, resultsCallback);
+        const expectedOrder = [
+            'insights',
+            'insight_gm_channel',
+        ];
+
+        expect(resultsCallback).toBeCalledWith(expect.objectContaining({
+            terms: expectedOrder,
+        }));
+    });
 });

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1425,6 +1425,7 @@ export const Constants = {
     INVITE_TEAM: 'I',
     OPEN_TEAM: 'O',
     THREADS: 'threads',
+    INSIGHTS: 'insights',
     MAX_POST_LEN: 4000,
     EMOJI_SIZE: 16,
     DEFAULT_EMOJI_PICKER_LEFT_OFFSET: 87,


### PR DESCRIPTION
#### Summary
Adding insights to the channel switcher with `cmd+k`. It follows the same procedure as threads

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45488

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Adding insights to the channel switcher
```
