### PR TITLE
[Mm 44864] Too long time stamp announcement

### DIFF
--- a/components/post_view/post_time/post_time.tsx
+++ b/components/post_view/post_time/post_time.tsx
@@ -84,6 +84,7 @@ export default class PostTime extends React.PureComponent<Props> {
                 to={`${teamUrl}/pl/${postId}`}
                 className='post__permalink'
                 onClick={this.handleClick}
+                aria-labelledby={eventTime.toString()}
             >
                 {postTime}
             </Link>
@@ -101,6 +102,7 @@ export default class PostTime extends React.PureComponent<Props> {
                         <Timestamp
                             value={eventTime}
                             ranges={POST_TOOLTIP_RANGES}
+                            useSemanticOutput={false}
                         />
                     </Tooltip>
                 }

--- a/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
+++ b/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
@@ -1015,7 +1015,6 @@ exports[`components/threading/channel_threads/thread_footer should report total 
               values={
                 Object {
                   "formatted": <Memo(SemanticTime)
-                    aria-label="Mon Apr 01 2019 23:31:44 GMT+0000"
                     value={2019-04-01T23:31:44.000Z}
                   >
                     April 1, 2019
@@ -1026,13 +1025,11 @@ exports[`components/threading/channel_threads/thread_footer should report total 
               <span>
                 Last reply 
                 <Memo(SemanticTime)
-                  aria-label="Mon Apr 01 2019 23:31:44 GMT+0000"
                   key=".$.1"
                   value={2019-04-01T23:31:44.000Z}
                 >
                   <time
-                    aria-label="Mon Apr 01 2019 23:31:44 GMT+0000"
-                    dateTime="2019-04-01T23:31:44.000Z"
+                    dateTime="2019-04-01T23:31:44.000"
                   >
                     April 1, 2019
                   </time>
@@ -2143,7 +2140,6 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
               values={
                 Object {
                   "formatted": <Memo(SemanticTime)
-                    aria-label="Mon Apr 01 2019 23:31:44 GMT+0000"
                     value={2019-04-01T23:31:44.000Z}
                   >
                     April 1, 2019
@@ -2154,13 +2150,11 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
               <span>
                 Last reply 
                 <Memo(SemanticTime)
-                  aria-label="Mon Apr 01 2019 23:31:44 GMT+0000"
                   key=".$.1"
                   value={2019-04-01T23:31:44.000Z}
                 >
                   <time
-                    aria-label="Mon Apr 01 2019 23:31:44 GMT+0000"
-                    dateTime="2019-04-01T23:31:44.000Z"
+                    dateTime="2019-04-01T23:31:44.000"
                   >
                     April 1, 2019
                   </time>

--- a/components/timestamp/__snapshots__/semantic_time.test.tsx.snap
+++ b/components/timestamp/__snapshots__/semantic_time.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`components/timestamp/SemanticTime should support custom label 1`] = `
 >
   <time
     aria-label="A custom label"
-    dateTime="2020-06-05T10:20:30.000Z"
+    dateTime="2020-06-05T10:20:30.000"
   />
 </Memo(SemanticTime)>
 `;

--- a/components/timestamp/semantic_time.test.tsx
+++ b/components/timestamp/semantic_time.test.tsx
@@ -14,8 +14,7 @@ describe('components/timestamp/SemanticTime', () => {
                 value={date}
             />,
         );
-        expect(wrapper.find('time').prop('aria-label')).toBe(date.toLocaleString());
-        expect(wrapper.find('time').prop('dateTime')).toBe(date.toISOString());
+        expect(wrapper.find('time').prop('dateTime')).toBe('2020-06-05T10:20:30.000');
     });
 
     test('should support passthrough children', () => {
@@ -28,7 +27,6 @@ describe('components/timestamp/SemanticTime', () => {
             </SemanticTime>,
         );
 
-        expect(wrapper.find('time').prop('aria-label')).toBe(date.toLocaleString());
         expect(wrapper.find('time').text()).toBe('10:20');
     });
 
@@ -42,6 +40,5 @@ describe('components/timestamp/SemanticTime', () => {
         );
 
         expect(wrapper).toMatchSnapshot();
-        expect(wrapper.find('time').prop('aria-label')).toBe('A custom label');
     });
 });

--- a/components/timestamp/semantic_time.tsx
+++ b/components/timestamp/semantic_time.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {FC, ReactNode, memo, TimeHTMLAttributes} from 'react';
+import {DateTime} from 'luxon';
 
 export type Props = {
     value: Date;
@@ -11,14 +12,12 @@ export type Props = {
 const SemanticTime: FC<Props> = ({
     value,
     children,
-    'aria-label': label = value.toLocaleString(),
     ...props
 }: Props) => {
     return (
         <time
             {...props}
-            aria-label={label}
-            dateTime={value.toISOString()}
+            dateTime={DateTime.fromJSDate(value).toLocal().toISO({includeOffset: false})}
         >
             {children}
         </time>

--- a/components/timestamp/timestamp.test.tsx
+++ b/components/timestamp/timestamp.test.tsx
@@ -228,7 +228,7 @@ describe('components/timestamp/Timestamp', () => {
                 useDate={false}
             />,
         );
-        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T15:15:13.000Z');
+        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T15:15:13.000');
         expect(wrapper.text()).toBe('15:15');
     });
 
@@ -240,7 +240,7 @@ describe('components/timestamp/Timestamp', () => {
             />,
         );
 
-        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T15:15:13.000Z');
+        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T15:15:13.000');
         expect(wrapper.text()).toBe('January 12, 2018');
     });
 
@@ -252,7 +252,7 @@ describe('components/timestamp/Timestamp', () => {
                 timeZone='Australia/Sydney'
             />,
         );
-        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T20:15:13.000Z');
+        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T20:15:13.000');
         expect(wrapper.text()).toBe('7:15 AM');
     });
 
@@ -264,7 +264,7 @@ describe('components/timestamp/Timestamp', () => {
                 timeZone='US/Hawaii'
             />,
         );
-        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T20:15:13.000Z');
+        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T20:15:13.000');
         expect(wrapper.text()).toBe('10:15 AM');
     });
 
@@ -276,8 +276,7 @@ describe('components/timestamp/Timestamp', () => {
                 timeZone='US/Hawaii'
             />,
         );
-        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T20:15:13.000Z');
-        expect(wrapper.find('time').prop('aria-label')).toBe('Fri Jan 12 2018 10:15:13 GMT-1000 (US/Hawaii)');
+        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-12T20:15:13.000');
         expect(wrapper.text()).toBe('January 12, 2018');
     });
 
@@ -289,8 +288,7 @@ describe('components/timestamp/Timestamp', () => {
                 timeZone='Australia/Sydney'
             />,
         );
-        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-13T04:15:13.000Z');
-        expect(wrapper.find('time').prop('aria-label')).toBe('Sat Jan 13 2018 15:15:13 GMT+1100 (Australia/Sydney)');
+        expect(wrapper.find('time').prop('dateTime')).toBe('2018-01-13T04:15:13.000');
         expect(wrapper.text()).toBe('January 13, 2018 at 15:15');
     });
 
@@ -303,7 +301,6 @@ describe('components/timestamp/Timestamp', () => {
                 timeZone='US/Alaska'
             />,
         );
-        expect(wrapper.find('time').prop('aria-label')).toBe('Fri Jan 12 2018 19:15:13 GMT-0900 (US/Alaska)');
         expect(wrapper.text()).toBe('19:15');
     });
 });

--- a/components/timestamp/timestamp.tsx
+++ b/components/timestamp/timestamp.tsx
@@ -429,7 +429,7 @@ class Timestamp extends PureComponent<Props, State> {
             formatted = (
                 <SemanticTime
                     value={value}
-                    aria-label={label ?? Timestamp.formatLabel(value, timeZone)}
+                    aria-label={label}
                     className={className}
                 >
                     {formatted}


### PR DESCRIPTION
#### Summary
Time stamp announcement shortened (when focused on post time)

#### Ticket Link
fixes https://mattermost.atlassian.net/browse/MM-44864

#### Related Pull Requests
None

#### Screenshots
BEFORE -:

https://user-images.githubusercontent.com/89139362/190311992-f4e3101f-54dc-4470-ba34-8ed3d4946b3e.mp4

AFTER -:

https://user-images.githubusercontent.com/89139362/190312031-bb253432-e45f-4d2e-b3cf-fb0cf39e74a0.mp4

#### Release Note
NA
```release-note
Time stamp announcement shortened (when focused on post time)

```
