### PR TITLE
[MM-44858] Screen reader fails in announcing no result found in dm modal

### DIFF
--- a/components/multiselect/multiselect_list.tsx
+++ b/components/multiselect/multiselect_list.tsx
@@ -191,9 +191,10 @@ export default class MultiSelectList<T extends Value> extends React.PureComponen
                         <p className='primary-message'>
                             <FormattedMessage
                                 id='multiselect.list.notFound'
-                                defaultMessage='No results found matching **{searchQuery}**'
+                                defaultMessage='No results found matching <b>{searchQuery}</b>'
                                 values={{
                                     searchQuery: this.props.query,
+                                    b: (value: string) => <b>{value}</b>,
                                 }}
                             />
                         </p>

--- a/components/multiselect/multiselect_list.tsx
+++ b/components/multiselect/multiselect_list.tsx
@@ -6,7 +6,8 @@ import React from 'react';
 
 import {getOptionValue} from 'react-select/src/builtins';
 
-import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+import {FormattedMessage} from 'react-intl';
+
 import Constants from 'utils/constants';
 import {cmdOrCtrlPressed} from 'utils/utils';
 
@@ -185,9 +186,10 @@ export default class MultiSelectList<T extends Value> extends React.PureComponen
                     <div
                         key='no-users-found'
                         className='no-channel-message'
+                        tabIndex={0}
                     >
                         <p className='primary-message'>
-                            <FormattedMarkdownMessage
+                            <FormattedMessage
                                 id='multiselect.list.notFound'
                                 defaultMessage='No results found matching **{searchQuery}**'
                                 values={{

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3991,7 +3991,7 @@
   "multiselect.createGroup": "Create Group",
   "multiselect.creating": "Creating...",
   "multiselect.go": "Go",
-  "multiselect.list.notFound": "No results found matching **{searchQuery}**",
+  "multiselect.list.notFound": "No results found matching <b>{searchQuery}</b>",
   "multiselect.loading": "Loading...",
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",


### PR DESCRIPTION
#### Summary
Screen reader fails in announcing No result found in dm modal.
https://mattermost.atlassian.net/browse/MM-44858

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-44858
 Fixes https://github.com/mattermost/mattermost-server/issues/21260

#### Related Pull Requests
None

#### Screenshots
|  before  |

https://user-images.githubusercontent.com/102028591/190338880-68cbabea-76e2-48f8-8a1c-8dc63dd5e91e.mp4

|  after  |

https://user-images.githubusercontent.com/102028591/190334214-97253e31-12e9-4e83-941b-37908a4e186a.mp4

#### Release Note
```release-note
 In the Direct Messages modal (+ next to Direct Messages) when we try to search anything which is not present, a message ( No results found matching)  is visible and not accessible by the screenreaders. 
```
