### PR TITLE
[MM-46988] Fixing channel info shortcut and closing rhs when opening insights

### DIFF
--- a/components/activity_and_insights/insights/insights.tsx
+++ b/components/activity_and_insights/insights/insights.tsx
@@ -4,6 +4,7 @@ import React, {memo, useEffect, useCallback} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {trackEvent} from 'actions/telemetry_actions';
+import {suppressRHS, unsuppressRHS} from 'actions/views/rhs';
 import {selectChannel} from 'mattermost-redux/actions/channels';
 import LocalStorageStore from 'stores/local_storage_store';
 import {useGlobalState} from 'stores/hooks';
@@ -59,12 +60,17 @@ const Insights = () => {
 
     useEffect(() => {
         dispatch(selectChannel(''));
+        dispatch(suppressRHS);
         const penultimateType = LocalStorageStore.getPreviousViewedType(currentUserId, currentTeamId);
 
         if (penultimateType !== PreviousViewedTypes.INSIGHTS) {
             LocalStorageStore.setPenultimateViewedType(currentUserId, currentTeamId, penultimateType);
             LocalStorageStore.setPreviousViewedType(currentUserId, currentTeamId, PreviousViewedTypes.INSIGHTS);
         }
+
+        return () => {
+            dispatch(unsuppressRHS);
+        };
     });
 
     return (

--- a/components/sidebar_right/sidebar_right.tsx
+++ b/components/sidebar_right/sidebar_right.tsx
@@ -110,7 +110,7 @@ export default class SidebarRight extends React.PureComponent<Props, State> {
                 e.preventDefault();
                 if (this.props.isOpen && this.props.isChannelInfo) {
                     this.props.actions.closeRightHandSide();
-                } else {
+                } else if (this.props.channel) {
                     this.props.actions.showChannelInfo(this.props.channel.id);
                 }
             }


### PR DESCRIPTION
#### Summary
Close the RHS when opening insights and reopen when navigating away. Also fix a JS error if you try use the channel info shortcut on the insights page

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46988

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
