### PR TITLE
MM-47044 Wrap Pluggable component in an error boundary

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4185,6 +4185,8 @@
   "picture_selector.image.ariaLabel": "Picture selector image",
   "picture_selector.remove_picture": "Remove picture",
   "picture_selector.select_button.ariaLabel": "Select picture",
+  "pluggable.errorOccurred": "An error occurred in the {pluginId} plugin.",
+  "pluggable.errorRefresh": "Refresh?",
   "post_body.check_for_out_of_channel_groups_mentions.message": "did not get notified by this mention because they are not in the channel. They cannot be added to the channel because they are not a member of the linked groups. To add them to this channel, they must be added to the linked groups.",
   "post_body.check_for_out_of_channel_mentions.link.and": " and ",
   "post_body.check_for_out_of_channel_mentions.link.private": "add them to this private channel",

--- a/plugins/pluggable/__snapshots__/pluggable.test.jsx.snap
+++ b/plugins/pluggable/__snapshots__/pluggable.test.jsx.snap
@@ -14,39 +14,42 @@ exports[`plugins/Pluggable should match snapshot with extended component 1`] = `
   pluggableName="PopoverSection1"
   theme={Object {}}
 >
-  <ProfilePopoverPlugin
+  <PluggableErrorBoundary
     key="PopoverSection1undefined"
-    theme={Object {}}
-    webSocketClient={
-      WebSocketClient {
-        "closeCallback": null,
-        "closeListeners": Set {},
-        "conn": null,
-        "connectFailCount": 0,
-        "connectionId": "",
-        "connectionUrl": null,
-        "errorCallback": null,
-        "errorListeners": Set {},
-        "eventCallback": null,
-        "firstConnectCallback": null,
-        "firstConnectListeners": Set {},
-        "messageListeners": Set {},
-        "missedEventCallback": null,
-        "missedMessageListeners": Set {},
-        "reconnectCallback": null,
-        "reconnectListeners": Set {},
-        "responseCallbacks": Object {},
-        "responseSequence": 1,
-        "serverSequence": 0,
-      }
-    }
   >
-    <span
-      id="pluginId"
+    <ProfilePopoverPlugin
+      theme={Object {}}
+      webSocketClient={
+        WebSocketClient {
+          "closeCallback": null,
+          "closeListeners": Set {},
+          "conn": null,
+          "connectFailCount": 0,
+          "connectionId": "",
+          "connectionUrl": null,
+          "errorCallback": null,
+          "errorListeners": Set {},
+          "eventCallback": null,
+          "firstConnectCallback": null,
+          "firstConnectListeners": Set {},
+          "messageListeners": Set {},
+          "missedEventCallback": null,
+          "missedMessageListeners": Set {},
+          "reconnectCallback": null,
+          "reconnectListeners": Set {},
+          "responseCallbacks": Object {},
+          "responseSequence": 1,
+          "serverSequence": 0,
+        }
+      }
     >
-      ProfilePopoverPlugin
-    </span>
-  </ProfilePopoverPlugin>
+      <span
+        id="pluginId"
+      >
+        ProfilePopoverPlugin
+      </span>
+    </ProfilePopoverPlugin>
+  </PluggableErrorBoundary>
 </Pluggable>
 `;
 
@@ -64,39 +67,42 @@ exports[`plugins/Pluggable should match snapshot with extended component with pl
   pluggableName="PopoverSection1"
   theme={Object {}}
 >
-  <ProfilePopoverPlugin
+  <PluggableErrorBoundary
     key="PopoverSection1undefined"
-    theme={Object {}}
-    webSocketClient={
-      WebSocketClient {
-        "closeCallback": null,
-        "closeListeners": Set {},
-        "conn": null,
-        "connectFailCount": 0,
-        "connectionId": "",
-        "connectionUrl": null,
-        "errorCallback": null,
-        "errorListeners": Set {},
-        "eventCallback": null,
-        "firstConnectCallback": null,
-        "firstConnectListeners": Set {},
-        "messageListeners": Set {},
-        "missedEventCallback": null,
-        "missedMessageListeners": Set {},
-        "reconnectCallback": null,
-        "reconnectListeners": Set {},
-        "responseCallbacks": Object {},
-        "responseSequence": 1,
-        "serverSequence": 0,
-      }
-    }
   >
-    <span
-      id="pluginId"
+    <ProfilePopoverPlugin
+      theme={Object {}}
+      webSocketClient={
+        WebSocketClient {
+          "closeCallback": null,
+          "closeListeners": Set {},
+          "conn": null,
+          "connectFailCount": 0,
+          "connectionId": "",
+          "connectionUrl": null,
+          "errorCallback": null,
+          "errorListeners": Set {},
+          "eventCallback": null,
+          "firstConnectCallback": null,
+          "firstConnectListeners": Set {},
+          "messageListeners": Set {},
+          "missedEventCallback": null,
+          "missedMessageListeners": Set {},
+          "reconnectCallback": null,
+          "reconnectListeners": Set {},
+          "responseCallbacks": Object {},
+          "responseSequence": 1,
+          "serverSequence": 0,
+        }
+      }
     >
-      ProfilePopoverPlugin
-    </span>
-  </ProfilePopoverPlugin>
+      <span
+        id="pluginId"
+      >
+        ProfilePopoverPlugin
+      </span>
+    </ProfilePopoverPlugin>
+  </PluggableErrorBoundary>
 </Pluggable>
 `;
 
@@ -138,39 +144,42 @@ exports[`plugins/Pluggable should match snapshot with null pluggableId 1`] = `
   pluggableName="PopoverSection1"
   theme={Object {}}
 >
-  <ProfilePopoverPlugin
+  <PluggableErrorBoundary
     key="PopoverSection1undefined"
-    theme={Object {}}
-    webSocketClient={
-      WebSocketClient {
-        "closeCallback": null,
-        "closeListeners": Set {},
-        "conn": null,
-        "connectFailCount": 0,
-        "connectionId": "",
-        "connectionUrl": null,
-        "errorCallback": null,
-        "errorListeners": Set {},
-        "eventCallback": null,
-        "firstConnectCallback": null,
-        "firstConnectListeners": Set {},
-        "messageListeners": Set {},
-        "missedEventCallback": null,
-        "missedMessageListeners": Set {},
-        "reconnectCallback": null,
-        "reconnectListeners": Set {},
-        "responseCallbacks": Object {},
-        "responseSequence": 1,
-        "serverSequence": 0,
-      }
-    }
   >
-    <span
-      id="pluginId"
+    <ProfilePopoverPlugin
+      theme={Object {}}
+      webSocketClient={
+        WebSocketClient {
+          "closeCallback": null,
+          "closeListeners": Set {},
+          "conn": null,
+          "connectFailCount": 0,
+          "connectionId": "",
+          "connectionUrl": null,
+          "errorCallback": null,
+          "errorListeners": Set {},
+          "eventCallback": null,
+          "firstConnectCallback": null,
+          "firstConnectListeners": Set {},
+          "messageListeners": Set {},
+          "missedEventCallback": null,
+          "missedMessageListeners": Set {},
+          "reconnectCallback": null,
+          "reconnectListeners": Set {},
+          "responseCallbacks": Object {},
+          "responseSequence": 1,
+          "serverSequence": 0,
+        }
+      }
     >
-      ProfilePopoverPlugin
-    </span>
-  </ProfilePopoverPlugin>
+      <span
+        id="pluginId"
+      >
+        ProfilePopoverPlugin
+      </span>
+    </ProfilePopoverPlugin>
+  </PluggableErrorBoundary>
 </Pluggable>
 `;
 
@@ -190,38 +199,41 @@ exports[`plugins/Pluggable should match snapshot with valid pluggableId 1`] = `
   pluggableName="PopoverSection1"
   theme={Object {}}
 >
-  <ProfilePopoverPlugin
+  <PluggableErrorBoundary
     key="PopoverSection1pluggableId"
-    theme={Object {}}
-    webSocketClient={
-      WebSocketClient {
-        "closeCallback": null,
-        "closeListeners": Set {},
-        "conn": null,
-        "connectFailCount": 0,
-        "connectionId": "",
-        "connectionUrl": null,
-        "errorCallback": null,
-        "errorListeners": Set {},
-        "eventCallback": null,
-        "firstConnectCallback": null,
-        "firstConnectListeners": Set {},
-        "messageListeners": Set {},
-        "missedEventCallback": null,
-        "missedMessageListeners": Set {},
-        "reconnectCallback": null,
-        "reconnectListeners": Set {},
-        "responseCallbacks": Object {},
-        "responseSequence": 1,
-        "serverSequence": 0,
-      }
-    }
   >
-    <span
-      id="pluginId"
+    <ProfilePopoverPlugin
+      theme={Object {}}
+      webSocketClient={
+        WebSocketClient {
+          "closeCallback": null,
+          "closeListeners": Set {},
+          "conn": null,
+          "connectFailCount": 0,
+          "connectionId": "",
+          "connectionUrl": null,
+          "errorCallback": null,
+          "errorListeners": Set {},
+          "eventCallback": null,
+          "firstConnectCallback": null,
+          "firstConnectListeners": Set {},
+          "messageListeners": Set {},
+          "missedEventCallback": null,
+          "missedMessageListeners": Set {},
+          "reconnectCallback": null,
+          "reconnectListeners": Set {},
+          "responseCallbacks": Object {},
+          "responseSequence": 1,
+          "serverSequence": 0,
+        }
+      }
     >
-      ProfilePopoverPlugin
-    </span>
-  </ProfilePopoverPlugin>
+      <span
+        id="pluginId"
+      >
+        ProfilePopoverPlugin
+      </span>
+    </ProfilePopoverPlugin>
+  </PluggableErrorBoundary>
 </Pluggable>
 `;

--- a/plugins/pluggable/error_boundary.tsx
+++ b/plugins/pluggable/error_boundary.tsx
@@ -15,12 +15,12 @@ type State = {
 }
 
 const WrapperDiv = styled.div`
-align-items: center;
-display: flex;
-flex-direction: column;
-height: 100%;
-justify-content: center;
-width: 100%;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    width: 100%;
 `;
 
 export default class PluggableErrorBoundary extends React.PureComponent<Props, State> {

--- a/plugins/pluggable/error_boundary.tsx
+++ b/plugins/pluggable/error_boundary.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import styled from 'styled-components';
+
+type Props = {
+    children: React.ReactNode;
+    pluginId?: string;
+}
+
+type State = {
+    hasError: boolean;
+}
+
+const WrapperDiv = styled.div`
+align-items: center;
+display: flex;
+flex-direction: column;
+height: 100%;
+justify-content: center;
+width: 100%;
+`;
+
+export default class PluggableErrorBoundary extends React.PureComponent<Props, State> {
+    state = {
+        hasError: false,
+    };
+
+    static getDerivedStateFromError() {
+        return {
+            hasError: true,
+        };
+    }
+
+    clearErrorState = (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        this.setState({hasError: false});
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <WrapperDiv>
+                    <FormattedMessage
+                        id='pluggable.errorOccurred'
+                        defaultMessage='An error occurred in the {pluginId} plugin.'
+                        values={{
+                            pluginId: this.props.pluginId,
+                        }}
+                    />
+                    <br/>
+                    <a
+                        href='#'
+                        onClick={this.clearErrorState}
+                    >
+                        <FormattedMessage
+                            id='pluggable.errorRefresh'
+                            defaultMessage='Refresh?'
+                            values={{
+                                pluginId: this.props.pluginId,
+                            }}
+                        />
+                    </a>
+                </WrapperDiv>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/plugins/pluggable/pluggable.test.jsx
+++ b/plugins/pluggable/pluggable.test.jsx
@@ -43,6 +43,7 @@ describe('plugins/Pluggable', () => {
 
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find('#pluginId').text()).toBe('ProfilePopoverPlugin');
+        expect(wrapper.find(ProfilePopoverPlugin).exists()).toBe(true);
     });
 
     test('should match snapshot with extended component with pluggableName', () => {
@@ -56,6 +57,7 @@ describe('plugins/Pluggable', () => {
 
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find('#pluginId').text()).toBe('ProfilePopoverPlugin');
+        expect(wrapper.find(ProfilePopoverPlugin).exists()).toBe(true);
     });
 
     test('should return null if neither pluggableName nor children is is defined in props', () => {
@@ -66,7 +68,7 @@ describe('plugins/Pluggable', () => {
             />,
         );
 
-        expect(wrapper.children().length).toBe(0);
+        expect(wrapper.find(ProfilePopoverPlugin).exists()).toBe(false);
     });
 
     test('should return null if with pluggableName but no children', () => {
@@ -90,7 +92,7 @@ describe('plugins/Pluggable', () => {
         );
 
         expect(wrapper).toMatchSnapshot();
-        expect(wrapper.children().length).toBe(0);
+        expect(wrapper.find(ProfilePopoverPlugin).exists()).toBe(false);
     });
 
     test('should match snapshot with null pluggableId', () => {
@@ -103,7 +105,7 @@ describe('plugins/Pluggable', () => {
         );
 
         expect(wrapper).toMatchSnapshot();
-        expect(wrapper.children().length).toBe(1);
+        expect(wrapper.find(ProfilePopoverPlugin).exists()).toBe(true);
     });
 
     test('should match snapshot with valid pluggableId', () => {
@@ -117,7 +119,6 @@ describe('plugins/Pluggable', () => {
         );
 
         expect(wrapper).toMatchSnapshot();
-        expect(wrapper.children().length).toBe(1);
-        expect(wrapper.childAt(0).type()).toBe(ProfilePopoverPlugin);
+        expect(wrapper.find(ProfilePopoverPlugin).exists()).toBe(true);
     });
 });

--- a/plugins/pluggable/pluggable.tsx
+++ b/plugins/pluggable/pluggable.tsx
@@ -12,6 +12,8 @@ import {GlobalState} from 'types/store';
 
 import webSocketClient from 'client/web_websocket_client';
 
+import PluggableErrorBoundary from './error_boundary';
+
 type Props = {
 
     /*
@@ -87,11 +89,15 @@ export default function Pluggable(props: Props): JSX.Element | null {
             const Component = pc[subComponentName]! as React.ComponentType<BaseChildProps>;
 
             return (
-                <Component
-                    {...otherProps}
-                    theme={theme}
+                <PluggableErrorBoundary
                     key={pluggableName + pc.id}
-                />
+                    pluginId={pc.pluginId}
+                >
+                    <Component
+                        {...otherProps}
+                        theme={theme}
+                    />
+                </PluggableErrorBoundary>
             );
         });
     } else {
@@ -103,12 +109,16 @@ export default function Pluggable(props: Props): JSX.Element | null {
             const Component = p.component as React.ComponentType<BaseChildProps>;
 
             return (
-                <Component
-                    {...otherProps}
-                    theme={theme}
+                <PluggableErrorBoundary
                     key={pluggableName + p.id}
-                    webSocketClient={webSocketClient}
-                />
+                    pluginId={p.pluginId}
+                >
+                    <Component
+                        {...otherProps}
+                        theme={theme}
+                        webSocketClient={webSocketClient}
+                    />
+                </PluggableErrorBoundary>
             );
         });
     }


### PR DESCRIPTION
While we can't guarantee plugins won't crash, we can at least guarantee that they won't crash the whole web app by using error boundaries. An error boundary stops a React error from crashing the web app with the sort of crash that makes the whole page go blank. Since we use this `Pluggable` component to wrap everywhere that a plugin injects content into the web app, this'll protect most of the app from errors.

Some of these examples are faked, but the one with clicking "unfollow run" is a real one.

https://user-images.githubusercontent.com/3277310/190820848-42c8dbdf-38fe-4374-b1e8-ffb24691dab8.mp4
https://user-images.githubusercontent.com/3277310/190820883-a834e9ab-4cc1-48f2-8f7f-d8903daf6add.mp4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47044

#### Release Note
```release-note
Prevent plugin components from crashing the entire web app
```
