### PR TITLE
[MM-45909] Fixing group permissions issue

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/roles.test.ts
+++ b/packages/mattermost-redux/src/selectors/entities/roles.test.ts
@@ -228,6 +228,50 @@ describe('Selectors.Roles', () => {
         expect(Selectors.haveIGroupPermission(testState, group2.id, Permissions.DELETE_CUSTOM_GROUP)).toEqual(true);
     });
 
+    it('should return false if i dont have a group permission on haveIGroupPermission', () => {
+        const roles = {
+            test_team1_role1: {permissions: ['team1_role1']},
+            test_team2_role1: {permissions: ['team2_role1']},
+            test_team2_role2: {permissions: ['team2_role2']},
+            test_channel_a_role1: {permissions: ['channel_a_role1']},
+            test_channel_a_role2: {permissions: ['channel_a_role2']},
+            test_channel_b_role2: {permissions: ['channel_b_role2']},
+            test_channel_c_role1: {permissions: ['channel_c_role1']},
+            test_channel_c_role2: {permissions: ['channel_c_role2']},
+            test_user_role2: {permissions: ['user_role2', Permissions.CREATE_CUSTOM_GROUP, Permissions.MANAGE_CUSTOM_GROUP_MEMBERS, Permissions.DELETE_CUSTOM_GROUP]},
+            custom_group_user: {permissions: ['custom_group_user']},
+        };
+        const newState = deepFreezeAndThrowOnMutation({
+            entities: {
+                users: {
+                    currentUserId: user.id,
+                    profiles,
+                },
+                teams: {
+                    currentTeamId: team1.id,
+                    myMembers: myTeamMembers,
+                },
+                channels: {
+                    currentChannelId: channel1.id,
+                    channels,
+                    roles: channelsRoles,
+                },
+                groups: {
+                    groups,
+                    myGroups: ['group1'],
+                },
+                roles: {
+                    roles,
+                },
+            },
+        });
+
+        expect(Selectors.haveIGroupPermission(newState, group2.id, Permissions.EDIT_CUSTOM_GROUP)).toEqual(false);
+        expect(Selectors.haveIGroupPermission(newState, group2.id, Permissions.CREATE_CUSTOM_GROUP)).toEqual(true);
+        expect(Selectors.haveIGroupPermission(newState, group2.id, Permissions.MANAGE_CUSTOM_GROUP_MEMBERS)).toEqual(true);
+        expect(Selectors.haveIGroupPermission(newState, group2.id, Permissions.DELETE_CUSTOM_GROUP)).toEqual(true);
+    });
+
     it('should return group set with permissions on getGroupListPermissions', () => {
         expect(Selectors.getGroupListPermissions(testState)).toEqual({
             [group1.id]: {can_delete: true, can_manage_members: true},

--- a/packages/mattermost-redux/src/selectors/entities/roles.ts
+++ b/packages/mattermost-redux/src/selectors/entities/roles.ts
@@ -176,10 +176,10 @@ export function haveITeamPermission(state: GlobalState, teamId: string, permissi
     );
 }
 
-export function haveIGroupPermission(state: GlobalState, groupID: string, permission: string) {
+export function haveIGroupPermission(state: GlobalState, groupID: string, permission: string): boolean {
     return (
         getMySystemPermissions(state).has(permission) ||
-        getMyPermissionsByGroup(state)[groupID]?.has(permission)
+        (getMyPermissionsByGroup(state)[groupID] ? getMyPermissionsByGroup(state)[groupID].has(permission) : false)
     );
 }
 


### PR DESCRIPTION
#### Summary
`haveIGroupPermission` was returning `undefined` when permission didn't exist. Now it returns false

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45909

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixing issue where custom group actions were appearing in the UI when you didn't have the permissions for them
```
