### PR TITLE
MM-47099 :  Migrate "components/channel_notifications_modal/components/expand_view.jsx" to Typescript

### DIFF
--- a/components/channel_notifications_modal/components/expand_view.test.jsx
+++ b/components/channel_notifications_modal/components/expand_view.test.jsx
@@ -6,7 +6,7 @@ import {shallow} from 'enzyme';
 
 import {NotificationLevels, NotificationSections} from 'utils/constants';
 
-import ExpandView from 'components/channel_notifications_modal/components/expand_view.jsx';
+import ExpandView from 'components/channel_notifications_modal/components/expand_view.tsx';
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),

--- a/components/channel_notifications_modal/components/expand_view.tsx
+++ b/components/channel_notifications_modal/components/expand_view.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
-import React from 'react';
+import React, {ChangeEvent} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector} from 'react-redux';
 
@@ -15,6 +14,18 @@ import SettingItemMax from 'components/setting_item_max.jsx';
 import Describe from './describe.jsx';
 import ExtraInfo from './extra_info.jsx';
 import SectionTitle from './section_title.jsx';
+type Props = {
+    ignoreChannelMentions?:string,
+    onChange: (e: ChangeEvent<HTMLInputElement>) => void,
+    onChangeThreads?: (e: ChangeEvent<HTMLInputElement>) => void,
+    onCollapseSection: (section: string) => void,
+    onSubmit: (setting?: string) => void,
+    globalNotifyLevel?: string,
+    memberNotifyLevel: string,
+    memberThreadsNotifyLevel?: string,
+    section: string,
+    serverError?: string,
+}
 
 export default function ExpandView({
     section,
@@ -27,7 +38,7 @@ export default function ExpandView({
     serverError,
     onCollapseSection,
     ignoreChannelMentions,
-}) {
+}: Props) {
     const isCRTEnabled = useSelector(isCollapsedThreadsEnabled);
 
     const inputs = [(
@@ -269,15 +280,4 @@ export default function ExpandView({
     );
 }
 
-ExpandView.propTypes = {
-    ignoreChannelMentions: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
-    onChangeThreads: PropTypes.func,
-    onCollapseSection: PropTypes.func.isRequired,
-    onSubmit: PropTypes.func.isRequired,
-    globalNotifyLevel: PropTypes.string,
-    memberNotifyLevel: PropTypes.string.isRequired,
-    memberThreadsNotifyLevel: PropTypes.string,
-    section: PropTypes.string.isRequired,
-    serverError: PropTypes.string,
-};
+

--- a/components/channel_notifications_modal/components/expand_view.tsx
+++ b/components/channel_notifications_modal/components/expand_view.tsx
@@ -15,16 +15,16 @@ import Describe from './describe.jsx';
 import ExtraInfo from './extra_info.jsx';
 import SectionTitle from './section_title.jsx';
 type Props = {
-    ignoreChannelMentions?:string,
-    onChange: (e: ChangeEvent<HTMLInputElement>) => void,
-    onChangeThreads?: (e: ChangeEvent<HTMLInputElement>) => void,
-    onCollapseSection: (section: string) => void,
-    onSubmit: (setting?: string) => void,
-    globalNotifyLevel?: string,
-    memberNotifyLevel: string,
-    memberThreadsNotifyLevel?: string,
-    section: string,
-    serverError?: string,
+    ignoreChannelMentions?: string;
+    onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    onChangeThreads?: (e: ChangeEvent<HTMLInputElement>) => void;
+    onCollapseSection: (section: string) => void;
+    onSubmit: (setting?: string) => void;
+    globalNotifyLevel?: string;
+    memberNotifyLevel: string;
+    memberThreadsNotifyLevel?: string;
+    section: string;
+    serverError?: string;
 }
 
 export default function ExpandView({
@@ -279,5 +279,3 @@ export default function ExpandView({
         />
     );
 }
-
-

--- a/components/channel_notifications_modal/components/notification_section.jsx
+++ b/components/channel_notifications_modal/components/notification_section.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {NotificationSections, NotificationLevels} from 'utils/constants';
 
 import CollapseView from './collapse_view.jsx';
-import ExpandView from './expand_view.jsx';
+import ExpandView from './expand_view.tsx';
 
 export default class NotificationSection extends React.PureComponent {
     static propTypes = {


### PR DESCRIPTION
#### Summary
Migrate expand view to typescript

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/21070
Fixes https://mattermost.atlassian.net/browse/MM-47099

#### Related Pull Requests
NA

#### Screenshots
NA

#### Release Note
```release-note
NONE
```
