### PR TITLE
MM-47118 : Migrate "components/post_markdown/index.test.js" to Typescript

### DIFF
--- a/components/post_markdown/index.test.ts
+++ b/components/post_markdown/index.test.ts
@@ -26,7 +26,7 @@ describe('makeGetMentionKeysForPost', () => {
         delete_at: 0,
     });
 
-    const baseState: GlobalState = {
+    const baseState = {
         entities: {
             users: {
                 currentUserId: user.id,

--- a/components/post_markdown/index.test.ts
+++ b/components/post_markdown/index.test.ts
@@ -6,8 +6,6 @@ import {TestHelper} from 'utils/test_helper';
 
 import {GlobalState} from 'types/store';
 
-import {Post} from '@mattermost/types/posts';
-
 import {makeGetMentionKeysForPost} from './index';
 
 describe('makeGetMentionKeysForPost', () => {
@@ -73,7 +71,7 @@ describe('makeGetMentionKeysForPost', () => {
     it('should return all mentionKeys', () => {
         const post = TestHelper.getPostMock({
             props: {
-                disable_group_highlight: true,
+                disable_group_highlight: false,
                 mentionHighlightDisabled: false,
             },
         });
@@ -99,8 +97,8 @@ describe('makeGetMentionKeysForPost', () => {
     it('should return group mentions and all mentions without channel mentions', () => {
         const post = TestHelper.getPostMock({
             props: {
-                disable_group_highlight: true,
-                mentionHighlightDisabled: false,
+                disable_group_highlight: false,
+                mentionHighlightDisabled: true,
             },
         });
         const getMentionKeysForPost = makeGetMentionKeysForPost();
@@ -113,7 +111,7 @@ describe('makeGetMentionKeysForPost', () => {
         const post = TestHelper.getPostMock({
             props: {
                 disable_group_highlight: true,
-                mentionHighlightDisabled: false,
+                mentionHighlightDisabled: true,
             },
         });
         const getMentionKeysForPost = makeGetMentionKeysForPost();

--- a/components/post_markdown/index.test.ts
+++ b/components/post_markdown/index.test.ts
@@ -4,25 +4,31 @@ import assert from 'assert';
 
 import {TestHelper} from 'utils/test_helper';
 
+import {GlobalState} from 'types/store';
+
+import {Post} from '@mattermost/types/posts';
+
 import {makeGetMentionKeysForPost} from './index';
 
 describe('makeGetMentionKeysForPost', () => {
     const channel = TestHelper.getChannelMock({});
     const team = TestHelper.getTeamMock({group_constrained: false});
-    const user = TestHelper.getUserMock({
+    let user = TestHelper.getUserMock({
         username: 'a123',
-        notify_props: {
-            channel: 'true',
-        },
     });
+    user = {...user,
+        notify_props: {
+            ...user.notify_props,
+            channel: 'true',
+        }};
     const group = TestHelper.getGroupMock({
-        id: 123,
+        id: '123',
         name: 'developers',
         allow_reference: true,
         delete_at: 0,
     });
 
-    const baseState = {
+    const baseState: GlobalState = {
         entities: {
             users: {
                 currentUserId: user.id,
@@ -63,7 +69,7 @@ describe('makeGetMentionKeysForPost', () => {
                 myPreferences: {},
             },
         },
-    };
+    } as unknown as GlobalState;
 
     it('should return all mentionKeys', () => {
         const post = {
@@ -71,8 +77,8 @@ describe('makeGetMentionKeysForPost', () => {
                 disable_group_highlight: false,
                 mentionHighlightDisabled: false,
             },
-        };
-        const getMentionKeysForPost = makeGetMentionKeysForPost(post, channel);
+        } as unknown as Post;
+        const getMentionKeysForPost = makeGetMentionKeysForPost();
         const results = getMentionKeysForPost(baseState, post, channel);
         const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}, {key: '@developers'}];
         assert.deepEqual(results, expected);
@@ -84,8 +90,8 @@ describe('makeGetMentionKeysForPost', () => {
                 disable_group_highlight: true,
                 mentionHighlightDisabled: false,
             },
-        };
-        const getMentionKeysForPost = makeGetMentionKeysForPost(post, channel);
+        } as unknown as Post;
+        const getMentionKeysForPost = makeGetMentionKeysForPost();
         const results = getMentionKeysForPost(baseState, post, channel);
         const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}];
         assert.deepEqual(results, expected);
@@ -97,8 +103,8 @@ describe('makeGetMentionKeysForPost', () => {
                 disable_group_highlight: false,
                 mentionHighlightDisabled: true,
             },
-        };
-        const getMentionKeysForPost = makeGetMentionKeysForPost(post, channel);
+        } as unknown as Post;
+        const getMentionKeysForPost = makeGetMentionKeysForPost();
         const results = getMentionKeysForPost(baseState, post, channel);
         const expected = [{key: '@a123'}, {key: '@developers'}];
         assert.deepEqual(results, expected);
@@ -110,8 +116,8 @@ describe('makeGetMentionKeysForPost', () => {
                 disable_group_highlight: true,
                 mentionHighlightDisabled: true,
             },
-        };
-        const getMentionKeysForPost = makeGetMentionKeysForPost(post, channel);
+        } as unknown as Post;
+        const getMentionKeysForPost = makeGetMentionKeysForPost();
         const results = getMentionKeysForPost(baseState, post, channel);
         const expected = [{key: '@a123'}];
         assert.deepEqual(results, expected);

--- a/components/post_markdown/index.test.ts
+++ b/components/post_markdown/index.test.ts
@@ -38,7 +38,6 @@ describe('makeGetMentionKeysForPost', () => {
             },
             groups: {
                 syncables: {},
-                members: {},
                 groups: {
                     [group.id]: group,
                 },
@@ -69,15 +68,15 @@ describe('makeGetMentionKeysForPost', () => {
                 myPreferences: {},
             },
         },
-    } as unknown as GlobalState;
+    } as GlobalState;
 
     it('should return all mentionKeys', () => {
-        const post = {
+        const post = TestHelper.getPostMock({
             props: {
-                disable_group_highlight: false,
+                disable_group_highlight: true,
                 mentionHighlightDisabled: false,
             },
-        } as unknown as Post;
+        });
         const getMentionKeysForPost = makeGetMentionKeysForPost();
         const results = getMentionKeysForPost(baseState, post, channel);
         const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}, {key: '@developers'}];
@@ -85,12 +84,12 @@ describe('makeGetMentionKeysForPost', () => {
     });
 
     it('should return mentionKeys without groups', () => {
-        const post = {
+        const post = TestHelper.getPostMock({
             props: {
                 disable_group_highlight: true,
                 mentionHighlightDisabled: false,
             },
-        } as unknown as Post;
+        });
         const getMentionKeysForPost = makeGetMentionKeysForPost();
         const results = getMentionKeysForPost(baseState, post, channel);
         const expected = [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@a123'}];
@@ -98,12 +97,12 @@ describe('makeGetMentionKeysForPost', () => {
     });
 
     it('should return group mentions and all mentions without channel mentions', () => {
-        const post = {
+        const post = TestHelper.getPostMock({
             props: {
-                disable_group_highlight: false,
-                mentionHighlightDisabled: true,
+                disable_group_highlight: true,
+                mentionHighlightDisabled: false,
             },
-        } as unknown as Post;
+        });
         const getMentionKeysForPost = makeGetMentionKeysForPost();
         const results = getMentionKeysForPost(baseState, post, channel);
         const expected = [{key: '@a123'}, {key: '@developers'}];
@@ -111,12 +110,12 @@ describe('makeGetMentionKeysForPost', () => {
     });
 
     it('should return all mentions without group mentions and channel mentions', () => {
-        const post = {
+        const post = TestHelper.getPostMock({
             props: {
                 disable_group_highlight: true,
-                mentionHighlightDisabled: true,
+                mentionHighlightDisabled: false,
             },
-        } as unknown as Post;
+        });
         const getMentionKeysForPost = makeGetMentionKeysForPost();
         const results = getMentionKeysForPost(baseState, post, channel);
         const expected = [{key: '@a123'}];


### PR DESCRIPTION
#### Summary
Migrate post_markdown index.test.js to typescript

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/21052
  Fixes https://mattermost.atlassian.net/browse/MM-47118

#### Related Pull Requests
NA

#### Screenshots
NA

#### Release Note
```release-note
NONE
```
