### PR TITLE
Adds redux action to move a thread

### DIFF
--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -2068,6 +2068,14 @@ export default class Client4 {
         );
     };
 
+    moveThread = (postId: string, channelId: string) => {
+        const url = this.getPostRoute(postId) + '/move';
+        return this.doFetch<StatusOK>(
+            url,
+            {method: 'post', body: JSON.stringify({channel_id: channelId})},
+        );
+    }
+
     getFileInfosForPost = (postId: string) => {
         return this.doFetch<FileInfo[]>(
             `${this.getPostRoute(postId)}/files/info`,

--- a/packages/mattermost-redux/src/action_types/posts.ts
+++ b/packages/mattermost-redux/src/action_types/posts.ts
@@ -54,4 +54,7 @@ export default keyMirror({
     MOVE_HISTORY_INDEX_FORWARD: null,
 
     RESET_POSTS_IN_CHANNEL: null,
+
+    MOVE_POST_SUCCESS: null,
+    MOVE_POST_FAILURE: null,
 });

--- a/packages/mattermost-redux/src/actions/posts.ts
+++ b/packages/mattermost-redux/src/actions/posts.ts
@@ -4,15 +4,7 @@
 import {AnyAction} from 'redux';
 import {batchActions} from 'redux-batched-actions';
 
-import {FetchPaginatedThreadOptions} from '@mattermost/types/client4';
-import {ChannelUnread} from '@mattermost/types/channels';
-import {GlobalState} from '@mattermost/types/store';
-import {Post, PostList} from '@mattermost/types/posts';
-import {Reaction} from '@mattermost/types/reactions';
-import {UserProfile} from '@mattermost/types/users';
-
 import {Client4, DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE} from 'mattermost-redux/client';
-import {General, Preferences, Posts} from '../constants';
 import {PostTypes, ChannelTypes, FileTypes, IntegrationTypes} from 'mattermost-redux/action_types';
 
 import {getCurrentChannelId, getMyChannelMember as getMyChannelMemberSelector} from 'mattermost-redux/selectors/entities/channels';
@@ -25,6 +17,15 @@ import {isCombinedUserActivityPost} from 'mattermost-redux/utils/post_list';
 import {ActionResult, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {getUnreadScrollPositionPreference, isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
+
+import {FetchPaginatedThreadOptions} from '@mattermost/types/client4';
+import {ChannelUnread} from '@mattermost/types/channels';
+import {GlobalState} from '@mattermost/types/store';
+import {Post, PostList} from '@mattermost/types/posts';
+import {Reaction} from '@mattermost/types/reactions';
+import {UserProfile} from '@mattermost/types/users';
+
+import {General, Preferences, Posts} from '../constants';
 
 import {getProfilesByIds, getProfilesByUsernames, getStatusesByIds} from './users';
 import {
@@ -1326,6 +1327,23 @@ export function resetReloadPostsInChannel() {
             await dispatch(selectChannel('')); // do not remove await
             dispatch(selectChannel(currentChannelId));
         }
+        return {data: true};
+    };
+}
+
+export function moveThread(postId: string, channelId: string) {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        try {
+            await Client4.moveThread(postId, channelId);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch, getState);
+            dispatch({type: PostTypes.MOVE_POST_FAILURE, error});
+            dispatch(logError(error));
+            return {error};
+        }
+
+        dispatch({type: PostTypes.MOVE_POST_SUCCESS});
+
         return {data: true};
     };
 }


### PR DESCRIPTION
#### Summary

Adds `client4.moveThread` method to call the thread move endpoint,
and a redux action (`moveThread`) to dispatch.

#### Release Note

```release-note
NONE
```
