### PR TITLE
support general recently viewed & search handlers

### DIFF
--- a/components/command_palette/utils.ts
+++ b/components/command_palette/utils.ts
@@ -88,6 +88,20 @@ export function channelToCommandPaletteItemTransformer(channels: Channel[], team
     });
 }
 
+export function defaultsTransformer(items: any[], teams: Record<string, Team>): CommandPaletteItem[] {
+    return items.filter((item) => Boolean(item)).map((item) => {
+        return {
+            teamName: teams[item.teamId]?.name,
+            pictograph: {
+                type: CmdPalettePictographType.ICON,
+                pictographItem: CmdPalettePictographIcon.GLOBE,
+            },
+
+            ...item,
+        };
+    });
+}
+
 function sortChannelsByTypeAndDisplayName(locale: string, cmdPaletteItemA: CommandPaletteItem, cmdPaletteItemB: CommandPaletteItem): number {
     if (channelTypeOrder[cmdPaletteItemA.subType] !== channelTypeOrder[cmdPaletteItemB.subType]) {
         if (channelTypeOrder[cmdPaletteItemA.subType] < channelTypeOrder[cmdPaletteItemB.subType]) {


### PR DESCRIPTION
#### Summary
Support a more generalized handlers callback, allowing playbooks to register a recently viewed handler and a search handler prototype as part of https://github.com/mattermost/mattermost-plugin-playbooks/tree/poc-command-palette.