### PR TITLE
[contributor / wysiwyg] Add Feature Flag

### DIFF
--- a/components/user_settings/advanced/index.ts
+++ b/components/user_settings/advanced/index.ts
@@ -6,7 +6,7 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import {get, getUnreadScrollPositionPreference, makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
+import {get, getUnreadScrollPositionPreference, makeGetCategory, isWysiwygAllowed} from 'mattermost-redux/selectors/entities/preferences';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {updateUserActive, revokeAllSessionsForUser} from 'mattermost-redux/actions/users';
 
@@ -25,6 +25,7 @@ function makeMapStateToProps() {
 
         const enablePreviewFeatures = config.EnablePreviewFeatures === 'true';
         const enableUserDeactivation = config.EnableUserDeactivation === 'true';
+        const wysiwygAllowed = isWysiwygAllowed(state);
 
         return {
             advancedSettingsCategory: getAdvancedSettingsCategory(state, Preferences.CATEGORY_ADVANCED_SETTINGS),
@@ -36,6 +37,7 @@ function makeMapStateToProps() {
             unreadScrollPosition: getUnreadScrollPositionPreference(state),
             enablePreviewFeatures,
             enableUserDeactivation,
+            wysiwygAllowed,
         };
     };
 }

--- a/components/user_settings/advanced/index.ts
+++ b/components/user_settings/advanced/index.ts
@@ -25,7 +25,6 @@ function makeMapStateToProps() {
 
         const enablePreviewFeatures = config.EnablePreviewFeatures === 'true';
         const enableUserDeactivation = config.EnableUserDeactivation === 'true';
-        const wysiwygAllowed = isWysiwygAllowed(state);
 
         return {
             advancedSettingsCategory: getAdvancedSettingsCategory(state, Preferences.CATEGORY_ADVANCED_SETTINGS),
@@ -37,7 +36,7 @@ function makeMapStateToProps() {
             unreadScrollPosition: getUnreadScrollPositionPreference(state),
             enablePreviewFeatures,
             enableUserDeactivation,
-            wysiwygAllowed,
+            wysiwygAllowed: isWysiwygAllowed(state),
         };
     };
 }

--- a/components/user_settings/advanced/user_settings_advanced.tsx
+++ b/components/user_settings/advanced/user_settings_advanced.tsx
@@ -17,13 +17,13 @@ import SettingItemMin from 'components/setting_item_min';
 import ConfirmModal from 'components/confirm_modal';
 import BackIcon from 'components/widgets/icons/fa_back_icon';
 
+import {ActionResult} from 'mattermost-redux/types/actions';
+
 import {UserProfile} from '@mattermost/types/users';
 import {PreferenceType} from '@mattermost/types/preferences';
 
-import {ActionResult} from 'mattermost-redux/types/actions';
-
 import JoinLeaveSection from './join_leave_section';
-import WysiwygSection from './wysiwyg';
+import WysiwygSection from './wysiwyg_section';
 import PerformanceDebuggingSection from './performance_debugging_section';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
@@ -50,6 +50,7 @@ export type Props = {
     collapseModal: () => void;
     enablePreviewFeatures: boolean;
     enableUserDeactivation: boolean;
+    wysiwygAllowed: boolean;
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<ActionResult>;
         updateUserActive: (userId: string, active: boolean) => Promise<ActionResult>;
@@ -802,11 +803,13 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
                     <div className='divider-dark first'/>
                     {ctrlSendSection}
                     {formattingSectionDivider}
-                    <WysiwygSection
-                        activeSection={this.props.activeSection}
-                        onUpdateSection={this.handleUpdateSection}
-                        renderOnOffLabel={this.renderOnOffLabel}
-                    />
+                    {this.props.wysiwygAllowed &&
+                        <WysiwygSection
+                            activeSection={this.props.activeSection}
+                            onUpdateSection={this.handleUpdateSection}
+                            renderOnOffLabel={this.renderOnOffLabel}
+                        />
+                    }
                     {formattingSectionDivider}
                     {formattingSection}
                     <div className='divider-light'/>

--- a/components/user_settings/advanced/wysiwyg_section/index.tsx
+++ b/components/user_settings/advanced/wysiwyg_section/index.tsx
@@ -12,7 +12,7 @@ import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getWysiwygPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import WysiwygSection from './wysiwyg_editor';
+import WysiwygSection from './wysiwyg_section';
 
 function mapStateToProps(state: GlobalState) {
     return {

--- a/components/user_settings/advanced/wysiwyg_section/index.tsx
+++ b/components/user_settings/advanced/wysiwyg_section/index.tsx
@@ -9,23 +9,15 @@ import {GlobalState} from 'types/store/index.js';
 import {GenericAction} from 'mattermost-redux/types/actions.js';
 
 import {savePreferences} from 'mattermost-redux/actions/preferences';
-import {Preferences} from 'mattermost-redux/constants';
-import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
+import {getWysiwygPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import WysiwygSection from './wysiwyg_editor';
 
 function mapStateToProps(state: GlobalState) {
-    const wysiwyg = getPreference(
-        state,
-        Preferences.CATEGORY_ADVANCED_SETTINGS,
-        Preferences.ADVANCED_WYSIWYG,
-        'true',
-    );
-
     return {
         currentUserId: getCurrentUserId(state),
-        wysiwyg,
+        wysiwygEnabled: getWysiwygPreference(state),
     };
 }
 

--- a/components/user_settings/advanced/wysiwyg_section/wysiwyg_section.tsx
+++ b/components/user_settings/advanced/wysiwyg_section/wysiwyg_section.tsx
@@ -10,8 +10,10 @@ import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min';
 
 import {AdvancedSections} from 'utils/constants';
-import {PreferenceType} from '@mattermost/types/preferences';
+
 import {t} from 'utils/i18n';
+
+import {PreferenceType} from '@mattermost/types/preferences';
 
 const messages = defineMessages({
     title: {

--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -9,12 +9,12 @@ import {getConfig, getFeatureFlagValue, getLicense} from 'mattermost-redux/selec
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {isGuest} from 'mattermost-redux/utils/user_utils';
 
-import {PreferenceType} from '@mattermost/types/preferences';
-import {GlobalState} from '@mattermost/types/store';
-
 import {createShallowSelector} from 'mattermost-redux/utils/helpers';
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 import {setThemeDefaults} from 'mattermost-redux/utils/theme_utils';
+
+import {GlobalState} from '@mattermost/types/store';
+import {PreferenceType} from '@mattermost/types/preferences';
 import {CollapsedThreads} from '@mattermost/types/config';
 
 export function getMyPreferences(state: GlobalState): { [x: string]: PreferenceType } {
@@ -266,3 +266,23 @@ export function isGraphQLEnabled(state: GlobalState): boolean {
 export function getHasDismissedSystemConsoleLimitReached(state: GlobalState): boolean {
     return getBool(state, Preferences.CATEGORY_UPGRADE_CLOUD, Preferences.SYSTEM_CONSOLE_LIMIT_REACHED, false);
 }
+
+export function getWysiwygPreference(state: GlobalState): boolean {
+    return get(
+        state,
+        Preferences.CATEGORY_ADVANCED_SETTINGS,
+        Preferences.ADVANCED_WYSIWYG,
+        'false',
+    );
+}
+
+export function isWysiwygAllowed(state: GlobalState): boolean {
+    return getFeatureFlagValue(state, 'WysiwygEditor') === 'true';
+}
+
+export function isWysiwygEnabled(state: GlobalState): boolean {
+    const isAllowed = isCollapsedThreadsAllowed(state);
+    const userPreference = getWysiwygPreference(state);
+    return isAllowed && userPreference;
+}
+


### PR DESCRIPTION
#### Summary
This PR adds the feature flag check for WYSIWYG Editor.

Unless the Feature Flag is set to true, the user cannot enable the feature through `Settings` > `Advanced` > `WYSIWYG Message Editor`.  The feature will not show in the settings. 

Once the feature flag is enabled, the user preference to turn the feature `on` or `off` is shown.

#### Ticket Link
N/A

#### Related Pull Requests
- Has server changes (please link here)
  - Adds the Feature Flag - https://github.com/mattermost/mattermost-server/pull/21120
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
