### PR TITLE
MM-47065 : Migrate "components/suggestion/search_date_provider.jsx" to Typescript

### DIFF
--- a/components/suggestion/search_date_provider.tsx
+++ b/components/suggestion/search_date_provider.tsx
@@ -1,25 +1,29 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import React from 'react';
+import {TypeOf} from 'yup';
+
 import Provider from './provider.jsx';
 import SearchDateSuggestion from './search_date_suggestion';
 
 export default class SearchDateProvider extends Provider {
-    handlePretextChanged(pretext, resultsCallback) {
+    handlePretextChanged(pretext: string, resultsCallback: (result: {matchedPretext: string;terms: string[];items: {lable: string; date: string}[];component:typeof SearchDateSuggestion,}
+    ) => void) {
         const captured = (/\b(?:on|before|after):\s*(\S*)$/i).exec(pretext.toLowerCase());
         if (captured) {
             const datePrefix = captured[1];
 
             this.startNewRequest(datePrefix);
 
-            const dates = Object.assign([], [{label: 'Selected Date', date: datePrefix}]);
+            const dates: Array<{lable: string;date: string}> = Object.assign([], [{label: 'Selected Date', date: datePrefix}]);
             const terms = dates.map((date) => date.date);
 
             resultsCallback({
                 matchedPretext: datePrefix,
                 terms,
                 items: dates,
-                component: SearchDateSuggestion,
+                component: SearchDateSuggestion
             });
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
MM-47065 : Migrate "components/suggestion/search_date_provider.jsx" to Typescript

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/21098
Fixes  https://mattermost.atlassian.net/browse/MM-47065

#### Related Pull Requests
None 

#### Screenshots
None


#### Release Note
```release-note
NONE
```
