### PR TITLE
MM-47074 :  Migrate "components/suggestion/generic_channel_provider.jsx" to Typescript

### DIFF
--- a/components/apps_form/apps_form_field/apps_form_field.test.tsx
+++ b/components/apps_form/apps_form_field/apps_form_field.test.tsx
@@ -10,7 +10,7 @@ import TextSetting from 'components/widgets/settings/text_setting';
 
 import AutocompleteSelector from 'components/autocomplete_selector';
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
-import GenericChannelProvider from 'components/suggestion/generic_channel_provider.jsx';
+import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
 import Markdown from 'components/markdown';
 
 import AppsFormField, {Props} from './apps_form_field';

--- a/components/apps_form/apps_form_field/apps_form_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_field.tsx
@@ -11,7 +11,7 @@ import {AppFieldTypes} from 'mattermost-redux/constants/apps';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
-import GenericChannelProvider from 'components/suggestion/generic_channel_provider.jsx';
+import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
 
 import TextSetting, {InputTypes} from 'components/widgets/settings/text_setting';
 import AutocompleteSelector from 'components/autocomplete_selector';
@@ -38,7 +38,7 @@ export interface Props {
     listComponent?: React.ComponentProps<typeof AutocompleteSelector>['listComponent'];
     performLookup: (name: string, userInput: string) => Promise<AppSelectOption[]>;
     actions: {
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => (dispatch: any, getState: any) => Promise<void>;
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
         autocompleteUsers: (search: string) => Promise<UserProfile[]>;
     };
 }

--- a/components/apps_form/apps_form_field/apps_form_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_field.tsx
@@ -3,10 +3,6 @@
 
 import React from 'react';
 
-import {AppField, AppSelectOption} from '@mattermost/types/apps';
-import {Channel} from '@mattermost/types/channels';
-import {UserProfile} from '@mattermost/types/users';
-
 import {AppFieldTypes} from 'mattermost-redux/constants/apps';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
@@ -20,6 +16,13 @@ import BoolSetting from 'components/widgets/settings/bool_setting';
 import Provider from 'components/suggestion/provider';
 
 import Markdown from 'components/markdown';
+
+import {ActionResult} from 'mattermost-redux/types/actions';
+
+import {ServerError} from '@mattermost/types/errors';
+import {AppField, AppSelectOption} from '@mattermost/types/apps';
+import {UserProfile} from '@mattermost/types/users';
+import {Channel} from '@mattermost/types/channels';
 
 import AppsFormSelectField from './apps_form_select_field';
 
@@ -38,7 +41,7 @@ export interface Props {
     listComponent?: React.ComponentProps<typeof AutocompleteSelector>['listComponent'];
     performLookup: (name: string, userInput: string) => Promise<AppSelectOption[]>;
     actions: {
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>;
         autocompleteUsers: (search: string) => Promise<UserProfile[]>;
     };
 }

--- a/components/apps_form/apps_form_field/apps_form_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_field.tsx
@@ -3,11 +3,16 @@
 
 import React from 'react';
 
+import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
+
+import {AppField, AppSelectOption} from '@mattermost/types/apps';
+import {Channel} from '@mattermost/types/channels';
+import {UserProfile} from '@mattermost/types/users';
+
 import {AppFieldTypes} from 'mattermost-redux/constants/apps';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
-import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
 
 import TextSetting, {InputTypes} from 'components/widgets/settings/text_setting';
 import AutocompleteSelector from 'components/autocomplete_selector';
@@ -17,12 +22,8 @@ import Provider from 'components/suggestion/provider';
 
 import Markdown from 'components/markdown';
 
-import {ActionResult} from 'mattermost-redux/types/actions';
-
+import {ActionFunc} from 'mattermost-redux/types/actions';
 import {ServerError} from '@mattermost/types/errors';
-import {AppField, AppSelectOption} from '@mattermost/types/apps';
-import {UserProfile} from '@mattermost/types/users';
-import {Channel} from '@mattermost/types/channels';
 
 import AppsFormSelectField from './apps_form_select_field';
 
@@ -41,7 +42,7 @@ export interface Props {
     listComponent?: React.ComponentProps<typeof AutocompleteSelector>['listComponent'];
     performLookup: (name: string, userInput: string) => Promise<AppSelectOption[]>;
     actions: {
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>;
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
         autocompleteUsers: (search: string) => Promise<UserProfile[]>;
     };
 }

--- a/components/apps_form/apps_form_field/apps_form_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_field.tsx
@@ -3,8 +3,6 @@
 
 import React from 'react';
 
-import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
-
 import {AppField, AppSelectOption} from '@mattermost/types/apps';
 import {Channel} from '@mattermost/types/channels';
 import {UserProfile} from '@mattermost/types/users';
@@ -13,6 +11,7 @@ import {AppFieldTypes} from 'mattermost-redux/constants/apps';
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
+import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
 
 import TextSetting, {InputTypes} from 'components/widgets/settings/text_setting';
 import AutocompleteSelector from 'components/autocomplete_selector';
@@ -42,7 +41,7 @@ export interface Props {
     listComponent?: React.ComponentProps<typeof AutocompleteSelector>['listComponent'];
     performLookup: (name: string, userInput: string) => Promise<AppSelectOption[]>;
     actions: {
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error?: (err: ServerError) => void) => ActionFunc;
         autocompleteUsers: (search: string) => Promise<UserProfile[]>;
     };
 }

--- a/components/apps_form/apps_form_field/index.ts
+++ b/components/apps_form/apps_form_field/index.ts
@@ -4,16 +4,20 @@
 import {connect} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
-import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
-import {Channel} from '@mattermost/types/channels';
-import {UserProfile} from '@mattermost/types/users';
+import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
 
 import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 
+import {autocompleteChannels} from 'actions/channel_actions';
+
+import {autocompleteUsers} from 'actions/user_actions';
+
+import {Channel} from '@mattermost/types/channels';
+import {UserProfile} from '@mattermost/types/users';
+
 import {GlobalState} from '@mattermost/types/store';
 
-import {autocompleteChannels} from 'actions/channel_actions';
-import {autocompleteUsers} from 'actions/user_actions';
+import {ServerError} from '@mattermost/types/errors';
 
 import AppsFormField from './apps_form_field';
 
@@ -23,7 +27,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 type Actions = {
-    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
+    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>;
     autocompleteUsers: (search: string) => Promise<UserProfile[]>;
 };
 

--- a/components/apps_form/apps_form_field/index.ts
+++ b/components/apps_form/apps_form_field/index.ts
@@ -5,17 +5,15 @@ import {connect} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
-
-import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
-
-import {autocompleteChannels} from 'actions/channel_actions';
-
-import {autocompleteUsers} from 'actions/user_actions';
-
 import {Channel} from '@mattermost/types/channels';
 import {UserProfile} from '@mattermost/types/users';
 
+import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
+
 import {GlobalState} from '@mattermost/types/store';
+
+import {autocompleteChannels} from 'actions/channel_actions';
+import {autocompleteUsers} from 'actions/user_actions';
 
 import {ServerError} from '@mattermost/types/errors';
 
@@ -27,7 +25,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 type Actions = {
-    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
+    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error?: (err: ServerError) => void) => ActionFunc;
     autocompleteUsers: (search: string) => Promise<UserProfile[]>;
 };
 

--- a/components/apps_form/apps_form_field/index.ts
+++ b/components/apps_form/apps_form_field/index.ts
@@ -23,7 +23,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 type Actions = {
-    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => (dispatch: any, getState: any) => Promise<void>;
+    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
     autocompleteUsers: (search: string) => Promise<UserProfile[]>;
 };
 

--- a/components/apps_form/apps_form_field/index.ts
+++ b/components/apps_form/apps_form_field/index.ts
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
-import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
+import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
 
 import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 
@@ -27,7 +27,7 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 type Actions = {
-    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>;
+    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
     autocompleteUsers: (search: string) => Promise<UserProfile[]>;
 };
 

--- a/components/interactive_dialog/dialog_element/dialog_element.tsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.tsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import MenuActionProvider from 'components/suggestion/menu_action_provider';
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
-import GenericChannelProvider from 'components/suggestion/generic_channel_provider.jsx';
+import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
 
 import TextSetting, {InputTypes} from 'components/widgets/settings/text_setting';
 import AutocompleteSelector from 'components/autocomplete_selector';

--- a/components/interactive_dialog/dialog_element/dialog_element.tsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.tsx
@@ -14,9 +14,15 @@ import AutocompleteSelector from 'components/autocomplete_selector';
 import ModalSuggestionList from 'components/suggestion/modal_suggestion_list.jsx';
 import BoolSetting from 'components/widgets/settings/bool_setting';
 import RadioSetting from 'components/widgets/settings/radio_setting';
+
+import Provider from 'components/suggestion/provider';
+
+import {ActionResult} from 'mattermost-redux/types/actions';
+
 import {UserProfile} from '@mattermost/types/users';
 import {Channel} from '@mattermost/types/channels';
-import Provider from 'components/suggestion/provider';
+
+import {ServerError} from '@mattermost/types/errors';
 
 const TEXT_DEFAULT_MAX_LENGTH = 150;
 const TEXTAREA_DEFAULT_MAX_LENGTH = 3000;
@@ -40,7 +46,7 @@ type Props = {
     onChange: (name: string, selected: string) => void;
     autoFocus?: boolean;
     actions: {
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>;
         autocompleteUsers: (search: string) => Promise<UserProfile[]>;
     };
 }

--- a/components/interactive_dialog/dialog_element/dialog_element.tsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.tsx
@@ -17,7 +17,7 @@ import RadioSetting from 'components/widgets/settings/radio_setting';
 
 import Provider from 'components/suggestion/provider';
 
-import {ActionResult} from 'mattermost-redux/types/actions';
+import {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {UserProfile} from '@mattermost/types/users';
 import {Channel} from '@mattermost/types/channels';
@@ -46,7 +46,7 @@ type Props = {
     onChange: (name: string, selected: string) => void;
     autoFocus?: boolean;
     actions: {
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>;
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
         autocompleteUsers: (search: string) => Promise<UserProfile[]>;
     };
 }

--- a/components/interactive_dialog/dialog_element/dialog_element.tsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.tsx
@@ -14,13 +14,10 @@ import AutocompleteSelector from 'components/autocomplete_selector';
 import ModalSuggestionList from 'components/suggestion/modal_suggestion_list.jsx';
 import BoolSetting from 'components/widgets/settings/bool_setting';
 import RadioSetting from 'components/widgets/settings/radio_setting';
-
-import Provider from 'components/suggestion/provider';
-
 import {ActionFunc} from 'mattermost-redux/types/actions';
-
 import {UserProfile} from '@mattermost/types/users';
 import {Channel} from '@mattermost/types/channels';
+import Provider from 'components/suggestion/provider';
 
 import {ServerError} from '@mattermost/types/errors';
 
@@ -46,7 +43,7 @@ type Props = {
     onChange: (name: string, selected: string) => void;
     autoFocus?: boolean;
     actions: {
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error?: (err: ServerError) => void) => ActionFunc;
         autocompleteUsers: (search: string) => Promise<UserProfile[]>;
     };
 }

--- a/components/interactive_dialog/dialog_element/index.ts
+++ b/components/interactive_dialog/dialog_element/index.ts
@@ -7,16 +7,18 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 import {autocompleteChannels} from 'actions/channel_actions';
 import {autocompleteUsers} from 'actions/user_actions';
 
-import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
+import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
 
 import {UserProfile} from '@mattermost/types/users';
 
 import {Channel} from '@mattermost/types/channels';
 
+import {ServerError} from '@mattermost/types/errors';
+
 import DialogElement from './dialog_element';
 
 type Actions = {
-    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
+    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>;
     autocompleteUsers: (search: string) => Promise<UserProfile[]>;
 };
 

--- a/components/interactive_dialog/dialog_element/index.ts
+++ b/components/interactive_dialog/dialog_element/index.ts
@@ -18,7 +18,7 @@ import {ServerError} from '@mattermost/types/errors';
 import DialogElement from './dialog_element';
 
 type Actions = {
-    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
+    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error?: (err: ServerError) => void) => ActionFunc;
     autocompleteUsers: (search: string) => Promise<UserProfile[]>;
 };
 

--- a/components/interactive_dialog/dialog_element/index.ts
+++ b/components/interactive_dialog/dialog_element/index.ts
@@ -7,7 +7,7 @@ import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 import {autocompleteChannels} from 'actions/channel_actions';
 import {autocompleteUsers} from 'actions/user_actions';
 
-import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/actions';
+import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
 
 import {UserProfile} from '@mattermost/types/users';
 
@@ -18,7 +18,7 @@ import {ServerError} from '@mattermost/types/errors';
 import DialogElement from './dialog_element';
 
 type Actions = {
-    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>;
+    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
     autocompleteUsers: (search: string) => Promise<UserProfile[]>;
 };
 

--- a/components/post_view/message_attachments/action_menu/action_menu.test.tsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.test.tsx
@@ -28,11 +28,6 @@ describe('components/post_view/message_attachments/ActionMenu', () => {
         autocompleteChannels: jest.fn(),
         autocompleteUsers: jest.fn(),
         selectAttachmentMenuAction: jest.fn(),
-        actions: {
-            autocompleteChannels: jest.fn(),
-            autocompleteUsers: jest.fn(),
-            selectAttachmentMenuAction: jest.fn(),
-        },
     };
 
     test('should start with nothing selected', () => {

--- a/components/post_view/message_attachments/action_menu/action_menu.test.tsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.test.tsx
@@ -25,9 +25,11 @@ describe('components/post_view/message_attachments/ActionMenu', () => {
             cookie: 'cookie',
         },
         selected: undefined,
-        autocompleteChannels: jest.fn(),
-        autocompleteUsers: jest.fn(),
-        selectAttachmentMenuAction: jest.fn(),
+        actions: {
+            autocompleteChannels: jest.fn(),
+            autocompleteUsers: jest.fn(),
+            selectAttachmentMenuAction: jest.fn(),
+        },
     };
 
     test('should start with nothing selected', () => {

--- a/components/post_view/message_attachments/action_menu/action_menu.test.tsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.test.tsx
@@ -28,6 +28,11 @@ describe('components/post_view/message_attachments/ActionMenu', () => {
         autocompleteChannels: jest.fn(),
         autocompleteUsers: jest.fn(),
         selectAttachmentMenuAction: jest.fn(),
+        actions: {
+            autocompleteChannels: jest.fn(),
+            autocompleteUsers: jest.fn(),
+            selectAttachmentMenuAction: jest.fn(),
+        },
     };
 
     test('should start with nothing selected', () => {

--- a/components/post_view/message_attachments/action_menu/action_menu.tsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.tsx
@@ -3,15 +3,14 @@
 
 import React from 'react';
 
+import {UserProfile} from '@mattermost/types/users';
+import {Channel} from '@mattermost/types/channels';
+
 import MenuActionProvider from 'components/suggestion/menu_action_provider';
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
 import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
 import AutocompleteSelector from 'components/autocomplete_selector';
 import PostContext from 'components/post_view/post_context';
-
-import {Channel} from '@mattermost/types/channels';
-
-import {UserProfile} from '@mattermost/types/users';
 
 import {PostAction} from '@mattermost/types/integration_actions';
 import {ServerError} from '@mattermost/types/errors';
@@ -35,7 +34,7 @@ export type Props = {
         selectAttachmentMenuAction: (postId: any, actionId: any, cookie: any, dataSource: any, text: any, value: any) => (dispatch: any) => Promise<{
             data: boolean;
         }>;
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc;
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error?: (err: ServerError) => void) => ActionFunc;
         autocompleteUsers: (search: string) => Promise<UserProfile[]>;
     };
 }

--- a/components/post_view/message_attachments/action_menu/action_menu.tsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.tsx
@@ -8,7 +8,7 @@ import {Channel} from '@mattermost/types/channels';
 
 import MenuActionProvider from 'components/suggestion/menu_action_provider';
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
-import GenericChannelProvider from 'components/suggestion/generic_channel_provider.jsx';
+import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
 import AutocompleteSelector from 'components/autocomplete_selector';
 import PostContext from 'components/post_view/post_context';
 
@@ -40,9 +40,9 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
         this.providers = [];
         if (action) {
             if (action.data_source === 'users') {
-                this.providers = [new GenericUserProvider(props.autocompleteUsers)];
+                this.providers = [new GenericUserProvider(props.actions.autocompleteUsers)];
             } else if (action.data_source === 'channels') {
-                this.providers = [new GenericChannelProvider(props.autocompleteChannels)];
+                this.providers = [new GenericChannelProvider(props.actions.autocompleteChannels)];
             } else if (action.options) {
                 this.providers = [new MenuActionProvider(action.options)];
             }
@@ -97,7 +97,7 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
             value = option.value;
         }
 
-        this.props.selectAttachmentMenuAction(
+        this.props.actions.selectAttachmentMenuAction(
             this.props.postId, this.props.action.id || '', this.props.action.cookie || '', this.props.action?.data_source, text, value);
 
         this.setState({value: text});

--- a/components/post_view/message_attachments/action_menu/action_menu.tsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.tsx
@@ -3,14 +3,15 @@
 
 import React from 'react';
 
-import {UserProfile} from '@mattermost/types/users';
-import {Channel} from '@mattermost/types/channels';
-
 import MenuActionProvider from 'components/suggestion/menu_action_provider';
 import GenericUserProvider from 'components/suggestion/generic_user_provider.jsx';
 import GenericChannelProvider from 'components/suggestion/generic_channel_provider';
 import AutocompleteSelector from 'components/autocomplete_selector';
 import PostContext from 'components/post_view/post_context';
+
+import {Channel} from '@mattermost/types/channels';
+
+import {UserProfile} from '@mattermost/types/users';
 
 import type {OwnProps, PropsFromRedux} from './index';
 
@@ -40,9 +41,9 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
         this.providers = [];
         if (action) {
             if (action.data_source === 'users') {
-                this.providers = [new GenericUserProvider(props.actions.autocompleteUsers)];
+                this.providers = [new GenericUserProvider(props.autocompleteUsers)];
             } else if (action.data_source === 'channels') {
-                this.providers = [new GenericChannelProvider(props.actions.autocompleteChannels)];
+                this.providers = [new GenericChannelProvider(props.autocompleteChannels)];
             } else if (action.options) {
                 this.providers = [new MenuActionProvider(action.options)];
             }
@@ -97,7 +98,7 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
             value = option.value;
         }
 
-        this.props.actions.selectAttachmentMenuAction(
+        this.props.selectAttachmentMenuAction(
             this.props.postId, this.props.action.id || '', this.props.action.cookie || '', this.props.action?.data_source, text, value);
 
         this.setState({value: text});

--- a/components/post_view/message_attachments/action_menu/index.ts
+++ b/components/post_view/message_attachments/action_menu/index.ts
@@ -3,6 +3,8 @@
 
 import {connect, ConnectedProps} from 'react-redux';
 
+import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
+
 import {PostAction} from '@mattermost/types/integration_actions';
 
 import {GlobalState} from 'types/store';
@@ -12,10 +14,20 @@ import {selectAttachmentMenuAction} from 'actions/views/posts';
 
 import ActionMenu from './action_menu';
 
+import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
+import {Channel, UserProfile} from 'components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies';
+
 export type OwnProps = {
     postId: string;
     action: PostAction;
     disabled?: boolean;
+    actions?: {
+        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
+        autocompleteUsers: (search: string) => Promise<UserProfile[]>;
+        selectAttachmentMenuAction: (postId: any, actionId: any, cookie: any, dataSource: any, text: any, value: any) => (dispatch: any) => Promise<{
+            data: boolean;
+        }>;
+    };
 }
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
@@ -27,11 +39,23 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     };
 }
 
-const mapDispatchToProps = {
-    selectAttachmentMenuAction,
-    autocompleteChannels,
-    autocompleteUsers,
+type Actions = {
+    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
+    autocompleteUsers: (search: string) => Promise<UserProfile[]>;
+    selectAttachmentMenuAction: (postId: any, actionId: any, cookie: any, dataSource: any, text: any, value: any) => (dispatch: any) => Promise<{
+        data: boolean;
+    }>;
 };
+
+function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+    return {
+        actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Actions>({
+            selectAttachmentMenuAction,
+            autocompleteChannels,
+            autocompleteUsers,
+        }, dispatch),
+    };
+}
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 

--- a/components/post_view/message_attachments/action_menu/index.ts
+++ b/components/post_view/message_attachments/action_menu/index.ts
@@ -12,10 +12,10 @@ import {autocompleteChannels} from 'actions/channel_actions';
 import {autocompleteUsers} from 'actions/user_actions';
 import {selectAttachmentMenuAction} from 'actions/views/posts';
 
-import ActionMenu from './action_menu';
-
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
 import {Channel, UserProfile} from 'components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies';
+
+import ActionMenu from './action_menu';
 
 export type OwnProps = {
     postId: string;

--- a/components/post_view/message_attachments/action_menu/index.ts
+++ b/components/post_view/message_attachments/action_menu/index.ts
@@ -3,6 +3,8 @@
 
 import {connect, ConnectedProps} from 'react-redux';
 
+import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
+
 import {GlobalState} from 'types/store';
 import {autocompleteChannels} from 'actions/channel_actions';
 import {autocompleteUsers} from 'actions/user_actions';
@@ -10,7 +12,9 @@ import {selectAttachmentMenuAction} from 'actions/views/posts';
 
 import {PostAction} from '@mattermost/types/integration_actions';
 
-import ActionMenu from './action_menu';
+import {ActionFunc} from 'mattermost-redux/types/actions';
+
+import ActionMenu, {Props} from './action_menu';
 
 export type OwnProps = {
     postId: string;
@@ -27,11 +31,15 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     };
 }
 
-const mapDispatchToProps = {
-    selectAttachmentMenuAction,
-    autocompleteChannels,
-    autocompleteUsers,
-};
+function mapDispatchToProps(dispatch: Dispatch) {
+    return {
+        actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Props['actions']>({
+            selectAttachmentMenuAction,
+            autocompleteChannels,
+            autocompleteUsers,
+        }, dispatch),
+    };
+}
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 

--- a/components/post_view/message_attachments/action_menu/index.ts
+++ b/components/post_view/message_attachments/action_menu/index.ts
@@ -3,17 +3,12 @@
 
 import {connect, ConnectedProps} from 'react-redux';
 
-import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
-
-import {PostAction} from '@mattermost/types/integration_actions';
-
 import {GlobalState} from 'types/store';
 import {autocompleteChannels} from 'actions/channel_actions';
 import {autocompleteUsers} from 'actions/user_actions';
 import {selectAttachmentMenuAction} from 'actions/views/posts';
 
-import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
-import {Channel, UserProfile} from 'components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies';
+import {PostAction} from '@mattermost/types/integration_actions';
 
 import ActionMenu from './action_menu';
 
@@ -21,13 +16,6 @@ export type OwnProps = {
     postId: string;
     action: PostAction;
     disabled?: boolean;
-    actions?: {
-        autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
-        autocompleteUsers: (search: string) => Promise<UserProfile[]>;
-        selectAttachmentMenuAction: (postId: any, actionId: any, cookie: any, dataSource: any, text: any, value: any) => (dispatch: any) => Promise<{
-            data: boolean;
-        }>;
-    };
 }
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
@@ -39,23 +27,11 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     };
 }
 
-type Actions = {
-    autocompleteChannels: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>;
-    autocompleteUsers: (search: string) => Promise<UserProfile[]>;
-    selectAttachmentMenuAction: (postId: any, actionId: any, cookie: any, dataSource: any, text: any, value: any) => (dispatch: any) => Promise<{
-        data: boolean;
-    }>;
+const mapDispatchToProps = {
+    selectAttachmentMenuAction,
+    autocompleteChannels,
+    autocompleteUsers,
 };
-
-function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
-    return {
-        actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Actions>({
-            selectAttachmentMenuAction,
-            autocompleteChannels,
-            autocompleteUsers,
-        }, dispatch),
-    };
-}
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 

--- a/components/post_view/message_attachments/action_menu/index.ts
+++ b/components/post_view/message_attachments/action_menu/index.ts
@@ -5,12 +5,12 @@ import {connect, ConnectedProps} from 'react-redux';
 
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
+import {PostAction} from '@mattermost/types/integration_actions';
+
 import {GlobalState} from 'types/store';
 import {autocompleteChannels} from 'actions/channel_actions';
 import {autocompleteUsers} from 'actions/user_actions';
 import {selectAttachmentMenuAction} from 'actions/views/posts';
-
-import {PostAction} from '@mattermost/types/integration_actions';
 
 import {ActionFunc} from 'mattermost-redux/types/actions';
 

--- a/components/suggestion/generic_channel_provider.tsx
+++ b/components/suggestion/generic_channel_provider.tsx
@@ -1,10 +1,20 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Channel} from '@mattermost/types/channels.js';
 import React from 'react';
 
 import Provider from './provider.jsx';
 import Suggestion from './suggestion.jsx';
+
+export type Results = {
+    matchedPretext: string;
+    terms: string[];
+    items: Channel[];
+    component: React.ElementType;
+}
+
+type ResultsCallback = (results: Results) => void;
 
 class ChannelSuggestion extends Suggestion {
     render() {
@@ -53,24 +63,25 @@ class ChannelSuggestion extends Suggestion {
 }
 
 export default class ChannelProvider extends Provider {
-    constructor(channelSearchFunc) {
+    autocompleteChannels: any;
+    constructor(channelSearchFunc: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>) {
         super();
 
         this.autocompleteChannels = channelSearchFunc;
     }
 
-    handlePretextChanged(pretext, resultsCallback) {
+    handlePretextChanged(pretext: string, resultsCallback: ResultsCallback) {
         const normalizedPretext = pretext.toLowerCase();
         this.startNewRequest(normalizedPretext);
 
         this.autocompleteChannels(
             normalizedPretext,
-            (data) => {
+            (data: Channel[]) => {
                 if (this.shouldCancelDispatch(normalizedPretext)) {
                     return;
                 }
 
-                const channels = Object.assign([], data);
+                const channels: Channel[] = Object.assign([], data);
 
                 resultsCallback({
                     matchedPretext: normalizedPretext,

--- a/components/suggestion/generic_channel_provider.tsx
+++ b/components/suggestion/generic_channel_provider.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Channel} from '@mattermost/types/channels.js';
-import {ServerError} from '@mattermost/types/errors.js';
-import {ActionResult} from 'mattermost-redux/types/actions.js';
+import {Channel} from '@mattermost/types/channels';
+import {ServerError} from '@mattermost/types/errors';
+import {ActionFunc} from 'mattermost-redux/types/actions';
 import React from 'react';
 
 import Provider from './provider.jsx';
@@ -66,7 +66,7 @@ class ChannelSuggestion extends Suggestion {
 
 export default class ChannelProvider extends Provider {
     autocompleteChannels: any;
-    constructor(channelSearchFunc: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>) {
+    constructor(channelSearchFunc: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc) {
         super();
 
         this.autocompleteChannels = channelSearchFunc;

--- a/components/suggestion/generic_channel_provider.tsx
+++ b/components/suggestion/generic_channel_provider.tsx
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 
 import {Channel} from '@mattermost/types/channels.js';
+import {ServerError} from '@mattermost/types/errors.js';
+import {ActionResult} from 'mattermost-redux/types/actions.js';
 import React from 'react';
 
 import Provider from './provider.jsx';
@@ -64,7 +66,7 @@ class ChannelSuggestion extends Suggestion {
 
 export default class ChannelProvider extends Provider {
     autocompleteChannels: any;
-    constructor(channelSearchFunc: (term: string, success: (channels: Channel[]) => void, error: () => void) => Promise<void>) {
+    constructor(channelSearchFunc: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionResult<any, any> | Promise<ActionResult<any, any> | Array<ActionResult<any, any>>>) {
         super();
 
         this.autocompleteChannels = channelSearchFunc;

--- a/components/suggestion/generic_channel_provider.tsx
+++ b/components/suggestion/generic_channel_provider.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import React from 'react';
+
 import {Channel} from '@mattermost/types/channels';
 import {ServerError} from '@mattermost/types/errors';
 import {ActionFunc} from 'mattermost-redux/types/actions';
-import React from 'react';
 
 import Provider from './provider.jsx';
 import Suggestion from './suggestion.jsx';
@@ -17,6 +18,7 @@ export type Results = {
 }
 
 type ResultsCallback = (results: Results) => void;
+type ChannelSearchFunc = (term: string, success: (channels: Channel[]) => void, error?: (err: ServerError) => void) => ActionFunc;
 
 class ChannelSuggestion extends Suggestion {
     render() {
@@ -65,8 +67,8 @@ class ChannelSuggestion extends Suggestion {
 }
 
 export default class ChannelProvider extends Provider {
-    autocompleteChannels: any;
-    constructor(channelSearchFunc: (term: string, success: (channels: Channel[]) => void, error: (err: ServerError) => void) => ActionFunc) {
+    autocompleteChannels: ChannelSearchFunc;
+    constructor(channelSearchFunc: ChannelSearchFunc) {
         super();
 
         this.autocompleteChannels = channelSearchFunc;


### PR DESCRIPTION
#### Summary
Genric_channel_provider.jsx to typescript

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21095
Fixes https://mattermost.atlassian.net/browse/MM-47074

#### Related Pull Requests
None
#### Screenshots
NA

#### Release Note
None
```release-note
NONE
```
