### PR TITLE
MM-47098:  Migrate "components/channel_notifications_modal/channel_notifications_modal.jsx" to Typescript

### DIFF
--- a/components/channel_notifications_modal/channel_notifications_modal.test.jsx
+++ b/components/channel_notifications_modal/channel_notifications_modal.test.jsx
@@ -5,7 +5,7 @@ import {shallow} from 'enzyme';
 
 import {IgnoreChannelMentions, NotificationLevels, NotificationSections} from 'utils/constants';
 
-import ChannelNotificationsModal from 'components/channel_notifications_modal/channel_notifications_modal.jsx';
+import ChannelNotificationsModal from 'components/channel_notifications_modal/channel_notifications_modal';
 
 describe('components/channel_notifications_modal/ChannelNotificationsModal', () => {
     const baseProps = {

--- a/components/channel_notifications_modal/index.js
+++ b/components/channel_notifications_modal/index.js
@@ -8,7 +8,7 @@ import {updateChannelNotifyProps} from 'mattermost-redux/actions/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getMyCurrentChannelMembership} from 'mattermost-redux/selectors/entities/channels';
 
-import ChannelNotificationsModal from './channel_notifications_modal.jsx';
+import ChannelNotificationsModal from './channel_notifications_modal';
 
 const mapStateToProps = (state) => ({
     channelMember: getMyCurrentChannelMembership(state),

--- a/packages/types/src/channels.ts
+++ b/packages/types/src/channels.ts
@@ -25,6 +25,8 @@ export type ChannelNotifyProps = {
     mark_unread: 'all' | 'mention';
     push: 'default' | 'all' | 'mention' | 'none';
     ignore_channel_mentions: 'default' | 'off' | 'on';
+    desktop_threads: 'default' | 'all' | 'mention' | 'none';
+    push_threads: 'default' | 'all' | 'mention' | 'none';
 };
 
 export type Channel = {


### PR DESCRIPTION
#### Summary
Migrate components/channel_notifications_modal/channel_notifications_modal.test.jsx to typescript

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21071
Fixes https://mattermost.atlassian.net/browse/MM-47098

#### Related Pull Requests
None

#### Screenshots
None

#### Release Note

```release-note
NONE
```
