### PR TITLE
Fix profile popovers closing action due to react update

### DIFF
--- a/components/at_mention/at_mention.tsx
+++ b/components/at_mention/at_mention.tsx
@@ -57,9 +57,6 @@ export default class AtMention extends React.PureComponent<Props, State> {
     }
 
     handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        if (e.stopPropagation) {
-            e.stopPropagation();
-        }
         const targetBounds = this.overlayRef.current?.getBoundingClientRect();
 
         if (targetBounds) {


### PR DESCRIPTION

#### Summary
We added an extra e.preventDefault during fixing react 17 bugs for other popovers. This one was redundant and was causing issues with closing the popovers. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47153

#### Release Note

```release-note
NONE
```
