### PR TITLE
[MM-45719] Combine focus on avatar and status icon in global header

### DIFF
--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -7,8 +7,9 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
   onToggle={[Function]}
   open={false}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -20,16 +21,15 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"
@@ -236,8 +236,9 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
   onToggle={[Function]}
   open={true}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -249,16 +250,15 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"
@@ -546,8 +546,9 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
   onToggle={[Function]}
   open={true}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -559,16 +560,15 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"
@@ -808,8 +808,9 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
   onToggle={[Function]}
   open={true}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -821,16 +822,15 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"
@@ -1070,8 +1070,9 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
   onToggle={[Function]}
   open={true}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -1083,16 +1084,15 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"
@@ -1333,8 +1333,9 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
   onToggle={[Function]}
   open={false}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -1350,16 +1351,15 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
       size="sm"
       url="http://localhost:8065/api/v4/users/jsx5jmdiyjyuzp9rzwfaf5pwjo/image?_=1590519110944"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"
@@ -1570,8 +1570,9 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
   onToggle={[Function]}
   open={true}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -1583,16 +1584,15 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"
@@ -1799,8 +1799,9 @@ exports[`components/StatusDropdown should not show clear status button when cust
   onToggle={[Function]}
   open={true}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -1812,16 +1813,15 @@ exports[`components/StatusDropdown should not show clear status button when cust
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"
@@ -2061,8 +2061,9 @@ exports[`components/StatusDropdown should show clear status button when custom s
   onToggle={[Function]}
   open={true}
 >
-  <div
-    className="status-wrapper"
+  <button
+    aria-label="Set a status"
+    className="status-wrapper style--none"
   >
     <Memo(CustomStatusEmoji)
       emojiStyle={
@@ -2074,16 +2075,15 @@ exports[`components/StatusDropdown should show clear status button when custom s
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
-      aria-label="Set a status"
-      className="status style--none"
+    <div
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
-  </div>
+    </div>
+  </button>
   <Menu
     ariaLabel="Set a status"
     id="statusDropdownMenu"

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -271,6 +271,9 @@ button.custom_status__row {
             bottom: -4px;
             width: 16px;
             height: 16px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
             background-color: var(--global-header-background);
             color: var(--global-header-text);
 

--- a/components/status_dropdown/status_dropdown.scss
+++ b/components/status_dropdown/status_dropdown.scss
@@ -269,9 +269,9 @@ button.custom_status__row {
             top: auto;
             right: -4px;
             bottom: -4px;
+            display: inline-flex;
             width: 16px;
             height: 16px;
-            display: inline-flex;
             align-items: center;
             justify-content: center;
             background-color: var(--global-header-background);

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -182,6 +182,7 @@ export default class StatusDropdown extends React.PureComponent<Props, State> {
             <Avatar
                 size={size}
                 url={this.props.profilePicture}
+                tabIndex={undefined}
             />
         );
     }
@@ -406,7 +407,10 @@ export default class StatusDropdown extends React.PureComponent<Props, State> {
                     active: this.props.isStatusDropdownOpen || isStatusSet,
                 })}
             >
-                <div className='status-wrapper'>
+                <button
+                    className='status-wrapper style--none'
+                    aria-label={localizeMessage('status_dropdown.menuAriaLabel', 'Set a status')}
+                >
                     <CustomStatusEmoji
                         showTooltip={true}
                         tooltipDirection={'bottom'}
@@ -414,16 +418,13 @@ export default class StatusDropdown extends React.PureComponent<Props, State> {
                         onClick={this.handleCustomStatusEmojiClick as () => void}
                     />
                     {this.renderProfilePicture('sm')}
-                    <button
-                        className='status style--none'
-                        aria-label={localizeMessage('status_dropdown.menuAriaLabel', 'Set a status')}
-                    >
+                    <div className='status'>
                         <StatusIcon
                             size={'sm'}
                             status={(this.props.status || 'offline') as TUserStatus}
                         />
-                    </button>
-                </div>
+                    </div>
+                </button>
                 <Menu
                     ariaLabel={localizeMessage('status_dropdown.menuAriaLabel', 'Set a status')}
                     id={'statusDropdownMenu'}

--- a/components/widgets/users/avatar/avatar.tsx
+++ b/components/widgets/users/avatar/avatar.tsx
@@ -44,9 +44,9 @@ const Avatar = ({
 
     return (
         <img
+            tabIndex={0}
             {...attrs}
             className={classes}
-            tabIndex={0}
             alt={`${username || 'user'} profile image`}
             src={url}
             onError={(e) => {


### PR DESCRIPTION
#### Summary

Combine the avatar and status icon in global header into one button that can be focused.

#### Ticket Link

[Jira ticket](https://mattermost.atlassian.net/browse/MM-45719)

#### Screenshots

<img width="171" alt="Screen Shot 2022-09-29 at 11 21 32 AM" src="https://user-images.githubusercontent.com/112951043/193073768-c02b7069-861e-4796-887a-9dc1018451b6.png">

#### Release Note

```release-note
NONE
```
