### PR TITLE
Fix displaying of Add bot account link disclaimer

### DIFF
--- a/components/integrations/bots/add_bot/add_bot.tsx
+++ b/components/integrations/bots/add_bot/add_bot.tsx
@@ -627,10 +627,21 @@ export default class AddBot extends React.PureComponent<Props, State> {
                         </div>
                         <div className='row bot-profile__section'>
                             <div className='col-md-5 col-sm-8 col-sm-offset-4'>
-                                <FormattedMarkdownMessage
-                                    id='admin.manage_roles.additionalRoles'
-                                    defaultMessage='Select additional permissions for the account. [Read more about roles and permissions](!https://developers.mattermost.com/integrate/admin-guide/admin-personal-access-token/).'
-                                />
+                            <FormattedMessage
+                                id='admin.manage_roles.additionalRoles'
+                                defaultMessage='Select additional permissions for the account. <link>Read more about roles and permissions</link>.'
+                                values={{
+                                    link: (msg: React.ReactNode) => (
+                                        <a
+                                            href='https://developers.mattermost.com/integrate/admin-guide/admin-personal-access-token/'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                }}
+                            />
                             </div>
                         </div>
                         <div className='form-group'>


### PR DESCRIPTION
#### Summary
Fixes the display of the disclaimer link in add bot modal

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45797

#### Release Note

```release-note
NONE
```
