### PR TITLE
[Contribute] Command Palette - Add Initial Channel and User Autocomplete

### DIFF
--- a/components/command_palette/command_palette_list/command_palette_list.tsx
+++ b/components/command_palette/command_palette_list/command_palette_list.tsx
@@ -28,7 +28,7 @@ export const CommandPaletteList = ({itemList, onItemSelected}: Props) => {
             setSelectedItemIndex(selectedItemIndex + 1);
             e.preventDefault();
         }
-    }, [selectedItemIndex]);
+    }, [KeyCodes.DOWN, KeyCodes.UP, selectedItemIndex]);
 
     useEffect(() => {
         document.addEventListener('keydown', handleKeyDown);

--- a/components/command_palette/command_palette_list_item/command_palette_list_item.scss
+++ b/components/command_palette/command_palette_list_item/command_palette_list_item.scss
@@ -71,3 +71,38 @@
         font-weight: 400;
     }
 }
+
+.suggestion-list__icon {
+    display: inline-flex;
+    flex: 0 0 1.6rem;
+    align-items: center;
+    justify-content: center;
+    fill: v(center-channel-color);
+    opacity: 0.56;
+
+    &--standard {
+        width: 2rem;
+        height: 2rem;
+        flex: 0 0 2.4rem;
+        margin: 0 12px 0 0;
+        font-size: 1.2rem;
+    }
+
+    &--large {
+        width: 2.4rem;
+        height: 2.4rem;
+        flex: 0 0 2.4rem;
+        margin: 0 12px 0 0;
+        font-size: 2rem;
+    }
+
+    .status--group {
+        display: flex;
+        width: 1.8rem;
+        height: 1.8rem;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        background-color: rgba(var(--center-channel-color-rgb), 0.2);
+    }
+}

--- a/components/command_palette/command_palette_list_item/command_palette_list_item.tsx
+++ b/components/command_palette/command_palette_list_item/command_palette_list_item.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 
 import {Channel} from '@mattermost/types/channels';
+import {UserProfile} from '@mattermost/types/users';
 
 import RenderEmoji from 'components/emoji/render_emoji';
 import BotBadge from 'components/widgets/badges/bot_badge';
@@ -31,6 +32,7 @@ export interface CommandPaletteItem {
     lastViewedAt?: number;
     isDeactivated?: boolean;
     channel?: Channel;
+    user?: UserProfile;
     type: CommandPaletteEntities;
     subType: ChannelType | BoardsType | PlaybooksType | GotoType;
     isSelected?: boolean;

--- a/components/command_palette/command_palette_list_item/command_palette_list_item_pictograph.tsx
+++ b/components/command_palette/command_palette_list_item/command_palette_list_item_pictograph.tsx
@@ -12,6 +12,7 @@ export enum CmdPalettePictographType {
     GOTO_ICON= 'goto_icon',
     EMOJI= 'emoji',
     TEXT= 'text',
+    GROUP_ICON = 'status status--group'
 }
 
 export enum CmdPalettePictographIcon{
@@ -50,6 +51,12 @@ export const CommandPaletteListItemPictograph = ({type, pictographItem, userStat
             <RenderEmoji
                 emojiName={pictographItem}
             />);
+    } else if (type === CmdPalettePictographType.GROUP_ICON) {
+        return (
+            <span className='suggestion-list__icon suggestion-list__icon--large'>
+                <div className='status status--group'>{'G'}</div>
+            </span>
+        );
     }
     return null;
 };

--- a/components/command_palette/command_palette_modal/index.ts
+++ b/components/command_palette/command_palette_modal/index.ts
@@ -2,7 +2,20 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators, Dispatch} from 'redux';
+
+import {autocompleteUsersInTeam} from 'actions/user_actions';
+
+import {GenericAction} from 'mattermost-redux/types/actions';
 
 import CommandPaletteModal from './command_palette_modal';
 
-export default connect(null, null)(CommandPaletteModal);
+function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+    return {
+        actions: bindActionCreators({
+            autocompleteUsersInTeam,
+        }, dispatch),
+    };
+}
+
+export default connect(null, mapDispatchToProps)(CommandPaletteModal);

--- a/components/command_palette/types/index.ts
+++ b/components/command_palette/types/index.ts
@@ -9,6 +9,7 @@ export enum CommandPaletteEntities {
     Files = 'files',
     Runs = 'runs',
     GoTo = 'goTo',
+    User = 'user',
 }
 
 export enum ChannelType {

--- a/components/command_palette/utils.ts
+++ b/components/command_palette/utils.ts
@@ -2,6 +2,9 @@
 // See LICENSE.txt for license information.
 import {Channel} from '@mattermost/types/channels';
 import {Team} from '@mattermost/types/teams';
+import {UserProfile} from '@mattermost/types/users';
+
+import {imageURLForUser} from 'utils/utils';
 
 import {CommandPaletteItem} from './command_palette_list_item/command_palette_list_item';
 import {
@@ -61,6 +64,21 @@ export function boardToCommandPaletteItemTransformer(boards: Board[], teams: Rec
     });
 }
 
+export function userToCommandPaletteItemTransform(users: UserProfile[]): CommandPaletteItem[] {
+    return users.map((user) => {
+        return {
+            title: user.username,
+            id: user.id,
+            type: CommandPaletteEntities.User,
+            pictograph: {
+                type: CmdPalettePictographType.IMAGE,
+                pictographItem: imageURLForUser(user.id, user.last_picture_update),
+            },
+            user,
+        };
+    });
+}
+
 export function channelToCommandPaletteItemTransformer(channels: Channel[], teams: Record<string, Team>): CommandPaletteItem[] {
     return channels.map((channel) => {
         const isArchived = channel.delete_at ? channel.delete_at !== 0 : false;
@@ -68,6 +86,8 @@ export function channelToCommandPaletteItemTransformer(channels: Channel[], team
         let channelIcon = CmdPalettePictographIcon.GLOBE;
         if (isArchived) {
             channelIcon = CmdPalettePictographIcon.ARCHIVE;
+        } else if (channel.type === ChannelType.PRIVATE_CHANNEL) {
+            channelIcon = CmdPalettePictographIcon.LOCK;
         }
         return {
             description: channel.type === ChannelType.DM_CHANNEL ? channel.name : '',
@@ -75,7 +95,7 @@ export function channelToCommandPaletteItemTransformer(channels: Channel[], team
             isDeactivated: isArchived,
             teamName: teams[channel.team_id]?.name,
             pictograph: {
-                type: CmdPalettePictographType.ICON,
+                type: channel.type === ChannelType.GM_CHANNEL ? CmdPalettePictographType.GROUP_ICON : CmdPalettePictographType.ICON,
                 pictographItem: channelIcon,
             },
             subType: channel.type as ChannelType,

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -428,6 +428,30 @@ export default class SwitchChannelProvider extends Provider {
         return true;
     }
 
+    handlePretextChangedForChannelSearch(channelPrefix, resultsCallback) {
+        if (channelPrefix) {
+            prefix = channelPrefix;
+            this.startNewRequest(channelPrefix);
+            if (this.shouldCancelDispatch(channelPrefix)) {
+                return false;
+            }
+
+            // Dispatch suggestions for local data
+            const channels = getChannelsInAllTeams(getState()).concat(getDirectAndGroupChannels(getState()));
+            const formattedData = this.formatList(channelPrefix, [ThreadsChannel, ...channels], [], true, true);
+            if (formattedData) {
+                resultsCallback(formattedData);
+            }
+
+            // Fetch data from the server and dispatch
+            this.fetchChannels(channelPrefix, resultsCallback);
+        } else {
+            this.fetchAndFormatRecentlyViewedChannels(resultsCallback);
+        }
+
+        return true;
+    }
+
     async fetchUsersAndChannels(channelPrefix, resultsCallback) {
         const state = getState();
         const teamId = getCurrentTeamId(state);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Adds autocomplete for channels and users in command palette.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.

- Has server changes (please link here)
- Has mobile changes (please link here)
-->


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
