### PR TITLE
MM-47217 Reorder the leave channel menu item

### DIFF
--- a/components/channel_header_dropdown/__snapshots__/channel_header_dropdown.test.jsx.snap
+++ b/components/channel_header_dropdown/__snapshots__/channel_header_dropdown.test.jsx.snap
@@ -368,8 +368,6 @@ exports[`components/ChannelHeaderDropdown should match snapshot with no plugin i
         text="Archive Channel"
       />
     </Connect(ChannelPermissionGate)>
-  </MenuGroup>
-  <MenuGroup>
     <Connect(LeaveChannel)
       channel={
         Object {
@@ -802,8 +800,6 @@ exports[`components/ChannelHeaderDropdown should match snapshot with plugins 1`]
         text="Archive Channel"
       />
     </Connect(ChannelPermissionGate)>
-  </MenuGroup>
-  <MenuGroup>
     <Connect(LeaveChannel)
       channel={
         Object {

--- a/components/channel_header_dropdown/__snapshots__/channel_header_dropdown.test.jsx.snap
+++ b/components/channel_header_dropdown/__snapshots__/channel_header_dropdown.test.jsx.snap
@@ -369,7 +369,6 @@ exports[`components/ChannelHeaderDropdown should match snapshot with no plugin i
       />
     </Connect(ChannelPermissionGate)>
   </MenuGroup>
-  <MenuGroup />
   <MenuGroup>
     <Connect(LeaveChannel)
       channel={
@@ -399,6 +398,7 @@ exports[`components/ChannelHeaderDropdown should match snapshot with no plugin i
       isArchived={false}
     />
   </MenuGroup>
+  <MenuGroup />
   <MenuGroup>
     <Connect(ChannelPermissionGate)
       channelId="test-channel-id"
@@ -804,22 +804,6 @@ exports[`components/ChannelHeaderDropdown should match snapshot with plugins 1`]
     </Connect(ChannelPermissionGate)>
   </MenuGroup>
   <MenuGroup>
-    <MenuItemAction
-      id="plugin-1_pluginmenuitem"
-      key="plugin-1_pluginmenuitem"
-      onClick={[Function]}
-      show={true}
-      text="plugin-1-text"
-    />
-    <MenuItemAction
-      id="plugin-2_pluginmenuitem"
-      key="plugin-2_pluginmenuitem"
-      onClick={[Function]}
-      show={true}
-      text="plugin-2-text"
-    />
-  </MenuGroup>
-  <MenuGroup>
     <Connect(LeaveChannel)
       channel={
         Object {
@@ -846,6 +830,22 @@ exports[`components/ChannelHeaderDropdown should match snapshot with plugins 1`]
     <Connect(CloseChannel)
       id="channelCloseChannel"
       isArchived={false}
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      id="plugin-1_pluginmenuitem"
+      key="plugin-1_pluginmenuitem"
+      onClick={[Function]}
+      show={true}
+      text="plugin-1-text"
+    />
+    <MenuItemAction
+      id="plugin-2_pluginmenuitem"
+      key="plugin-2_pluginmenuitem"
+      onClick={[Function]}
+      show={true}
+      text="plugin-2-text"
     />
   </MenuGroup>
   <MenuGroup>

--- a/components/channel_header_dropdown/channel_header_dropdown_items.js
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.js
@@ -288,7 +288,7 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                         />
                     </ChannelPermissionGate>
                 </Menu.Group>
-                <Menu.Group divider={divider}>
+                <Menu.Group>
                     {isMobile &&
                         <MobileChannelHeaderPlug
                             channel={channel}

--- a/components/channel_header_dropdown/channel_header_dropdown_items.js
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.js
@@ -287,8 +287,6 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                             text={localizeMessage('channel_header.delete', 'Archive Channel')}
                         />
                     </ChannelPermissionGate>
-                </Menu.Group>
-                <Menu.Group>
                     {isMobile &&
                         <MobileChannelHeaderPlug
                             channel={channel}

--- a/components/channel_header_dropdown/channel_header_dropdown_items.js
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.js
@@ -288,9 +288,6 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                         />
                     </ChannelPermissionGate>
                 </Menu.Group>
-                <Menu.Group>
-                    {pluginItems}
-                </Menu.Group>
                 <Menu.Group divider={divider}>
                     {isMobile &&
                         <MobileChannelHeaderPlug
@@ -313,7 +310,9 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                         isArchived={isArchived}
                     />
                 </Menu.Group>
-
+                <Menu.Group>
+                    {pluginItems}
+                </Menu.Group>
                 <Menu.Group divider={divider}>
                     <ChannelPermissionGate
                         channelId={channel.id}


### PR DESCRIPTION
Temporary fix to reorder the "leave channel" menu option above the plugin menu entries so users on smaller monitors still have the ability to leave a channel. The full fix will be addressed with https://mattermost.atlassian.net/browse/MM-40156 and the web platform teams Q4 OKRs for menus

Root cause is this bug: https://mattermost.atlassian.net/browse/MM-47217

#### Release Note
```release-note
NONE
```