### PR TITLE
MM-47089 : Migrate "components/integrations/integration_option.jsx" to Typescript 

### DIFF
--- a/components/integrations/integration_option.tsx
+++ b/components/integrations/integration_option.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-
 import {Link} from 'react-router-dom';
 
 type Props = {

--- a/components/integrations/integration_option.tsx
+++ b/components/integrations/integration_option.tsx
@@ -1,28 +1,18 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes, {ReactNodeLike} from 'prop-types';
-
 import React from 'react';
 
 import {Link} from 'react-router-dom';
 
 type Props = {
     image: string;
-    title: ReactNodeLike;
-    description: ReactNodeLike;
+    title: JSX.Element;
+    description: JSX.Element;
     link: string;
 }
-export default class IntegrationOption extends React.PureComponent <Props> {
-    static get propTypes() {
-        return {
-            image: PropTypes.string.isRequired,
-            title: PropTypes.node.isRequired,
-            description: PropTypes.node.isRequired,
-            link: PropTypes.string.isRequired,
-        };
-    }
 
+export default class IntegrationOption extends React.PureComponent <Props> {
     render() {
         const {image, title, description, link} = this.props;
 

--- a/components/integrations/integration_option.tsx
+++ b/components/integrations/integration_option.tsx
@@ -1,11 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
+import PropTypes, {ReactNodeLike} from 'prop-types';
+
 import React from 'react';
+
 import {Link} from 'react-router-dom';
 
-export default class IntegrationOption extends React.PureComponent {
+type Props = {
+    image: string;
+    title: ReactNodeLike;
+    description: ReactNodeLike;
+    link: string;
+}
+export default class IntegrationOption extends React.PureComponent <Props> {
     static get propTypes() {
         return {
             image: PropTypes.string.isRequired,

--- a/components/integrations/integrations.jsx
+++ b/components/integrations/integrations.jsx
@@ -18,7 +18,7 @@ import SlashCommandIcon from 'images/slash_command_icon.jpg';
 import SystemPermissionGate from 'components/permissions_gates/system_permission_gate';
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
 
-import IntegrationOption from './integration_option.jsx';
+import IntegrationOption from './integration_option';
 
 export default class Integrations extends React.PureComponent {
     static get propTypes() {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
MM-47089:Migrate "components/integrations/integration_option.jsx" to Typescript

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/21080
Fixes  https://mattermost.atlassian.net/browse/MM-47089

#### Related Pull Requests
None 

#### Screenshots
None


#### Release Note
```release-note
NONE
```