### PR TITLE
MM-46316 Fix a few broken links in the System Console

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -4904,37 +4904,39 @@ const AdminDefinition = {
                                 help_text: t('admin.google.EnableMarkdownDesc'),
                                 help_text_default: '1. <linkLogin>Log in</linkLogin> to your Google account.\n2. Go to <linkConsole>https://console.developers.google.com</linkConsole>, click <strong>Credentials</strong> in the left hand sidebar and enter "Mattermost - your-company-name" as the <strong>Project Name</strong>, then click <strong>Create</strong>.\n3. Click the <strong>OAuth consent screen</strong> header and enter "Mattermost" as the <strong>Product name shown to users</strong>, then click <strong>Save</strong>.\n4. Under the <strong>Credentials</strong> header, click <strong>Create credentials</strong>, choose <strong>OAuth client ID</strong> and select <strong>Web Application</strong>.\n5. Under <strong>Restrictions</strong> and <strong>Authorized redirect URIs</strong> enter <strong>your-mattermost-url/signup/google/complete</strong> (example: http://localhost:8065/signup/google/complete). Click <strong>Create</strong>.\n6. Paste the <strong>Client ID</strong> and <strong>Client Secret</strong> to the fields below, then click <strong>Save</strong>.\n7. Go to the <linkAPI>Google People API</linkAPI> and click <strong>Enable</strong>.',
                                 help_text_markdown: false,
-                                linkLogin: (msg) => (
-                                    <a
-                                        href='https://accounts.google.com/login'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                linkConsole: (msg) => (
-                                    <a
-                                        href='https://console.developers.google.com'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                linkAPI: (msg) => (
-                                    <a
-                                        href='https://console.developers.google.com/apis/library/people.googleapis.com'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                strong: (msg) => <strong>{msg}</strong>,
+                                help_text_values: {
+                                    linkLogin: (msg) => (
+                                        <a
+                                            href='https://accounts.google.com/login'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    linkConsole: (msg) => (
+                                        <a
+                                            href='https://console.developers.google.com'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    linkAPI: (msg) => (
+                                        <a
+                                            href='https://console.developers.google.com/apis/library/people.googleapis.com'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    strong: (msg) => <strong>{msg}</strong>,
+                                },
                             },
                             {
                                 value: Constants.OFFICE365_SERVICE,
@@ -4944,37 +4946,39 @@ const AdminDefinition = {
                                 help_text: t('admin.office365.EnableMarkdownDesc'),
                                 help_text_default: '1. <linkLogin>Log in</linkLogin> to your Microsoft or Office 365 account. Make sure it`s the account on the same <linkTenant>tenant</linkTenant> that you would like users to log in with.\n2. Go to <linkApps>https://apps.dev.microsoft.com</linkApps>, click <strong>Go to app list</strong> > <strong>Add an app</strong> and use "Mattermost - your-company-name" as the <strong>Application Name</strong>.\n3. Under <strong>Application Secrets</strong>, click <strong>Generate New Password</strong> and paste it to the <strong>Application Secret Password<strong> field below.\n4. Under <strong>Platforms</strong>, click <strong>Add Platform</strong>, choose <strong>Web</strong> and enter <strong>your-mattermost-url/signup/office365/complete</strong> (example: http://localhost:8065/signup/office365/complete) under <strong>Redirect URIs</strong>. Also uncheck <strong>Allow Implicit Flow</strong>.\n5. Finally, click <strong>Save</strong> and then paste the <strong>Application ID</strong> below.',
                                 help_text_markdown: false,
-                                linkLogin: (msg) => (
-                                    <a
-                                        href='https://login.microsoftonline.com/'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                linkTenant: (msg) => (
-                                    <a
-                                        href='https://msdn.microsoft.com/en-us/library/azure/jj573650.aspx#Anchor_0'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                linkApps: (msg) => (
-                                    <a
-                                        href='https://apps.dev.microsoft.com'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                strong: (msg) => <strong>{msg}</strong>,
+                                help_text_values: {
+                                    linkLogin: (msg) => (
+                                        <a
+                                            href='https://login.microsoftonline.com/'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    linkTenant: (msg) => (
+                                        <a
+                                            href='https://msdn.microsoft.com/en-us/library/azure/jj573650.aspx#Anchor_0'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    linkApps: (msg) => (
+                                        <a
+                                            href='https://apps.dev.microsoft.com'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    strong: (msg) => <strong>{msg}</strong>,
+                                },
                             },
                         ],
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.OPENID)),
@@ -5329,38 +5333,39 @@ const AdminDefinition = {
                                 help_text: t('admin.office365.EnableMarkdownDesc'),
                                 help_text_default: '1. <linkLogin>Log in</linkLogin> to your Microsoft or Office 365 account. Make sure it`s the account on the same <linkTenant>tenant</linkTenant> that you would like users to log in with.\n2. Go to <linkApps>https://apps.dev.microsoft.com</linkApps>, click <strong>Go to Azure Portal</strong> > click <strong>New Registration</strong>.\n3. Use "Mattermost - your-company-name" as the <strong>Application Name</strong>, click <strong>Registration</strong>, paste <strong>Client ID</strong> and <strong>Tenant ID</strong> below.\n4. Click <strong>Authentication</strong>, under <strong>Platforms</strong>, click <strong>Add Platform</strong>, choose <strong>Web</strong> and enter <strong>your-mattermost-url/signup/office365/complete</strong> (example: http://localhost:8065/signup/office365/complete) under <strong>Redirect URIs</strong>. Also uncheck <strong>Allow Implicit Flow</strong>.\n5. Click <strong>Certificates & secrets</strong>, Generate <strong>New client secret</strong> and paste secret value in <strong>Client Secret</strong> field below.',
                                 help_text_markdown: false,
-                                linkLogin: (msg) => (
-                                    <a
-                                        href='https://login.microsoftonline.com/'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                linkTenant: (msg) => (
-                                    <a
-                                        href='https://msdn.microsoft.com/en-us/library/azure/jj573650.aspx#Anchor_0'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                linkApps: (msg) => (
-                                    <a
-                                        href='https://apps.dev.microsoft.com'
-                                        referrer='noreferrer'
-                                        target='_blank'
-                                        rel='noreferrer'
-                                    >
-                                        {msg}
-                                    </a>
-                                ),
-                                strong: (msg) => <strong>{msg}</strong>,
-
+                                help_text_values: {
+                                    linkLogin: (msg) => (
+                                        <a
+                                            href='https://login.microsoftonline.com/'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    linkTenant: (msg) => (
+                                        <a
+                                            href='https://msdn.microsoft.com/en-us/library/azure/jj573650.aspx#Anchor_0'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    linkApps: (msg) => (
+                                        <a
+                                            href='https://apps.dev.microsoft.com'
+                                            referrer='noreferrer'
+                                            target='_blank'
+                                            rel='noreferrer'
+                                        >
+                                            {msg}
+                                        </a>
+                                    ),
+                                    strong: (msg) => <strong>{msg}</strong>,
+                                },
                             },
                             {
                                 value: Constants.OPENID_SERVICE,

--- a/components/admin_console/group_settings/__snapshots__/group_settings.test.tsx.snap
+++ b/components/admin_console/group_settings/__snapshots__/group_settings.test.tsx.snap
@@ -39,11 +39,11 @@ For more information on Groups, please see <link>documentation</link>."
       <AdminPanel
         className=""
         id="ldap_groups"
-        subtitleDefault="Connect AD/LDAP and create groups in Mattermost. To get started, configure group attributes on the [AD/LDAP]({siteURL}/admin_console/authentication/ldap) configuration page."
+        subtitleDefault="Connect AD/LDAP and create groups in Mattermost. To get started, configure group attributes on the <link>AD/LDAP</link> configuration page."
         subtitleId="admin.group_settings.ldapGroupsDescription"
         subtitleValues={
           Object {
-            "siteURL": "http://localhost:8065",
+            "link": [Function],
           }
         }
         titleDefault="AD/LDAP Groups"

--- a/components/admin_console/group_settings/group_settings.tsx
+++ b/components/admin_console/group_settings/group_settings.tsx
@@ -52,8 +52,18 @@ const GroupSettings = ({isDisabled}: Props) => {
                         titleId={t('admin.group_settings.ldapGroupsTitle')}
                         titleDefault='AD/LDAP Groups'
                         subtitleId={t('admin.group_settings.ldapGroupsDescription')}
-                        subtitleDefault={'Connect AD/LDAP and create groups in Mattermost. To get started, configure group attributes on the [AD/LDAP]({siteURL}/admin_console/authentication/ldap) configuration page.'}
-                        subtitleValues={{siteURL}}
+                        subtitleDefault={'Connect AD/LDAP and create groups in Mattermost. To get started, configure group attributes on the <link>AD/LDAP</link> configuration page.'}
+                        subtitleValues={{
+                            link: (msg: React.ReactNode) => (
+                                <a
+                                    href={`${siteURL}/admin_console/authentication/ldap`}
+                                    target='_blank'
+                                    rel='noreferrer'
+                                >
+                                    {msg}
+                                </a>
+                            ),
+                        }}
                     >
                         <GroupsList
                             readOnly={isDisabled}

--- a/components/admin_console/team_channel_settings/team/details/__snapshots__/team_profile.test.tsx.snap
+++ b/components/admin_console/team_channel_settings/team/details/__snapshots__/team_profile.test.tsx.snap
@@ -181,18 +181,14 @@ exports[`admin_console/team_channel_settings/team/TeamProfile__Cloud restore sho
             <div
               className="mt-2"
             >
-              <FormattedMarkdownMessage
+              <FormattedMessage
                 defaultMessage="Summary of the team, including team name and description."
                 id="admin.team_settings.team_detail.profileDescription"
               >
-                <span
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "Summary of the team, including team name and description.",
-                    }
-                  }
-                />
-              </FormattedMarkdownMessage>
+                <span>
+                  Summary of the team, including team name and description.
+                </span>
+              </FormattedMessage>
             </div>
           </div>
         </div>
@@ -429,18 +425,14 @@ exports[`admin_console/team_channel_settings/team/TeamProfile__Cloud should matc
             <div
               className="mt-2"
             >
-              <FormattedMarkdownMessage
+              <FormattedMessage
                 defaultMessage="Summary of the team, including team name and description."
                 id="admin.team_settings.team_detail.profileDescription"
               >
-                <span
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "Summary of the team, including team name and description.",
-                    }
-                  }
-                />
-              </FormattedMarkdownMessage>
+                <span>
+                  Summary of the team, including team name and description.
+                </span>
+              </FormattedMessage>
             </div>
           </div>
         </div>
@@ -810,18 +802,14 @@ exports[`admin_console/team_channel_settings/team/TeamProfile__Cloud should matc
             <div
               className="mt-2"
             >
-              <FormattedMarkdownMessage
+              <FormattedMessage
                 defaultMessage="Summary of the team, including team name and description."
                 id="admin.team_settings.team_detail.profileDescription"
               >
-                <span
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "Summary of the team, including team name and description.",
-                    }
-                  }
-                />
-              </FormattedMarkdownMessage>
+                <span>
+                  Summary of the team, including team name and description.
+                </span>
+              </FormattedMessage>
             </div>
           </div>
         </div>

--- a/components/widgets/admin_console/admin_panel.test.tsx
+++ b/components/widgets/admin_console/admin_panel.test.tsx
@@ -39,7 +39,7 @@ describe('components/widgets/admin_console/AdminPanel', () => {
                   <div
                     className="mt-2"
                   >
-                    <FormattedMarkdownMessage
+                    <MemoizedFormattedMessage
                       defaultMessage="test-subtitle-default"
                       id="test-subtitle-id"
                       values={
@@ -83,7 +83,7 @@ describe('components/widgets/admin_console/AdminPanel', () => {
                   <div
                     className="mt-2"
                   >
-                    <FormattedMarkdownMessage
+                    <MemoizedFormattedMessage
                       defaultMessage="test-subtitle-default"
                       id="test-subtitle-id"
                       values={
@@ -135,7 +135,7 @@ describe('components/widgets/admin_console/AdminPanel', () => {
                   <div
                     className="mt-2"
                   >
-                    <FormattedMarkdownMessage
+                    <MemoizedFormattedMessage
                       defaultMessage="test-subtitle-default"
                       id="test-subtitle-id"
                       values={

--- a/components/widgets/admin_console/admin_panel.tsx
+++ b/components/widgets/admin_console/admin_panel.tsx
@@ -6,8 +6,6 @@ import {FormattedMessage} from 'react-intl';
 
 import './admin_panel.scss';
 
-import FormattedMarkdownMessage from 'components/formatted_markdown_message';
-
 type Props = {
     id?: string;
     className?: string;
@@ -38,7 +36,7 @@ const AdminPanel: React.FC<Props> = (props: Props) => (
                     />
                 </h3>
                 <div className='mt-2'>
-                    <FormattedMarkdownMessage
+                    <FormattedMessage
                         id={props.subtitleId}
                         defaultMessage={props.subtitleDefault}
                         values={props.subtitleValues}

--- a/components/widgets/admin_console/admin_panel_with_link.tsx
+++ b/components/widgets/admin_console/admin_panel_with_link.tsx
@@ -34,7 +34,6 @@ const AdminPanelWithLink = (props: Props) => {
             <FormattedMessage
                 id={props.linkTextId}
                 defaultMessage={props.linkTextDefault}
-                values={props.subtitleValues}
             />
         </Link>
     );
@@ -48,6 +47,7 @@ const AdminPanelWithLink = (props: Props) => {
             titleDefault={props.titleDefault}
             subtitleId={props.subtitleId}
             subtitleDefault={props.subtitleDefault}
+            subtitleValues={props.subtitleValues}
             button={button}
         >
             {props.children}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1049,7 +1049,7 @@
   "admin.group_settings.groups_list.unlink_selected": "Unlink Selected Groups",
   "admin.group_settings.groupsPageTitle": "Groups",
   "admin.group_settings.introBanner": "Groups are a way to organize users and apply actions to all users within that group.\nFor more information on Groups, please see <link>documentation</link>.",
-  "admin.group_settings.ldapGroupsDescription": "Connect AD/LDAP and create groups in Mattermost. To get started, configure group attributes on the [AD/LDAP]({siteURL}/admin_console/authentication/ldap) configuration page.",
+  "admin.group_settings.ldapGroupsDescription": "Connect AD/LDAP and create groups in Mattermost. To get started, configure group attributes on the <link>AD/LDAP</link> configuration page.",
   "admin.group_settings.ldapGroupsTitle": "AD/LDAP Groups",
   "admin.group_settings.need_groupname": "You must specify a group mention.",
   "admin.group_teams_and_channels_row.channelAdmin": "Channel Admin",

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -183,6 +183,10 @@
             }
         }
 
+        .help-text {
+            white-space: pre-line;
+        }
+
         .form-group {
             margin-bottom: 25px;
 


### PR DESCRIPTION
1. There were some broken links in places that used the `AdminPanel` component because it still used a `FormattedMessage`. Since it only used Markdown in one place, I just changed that case to not use Markdown instead of adding an option to switch between Markdown and non-Markdown.
2. In the comments of the ticket, there was also an issue reported where links in the OpenID/OAuth settings were broken, so I fixed those as well. Since we no longer generate a proper list in those elements, I changed the CSS so that the newlines we added to that help text were visible. Ideally, we'd break that down into a proper list, but the System Console schema doesn't support arbitrary elements in help text.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46316

#### Release Note
```release-note
Fixed a few broken links in the System Console
```
