### PR TITLE
MM-47192 : Migrate "utils/policy_roles_adapter.js" to typescript

### DIFF
--- a/utils/policy_roles_adapter.test.jsx
+++ b/utils/policy_roles_adapter.test.jsx
@@ -100,14 +100,14 @@ describe('PolicyRolesAdapter', () => {
         describe('enableTeamCreation', () => {
             test('true', () => {
                 roles.system_user.permissions = [];
-                const updatedRoles = rolesFromMapping({enableTeamCreation: 'true'}, roles);
+                const updatedRoles = rolesFromMapping({enableTeamCreation: 'True'}, roles);
                 expect(Object.values(updatedRoles).length).toEqual(1);
                 expect(updatedRoles.system_user.permissions).toEqual(expect.arrayContaining([Permissions.CREATE_TEAM]));
             });
 
             test('false', () => {
                 roles.system_user.permissions = [Permissions.CREATE_TEAM];
-                const updatedRoles = rolesFromMapping({enableTeamCreation: 'false'}, roles);
+                const updatedRoles = rolesFromMapping({enableTeamCreation: 'False'}, roles);
                 expect(Object.values(updatedRoles).length).toEqual(1);
                 expect(updatedRoles.system_user.permissions).not.toEqual(expect.arrayContaining([Permissions.CREATE_TEAM]));
             });
@@ -124,11 +124,11 @@ describe('PolicyRolesAdapter', () => {
             test('returns the expected policy value for a enableTeamCreation policy', () => {
                 addPermissionToRole(Permissions.CREATE_TEAM, roles.system_user);
                 let value = mappingValueFromRoles('enableTeamCreation', roles);
-                expect(value).toEqual('true');
+                expect(value).toEqual('True');
 
                 removePermissionFromRole(Permissions.CREATE_TEAM, roles.system_user);
                 value = mappingValueFromRoles('enableTeamCreation', roles);
-                expect(value).toEqual('false');
+                expect(value).toEqual('False');
             });
         });
     });

--- a/utils/policy_roles_adapter.test.jsx
+++ b/utils/policy_roles_adapter.test.jsx
@@ -100,14 +100,14 @@ describe('PolicyRolesAdapter', () => {
         describe('enableTeamCreation', () => {
             test('true', () => {
                 roles.system_user.permissions = [];
-                const updatedRoles = rolesFromMapping({enableTeamCreation: 'True'}, roles);
+                const updatedRoles = rolesFromMapping({enableTeamCreation: 'true'}, roles);
                 expect(Object.values(updatedRoles).length).toEqual(1);
                 expect(updatedRoles.system_user.permissions).toEqual(expect.arrayContaining([Permissions.CREATE_TEAM]));
             });
 
             test('false', () => {
                 roles.system_user.permissions = [Permissions.CREATE_TEAM];
-                const updatedRoles = rolesFromMapping({enableTeamCreation: 'False'}, roles);
+                const updatedRoles = rolesFromMapping({enableTeamCreation: 'false'}, roles);
                 expect(Object.values(updatedRoles).length).toEqual(1);
                 expect(updatedRoles.system_user.permissions).not.toEqual(expect.arrayContaining([Permissions.CREATE_TEAM]));
             });
@@ -124,11 +124,11 @@ describe('PolicyRolesAdapter', () => {
             test('returns the expected policy value for a enableTeamCreation policy', () => {
                 addPermissionToRole(Permissions.CREATE_TEAM, roles.system_user);
                 let value = mappingValueFromRoles('enableTeamCreation', roles);
-                expect(value).toEqual('True');
+                expect(value).toEqual('true');
 
                 removePermissionFromRole(Permissions.CREATE_TEAM, roles.system_user);
                 value = mappingValueFromRoles('enableTeamCreation', roles);
-                expect(value).toEqual('False');
+                expect(value).toEqual('false');
             });
         });
     });

--- a/utils/policy_roles_adapter.ts
+++ b/utils/policy_roles_adapter.ts
@@ -4,31 +4,34 @@
 import {Role} from '@mattermost/types/roles';
 import {Permissions} from 'mattermost-redux/constants/index';
 
+const trueString = 'true';
+const falseString = 'false';
+
 const MAPPING = {
     enableTeamCreation: {
-        True: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: true}],
-        False: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: false}],
+        [trueString]: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: true}],
+        [falseString]: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: false}],
     },
 
     editOthersPosts: {
-        True: [
+        [trueString]: [
             {roleName: 'system_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
             {roleName: 'team_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
         ],
-        False: [
+        [falseString]: [
             {roleName: 'team_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: false},
             {roleName: 'system_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
         ],
     },
 
     enableOnlyAdminIntegrations: {
-        True: [
+        [trueString]: [
             {roleName: 'team_user', permission: Permissions.MANAGE_INCOMING_WEBHOOKS, shouldHave: false},
             {roleName: 'team_user', permission: Permissions.MANAGE_OUTGOING_WEBHOOKS, shouldHave: false},
             {roleName: 'team_user', permission: Permissions.MANAGE_SLASH_COMMANDS, shouldHave: false},
             {roleName: 'system_user', permission: Permissions.MANAGE_OAUTH, shouldHave: false},
         ],
-        False: [
+        [falseString]: [
             {roleName: 'team_user', permission: Permissions.MANAGE_INCOMING_WEBHOOKS, shouldHave: true},
             {roleName: 'team_user', permission: Permissions.MANAGE_OUTGOING_WEBHOOKS, shouldHave: true},
             {roleName: 'team_user', permission: Permissions.MANAGE_SLASH_COMMANDS, shouldHave: true},
@@ -102,7 +105,7 @@ function purgeNonPertinentRoles(roles: Record<string, Role>) {
     });
 }
 
-function mutateRolesBasedOnMapping(mappingKey: MappingKeyTypes, value: 'True' | 'False', roles: Record<string, Role>) {
+function mutateRolesBasedOnMapping(mappingKey: MappingKeyTypes, value: 'true' | 'false', roles: Record<string, Role>) {
     const roleRules = MAPPING[mappingKey][value];
 
     if (typeof roleRules === 'undefined') {

--- a/utils/policy_roles_adapter.ts
+++ b/utils/policy_roles_adapter.ts
@@ -1,39 +1,45 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Role} from '@mattermost/types/roles';
 import {Permissions} from 'mattermost-redux/constants/index';
 
 const MAPPING = {
     enableTeamCreation: {
-        true: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: true}],
-        false: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: false}],
+        True: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: true}],
+        False: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: false}],
     },
 
     editOthersPosts: {
-        true: [
+        True: [
             {roleName: 'system_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
             {roleName: 'team_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
         ],
-        false: [
+        False: [
             {roleName: 'team_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: false},
             {roleName: 'system_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
         ],
     },
 
     enableOnlyAdminIntegrations: {
-        true: [
+        True: [
             {roleName: 'team_user', permission: Permissions.MANAGE_INCOMING_WEBHOOKS, shouldHave: false},
             {roleName: 'team_user', permission: Permissions.MANAGE_OUTGOING_WEBHOOKS, shouldHave: false},
             {roleName: 'team_user', permission: Permissions.MANAGE_SLASH_COMMANDS, shouldHave: false},
             {roleName: 'system_user', permission: Permissions.MANAGE_OAUTH, shouldHave: false},
         ],
-        false: [
+        False: [
             {roleName: 'team_user', permission: Permissions.MANAGE_INCOMING_WEBHOOKS, shouldHave: true},
             {roleName: 'team_user', permission: Permissions.MANAGE_OUTGOING_WEBHOOKS, shouldHave: true},
             {roleName: 'team_user', permission: Permissions.MANAGE_SLASH_COMMANDS, shouldHave: true},
             {roleName: 'system_user', permission: Permissions.MANAGE_OAUTH, shouldHave: true},
         ],
     },
+};
+type MappingKeyTypes = 'enableTeamCreation' | 'editOthersPosts' | 'enableOnlyAdminIntegrations';
+type MappingValueTypes = {roleName: string;
+    permission: string;
+    shouldHave: boolean;
 };
 
 /**
@@ -43,8 +49,8 @@ const MAPPING = {
  * @param {object} roles same structure as returned by mattermost-redux `getRoles`.
  * @return {object} the updated roles (only) in the same structure as returned by mattermost-redux `getRoles`.
  */
-export function rolesFromMapping(mappingValues, roles) {
-    const rolesClone = JSON.parse(JSON.stringify(roles));
+export function rolesFromMapping(mappingValues: Record<string, any>, roles: Record<string, Role>): Record<string, Role> {
+    const rolesClone: Record<string, Role> = JSON.parse(JSON.stringify(roles));
 
     // Purge roles that aren't present in MAPPING, we don't care about them.
     purgeNonPertinentRoles(rolesClone);
@@ -52,7 +58,7 @@ export function rolesFromMapping(mappingValues, roles) {
     Object.keys(MAPPING).forEach((mappingKey) => {
         const value = mappingValues[mappingKey];
         if (value) {
-            mutateRolesBasedOnMapping(mappingKey, value, rolesClone);
+            mutateRolesBasedOnMapping(mappingKey as MappingKeyTypes, value, rolesClone);
         }
     });
 
@@ -77,7 +83,7 @@ export function rolesFromMapping(mappingValues, roles) {
  * @param {object} roles same structure as returned by mattermost-redux `getRoles`.
  * @return {string} the value that the roles/permissions assignment match in the mapping.
  */
-export function mappingValueFromRoles(key, roles) {
+export function mappingValueFromRoles(key: MappingKeyTypes, roles: Record<string, Role>): string {
     for (const o of mappingPartIterator(MAPPING[key], roles)) {
         if (o.allConditionsAreMet) {
             return o.value;
@@ -86,7 +92,7 @@ export function mappingValueFromRoles(key, roles) {
     throw new Error(`No matching mapping value found for key '${key}' with the given roles.`);
 }
 
-function purgeNonPertinentRoles(roles) {
+function purgeNonPertinentRoles(roles: Record<string, Role>) {
     const pertinentRoleNames = roleNamesInMapping();
 
     Object.keys(roles).forEach((key) => {
@@ -96,7 +102,7 @@ function purgeNonPertinentRoles(roles) {
     });
 }
 
-function mutateRolesBasedOnMapping(mappingKey, value, roles) {
+function mutateRolesBasedOnMapping(mappingKey: MappingKeyTypes, value: 'True' | 'False', roles: Record<string, Role>) {
     const roleRules = MAPPING[mappingKey][value];
 
     if (typeof roleRules === 'undefined') {
@@ -115,7 +121,7 @@ function mutateRolesBasedOnMapping(mappingKey, value, roles) {
 
 // Returns a set of the role names present in MAPPING.
 function roleNamesInMapping() {
-    let roleNames = [];
+    let roleNames: string[] = [];
 
     Object.values(MAPPING).forEach((v1) => {
         Object.values(v1).forEach((v2) => {
@@ -127,12 +133,12 @@ function roleNamesInMapping() {
     return [...new Set(roleNames.map((item) => item))];
 }
 
-function* mappingPartIterator(mappingPart, roles) {
+function* mappingPartIterator(mappingPart: Record<string, MappingValueTypes[]>, roles: Record<string, Role>) {
     for (const value in mappingPart) {
         if (mappingPart.hasOwnProperty(value)) {
             const roleRules = mappingPart[value];
 
-            const hasUnmetCondition = roleRules.some((item) => {
+            const hasUnmetCondition = roleRules.some((item: MappingValueTypes) => {
                 const role = roles[item.roleName];
                 return (item.shouldHave && !role.permissions.includes(item.permission)) || (!item.shouldHave && role.permissions.includes(item.permission));
             });
@@ -142,13 +148,13 @@ function* mappingPartIterator(mappingPart, roles) {
     }
 }
 
-function addPermissionToRole(permission, role) {
+function addPermissionToRole(permission: string, role: Role) {
     if (!role.permissions.includes(permission)) {
         role.permissions.push(permission);
     }
 }
 
-function removePermissionFromRole(permission, role) {
+function removePermissionFromRole(permission: string, role: Role) {
     const permissionIndex = role.permissions.indexOf(permission);
     if (permissionIndex !== -1) {
         role.permissions.splice(permissionIndex, 1);


### PR DESCRIPTION
#### Summary
Migrate utils/policy_roles_adapter.js to typescript

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21167
JIRA: https://mattermost.atlassian.net/browse/MM-47192

#### Related Pull Requests
None

#### Screenshots
None

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
