### PR TITLE
Prevent clean from failing because of missing files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ clean: ## Clears cached; deletes node_modules and dist directories
 	rm -rf dist
 	rm -rf node_modules
 
-	rm .eslintcache
-	rm .stylelintcache
+	rm -f .eslintcache
+	rm -f .stylelintcache
 
 e2e-test: node_modules
 	@echo E2E: Running mattermost-mysql-e2e


### PR DESCRIPTION
The current commands to delete those files fail when the file doesn't exist

#### Release Note
```release-note
NONE
```
