### PR TITLE
Downgraded Brazilian Portuguese and Romanian language support to Alpha

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -334,12 +334,12 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 9,
-                  "text": "Português (Brasil) (Beta)",
+                  "text": "Português (Brasil) (Alpha)",
                   "value": "pt-BR",
                 },
                 Object {
                   "order": 10,
-                  "text": "Română (Beta)",
+                  "text": "Română (Alpha)",
                   "value": "ro",
                 },
                 Object {
@@ -465,12 +465,12 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 9,
-                  "text": "Português (Brasil) (Beta)",
+                  "text": "Português (Brasil) (Alpha)",
                   "value": "pt-BR",
                 },
                 Object {
                   "order": 10,
-                  "text": "Română (Beta)",
+                  "text": "Română (Alpha)",
                   "value": "ro",
                 },
                 Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -85,13 +85,13 @@ const languages = {
     },
     'pt-BR': {
         value: 'pt-BR',
-        name: 'Português (Brasil) (Beta)',
+        name: 'Português (Brasil) (Alpha)',
         order: 9,
         url: ptBR,
     },
     ro: {
         value: 'ro',
-        name: 'Română (Beta)',
+        name: 'Română (Alpha)',
         order: 10,
         url: ro,
     },


### PR DESCRIPTION
#### Summary
Brazilian Portuguese and Romanian product translations haven't been actively maintained, and with this reduction in translation quality, these two languages are being downgraded to Alpha.

#### Release Note
```release-note
Downgraded Brazilian Portuguese and Romanian language support to Alpha.
```
