### PR TITLE
make `make clean` more idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ clean: ## Clears cached; deletes node_modules and dist directories
 	rm -rf dist
 	rm -rf node_modules
 
-	rm .eslintcache
-	rm .stylelintcache
+	rm -f .eslintcache
+	rm -f .stylelintcache
 
 e2e-test: node_modules
 	@echo E2E: Running mattermost-mysql-e2e


### PR DESCRIPTION

#### Summary
`make nuke` was failing due to `.stylelintcache` being non exist. I think it's a good practice to have a fail safe approach here.

#### Release Note

```release-note
NONE
```
