### PR TITLE
[MM-46933] Force profile popover to dismiss from avatars widget

### DIFF
--- a/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
+++ b/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
             overlay={
               <Memo(Connect(injectIntl(ProfilePopover)))
                 className="user-profile-popover"
+                hide={[Function]}
                 src="/api/v4/users/5/image?_=0"
                 userId="5"
               />
@@ -102,6 +103,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
               overlay={
                 <OverlayWrapper
                   className="user-profile-popover"
+                  hide={[Function]}
                   intl={
                     Object {
                       "defaultFormats": Object {},
@@ -299,6 +301,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
             overlay={
               <Memo(Connect(injectIntl(ProfilePopover)))
                 className="user-profile-popover"
+                hide={[Function]}
                 src="/api/v4/users/4/image?_=0"
                 userId="4"
               />
@@ -312,6 +315,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
               overlay={
                 <OverlayWrapper
                   className="user-profile-popover"
+                  hide={[Function]}
                   intl={
                     Object {
                       "defaultFormats": Object {},
@@ -509,6 +513,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
             overlay={
               <Memo(Connect(injectIntl(ProfilePopover)))
                 className="user-profile-popover"
+                hide={[Function]}
                 src="/api/v4/users/3/image?_=0"
                 userId="3"
               />
@@ -522,6 +527,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
               overlay={
                 <OverlayWrapper
                   className="user-profile-popover"
+                  hide={[Function]}
                   intl={
                     Object {
                       "defaultFormats": Object {},
@@ -1190,6 +1196,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
             overlay={
               <Memo(Connect(injectIntl(ProfilePopover)))
                 className="user-profile-popover"
+                hide={[Function]}
                 src="/api/v4/users/5/image?_=0"
                 userId="5"
               />
@@ -1203,6 +1210,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
               overlay={
                 <OverlayWrapper
                   className="user-profile-popover"
+                  hide={[Function]}
                   intl={
                     Object {
                       "defaultFormats": Object {},
@@ -1400,6 +1408,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
             overlay={
               <Memo(Connect(injectIntl(ProfilePopover)))
                 className="user-profile-popover"
+                hide={[Function]}
                 src="/api/v4/users/4/image?_=0"
                 userId="4"
               />
@@ -1413,6 +1422,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
               overlay={
                 <OverlayWrapper
                   className="user-profile-popover"
+                  hide={[Function]}
                   intl={
                     Object {
                       "defaultFormats": Object {},
@@ -1610,6 +1620,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
             overlay={
               <Memo(Connect(injectIntl(ProfilePopover)))
                 className="user-profile-popover"
+                hide={[Function]}
                 src="/api/v4/users/3/image?_=0"
                 userId="3"
               />
@@ -1623,6 +1634,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
               overlay={
                 <OverlayWrapper
                   className="user-profile-popover"
+                  hide={[Function]}
                   intl={
                     Object {
                       "defaultFormats": Object {},

--- a/components/widgets/users/avatars/__snapshots__/avatars.test.tsx.snap
+++ b/components/widgets/users/avatars/__snapshots__/avatars.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/1/image?_=0"
             userId="1"
           />
@@ -56,6 +57,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},
@@ -253,6 +255,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/6/image?_=0"
             userId="6"
           />
@@ -266,6 +269,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},
@@ -463,6 +467,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/7/image?_=0"
             userId="7"
           />
@@ -476,6 +481,7 @@ exports[`components/widgets/users/Avatars should fetch missing users 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},
@@ -814,6 +820,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/1/image?_=0"
             userId="1"
           />
@@ -827,6 +834,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},
@@ -1024,6 +1032,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/2/image?_=0"
             userId="2"
           />
@@ -1037,6 +1046,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},
@@ -1234,6 +1244,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/3/image?_=0"
             userId="3"
           />
@@ -1247,6 +1258,7 @@ exports[`components/widgets/users/Avatars should properly count overflow 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},
@@ -1583,6 +1595,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/1/image?_=0"
             userId="1"
           />
@@ -1596,6 +1609,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},
@@ -1793,6 +1807,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/2/image?_=0"
             userId="2"
           />
@@ -1806,6 +1821,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},
@@ -2003,6 +2019,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
         overlay={
           <Memo(Connect(injectIntl(ProfilePopover)))
             className="user-profile-popover"
+            hide={[Function]}
             src="/api/v4/users/3/image?_=0"
             userId="3"
           />
@@ -2016,6 +2033,7 @@ exports[`components/widgets/users/Avatars should support userIds 1`] = `
           overlay={
             <OverlayWrapper
               className="user-profile-popover"
+              hide={[Function]}
               intl={
                 Object {
                   "defaultFormats": Object {},

--- a/components/widgets/users/avatars/avatars.tsx
+++ b/components/widgets/users/avatars/avatars.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {memo, ComponentProps, CSSProperties, useMemo, useEffect} from 'react';
+import React, {memo, ComponentProps, CSSProperties, useMemo, useEffect, useRef} from 'react';
 import {useIntl} from 'react-intl';
 import {useSelector, useDispatch} from 'react-redux';
 import tinycolor from 'tinycolor2';
@@ -19,7 +19,7 @@ import {imageURLForUser} from 'utils/utils';
 import SimpleTooltip, {useSynchronizedImmediate} from 'components/widgets/simple_tooltip';
 import Avatar from 'components/widgets/users/avatar';
 import ProfilePopover from 'components/profile_popover';
-import OverlayTrigger from 'components/overlay_trigger';
+import OverlayTrigger, {BaseOverlayTrigger} from 'components/overlay_trigger';
 
 import './avatars.scss';
 
@@ -31,6 +31,10 @@ type Props = {
     fetchMissingUsers?: boolean;
     disableProfileOverlay?: boolean;
 };
+
+interface MMOverlayTrigger extends BaseOverlayTrigger {
+    hide: () => void;
+}
 
 const OTHERS_DISPLAY_LIMIT = 99;
 
@@ -66,17 +70,25 @@ function UserAvatar({
 
     const profilePictureURL = userId ? imageURLForUser(userId) : '';
 
+    const overlay = useRef<MMOverlayTrigger>(null);
+
+    const hideProfilePopover = () => {
+        overlay.current?.hide();
+    };
+
     return (
         <OverlayTrigger
             trigger='click'
             disabled={disableProfileOverlay}
             placement='right'
             rootClose={true}
+            ref={overlay}
             overlay={
                 <ProfilePopover
                     className='user-profile-popover'
                     userId={userId}
                     src={profilePictureURL}
+                    hide={hideProfilePopover}
                 />
             }
         >


### PR DESCRIPTION
#### Summary

Fixes a bug where the profile popover, when activated from the avatars widget, would not dismiss when a link inside the popover was clicked. Uses the same strategy to dismiss the popover as the post component. 
 
#### Ticket Link

[Jira ticket](https://mattermost.atlassian.net/browse/MM-46933)

Steps to reproduce:

View the video through the link to see how to reproduce it. 

#### Release Note

```release-note
NONE
```
