### PR TITLE
MM-46953 : Add "Threads" to the unread filter view even if there aren't unread threads

### DIFF
--- a/components/threading/global_threads_link/global_threads_link.tsx
+++ b/components/threading/global_threads_link/global_threads_link.tsx
@@ -15,7 +15,6 @@ import {getThreadCounts} from 'mattermost-redux/actions/threads';
 
 import {t} from 'utils/i18n';
 
-import {isUnreadFilterEnabled} from 'selectors/views/channel_sidebar';
 import {useThreadRouting} from '../hooks';
 import {trackEvent} from 'actions/telemetry_actions';
 
@@ -50,7 +49,6 @@ const GlobalThreadsLink = () => {
     const {currentTeamId, currentUserId} = useThreadRouting();
 
     const counts = useSelector(getThreadCountsInCurrentTeam);
-    const unreadsOnly = useSelector(isUnreadFilterEnabled);
     const someUnreadThreads = counts?.total_unread_threads;
     const appHaveOpenModal = useSelector(isAnyModalOpen);
     const tipStep = useSelector((state: GlobalState) => getInt(state, Preferences.CRT_TUTORIAL_STEP, currentUserId, CrtTutorialSteps.WELCOME_POPOVER));
@@ -75,8 +73,8 @@ const GlobalThreadsLink = () => {
         }
     }, [currentUserId, currentTeamId, isFeatureEnabled]);
 
-    if (!isFeatureEnabled || (unreadsOnly && !inGlobalThreads && !someUnreadThreads)) {
-        // hide link if feature disabled or filtering unreads and there are no unread threads
+    if (!isFeatureEnabled) {
+        // hide link if feature disabled
         return null;
     }
 


### PR DESCRIPTION
#### Summary

Added "Threads" to the unread filter view even if there aren't unread threads.

Note this only applies when the following conditions are fulfilled:

- The "Collapsed Reply Threads" setting is enabled.
- The “group unreads separately” setting is not enabled.

#### Ticket Link

Fixes [https://github.com/mattermost/mattermost-server/issues/21186](https://github.com/mattermost/mattermost-server/issues/21186)
Jira [https://mattermost.atlassian.net/browse/MM-46953](https://mattermost.atlassian.net/browse/MM-46953)

#### Screenshots

|  before  |
|----|

![8d543311-6656-4715-829f-df99b4b5da9f](https://user-images.githubusercontent.com/67257981/193836670-1af6e081-dcc2-4fdc-91e9-cb113930ef64.png)

|  after  |
|----|

<img width="240" alt="Screenshot 2022-10-04 at 6 47 15 PM" src="https://user-images.githubusercontent.com/67257981/193836789-af645aaf-813d-496b-8ad2-7febe0428896.png">

#### Release Note

```release-note
Added "Threads" to the unread filter view even if there aren't unread threads.
```
