### PR TITLE
Fix warning printed by SizeAwareImage

### DIFF
--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -276,7 +276,7 @@ export default class SizeAwareImage extends React.PureComponent {
                     target='_blank'
                     rel='noopener noreferrer'
                     download={true}
-                    role={this.isInternalImage ? 'button' : false}
+                    role={this.isInternalImage ? 'button' : undefined}
                     aria-label={localizeMessage('single_image_view.download_tooltip', 'Download')}
                 >
                     <DownloadOutlineIcon


### PR DESCRIPTION
React complains when this value is set to a boolean and recommends setting it to undefined in this case. I can't remember if this warning is exclusive to dev mode or if it only happens when there's no image proxy enabled, but it doesn't trigger on community from what I can tell

#### Release Note
```release-note
NONE
```
