### PR TITLE
MM-46528_Verify Invitation Flow Tracking Telemetry

### DIFF
--- a/actions/telemetry_actions.jsx
+++ b/actions/telemetry_actions.jsx
@@ -40,9 +40,9 @@ export function trackEvent(category, event, props) {
     }
 
     Client4.trackEvent(category, event, props);
-    if (isDevMode() && category === 'performance' && props) {
+    if (isDevMode() && props) {
         // eslint-disable-next-line no-console
-        console.log(event + ' - ' + Object.entries(props).map(([key, value]) => `${key}: ${value}`).join(', '));
+        console.log(category + ' - ' + event + ' - ' + Object.entries(props).map(([key, value]) => `${key}: ${value}`).join(', '));
     }
 }
 

--- a/components/do_verify_email/do_verify_email.tsx
+++ b/components/do_verify_email/do_verify_email.tsx
@@ -20,6 +20,7 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {DispatchFunc} from 'mattermost-redux/types/actions';
 
 import {AnnouncementBarTypes, AnnouncementBarMessages, Constants} from 'utils/constants';
+import {getRoleFromTrackFlow} from 'utils/utils';
 
 import './do_verify_email.scss';
 
@@ -45,6 +46,7 @@ const DoVerifyEmail = () => {
     const [serverError, setServerError] = useState('');
 
     useEffect(() => {
+        trackEvent('signup', 'do_verify_email', getRoleFromTrackFlow());
         verifyEmail();
     }, []);
 

--- a/components/invitation_modal/invitation_modal.tsx
+++ b/components/invitation_modal/invitation_modal.tsx
@@ -19,6 +19,8 @@ import {trackEvent} from 'actions/telemetry_actions';
 
 import {isEmail} from 'mattermost-redux/utils/helpers';
 
+import {getRoleForTrackFlow} from 'utils/utils';
+
 import ResultView, {ResultState, defaultResultState, InviteResults} from './result_view';
 import InviteView, {InviteState, initializeInviteState} from './invite_view';
 import NoPermissionsView from './no_permissions_view';
@@ -157,11 +159,12 @@ export class InvitationModal extends React.PureComponent<Props, State> {
     }
 
     invite = async () => {
+        const roleForTrackFlow = getRoleForTrackFlow();
         const inviteAs = this.state.invite.inviteType;
         if (inviteAs === InviteType.MEMBER && this.props.isCloud) {
-            trackEvent('cloud_invite_users', 'click_send_invitations', {num_invitations: this.state.invite.usersEmails.length});
+            trackEvent('cloud_invite_users', 'click_send_invitations', {num_invitations: this.state.invite.usersEmails.length, ...roleForTrackFlow});
         }
-        trackEvent('invite_users', 'click_invite');
+        trackEvent('invite_users', 'click_invite', roleForTrackFlow);
 
         const users: UserProfile[] = [];
         const emails: string[] = [];

--- a/components/invitation_modal/invite_view.tsx
+++ b/components/invitation_modal/invite_view.tsx
@@ -19,6 +19,7 @@ import UsersEmailsInput from 'components/widgets/inputs/users_emails_input';
 import {getAnalyticsCategory} from 'components/onboarding_tasks';
 
 import {t} from 'utils/i18n';
+import {getRoleForTrackFlow} from 'utils/utils';
 
 import AddToChannels, {CustomMessageProps, InviteChannels, defaultCustomMessage, defaultInviteChannels} from './add_to_channels';
 import InviteAs, {InviteType} from './invite_as';
@@ -82,7 +83,7 @@ export default function InviteView(props: Props) {
     }, [props.currentTeam.invite_id]);
 
     const copyText = useCopyText({
-        trackCallback: () => trackEvent(getAnalyticsCategory(props.isAdmin), 'click_copy_invite_link'),
+        trackCallback: () => trackEvent(getAnalyticsCategory(props.isAdmin), 'click_copy_invite_link', getRoleForTrackFlow()),
         text: inviteURL,
     });
 

--- a/components/should_verify_email/should_verify_email.tsx
+++ b/components/should_verify_email/should_verify_email.tsx
@@ -1,11 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useCallback} from 'react';
+import React, {useState, useCallback, useEffect} from 'react';
 import {useIntl} from 'react-intl';
 import {useDispatch} from 'react-redux';
 import {useLocation, useHistory} from 'react-router-dom';
 import classNames from 'classnames';
+
+import {trackEvent} from 'actions/telemetry_actions';
 
 import ManWithMailboxSVG from 'components/common/svg_images_components/man_with_mailbox_svg';
 import ColumnLayout from 'components/header_footer_route/content_layouts/column';
@@ -13,6 +15,8 @@ import SaveButton from 'components/save_button';
 
 import {sendVerificationEmail} from 'mattermost-redux/actions/users';
 import {DispatchFunc} from 'mattermost-redux/types/actions';
+
+import {getRoleFromTrackFlow} from 'utils/utils';
 
 import './should_verify_email.scss';
 
@@ -33,6 +37,10 @@ const ShouldVerifyEmail = () => {
 
     const [resendStatus, setResendStatus] = useState(ResendStatus.PENDING);
     const [isWaiting, setIsWaiting] = useState(false);
+
+    useEffect(() => {
+        trackEvent('signup', 'should_verify_email', getRoleFromTrackFlow());
+    }, []);
 
     const handleReturnButtonOnClick = useCallback(() => {
         history.push('/');

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -50,7 +50,7 @@ import PasswordInput from 'components/widgets/inputs/password_input/password_inp
 import SaveButton from 'components/save_button';
 
 import {Constants, ItemStatus, ValidationErrors} from 'utils/constants';
-import {isValidUsername, isValidPassword, getPasswordConfig} from 'utils/utils';
+import {isValidUsername, isValidPassword, getPasswordConfig, getRoleFromTrackFlow} from 'utils/utils';
 
 import './signup.scss';
 
@@ -281,7 +281,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
     useEffect(() => {
         dispatch(removeGlobalItem('team'));
-        trackEvent('signup', 'signup_user_01_welcome');
+        trackEvent('signup', 'signup_user_01_welcome', getRoleFromTrackFlow());
 
         onWindowResize();
 
@@ -401,7 +401,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
     };
 
     const handleSignupSuccess = async (user: UserProfile, data: UserProfile) => {
-        trackEvent('signup', 'signup_user_02_complete');
+        trackEvent('signup', 'signup_user_02_complete', getRoleFromTrackFlow());
 
         if (reminderInterval) {
             trackEvent('signup', `signup_from_reminder_${reminderInterval}`, {user: user.id});
@@ -512,7 +512,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
     const handleSubmit = async (e: React.MouseEvent | React.KeyboardEvent) => {
         e.preventDefault();
-        trackEvent('signup_email', 'click_create_account');
+        trackEvent('signup_email', 'click_create_account', getRoleFromTrackFlow());
         setIsWaiting(true);
 
         if (isUserValid()) {

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1873,6 +1873,7 @@ export const Constants = {
     TRIAL_MODAL_AUTO_SHOWN: 'trial_modal_auto_shown',
     DEFAULT_SITE_URL: 'http://localhost:8065',
     CHANNEL_HEADER_BUTTON_DISABLE_TIMEOUT: 1000,
+    FIRST_ADMIN_ROLE: 'first_admin',
 };
 
 export const ValidationErrors = {

--- a/utils/utils.tsx
+++ b/utils/utils.tsx
@@ -20,7 +20,7 @@ import {
 import {getPost as getPostAction} from 'mattermost-redux/actions/posts';
 import {getTeamByName as getTeamByNameAction} from 'mattermost-redux/actions/teams';
 import {Client4} from 'mattermost-redux/client';
-import {Posts, Preferences} from 'mattermost-redux/constants';
+import {Posts, Preferences, General} from 'mattermost-redux/constants';
 import {
     getChannel,
     getChannelsNameMapInTeam,
@@ -30,7 +30,7 @@ import {
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getBool, getTeammateNameDisplaySetting, Theme} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUser, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUser, getCurrentUserId, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 import {blendColors, changeOpacity} from 'mattermost-redux/utils/theme_utils';
 import {displayUsername, isSystemAdmin} from 'mattermost-redux/utils/user_utils';
 import {
@@ -1813,4 +1813,41 @@ export function numberToFixedDynamic(num: number, places: number): string {
         return str;
     }
     return str.slice(0, indexToExclude);
+}
+
+export function getRoleForTrackFlow() {
+    const state = store.getState();
+    let startedByRole;
+
+    if (isFirstAdmin(state)) {
+        startedByRole = Constants.FIRST_ADMIN_ROLE;
+    } else if (isSystemAdmin(getCurrentUser(state).roles)) {
+        startedByRole = General.SYSTEM_ADMIN_ROLE;
+    } else {
+        startedByRole = General.SYSTEM_USER_ROLE;
+    }
+
+    return {started_by_role: startedByRole};
+}
+
+export function getRoleFromTrackFlow() {
+    const params = new URLSearchParams(window.location.search);
+    const sbr = params.get('sbr');
+    let startedByRole;
+
+    switch (sbr) {
+    case 'fa':
+        startedByRole = Constants.FIRST_ADMIN_ROLE;
+        break;
+    case 'sa':
+        startedByRole = General.SYSTEM_ADMIN_ROLE;
+        break;
+    case 'su':
+        startedByRole = General.SYSTEM_USER_ROLE;
+        break;
+    default:
+        startedByRole = '';
+    }
+
+    return {started_by_role: startedByRole};
 }


### PR DESCRIPTION
#### Summary
We want to track the number of invited users by admins and by end users, as well as the success rate of invitations for each.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46528

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/21207)

#### Screenshots


#### Release Note
```release-note
NONE
```
