### PR TITLE
MM-T2044 added profile-settings test spec

### DIFF
--- a/e2e/cypress/tests/integration/profile_settings/profile_settings_spec.js
+++ b/e2e/cypress/tests/integration/profile_settings/profile_settings_spec.js
@@ -11,16 +11,12 @@
 
 describe('Profile Settings', () => {
     let testUser;
-    let testTeam;
-    let offTopic;
 
     before(() => {
         // # Login as new user and visit off-topic
-        cy.apiInitSetup({prefix: 'other', loginAfter: true}).then(({offTopicUrl, user, team}) => {
+        cy.apiInitSetup({prefix: 'other', loginAfter: true}).then(({offTopicUrl, user}) => {
             cy.visit(offTopicUrl);
-            offTopic = offTopicUrl;
             testUser = user;
-            testTeam = team;
         });
     });
 
@@ -46,7 +42,7 @@ describe('Profile Settings', () => {
         cy.uiCancel();
 
         // * Check that the full name was not updated since it was not saved
-        cy.get('#nameDesc').should('be.visible').should('contain', testUser.first_name +" "+testUser.last_name);
+        cy.get('#nameDesc').should('be.visible').should('contain', testUser.first_name + ' ' + testUser.last_name);
 
         // # Close the modal
         cy.uiClose();

--- a/e2e/cypress/tests/integration/profile_settings/profile_settings_spec.js
+++ b/e2e/cypress/tests/integration/profile_settings/profile_settings_spec.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @profile_settings
+
+describe('Profile Settings', () => {
+    let testUser;
+    let testTeam;
+    let offTopic;
+
+    before(() => {
+        // # Login as new user and visit off-topic
+        cy.apiInitSetup({prefix: 'other', loginAfter: true}).then(({offTopicUrl, user, team}) => {
+            cy.visit(offTopicUrl);
+            offTopic = offTopicUrl;
+            testUser = user;
+            testTeam = team;
+        });
+    });
+
+    it('MM-T2044 Clear fields, values revert', () => {
+        cy.uiOpenProfileModal();
+
+        // # Click "Edit" to the right of "Full Name"
+        cy.get('#nameEdit').should('be.visible').click();
+
+        // # Clear the first name
+        cy.get('#firstName').clear();
+
+        // # Type a new first name
+        cy.get('#firstName').should('be.visible').type('newFirstName');
+
+        // # Clear the last name
+        cy.get('#lastName').should('be.visible').clear();
+
+        // # Type a new first name
+        cy.get('#lastName').should('be.visible').type('newLastName');
+
+        // # Click 'Cancel'
+        cy.uiCancel();
+
+        // * Check that the full name was not updated since it was not saved
+        cy.get('#nameDesc').should('be.visible').should('contain', testUser.first_name +" "+testUser.last_name);
+
+        // # Close the modal
+        cy.uiClose();
+    });
+});

--- a/e2e/cypress/tests/integration/profile_settings/profile_settings_spec.js
+++ b/e2e/cypress/tests/integration/profile_settings/profile_settings_spec.js
@@ -35,7 +35,7 @@ describe('Profile Settings', () => {
         // # Clear the last name
         cy.get('#lastName').should('be.visible').clear();
 
-        // # Type a new first name
+        // # Type a new last name
         cy.get('#lastName').should('be.visible').type('newLastName');
 
         // # Click 'Cancel'


### PR DESCRIPTION
#### Summary

This tests the profile settings feature in our app. On navigating to profile settings (User menu > Profile > Profile Settings), when we edit the full name, we click on cancel instead of saving since we had not saved it, so it should reflect the full name which was there initially(before we clicked on edit). 

#### Ticket Link

Addresses https://github.com/mattermost/mattermost-server/issues/18819

#### Release Note

Added a new e2e cypress test for testing editing of full name in profile settings

