### PR TITLE
[MM-47054] Change button label if upgrade is executed from System Console

### DIFF
--- a/components/purchase_modal/process_payment_setup.tsx
+++ b/components/purchase_modal/process_payment_setup.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import {Stripe} from '@stripe/stripe-js';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, injectIntl, IntlShape} from 'react-intl';
 import {RouteComponentProps, withRouter} from 'react-router-dom';
 
 import {BillingDetails} from 'types/cloud/sku';
@@ -30,8 +30,14 @@ type Props = RouteComponentProps & {
     isDevMode: boolean;
     contactSupportLink: string;
     currentTeam: Team;
-    addPaymentMethod: (stripe: Stripe, billingDetails: BillingDetails, isDevMode: boolean) => Promise<boolean | null>;
-    subscribeCloudSubscription: ((productId: string) => Promise<boolean | null>) | null;
+    addPaymentMethod: (
+        stripe: Stripe,
+        billingDetails: BillingDetails,
+        isDevMode: boolean
+    ) => Promise<boolean | null>;
+    subscribeCloudSubscription:
+    | ((productId: string) => Promise<boolean | null>)
+    | null;
     onBack: () => void;
     onClose: () => void;
     selectedProduct?: Product | null | undefined;
@@ -41,7 +47,8 @@ type Props = RouteComponentProps & {
     setIsUpgradeFromTrialToFalse: () => void;
     telemetryProps?: { callerInfo: string };
     onSuccess?: () => void;
-}
+    intl: IntlShape;
+};
 
 type State = {
     progress: number;
@@ -169,9 +176,13 @@ class ProcessPaymentSetup extends React.PureComponent<Props, State> {
             <FormattedMessage
                 defaultMessage='Return to {team}'
                 id='admin.billing.subscription.returnToTeam'
-                values={{team: this.props.currentTeam.display_name}}
+                values={{
+                    team: this.props.currentTeam?.display_name || this.props.intl.formatMessage({
+                        id: 'admin.sidebarHeader.systemConsole',
+                        defaultMessage: 'System Console',
+                    }),
+                }}
             />
-
         );
         if (this.props.isProratedPayment) {
             const formattedTitle = (
@@ -319,5 +330,5 @@ class ProcessPaymentSetup extends React.PureComponent<Props, State> {
     }
 }
 
-export default withRouter(ProcessPaymentSetup);
+export default injectIntl(withRouter(ProcessPaymentSetup));
 


### PR DESCRIPTION
#### Summary
When you enter the System Console, `currentTeamId` and therefore `currentTeam` are cleared (this is core mattermost functionality, and has been this way always), so we are unable to display `Return to {team}` as we don't know which team to return to. Since `currentTeam` was undefined, it was causing a javascript error `cannot read display_name of undefined`, triggering a white screen instead of the success page. This PR makes it so that if the `currentTeam` is undefined (ie, if the upgrade flow is accessed from the system console) the button label will read `Return to System Console`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47054

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
