### PR TITLE
MM-34347: Migrate 'components/toast_wrapper' and associated tests to TypeScript

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.tsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.tsx
@@ -626,7 +626,6 @@ export default class PostList extends React.PureComponent<Props, State> {
                 updateNewMessagesAtInChannel={this.updateNewMessagesAtInChannel}
                 updateLastViewedBottomAt={this.updateLastViewedBottomAt}
                 shouldStartFromBottomWhenUnread={this.props.shouldStartFromBottomWhenUnread}
-
                 isNewMessageLineReached={this.state.isNewMessageLineReached}
                 channelId={this.props.channelId}
                 focusedPostId={this.props.focusedPostId}

--- a/components/toast_wrapper/index.ts
+++ b/components/toast_wrapper/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {connect, ConnectedProps} from 'react-redux';
+import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
 import {withRouter} from 'react-router-dom';
 
@@ -20,7 +20,7 @@ import {updateToastStatus} from 'actions/views/channel';
 
 import ToastWrapper from './toast_wrapper';
 
-export type OwnProps = {
+interface OwnProps {
     atLatestPost?: boolean;
     channelId: string;
 };
@@ -52,8 +52,8 @@ export function makeCountUnreadsBelow() {
         'makeCountUnreadsBelow',
         getAllPosts,
         getCurrentUserId,
-        (state: GlobalState, postIds?: string[] | null) => postIds,
-        (state: GlobalState, postIds: string[] | null | undefined, lastViewedBottom: number) => lastViewedBottom,
+        (state: GlobalState, postIds: string[]) => postIds,
+        (state: GlobalState, postIds, lastViewedBottom: number) => lastViewedBottom,
         isCollapsedThreadsEnabled,
         (allPosts, currentUserId, postIds, lastViewedBottom, isCollapsed) => {
             if (!postIds) {
@@ -92,7 +92,7 @@ function makeMapStateToProps() {
         const lastViewedAt = state.views.channel.lastChannelViewTime[ownProps.channelId];
         const unreadScrollPosition = getUnreadScrollPositionPreference(state);
         if (!ownProps.atLatestPost) {
-            let postIds = getPostIdsInChannel(state, ownProps.channelId);
+            let postIds = getPostIdsInChannel(state, ownProps.channelId) || [];
             if (postIds) {
                 postIds = preparePostIdsForPostList(state, {postIds, lastViewedAt});
             }
@@ -118,8 +118,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-const connector = connect(makeMapStateToProps, mapDispatchToProps);
-
-export type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export default withRouter(connector(ToastWrapper));
+export default withRouter(connect(makeMapStateToProps, mapDispatchToProps)(ToastWrapper));

--- a/components/toast_wrapper/index.ts
+++ b/components/toast_wrapper/index.ts
@@ -23,7 +23,7 @@ import ToastWrapper from './toast_wrapper';
 interface OwnProps {
     atLatestPost?: boolean;
     channelId: string;
-};
+}
 
 export function makeGetRootPosts() {
     return createSelector(

--- a/components/toast_wrapper/toast_wrapper.test.tsx
+++ b/components/toast_wrapper/toast_wrapper.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {ComponentProps} from 'react';
 
 import Preferences from 'mattermost-redux/constants/preferences';
 
@@ -12,10 +12,12 @@ import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import {PostListRowListIds} from 'utils/constants';
 import {browserHistory} from 'utils/browser_history';
 
-import ToastWrapper from './toast_wrapper.jsx';
+import ToastWrapper, {Props, ToastWrapperClass} from './toast_wrapper';
+
+// import ToastWrapperComp from '.';
 
 describe('components/ToastWrapper', () => {
-    const baseProps = {
+    const baseProps: ComponentProps<typeof ToastWrapper> = {
         unreadCountInChannel: 0,
         unreadScrollPosition: Preferences.UNREAD_SCROLL_POSITION_START_FROM_LEFT,
         newRecentMessagesCount: 0,
@@ -38,6 +40,13 @@ describe('components/ToastWrapper', () => {
         scrollToLatestMessages: jest.fn(),
         updateLastViewedBottomAt: jest.fn(),
         lastViewedAt: 12344,
+        channelId: '',
+        isCollapsedThreadsEnabled: false,
+        rootPosts: {} as Props['rootPosts'],
+        initScrollOffsetFromBottom: 1001,
+        scrollToUnreadMessages: jest.fn(),
+        showSearchHintToast: true,
+        onSearchHintDismiss: jest.fn(),
         actions: {
             updateToastStatus: jest.fn(),
         },
@@ -45,8 +54,8 @@ describe('components/ToastWrapper', () => {
             params: {
                 team: 'team',
             },
-        },
-    };
+        } as unknown as Props['match'],
+    } as unknown as Props;
 
     describe('unread count logic', () => {
         test('If not atLatestPost and channelMarkedAsUnread is false then unread count is equal to unreads in present chunk plus recent messages', () => {
@@ -328,7 +337,7 @@ describe('components/ToastWrapper', () => {
 
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
             expect(wrapper.state('showUnreadToast')).toBe(true);
-            wrapper.instance().scrollToLatestMessages();
+            (wrapper.instance() as ToastWrapperClass).scrollToLatestMessages();
             expect(wrapper.state('showUnreadToast')).toBe(false);
             expect(baseProps.scrollToLatestMessages).toHaveBeenCalledTimes(1);
         });
@@ -353,7 +362,7 @@ describe('components/ToastWrapper', () => {
             wrapper.setProps({lastViewedBottom: 1234, latestPostTimeStamp: 1235, atBottom: false});
             expect(wrapper.state('showNewMessagesToast')).toBe(true);
             wrapper.setProps({lastViewedBottom: 1235, latestPostTimeStamp: 1235});
-            wrapper.instance().scrollToNewMessage();
+            (wrapper.instance() as ToastWrapperClass).scrollToNewMessage();
             expect(wrapper.state('showNewMessagesToast')).toBe(false);
             expect(baseProps.scrollToNewMessage).toHaveBeenCalledTimes(1);
         });
@@ -376,7 +385,7 @@ describe('components/ToastWrapper', () => {
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
             expect(wrapper.state('showUnreadToast')).toBe(true);
 
-            wrapper.instance().handleShortcut({key: 'ESC', keyCode: 27});
+            (wrapper.instance() as ToastWrapperClass).handleShortcut({key: 'ESC', keyCode: 27});
             expect(wrapper.state('showUnreadToast')).toBe(false);
         });
 
@@ -399,7 +408,7 @@ describe('components/ToastWrapper', () => {
             wrapper.setState({atBottom: false, showUnreadToast: false});
             wrapper.setProps({atBottom: false, lastViewedBottom: 1234, latestPostTimeStamp: 1235});
             expect(wrapper.state('showNewMessagesToast')).toBe(true);
-            wrapper.instance().handleShortcut({key: 'ESC', keyCode: 27});
+            (wrapper.instance() as ToastWrapperClass).handleShortcut({key: 'ESC', keyCode: 27});
             expect(baseProps.updateLastViewedBottomAt).toHaveBeenCalledTimes(1);
         });
 
@@ -531,7 +540,7 @@ describe('components/ToastWrapper', () => {
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
             expect(wrapper.state('showMessageHistoryToast')).toBe(true);
 
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as ToastWrapperClass;
             browserHistory.replace = jest.fn();
             instance.scrollToLatestMessages();
             expect(browserHistory.replace).toHaveBeenCalledWith('/team');
@@ -547,7 +556,7 @@ describe('components/ToastWrapper', () => {
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
             expect(wrapper.state('showMessageHistoryToast')).toBe(true);
 
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as ToastWrapperClass;
             browserHistory.replace = jest.fn();
             instance.scrollToNewMessage();
             expect(browserHistory.replace).toHaveBeenCalledWith('/team');
@@ -601,7 +610,7 @@ describe('components/ToastWrapper', () => {
             };
 
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as ToastWrapperClass;
 
             instance.hideSearchHintToast();
 

--- a/components/toast_wrapper/toast_wrapper.test.tsx
+++ b/components/toast_wrapper/toast_wrapper.test.tsx
@@ -14,8 +14,6 @@ import {browserHistory} from 'utils/browser_history';
 
 import ToastWrapper, {Props, ToastWrapperClass} from './toast_wrapper';
 
-// import ToastWrapperComp from '.';
-
 describe('components/ToastWrapper', () => {
     const baseProps: ComponentProps<typeof ToastWrapper> = {
         unreadCountInChannel: 0,
@@ -385,7 +383,7 @@ describe('components/ToastWrapper', () => {
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
             expect(wrapper.state('showUnreadToast')).toBe(true);
 
-            (wrapper.instance() as ToastWrapperClass).handleShortcut({key: 'ESC', keyCode: 27});
+            (wrapper.instance() as ToastWrapperClass).handleShortcut({key: 'ESC', keyCode: 27} as KeyboardEvent);
             expect(wrapper.state('showUnreadToast')).toBe(false);
         });
 
@@ -408,7 +406,7 @@ describe('components/ToastWrapper', () => {
             wrapper.setState({atBottom: false, showUnreadToast: false});
             wrapper.setProps({atBottom: false, lastViewedBottom: 1234, latestPostTimeStamp: 1235});
             expect(wrapper.state('showNewMessagesToast')).toBe(true);
-            (wrapper.instance() as ToastWrapperClass).handleShortcut({key: 'ESC', keyCode: 27});
+            (wrapper.instance() as ToastWrapperClass).handleShortcut({key: 'ESC', keyCode: 27} as KeyboardEvent);
             expect(baseProps.updateLastViewedBottomAt).toHaveBeenCalledTimes(1);
         });
 

--- a/components/toast_wrapper/toast_wrapper.tsx
+++ b/components/toast_wrapper/toast_wrapper.tsx
@@ -26,7 +26,7 @@ const TOAST_REL_RANGES = [
     RelativeRanges.TODAY_YESTERDAY,
 ];
 
-type Props = PropsFromRedux & OwnProps & WrappedComponentProps & RouteComponentProps<{team: string}> & {
+export type Props = PropsFromRedux & OwnProps & WrappedComponentProps & RouteComponentProps<{team: string}> & {
     channelMarkedAsUnread?: boolean;
     postListIds: string[];
     latestPostTimeStamp?: number;

--- a/components/toast_wrapper/toast_wrapper.tsx
+++ b/components/toast_wrapper/toast_wrapper.tsx
@@ -57,9 +57,8 @@ type State = {
     showUnreadWithBottomStartToast?: boolean;
 };
 
-class ToastWrapper extends React.PureComponent<Props, State> {
+export class ToastWrapperClass extends React.PureComponent<Props, State> {
     mounted?: boolean;
-    
     static defaultProps = {
         focusedPostId: '',
     };
@@ -71,7 +70,7 @@ class ToastWrapper extends React.PureComponent<Props, State> {
         };
     }
 
-    static countNewMessages = (rootPosts: Record<string, boolean>, isCollapsedThreadsEnabled: boolean, postListIds?: string[],) => {
+    static countNewMessages = (rootPosts: Record<string, boolean>, isCollapsedThreadsEnabled: boolean, postListIds?: string[]) => {
         const mark = getNewMessageIndex(postListIds || []);
         if (mark <= 0) {
             return 0;
@@ -91,7 +90,7 @@ class ToastWrapper extends React.PureComponent<Props, State> {
             if (props.unreadScrollPosition === Preferences.UNREAD_SCROLL_POSITION_START_FROM_NEWEST && prevState.unreadCountInChannel) {
                 unreadCount = prevState.unreadCountInChannel + props.newRecentMessagesCount;
             } else {
-                unreadCount = ToastWrapper.countNewMessages(props.rootPosts, props.isCollapsedThreadsEnabled, props.postListIds);
+                unreadCount = ToastWrapperClass.countNewMessages(props.rootPosts, props.isCollapsedThreadsEnabled, props.postListIds);
             }
         } else if (props.channelMarkedAsUnread) {
             if (props.unreadScrollPosition === Preferences.UNREAD_SCROLL_POSITION_START_FROM_NEWEST) {
@@ -462,4 +461,4 @@ class ToastWrapper extends React.PureComponent<Props, State> {
     }
 }
 
-export default injectIntl(ToastWrapper);
+export default injectIntl(ToastWrapperClass);

--- a/components/toast_wrapper/toast_wrapper.tsx
+++ b/components/toast_wrapper/toast_wrapper.tsx
@@ -2,19 +2,23 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import PropTypes from 'prop-types';
-import {FormattedMessage, injectIntl} from 'react-intl';
+import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
+import {RouteComponentProps} from 'react-router-dom';
 
-import Toast from 'components/toast/toast';
-import Timestamp, {RelativeRanges} from 'components/timestamp';
+import {Preferences} from 'mattermost-redux/constants';
+
 import {isIdNotPost, getNewMessageIndex} from 'utils/post_utils';
-import * as Utils from 'utils/utils';
+import {isKeyPressed, localizeMessage} from 'utils/utils';
 import {isToday} from 'utils/datetime';
 import Constants from 'utils/constants';
 import {browserHistory} from 'utils/browser_history';
+
+import Toast from 'components/toast/toast';
+import Timestamp, {RelativeRanges} from 'components/timestamp';
 import {SearchShortcut} from 'components/search_shortcut';
 import {HintToast} from 'components/hint-toast/hint_toast';
-import {Preferences} from 'mattermost-redux/constants';
+
+import type {OwnProps, PropsFromRedux} from '.';
 
 const TOAST_TEXT_COLLAPSE_WIDTH = 500;
 
@@ -22,75 +26,64 @@ const TOAST_REL_RANGES = [
     RelativeRanges.TODAY_YESTERDAY,
 ];
 
-class ToastWrapper extends React.PureComponent {
-    static propTypes = {
-        unreadCountInChannel: PropTypes.number,
-        newRecentMessagesCount: PropTypes.number,
-        channelMarkedAsUnread: PropTypes.bool,
-        isCollapsedThreadsEnabled: PropTypes.bool,
-        rootPosts: PropTypes.object,
-        atLatestPost: PropTypes.bool,
-        postListIds: PropTypes.array,
-        latestPostTimeStamp: PropTypes.number,
-        atBottom: PropTypes.bool,
-        lastViewedBottom: PropTypes.number,
-        width: PropTypes.number,
-        lastViewedAt: PropTypes.number,
-        focusedPostId: PropTypes.string,
-        initScrollOffsetFromBottom: PropTypes.number,
-        updateNewMessagesAtInChannel: PropTypes.func,
-        scrollToNewMessage: PropTypes.func,
-        scrollToLatestMessages: PropTypes.func,
-        scrollToUnreadMessages: PropTypes.func,
-        updateLastViewedBottomAt: PropTypes.func,
-        showSearchHintToast: PropTypes.bool,
-        onSearchHintDismiss: PropTypes.func,
-        shouldStartFromBottomWhenUnread: PropTypes.bool,
-        isNewMessageLineReached: PropTypes.bool,
-        unreadScrollPosition: PropTypes.string,
+type Props = PropsFromRedux & OwnProps & WrappedComponentProps & RouteComponentProps<{team: string}> & {
+    channelMarkedAsUnread?: boolean;
+    postListIds: string[];
+    latestPostTimeStamp?: number;
+    atBottom: boolean | null;
+    lastViewedBottom: number;
+    width: number;
+    focusedPostId?: string;
+    initScrollOffsetFromBottom: number;
+    updateNewMessagesAtInChannel: (lastViewedAt?: number) => void;
+    scrollToNewMessage: () => void;
+    scrollToLatestMessages: () => void;
+    scrollToUnreadMessages: () => void;
+    updateLastViewedBottomAt: (lastViewedBottom?: number) => void;
+    showSearchHintToast: boolean;
+    onSearchHintDismiss: () => void;
+    shouldStartFromBottomWhenUnread: boolean;
+    isNewMessageLineReached: boolean;
+};
 
-        /*
-         * Object from react-router
-         */
-        match: PropTypes.shape({
-            params: PropTypes.shape({
-                team: PropTypes.string,
-            }).isRequired,
-        }).isRequired,
+type State = {
+    unreadCount?: number;
+    unreadCountInChannel: number;
+    channelMarkedAsUnread?: boolean;
+    lastViewedAt?: number;
+    showUnreadToast?: boolean;
+    showNewMessagesToast?: boolean;
+    showMessageHistoryToast?: boolean;
+    showUnreadWithBottomStartToast?: boolean;
+};
 
-        actions: PropTypes.shape({
-
-            /**
-             * Action creator to update toast status
-             */
-            updateToastStatus: PropTypes.func.isRequired,
-        }).isRequired,
-    };
-
+class ToastWrapper extends React.PureComponent<Props, State> {
+    mounted?: boolean;
+    
     static defaultProps = {
         focusedPostId: '',
     };
 
-    constructor(props) {
+    constructor(props: Props) {
         super(props);
         this.state = {
             unreadCountInChannel: props.unreadCountInChannel,
         };
     }
 
-    static countNewMessages = (postListIds, rootPosts, isCollapsedThreadsEnabled) => {
-        const mark = getNewMessageIndex(postListIds);
+    static countNewMessages = (rootPosts: Record<string, boolean>, isCollapsedThreadsEnabled: boolean, postListIds?: string[],) => {
+        const mark = getNewMessageIndex(postListIds || []);
         if (mark <= 0) {
             return 0;
         }
-        let newMessages = postListIds.slice(0, mark).filter((id) => !isIdNotPost(id));
+        let newMessages = postListIds?.slice(0, mark).filter((id) => !isIdNotPost(id));
         if (isCollapsedThreadsEnabled) { // in collapsed mode we only count root posts
-            newMessages = newMessages.filter((id) => rootPosts[id]);
+            newMessages = newMessages?.filter((id) => rootPosts[id]);
         }
-        return newMessages.length;
+        return newMessages?.length;
     }
 
-    static getDerivedStateFromProps(props, prevState) {
+    static getDerivedStateFromProps(props: Props, prevState: State) {
         let {showUnreadToast, showNewMessagesToast, showMessageHistoryToast, showUnreadWithBottomStartToast} = prevState;
         let unreadCount;
 
@@ -98,7 +91,7 @@ class ToastWrapper extends React.PureComponent {
             if (props.unreadScrollPosition === Preferences.UNREAD_SCROLL_POSITION_START_FROM_NEWEST && prevState.unreadCountInChannel) {
                 unreadCount = prevState.unreadCountInChannel + props.newRecentMessagesCount;
             } else {
-                unreadCount = ToastWrapper.countNewMessages(props.postListIds, props.rootPosts, props.isCollapsedThreadsEnabled);
+                unreadCount = ToastWrapper.countNewMessages(props.rootPosts, props.isCollapsedThreadsEnabled, props.postListIds);
             }
         } else if (props.channelMarkedAsUnread) {
             if (props.unreadScrollPosition === Preferences.UNREAD_SCROLL_POSITION_START_FROM_NEWEST) {
@@ -111,11 +104,11 @@ class ToastWrapper extends React.PureComponent {
         }
 
         // show unread toast on mount when channel is not at bottom and unread count greater than 0
-        if (typeof showUnreadToast === 'undefined' && props.atBottom !== null) {
+        if (typeof showUnreadToast === 'undefined' && props.atBottom !== null && unreadCount) {
             showUnreadToast = unreadCount > 0 && !props.atBottom;
         }
 
-        if (typeof showMessageHistoryToast === 'undefined' && props.focusedPostId !== '' && props.atBottom !== null) {
+        if (typeof showMessageHistoryToast === 'undefined' && props.focusedPostId !== '' && props.atBottom !== null && props.initScrollOffsetFromBottom) {
             showMessageHistoryToast = props.initScrollOffsetFromBottom > 1000 || !props.atLatestPost;
         }
 
@@ -130,7 +123,7 @@ class ToastWrapper extends React.PureComponent {
             showUnreadToast = true;
         }
 
-        if (!showUnreadToast && unreadCount > 0 && !props.atBottom && (props.lastViewedBottom < props.latestPostTimeStamp)) {
+        if (!showUnreadToast && unreadCount && unreadCount > 0 && !props.atBottom && props.latestPostTimeStamp && (props.lastViewedBottom < props.latestPostTimeStamp)) {
             showNewMessagesToast = true;
         }
 
@@ -152,6 +145,7 @@ class ToastWrapper extends React.PureComponent {
             props.lastViewedAt &&
             props.lastViewedAt !== prevState.lastViewedAt &&
             props.shouldStartFromBottomWhenUnread &&
+            unreadCount &&
             unreadCount > 0 &&
             !props.isNewMessageLineReached
         ) {
@@ -178,7 +172,7 @@ class ToastWrapper extends React.PureComponent {
         this.props.actions.updateToastStatus(toastPresent);
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate(prevProps: Props, prevState: State) {
         const {showUnreadToast, showNewMessagesToast, showMessageHistoryToast, showUnreadWithBottomStartToast} = this.state;
         const {
             atBottom,
@@ -221,8 +215,8 @@ class ToastWrapper extends React.PureComponent {
         document.removeEventListener('keydown', this.handleShortcut);
     }
 
-    handleShortcut = (e) => {
-        if (Utils.isKeyPressed(e, Constants.KeyCodes.ESCAPE)) {
+    handleShortcut = (e: KeyboardEvent) => {
+        if (isKeyPressed(e, Constants.KeyCodes.ESCAPE)) {
             if (this.state.showUnreadToast) {
                 this.hideUnreadToast();
             } else if (this.state.showNewMessagesToast) {
@@ -276,7 +270,7 @@ class ToastWrapper extends React.PureComponent {
         }
     }
 
-    newMessagesToastText = (count, since) => {
+    newMessagesToastText = (count: number | undefined, since: number) => {
         if (this.props.width > TOAST_TEXT_COLLAPSE_WIDTH && typeof since !== 'undefined') {
             return (
                 <FormattedMessage
@@ -379,11 +373,11 @@ class ToastWrapper extends React.PureComponent {
             width,
             onDismiss: this.hideUnreadToast,
             onClick: this.scrollToLatestMessages,
-            onClickMessage: Utils.localizeMessage('postlist.toast.scrollToBottom', 'Jump to recents'),
+            onClickMessage: localizeMessage('postlist.toast.scrollToBottom', 'Jump to recents'),
             showActions: !atLatestPost || (atLatestPost && !atBottom),
         };
 
-        if (showUnreadToast && unreadCount > 0) {
+        if (showUnreadToast && unreadCount && unreadCount > 0) {
             return (
                 <Toast {...unreadToastProps}>
                     {this.newMessagesToastText(unreadCount, lastViewedAt)}
@@ -396,12 +390,12 @@ class ToastWrapper extends React.PureComponent {
             width,
             onDismiss: this.hideUnreadWithBottomStartToast,
             onClick: this.scrollToUnreadMessages,
-            onClickMessage: Utils.localizeMessage('postlist.toast.scrollToUnread', 'Jump to unreads'),
+            onClickMessage: localizeMessage('postlist.toast.scrollToUnread', 'Jump to unreads'),
             showActions: true,
-            jumpDirection: 'up',
+            jumpDirection: 'up' as const,
         };
 
-        if (showUnreadWithBottomStartToast && unreadCount > 0) {
+        if (showUnreadWithBottomStartToast && unreadCount && unreadCount > 0) {
             return (
                 <Toast {...unreadWithBottomStartToastProps}>
                     {this.newMessagesToastText(unreadCount, lastViewedAt)}
@@ -413,7 +407,7 @@ class ToastWrapper extends React.PureComponent {
             const showNewMessagesToastOverrides = {
                 onDismiss: this.hideNewMessagesToast,
                 onClick: this.scrollToNewMessage,
-                onClickMessage: Utils.localizeMessage('postlist.toast.scrollToLatest', 'Jump to new messages'),
+                onClickMessage: localizeMessage('postlist.toast.scrollToLatest', 'Jump to new messages'),
             };
 
             return (
@@ -432,7 +426,7 @@ class ToastWrapper extends React.PureComponent {
                 width,
                 onDismiss: this.hideArchiveToast,
                 onClick: this.scrollToLatestMessages,
-                onClickMessage: Utils.localizeMessage('postlist.toast.scrollToBottom', 'Jump to recents'),
+                onClickMessage: localizeMessage('postlist.toast.scrollToBottom', 'Jump to recents'),
                 showActions: true,
                 extraClasses: 'toast__history',
             };

--- a/components/toast_wrapper/toast_wrapper.tsx
+++ b/components/toast_wrapper/toast_wrapper.tsx
@@ -118,7 +118,7 @@ export class ToastWrapperClass extends React.PureComponent<Props, State> {
             showUnreadToast = unreadCount > 0 && !props.atBottom;
         }
 
-        if (typeof showMessageHistoryToast === 'undefined' && props.focusedPostId !== '' && props.atBottom !== null && props.initScrollOffsetFromBottom) {
+        if (typeof showMessageHistoryToast === 'undefined' && props.focusedPostId !== '' && props.atBottom !== null) {
             showMessageHistoryToast = props.initScrollOffsetFromBottom > 1000 || !props.atLatestPost;
         }
 

--- a/components/toast_wrapper/toast_wrapper.tsx
+++ b/components/toast_wrapper/toast_wrapper.tsx
@@ -86,11 +86,11 @@ export class ToastWrapperClass extends React.PureComponent<Props, State> {
         if (mark <= 0) {
             return 0;
         }
-        let newMessages = postListIds?.slice(0, mark).filter((id) => !isIdNotPost(id));
+        let newMessages = postListIds.slice(0, mark).filter((id) => !isIdNotPost(id));
         if (isCollapsedThreadsEnabled) { // in collapsed mode we only count root posts
-            newMessages = newMessages?.filter((id) => rootPosts[id]);
+            newMessages = newMessages.filter((id) => rootPosts[id]);
         }
-        return newMessages?.length;
+        return newMessages.length;
     }
 
     static getDerivedStateFromProps(props: Props, prevState: State) {

--- a/packages/mattermost-redux/src/utils/post_list.ts
+++ b/packages/mattermost-redux/src/utils/post_list.ts
@@ -33,7 +33,7 @@ function shouldShowJoinLeaveMessages(state: GlobalState) {
 interface PostFilterOptions {
     postIds: string[];
     lastViewedAt: number;
-    indicateNewMessages: boolean;
+    indicateNewMessages?: boolean;
 }
 
 export function makePreparePostIdsForPostList() {


### PR DESCRIPTION
#### Summary
This PR migrates 'components/toast_wrapper' and associated tests to TypeScript

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/17276
JIRA: https://mattermost.atlassian.net/browse/MM-34347

#### Release Note
```release-note
NONE
```
