### PR TITLE
GH-13865 : Add missing a11y__modal dialogClassName to <Modal> components

### DIFF
--- a/components/admin_console/billing/billing_history_modal.tsx
+++ b/components/admin_console/billing/billing_history_modal.tsx
@@ -56,6 +56,7 @@ export default function BillingHistoryModal(props: BillingHistoryModalProps) {
             onHide={onHide}
             id='cloud-billing-history-modal'
             className='CloudBillingHistoryModal'
+            dialogClassName='a11y__modal'
         >
             <Modal.Header closeButton={true}>
                 <Modal.Title className='CloudBillingHistoryModal__title'>{formatMessage({id: 'cloud_billing_history_modal.title', defaultMessage: 'Unpaid Invoice(s)'})}</Modal.Title>

--- a/components/cloud_invoice_preview/index.tsx
+++ b/components/cloud_invoice_preview/index.tsx
@@ -43,6 +43,7 @@ function CloudInvoicePreview(props: Props) {
             onHide={onHide}
             id='cloud-invoice-preview'
             className='CloudInvoicePreview'
+            dialogClassName='a11y__modal'
         >
             <Modal.Header closeButton={true}>
                 <Modal.Title>{'Invoice'}</Modal.Title>

--- a/components/start_trial_modal/index.tsx
+++ b/components/start_trial_modal/index.tsx
@@ -97,7 +97,8 @@ function StartTrialModal(props: Props): JSX.Element | null {
 
     return (
         <Modal
-            className={'StartTrialModal'}
+            className='StartTrialModal'
+            dialogClassName='a11y__modal'
             show={show}
             id='startTrialModal'
             role='dialog'


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add missing a11y__modal dialogClassName to <Modal> components.

This is the only references to `<Model>` without a11y__modal I found using `<Modal( |\n)((?:(?!a11y__modal).)*\n)+\s*>` regex
For a11y__popup I will need a little more background to see if I can found them. I did see `<Popover>` component, but no one use a11y__popup classname so I did not touch that.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/13865

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
