### PR TITLE
MM-22249 : Add automatic lazy loading of syntax highlighting libraries

### DIFF
--- a/components/code_block/__snapshots__/code_block.test.tsx.snap
+++ b/components/code_block/__snapshots__/code_block.test.tsx.snap
@@ -115,9 +115,9 @@ exports[`codeBlock should render html code block with proper indentation 1`] = `
         dangerouslySetInnerHTML={
           Object {
             "__html": "\`\`\`html
-<span class=\\"hljs-tag\\">&lt;<span class=\\"hljs-name\\">div</span> <span class=\\"hljs-attr\\">className</span>=<span class=\\"hljs-string\\">&#x27;myClass&#x27;</span>&gt;</span>
-  <span class=\\"hljs-tag\\">&lt;<span class=\\"hljs-name\\">a</span> <span class=\\"hljs-attr\\">href</span>=<span class=\\"hljs-string\\">&#x27;https://randomgibberishurl.com&#x27;</span>&gt;</span>ClickMe<span class=\\"hljs-tag\\">&lt;/<span class=\\"hljs-name\\">a</span>&gt;</span>
-<span class=\\"hljs-tag\\">&lt;/<span class=\\"hljs-name\\">div</span>&gt;</span>
+&lt;div className=&apos;myClass&apos;&gt;
+  &lt;a href=&apos;https://randomgibberishurl.com&apos;&gt;ClickMe&lt;/a&gt;
+&lt;/div&gt;
 \`\`\`
 ",
           }
@@ -242,11 +242,11 @@ const myFunction = () => {
       <code
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<span class=\\"hljs-string\\">\`\`</span><span class=\\"hljs-string\\">\`typescript
+            "__html": "\`\`\`typescript
 const myFunction = () =&gt; {
-    console.log(&#x27;This is a meaningful function&#x27;);
+    console.log(&apos;This is a meaningful function&apos;);
 };
-\`</span><span class=\\"hljs-string\\">\`\`</span>
+\`\`\`
 ",
           }
         }

--- a/components/code_block/__snapshots__/code_block.test.tsx.snap
+++ b/components/code_block/__snapshots__/code_block.test.tsx.snap
@@ -1,6 +1,361 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`codeBlock should render html code block with proper indentation 1`] = `
+exports[`codeBlock should render html code block with proper indentation after syntax highlighting 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <CodeBlock
+    code="\`\`\`html
+<div className='myClass'>
+  <a href='https://randomgibberishurl.com'>ClickMe</a>
+</div>
+\`\`\`
+"
+    id="randompostid"
+    language="html"
+  >
+    <div
+      className="post-code"
+    >
+      <div
+        className="post-code__overlay"
+      >
+        <CopyButton
+          afterCopyText="Copied"
+          content="\`\`\`html
+<div className='myClass'>
+  <a href='https://randomgibberishurl.com'>ClickMe</a>
+</div>
+\`\`\`
+"
+          placement="top"
+        >
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            delayShow={400}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="copyButton"
+                placement="right"
+              >
+                <Memo(MemoizedFormattedMessage)
+                  defaultMessage="Copy code"
+                  id="copy.code.message"
+                />
+              </Tooltip>
+            }
+            placement="top"
+            shouldUpdatePosition={true}
+            trigger={
+              Array [
+                "hover",
+                "focus",
+              ]
+            }
+          >
+            <OverlayTrigger
+              defaultOverlayShown={false}
+              delayShow={400}
+              overlay={
+                <OverlayWrapper
+                  bsClass="tooltip"
+                  id="copyButton"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "defaultRichTextElements": undefined,
+                      "formatDate": [Function],
+                      "formatDateTimeRange": [Function],
+                      "formatDateToParts": [Function],
+                      "formatDisplayName": [Function],
+                      "formatList": [Function],
+                      "formatListToParts": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatNumberToParts": [Function],
+                      "formatPlural": [Function],
+                      "formatRelativeTime": [Function],
+                      "formatTime": [Function],
+                      "formatTimeToParts": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getDisplayNames": [Function],
+                        "getListFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralRules": [Function],
+                        "getRelativeTimeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": Object {},
+                      "onError": [Function],
+                      "textComponent": Symbol(react.fragment),
+                      "timeZone": undefined,
+                      "wrapRichTextChunksInFragment": undefined,
+                    }
+                  }
+                  placement="right"
+                >
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Copy code"
+                    id="copy.code.message"
+                  />
+                </OverlayWrapper>
+              }
+              placement="top"
+              shouldUpdatePosition={true}
+              trigger={
+                Array [
+                  "hover",
+                  "focus",
+                ]
+              }
+            >
+              <span
+                className="post-code__clipboard"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+              >
+                <i
+                  className="icon icon-content-copy"
+                  role="button"
+                />
+              </span>
+            </OverlayTrigger>
+          </OverlayTrigger>
+        </CopyButton>
+        <span
+          className="post-code__language"
+        >
+          HTML, XML
+        </span>
+      </div>
+      <RootPortal>
+        <Portal
+          containerInfo={
+            <div>
+              <nav
+                class="react-contextmenu post-code__context-menu"
+                role="menu"
+                style="position: fixed; opacity: 0; pointer-events: none;"
+                tabindex="-1"
+              >
+                <div
+                  aria-disabled="false"
+                  class="react-contextmenu-item"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  Copy
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-orientation="horizontal"
+                  class="react-contextmenu-item react-contextmenu-item--divider"
+                  role="menuitem"
+                  tabindex="-1"
+                />
+                <div
+                  aria-disabled="false"
+                  class="react-contextmenu-item"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  Copy code block
+                </div>
+              </nav>
+            </div>
+          }
+        >
+          <ContextMenu
+            className="post-code__context-menu"
+            data={Object {}}
+            hideOnLeave={false}
+            id="copy-code-block-context-menu-randompostid"
+            onHide={[Function]}
+            onMouseLeave={[Function]}
+            onShow={[Function]}
+            preventHideOnContextMenu={false}
+            preventHideOnResize={false}
+            preventHideOnScroll={false}
+            rtl={false}
+            style={Object {}}
+          >
+            <nav
+              className="react-contextmenu post-code__context-menu"
+              onContextMenu={[Function]}
+              onMouseLeave={[Function]}
+              role="menu"
+              style={
+                Object {
+                  "opacity": 0,
+                  "pointerEvents": "none",
+                  "position": "fixed",
+                }
+              }
+              tabIndex="-1"
+            >
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={false}
+                key=".0"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation={null}
+                  className="react-contextmenu-item"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                >
+                  <FormattedMessage
+                    defaultMessage="Copy"
+                    id="copy.message"
+                  >
+                    Copy
+                  </FormattedMessage>
+                </div>
+              </MenuItem>
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={true}
+                key=".1"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation="horizontal"
+                  className="react-contextmenu-item react-contextmenu-item--divider"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                />
+              </MenuItem>
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={false}
+                key=".2"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation={null}
+                  className="react-contextmenu-item"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                >
+                  <FormattedMessage
+                    defaultMessage="Copy code block"
+                    id="copy.block.message"
+                  >
+                    Copy code block
+                  </FormattedMessage>
+                </div>
+              </MenuItem>
+            </nav>
+          </ContextMenu>
+        </Portal>
+      </RootPortal>
+      <ContextMenuTrigger
+        attributes={Object {}}
+        collect={[Function]}
+        disable={false}
+        disableIfShiftIsPressed={false}
+        holdToDisplay={-1}
+        id="copy-code-block-context-menu-randompostid"
+        mouseButton={2}
+        posX={0}
+        posY={0}
+        renderTag="div"
+      >
+        <div
+          className="react-contextmenu-wrapper"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onMouseDown={[Function]}
+          onMouseOut={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+        >
+          <div
+            className="hljs"
+          >
+            <div
+              className="post-code__line-numbers"
+            >
+              1
+2
+3
+4
+5
+6
+            </div>
+            <code
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "\`\`\`html
+<span class=\\"hljs-tag\\">&lt;<span class=\\"hljs-name\\">div</span> <span class=\\"hljs-attr\\">className</span>=<span class=\\"hljs-string\\">&#x27;myClass&#x27;</span>&gt;</span>
+  <span class=\\"hljs-tag\\">&lt;<span class=\\"hljs-name\\">a</span> <span class=\\"hljs-attr\\">href</span>=<span class=\\"hljs-string\\">&#x27;https://randomgibberishurl.com&#x27;</span>&gt;</span>ClickMe<span class=\\"hljs-tag\\">&lt;/<span class=\\"hljs-name\\">a</span>&gt;</span>
+<span class=\\"hljs-tag\\">&lt;/<span class=\\"hljs-name\\">div</span>&gt;</span>
+\`\`\`
+",
+                }
+              }
+            />
+          </div>
+        </div>
+      </ContextMenuTrigger>
+    </div>
+  </CodeBlock>
+</IntlProvider>
+`;
+
+exports[`codeBlock should render html code block with proper indentation before syntax highlighting 1`] = `
 <div
   className="post-code"
 >
@@ -128,7 +483,362 @@ exports[`codeBlock should render html code block with proper indentation 1`] = `
 </div>
 `;
 
-exports[`codeBlock should render typescript code block 1`] = `
+exports[`codeBlock should render typescript code block after syntax highlighting 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <CodeBlock
+    code="\`\`\`typescript
+const myFunction = () => {
+    console.log('This is a meaningful function');
+};
+\`\`\`
+"
+    id="randompostid"
+    language="typescript"
+  >
+    <div
+      className="post-code"
+    >
+      <div
+        className="post-code__overlay"
+      >
+        <CopyButton
+          afterCopyText="Copied"
+          content="\`\`\`typescript
+const myFunction = () => {
+    console.log('This is a meaningful function');
+};
+\`\`\`
+"
+          placement="top"
+        >
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            delayShow={400}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="copyButton"
+                placement="right"
+              >
+                <Memo(MemoizedFormattedMessage)
+                  defaultMessage="Copy code"
+                  id="copy.code.message"
+                />
+              </Tooltip>
+            }
+            placement="top"
+            shouldUpdatePosition={true}
+            trigger={
+              Array [
+                "hover",
+                "focus",
+              ]
+            }
+          >
+            <OverlayTrigger
+              defaultOverlayShown={false}
+              delayShow={400}
+              overlay={
+                <OverlayWrapper
+                  bsClass="tooltip"
+                  id="copyButton"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "defaultRichTextElements": undefined,
+                      "formatDate": [Function],
+                      "formatDateTimeRange": [Function],
+                      "formatDateToParts": [Function],
+                      "formatDisplayName": [Function],
+                      "formatList": [Function],
+                      "formatListToParts": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatNumberToParts": [Function],
+                      "formatPlural": [Function],
+                      "formatRelativeTime": [Function],
+                      "formatTime": [Function],
+                      "formatTimeToParts": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getDisplayNames": [Function],
+                        "getListFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralRules": [Function],
+                        "getRelativeTimeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": Object {},
+                      "onError": [Function],
+                      "textComponent": Symbol(react.fragment),
+                      "timeZone": undefined,
+                      "wrapRichTextChunksInFragment": undefined,
+                    }
+                  }
+                  placement="right"
+                >
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Copy code"
+                    id="copy.code.message"
+                  />
+                </OverlayWrapper>
+              }
+              placement="top"
+              shouldUpdatePosition={true}
+              trigger={
+                Array [
+                  "hover",
+                  "focus",
+                ]
+              }
+            >
+              <span
+                className="post-code__clipboard"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+              >
+                <i
+                  className="icon icon-content-copy"
+                  role="button"
+                />
+              </span>
+            </OverlayTrigger>
+          </OverlayTrigger>
+        </CopyButton>
+        <span
+          className="post-code__language"
+        >
+          TypeScript
+        </span>
+      </div>
+      <RootPortal>
+        <Portal
+          containerInfo={
+            <div>
+              <nav
+                class="react-contextmenu post-code__context-menu"
+                role="menu"
+                style="position: fixed; opacity: 0; pointer-events: none;"
+                tabindex="-1"
+              >
+                <div
+                  aria-disabled="false"
+                  class="react-contextmenu-item"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  Copy
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-orientation="horizontal"
+                  class="react-contextmenu-item react-contextmenu-item--divider"
+                  role="menuitem"
+                  tabindex="-1"
+                />
+                <div
+                  aria-disabled="false"
+                  class="react-contextmenu-item"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  Copy code block
+                </div>
+              </nav>
+            </div>
+          }
+        >
+          <ContextMenu
+            className="post-code__context-menu"
+            data={Object {}}
+            hideOnLeave={false}
+            id="copy-code-block-context-menu-randompostid"
+            onHide={[Function]}
+            onMouseLeave={[Function]}
+            onShow={[Function]}
+            preventHideOnContextMenu={false}
+            preventHideOnResize={false}
+            preventHideOnScroll={false}
+            rtl={false}
+            style={Object {}}
+          >
+            <nav
+              className="react-contextmenu post-code__context-menu"
+              onContextMenu={[Function]}
+              onMouseLeave={[Function]}
+              role="menu"
+              style={
+                Object {
+                  "opacity": 0,
+                  "pointerEvents": "none",
+                  "position": "fixed",
+                }
+              }
+              tabIndex="-1"
+            >
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={false}
+                key=".0"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation={null}
+                  className="react-contextmenu-item"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                >
+                  <FormattedMessage
+                    defaultMessage="Copy"
+                    id="copy.message"
+                  >
+                    Copy
+                  </FormattedMessage>
+                </div>
+              </MenuItem>
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={true}
+                key=".1"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation="horizontal"
+                  className="react-contextmenu-item react-contextmenu-item--divider"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                />
+              </MenuItem>
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={false}
+                key=".2"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation={null}
+                  className="react-contextmenu-item"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                >
+                  <FormattedMessage
+                    defaultMessage="Copy code block"
+                    id="copy.block.message"
+                  >
+                    Copy code block
+                  </FormattedMessage>
+                </div>
+              </MenuItem>
+            </nav>
+          </ContextMenu>
+        </Portal>
+      </RootPortal>
+      <ContextMenuTrigger
+        attributes={Object {}}
+        collect={[Function]}
+        disable={false}
+        disableIfShiftIsPressed={false}
+        holdToDisplay={-1}
+        id="copy-code-block-context-menu-randompostid"
+        mouseButton={2}
+        posX={0}
+        posY={0}
+        renderTag="div"
+      >
+        <div
+          className="react-contextmenu-wrapper"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onMouseDown={[Function]}
+          onMouseOut={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+        >
+          <div
+            className="hljs"
+          >
+            <div
+              className="post-code__line-numbers"
+            >
+              1
+2
+3
+4
+5
+6
+            </div>
+            <code
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "<span class=\\"hljs-string\\">\`\`</span><span class=\\"hljs-string\\">\`typescript
+const myFunction = () =&gt; {
+    console.log(&#x27;This is a meaningful function&#x27;);
+};
+\`</span><span class=\\"hljs-string\\">\`\`</span>
+",
+                }
+              }
+            />
+          </div>
+        </div>
+      </ContextMenuTrigger>
+    </div>
+  </CodeBlock>
+</IntlProvider>
+`;
+
+exports[`codeBlock should render typescript code block before syntax highlighting 1`] = `
 <div
   className="post-code"
 >
@@ -256,7 +966,344 @@ const myFunction = () =&gt; {
 </div>
 `;
 
-exports[`codeBlock should render unknown language 1`] = `
+exports[`codeBlock should render unknown language after syntax highlighting 1`] = `
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <CodeBlock
+    code="\`\`\`unknownLanguage
+this is my unknown language
+it shouldn't highlight, it's just garbage
+\`\`\`
+"
+    id="randompostid"
+    language="unknownLanguage"
+  >
+    <div
+      className="post-code"
+    >
+      <div
+        className="post-code__overlay"
+      >
+        <CopyButton
+          afterCopyText="Copied"
+          content="\`\`\`unknownLanguage
+this is my unknown language
+it shouldn't highlight, it's just garbage
+\`\`\`
+"
+          placement="top"
+        >
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            delayShow={400}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="copyButton"
+                placement="right"
+              >
+                <Memo(MemoizedFormattedMessage)
+                  defaultMessage="Copy code"
+                  id="copy.code.message"
+                />
+              </Tooltip>
+            }
+            placement="top"
+            shouldUpdatePosition={true}
+            trigger={
+              Array [
+                "hover",
+                "focus",
+              ]
+            }
+          >
+            <OverlayTrigger
+              defaultOverlayShown={false}
+              delayShow={400}
+              overlay={
+                <OverlayWrapper
+                  bsClass="tooltip"
+                  id="copyButton"
+                  intl={
+                    Object {
+                      "defaultFormats": Object {},
+                      "defaultLocale": "en",
+                      "defaultRichTextElements": undefined,
+                      "formatDate": [Function],
+                      "formatDateTimeRange": [Function],
+                      "formatDateToParts": [Function],
+                      "formatDisplayName": [Function],
+                      "formatList": [Function],
+                      "formatListToParts": [Function],
+                      "formatMessage": [Function],
+                      "formatNumber": [Function],
+                      "formatNumberToParts": [Function],
+                      "formatPlural": [Function],
+                      "formatRelativeTime": [Function],
+                      "formatTime": [Function],
+                      "formatTimeToParts": [Function],
+                      "formats": Object {},
+                      "formatters": Object {
+                        "getDateTimeFormat": [Function],
+                        "getDisplayNames": [Function],
+                        "getListFormat": [Function],
+                        "getMessageFormat": [Function],
+                        "getNumberFormat": [Function],
+                        "getPluralRules": [Function],
+                        "getRelativeTimeFormat": [Function],
+                      },
+                      "locale": "en",
+                      "messages": Object {},
+                      "onError": [Function],
+                      "textComponent": Symbol(react.fragment),
+                      "timeZone": undefined,
+                      "wrapRichTextChunksInFragment": undefined,
+                    }
+                  }
+                  placement="right"
+                >
+                  <Memo(MemoizedFormattedMessage)
+                    defaultMessage="Copy code"
+                    id="copy.code.message"
+                  />
+                </OverlayWrapper>
+              }
+              placement="top"
+              shouldUpdatePosition={true}
+              trigger={
+                Array [
+                  "hover",
+                  "focus",
+                ]
+              }
+            >
+              <span
+                className="post-code__clipboard"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+              >
+                <i
+                  className="icon icon-content-copy"
+                  role="button"
+                />
+              </span>
+            </OverlayTrigger>
+          </OverlayTrigger>
+        </CopyButton>
+      </div>
+      <RootPortal>
+        <Portal
+          containerInfo={
+            <div>
+              <nav
+                class="react-contextmenu post-code__context-menu"
+                role="menu"
+                style="position: fixed; opacity: 0; pointer-events: none;"
+                tabindex="-1"
+              >
+                <div
+                  aria-disabled="false"
+                  class="react-contextmenu-item"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  Copy
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-orientation="horizontal"
+                  class="react-contextmenu-item react-contextmenu-item--divider"
+                  role="menuitem"
+                  tabindex="-1"
+                />
+                <div
+                  aria-disabled="false"
+                  class="react-contextmenu-item"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  Copy code block
+                </div>
+              </nav>
+            </div>
+          }
+        >
+          <ContextMenu
+            className="post-code__context-menu"
+            data={Object {}}
+            hideOnLeave={false}
+            id="copy-code-block-context-menu-randompostid"
+            onHide={[Function]}
+            onMouseLeave={[Function]}
+            onShow={[Function]}
+            preventHideOnContextMenu={false}
+            preventHideOnResize={false}
+            preventHideOnScroll={false}
+            rtl={false}
+            style={Object {}}
+          >
+            <nav
+              className="react-contextmenu post-code__context-menu"
+              onContextMenu={[Function]}
+              onMouseLeave={[Function]}
+              role="menu"
+              style={
+                Object {
+                  "opacity": 0,
+                  "pointerEvents": "none",
+                  "position": "fixed",
+                }
+              }
+              tabIndex="-1"
+            >
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={false}
+                key=".0"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation={null}
+                  className="react-contextmenu-item"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                >
+                  <FormattedMessage
+                    defaultMessage="Copy"
+                    id="copy.message"
+                  >
+                    Copy
+                  </FormattedMessage>
+                </div>
+              </MenuItem>
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={true}
+                key=".1"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation="horizontal"
+                  className="react-contextmenu-item react-contextmenu-item--divider"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                />
+              </MenuItem>
+              <MenuItem
+                attributes={Object {}}
+                className=""
+                data={Object {}}
+                disabled={false}
+                divider={false}
+                key=".2"
+                onClick={[Function]}
+                onMouseLeave={[Function]}
+                onMouseMove={[Function]}
+                preventClose={false}
+                selected={false}
+              >
+                <div
+                  aria-disabled="false"
+                  aria-orientation={null}
+                  className="react-contextmenu-item"
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseMove={[Function]}
+                  onTouchEnd={[Function]}
+                  role="menuitem"
+                  tabIndex="-1"
+                >
+                  <FormattedMessage
+                    defaultMessage="Copy code block"
+                    id="copy.block.message"
+                  >
+                    Copy code block
+                  </FormattedMessage>
+                </div>
+              </MenuItem>
+            </nav>
+          </ContextMenu>
+        </Portal>
+      </RootPortal>
+      <ContextMenuTrigger
+        attributes={Object {}}
+        collect={[Function]}
+        disable={false}
+        disableIfShiftIsPressed={false}
+        holdToDisplay={-1}
+        id="copy-code-block-context-menu-randompostid"
+        mouseButton={2}
+        posX={0}
+        posY={0}
+        renderTag="div"
+      >
+        <div
+          className="react-contextmenu-wrapper"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onMouseDown={[Function]}
+          onMouseOut={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+        >
+          <div
+            className="hljs"
+          >
+            <code
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "\`\`\`unknownLanguage
+this is my unknown language
+it shouldn&apos;t highlight, it&apos;s just garbage
+\`\`\`
+",
+                }
+              }
+            />
+          </div>
+        </div>
+      </ContextMenuTrigger>
+    </div>
+  </CodeBlock>
+</IntlProvider>
+`;
+
+exports[`codeBlock should render unknown language before syntax highlighting 1`] = `
 <div
   className="post-code"
 >

--- a/components/code_block/code_block.test.tsx
+++ b/components/code_block/code_block.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import React from 'react';
 import {act} from 'react-dom/test-utils';

--- a/components/code_block/code_block.test.tsx
+++ b/components/code_block/code_block.test.tsx
@@ -1,15 +1,27 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-
-import {shallow} from 'enzyme';
+import {mount, ReactWrapper, shallow} from 'enzyme';
 import React from 'react';
+import {act} from 'react-dom/test-utils';
+import {IntlProvider} from 'react-intl';
 
 import CodeBlock from './code_block';
+
+const actImmediate = (wrapper: ReactWrapper) =>
+    act(
+        () =>
+            new Promise<void>((resolve) => {
+                setImmediate(() => {
+                    wrapper.update();
+                    resolve();
+                });
+            }),
+    );
 
 describe('codeBlock', () => {
     const postId = 'randompostid';
 
-    test('should render typescript code block', () => {
+    test('should render typescript code block before syntax highlighting', async () => {
         const language = 'typescript';
         const input = `\`\`\`${language}
 const myFunction = () => {
@@ -35,7 +47,36 @@ const myFunction = () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should render html code block with proper indentation', () => {
+    test('should render typescript code block after syntax highlighting', async () => {
+        const language = 'typescript';
+        const input = `\`\`\`${language}
+const myFunction = () => {
+    console.log('This is a meaningful function');
+};
+\`\`\`
+`;
+
+        const wrapper = mount(
+            <IntlProvider locale='en'>
+                <CodeBlock
+                    id={postId}
+                    code={input}
+                    language={language}
+                />
+            </IntlProvider>,
+        );
+        await actImmediate(wrapper);
+
+        const languageHeader = wrapper.find('span.post-code__language').text();
+        const lineNumbersDiv = wrapper.find('.post-code__line-numbers').exists();
+
+        expect(languageHeader).toEqual('TypeScript');
+        expect(lineNumbersDiv).toBeTruthy();
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render html code block with proper indentation before syntax highlighting', () => {
         const language = 'html';
         const input = `\`\`\`${language}
 <div className='myClass'>
@@ -60,7 +101,35 @@ const myFunction = () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should render unknown language', () => {
+    test('should render html code block with proper indentation after syntax highlighting', async () => {
+        const language = 'html';
+        const input = `\`\`\`${language}
+<div className='myClass'>
+  <a href='https://randomgibberishurl.com'>ClickMe</a>
+</div>
+\`\`\`
+`;
+
+        const wrapper = mount(
+            <IntlProvider locale='en'>
+                <CodeBlock
+                    id={postId}
+                    code={input}
+                    language={language}
+                />
+            </IntlProvider>,
+        );
+        await actImmediate(wrapper);
+
+        const languageHeader = wrapper.find('span.post-code__language').text();
+        const lineNumbersDiv = wrapper.find('.post-code__line-numbers').exists();
+
+        expect(languageHeader).toEqual('HTML, XML');
+        expect(lineNumbersDiv).toBeTruthy();
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render unknown language before syntax highlighting', () => {
         const language = 'unknownLanguage';
         const input = `\`\`\`${language}
 this is my unknown language
@@ -75,6 +144,33 @@ it shouldn't highlight, it's just garbage
                 language={language}
             />,
         );
+
+        const languageHeader = wrapper.find('span.post-code__language').exists();
+        const lineNumbersDiv = wrapper.find('.post-code__line-numbers').exists();
+
+        expect(languageHeader).toBeFalsy();
+        expect(lineNumbersDiv).toBeFalsy();
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render unknown language after syntax highlighting', async () => {
+        const language = 'unknownLanguage';
+        const input = `\`\`\`${language}
+this is my unknown language
+it shouldn't highlight, it's just garbage
+\`\`\`
+`;
+
+        const wrapper = mount(
+            <IntlProvider locale='en'>
+                <CodeBlock
+                    id={postId}
+                    code={input}
+                    language={language}
+                />
+            </IntlProvider>,
+        );
+        await actImmediate(wrapper);
 
         const languageHeader = wrapper.find('span.post-code__language').exists();
         const lineNumbersDiv = wrapper.find('.post-code__line-numbers').exists();

--- a/components/code_block/code_block.tsx
+++ b/components/code_block/code_block.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import React, {useCallback, useEffect, useState} from 'react';
 
 import {ContextMenu, ContextMenuTrigger, MenuItem} from 'react-contextmenu';

--- a/components/code_block/code_block.tsx
+++ b/components/code_block/code_block.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {ContextMenu, ContextMenuTrigger, MenuItem} from 'react-contextmenu';
 
@@ -13,6 +12,8 @@ import * as SyntaxHighlighting from 'utils/syntax_highlighting';
 
 import RootPortal from 'components/root_portal';
 import {copyToClipboard} from 'utils/utils';
+
+import * as TextFormatting from 'utils/text_formatting';
 
 type Props = {
     id: string;
@@ -63,7 +64,10 @@ const CodeBlock: React.FC<Props> = ({id, code, language, searchedContent}: Props
     // If we have to apply syntax highlighting AND highlighting of search terms, create two copies
     // of the code block, one with syntax highlighting applied and another with invisible text, but
     // search term highlighting and overlap them
-    const content = SyntaxHighlighting.highlight(usedLanguage, code);
+    const [content, setContent] = useState(TextFormatting.sanitizeHtml(code));
+    useEffect(() => {
+        SyntaxHighlighting.highlight(usedLanguage, code).then((content) => setContent(content));
+    }, [usedLanguage, code]);
 
     let htmlContent = content;
     if (searchedContent) {

--- a/components/code_preview.tsx
+++ b/components/code_preview.tsx
@@ -23,6 +23,7 @@ type Props = {
 type State = {
     code: string;
     lang: string;
+    highlighted: string;
     loading: boolean;
     success: boolean;
     prevFileUrl?: string;
@@ -88,7 +89,7 @@ export default class CodePreview extends React.PureComponent<Props, State> {
         }
     }
 
-    handleReceivedCode = (data: string | Node) => {
+    handleReceivedCode = async (data: string | Node) => {
         let code = data as string;
         const Data = data as Node;
         if (Data.nodeName === '#document') {

--- a/components/code_preview.tsx
+++ b/components/code_preview.tsx
@@ -35,6 +35,7 @@ export default class CodePreview extends React.PureComponent<Props, State> {
         this.state = {
             code: '',
             lang: '',
+            highlighted: '',
             loading: true,
             success: true,
         };
@@ -96,6 +97,7 @@ export default class CodePreview extends React.PureComponent<Props, State> {
         this.props.getContent?.(code);
         this.setState({
             code,
+            highlighted: await SyntaxHighlighting.highlight(this.state.lang, code),
             loading: false,
             success: true,
         });
@@ -129,8 +131,6 @@ export default class CodePreview extends React.PureComponent<Props, State> {
 
         const language = SyntaxHighlighting.getLanguageName(this.state.lang);
 
-        const highlighted = SyntaxHighlighting.highlight(this.state.lang, this.state.code);
-
         return (
             <div className='post-code code-preview'>
                 <span className='post-code__language'>
@@ -140,7 +140,7 @@ export default class CodePreview extends React.PureComponent<Props, State> {
                     <div className='post-code__line-numbers'>
                         {SyntaxHighlighting.renderLineNumbers(this.state.code)}
                     </div>
-                    <code dangerouslySetInnerHTML={{__html: highlighted}}/>
+                    <code dangerouslySetInnerHTML={{__html: this.state.highlighted}}/>
                 </div>
             </div>
         );

--- a/utils/syntax_highlighting.test.ts
+++ b/utils/syntax_highlighting.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import hlJS from 'highlight.js/lib/core';
+import swift from 'highlight.js/lib/languages/swift';
+import javascript from 'highlight.js/lib/languages/javascript';
+
+import {highlight} from './syntax_highlighting';
+
+jest.mock('highlight.js/lib/core', () => {
+    const originalModule = jest.requireActual('highlight.js/lib/core');
+    return {
+        __esModule: true,
+        ...originalModule,
+        default: {
+            ...originalModule.default,
+            highlight: jest.fn(() => ({value: ''})),
+            registerLanguage: jest.fn(),
+        },
+    };
+});
+
+describe('utils/syntax_highlighting.tsx', () => {
+    it('should register full name language', async () => {
+        await highlight('swift', '');
+
+        expect(hlJS.registerLanguage).toHaveBeenCalledWith('swift', swift);
+    });
+
+    it('should register alias language', async () => {
+        await highlight('js', '');
+
+        expect(hlJS.registerLanguage).toHaveBeenCalledWith('javascript', javascript);
+    });
+});

--- a/utils/syntax_highlighting.test.ts
+++ b/utils/syntax_highlighting.test.ts
@@ -7,27 +7,20 @@ import javascript from 'highlight.js/lib/languages/javascript';
 
 import {highlight} from './syntax_highlighting';
 
-jest.mock('highlight.js/lib/core', () => {
-    const originalModule = jest.requireActual('highlight.js/lib/core');
-    return {
-        __esModule: true,
-        ...originalModule,
-        default: {
-            ...originalModule.default,
-            highlight: jest.fn(() => ({value: ''})),
-            registerLanguage: jest.fn(),
-        },
-    };
-});
+jest.mock('highlight.js/lib/core');
 
 describe('utils/syntax_highlighting.tsx', () => {
     it('should register full name language', async () => {
+        expect.assertions(1);
+
         await highlight('swift', '');
 
         expect(hlJS.registerLanguage).toHaveBeenCalledWith('swift', swift);
     });
 
     it('should register alias language', async () => {
+        expect.assertions(1);
+
         await highlight('js', '');
 
         expect(hlJS.registerLanguage).toHaveBeenCalledWith('javascript', javascript);

--- a/utils/syntax_highlighting.tsx
+++ b/utils/syntax_highlighting.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {LanguageFn} from 'highlight.js';
 import hlJS from 'highlight.js/lib/core';
 
 import * as TextFormatting from 'utils/text_formatting';
@@ -82,201 +81,79 @@ function getLanguageFromNameOrAlias(name: string) {
 }
 
 async function registerLanguage(languageName: string) {
-    let language: LanguageFn | undefined;
-    switch (languageName) {
-    case '1c':
-        language = (await import('highlight.js/lib/languages/1c')).default;
-        break;
-    case 'actionscript':
-        language = (await import('highlight.js/lib/languages/actionscript')).default;
-        break;
-    case 'applescript':
-        language = (await import('highlight.js/lib/languages/applescript')).default;
-        break;
-    case 'bash':
-        language = (await import('highlight.js/lib/languages/bash')).default;
-        break;
-    case 'clojure':
-        language = (await import('highlight.js/lib/languages/clojure')).default;
-        break;
-    case 'coffeescript':
-        language = (await import('highlight.js/lib/languages/coffeescript')).default;
-        break;
-    case 'cpp':
-        language = (await import('highlight.js/lib/languages/cpp')).default;
-        break;
-    case 'csharp':
-        language = (await import('highlight.js/lib/languages/csharp')).default;
-        break;
-    case 'css':
-        language = (await import('highlight.js/lib/languages/css')).default;
-        break;
-    case 'd':
-        language = (await import('highlight.js/lib/languages/d')).default;
-        break;
-    case 'dart':
-        language = (await import('highlight.js/lib/languages/dart')).default;
-        break;
-    case 'delphi':
-        language = (await import('highlight.js/lib/languages/delphi')).default;
-        break;
-    case 'diff':
-        language = (await import('highlight.js/lib/languages/diff')).default;
-        break;
-    case 'django':
-        language = (await import('highlight.js/lib/languages/django')).default;
-        break;
-    case 'dockerfile':
-        language = (await import('highlight.js/lib/languages/dockerfile')).default;
-        break;
-    case 'elixir':
-        language = (await import('highlight.js/lib/languages/elixir')).default;
-        break;
-    case 'erlang':
-        language = (await import('highlight.js/lib/languages/erlang')).default;
-        break;
-    case 'fortran':
-        language = (await import('highlight.js/lib/languages/fortran')).default;
-        break;
-    case 'fsharp':
-        language = (await import('highlight.js/lib/languages/fsharp')).default;
-        break;
-    case 'gcode':
-        language = (await import('highlight.js/lib/languages/gcode')).default;
-        break;
-    case 'go':
-        language = (await import('highlight.js/lib/languages/go')).default;
-        break;
-    case 'groovy':
-        language = (await import('highlight.js/lib/languages/groovy')).default;
-        break;
-    case 'handlebars':
-        language = (await import('highlight.js/lib/languages/handlebars')).default;
-        break;
-    case 'haskell':
-        language = (await import('highlight.js/lib/languages/haskell')).default;
-        break;
-    case 'haxe':
-        language = (await import('highlight.js/lib/languages/haxe')).default;
-        break;
-    case 'java':
-        language = (await import('highlight.js/lib/languages/java')).default;
-        break;
-    case 'javascript':
-        language = (await import('highlight.js/lib/languages/javascript')).default;
-        break;
-    case 'json':
-        language = (await import('highlight.js/lib/languages/json')).default;
-        break;
-    case 'julia':
-        language = (await import('highlight.js/lib/languages/julia')).default;
-        break;
-    case 'kotlin':
-        language = (await import('highlight.js/lib/languages/kotlin')).default;
-        break;
-    case 'latex':
-        language = (await import('highlight.js/lib/languages/latex')).default;
-        break;
-    case 'less':
-        language = (await import('highlight.js/lib/languages/less')).default;
-        break;
-    case 'lisp':
-        language = (await import('highlight.js/lib/languages/lisp')).default;
-        break;
-    case 'lua':
-        language = (await import('highlight.js/lib/languages/lua')).default;
-        break;
-    case 'makefile':
-        language = (await import('highlight.js/lib/languages/makefile')).default;
-        break;
-    case 'markdown':
-        language = (await import('highlight.js/lib/languages/markdown')).default;
-        break;
-    case 'matlab':
-        language = (await import('highlight.js/lib/languages/matlab')).default;
-        break;
-    case 'objectivec':
-        language = (await import('highlight.js/lib/languages/objectivec')).default;
-        break;
-    case 'ocaml':
-        language = (await import('highlight.js/lib/languages/ocaml')).default;
-        break;
-    case 'perl':
-        language = (await import('highlight.js/lib/languages/perl')).default;
-        break;
-    case 'pgsql':
-        language = (await import('highlight.js/lib/languages/pgsql')).default;
-        break;
-    case 'php':
-        language = (await import('highlight.js/lib/languages/php')).default;
-        break;
-    case 'plaintext':
-        language = (await import('highlight.js/lib/languages/plaintext')).default;
-        break;
-    case 'powershell':
-        language = (await import('highlight.js/lib/languages/powershell')).default;
-        break;
-    case 'puppet':
-        language = (await import('highlight.js/lib/languages/puppet')).default;
-        break;
-    case 'python':
-        language = (await import('highlight.js/lib/languages/python')).default;
-        break;
-    case 'r':
-        language = (await import('highlight.js/lib/languages/r')).default;
-        break;
-    case 'ruby':
-        language = (await import('highlight.js/lib/languages/ruby')).default;
-        break;
-    case 'rust':
-        language = (await import('highlight.js/lib/languages/rust')).default;
-        break;
-    case 'scala':
-        language = (await import('highlight.js/lib/languages/scala')).default;
-        break;
-    case 'scheme':
-        language = (await import('highlight.js/lib/languages/scheme')).default;
-        break;
-    case 'scss':
-        language = (await import('highlight.js/lib/languages/scss')).default;
-        break;
-    case 'smalltalk':
-        language = (await import('highlight.js/lib/languages/smalltalk')).default;
-        break;
-    case 'sql':
-        language = (await import('highlight.js/lib/languages/sql')).default;
-        break;
-    case 'stylus':
-        language = (await import('highlight.js/lib/languages/stylus')).default;
-        break;
-    case 'swift':
-        language = (await import('highlight.js/lib/languages/swift')).default;
-        break;
-    case 'typescript':
-        language = (await import('highlight.js/lib/languages/typescript')).default;
-        break;
-    case 'vbnet':
-        language = (await import('highlight.js/lib/languages/vbnet')).default;
-        break;
-    case 'vbscript':
-        language = (await import('highlight.js/lib/languages/vbscript')).default;
-        break;
-    case 'verilog':
-        language = (await import('highlight.js/lib/languages/verilog')).default;
-        break;
-    case 'vhdl':
-        language = (await import('highlight.js/lib/languages/vhdl')).default;
-        break;
-    case 'xml':
-        language = (await import('highlight.js/lib/languages/xml')).default;
-        break;
-    case 'yaml':
-        language = (await import('highlight.js/lib/languages/yaml')).default;
-        break;
-    }
+    const languageImports: {
+        [key: string]: any;
+    } = {
+        '1c': () => import('highlight.js/lib/languages/1c'),
+        actionscript: () => import('highlight.js/lib/languages/actionscript'),
+        applescript: () => import('highlight.js/lib/languages/applescript'),
+        bash: () => import('highlight.js/lib/languages/bash'),
+        clojure: () => import('highlight.js/lib/languages/clojure'),
+        coffeescript: () => import('highlight.js/lib/languages/coffeescript'),
+        cpp: () => import('highlight.js/lib/languages/cpp'),
+        csharp: () => import('highlight.js/lib/languages/csharp'),
+        css: () => import('highlight.js/lib/languages/css'),
+        d: () => import('highlight.js/lib/languages/d'),
+        dart: () => import('highlight.js/lib/languages/dart'),
+        delphi: () => import('highlight.js/lib/languages/delphi'),
+        diff: () => import('highlight.js/lib/languages/diff'),
+        django: () => import('highlight.js/lib/languages/django'),
+        dockerfile: () => import('highlight.js/lib/languages/dockerfile'),
+        elixir: () => import('highlight.js/lib/languages/elixir'),
+        erlang: () => import('highlight.js/lib/languages/erlang'),
+        fortran: () => import('highlight.js/lib/languages/fortran'),
+        fsharp: () => import('highlight.js/lib/languages/fsharp'),
+        gcode: () => import('highlight.js/lib/languages/gcode'),
+        go: () => import('highlight.js/lib/languages/go'),
+        groovy: () => import('highlight.js/lib/languages/groovy'),
+        handlebars: () => import('highlight.js/lib/languages/handlebars'),
+        haskell: () => import('highlight.js/lib/languages/haskell'),
+        haxe: () => import('highlight.js/lib/languages/haxe'),
+        java: () => import('highlight.js/lib/languages/java'),
+        javascript: () => import('highlight.js/lib/languages/javascript'),
+        json: () => import('highlight.js/lib/languages/json'),
+        julia: () => import('highlight.js/lib/languages/julia'),
+        kotlin: () => import('highlight.js/lib/languages/kotlin'),
+        latex: () => import('highlight.js/lib/languages/latex'),
+        less: () => import('highlight.js/lib/languages/less'),
+        lisp: () => import('highlight.js/lib/languages/lisp'),
+        lua: () => import('highlight.js/lib/languages/lua'),
+        makefile: () => import('highlight.js/lib/languages/makefile'),
+        markdown: () => import('highlight.js/lib/languages/markdown'),
+        matlab: () => import('highlight.js/lib/languages/matlab'),
+        objectivec: () => import('highlight.js/lib/languages/objectivec'),
+        ocaml: () => import('highlight.js/lib/languages/ocaml'),
+        perl: () => import('highlight.js/lib/languages/perl'),
+        pgsql: () => import('highlight.js/lib/languages/pgsql'),
+        php: () => import('highlight.js/lib/languages/php'),
+        plaintext: () => import('highlight.js/lib/languages/plaintext'),
+        powershell: () => import('highlight.js/lib/languages/powershell'),
+        puppet: () => import('highlight.js/lib/languages/puppet'),
+        python: () => import('highlight.js/lib/languages/python'),
+        r: () => import('highlight.js/lib/languages/r'),
+        ruby: () => import('highlight.js/lib/languages/ruby'),
+        rust: () => import('highlight.js/lib/languages/rust'),
+        scala: () => import('highlight.js/lib/languages/scala'),
+        scheme: () => import('highlight.js/lib/languages/scheme'),
+        scss: () => import('highlight.js/lib/languages/scss'),
+        smalltalk: () => import('highlight.js/lib/languages/smalltalk'),
+        sql: () => import('highlight.js/lib/languages/sql'),
+        stylus: () => import('highlight.js/lib/languages/stylus'),
+        swift: () => import('highlight.js/lib/languages/swift'),
+        typescript: () => import('highlight.js/lib/languages/typescript'),
+        vbnet: () => import('highlight.js/lib/languages/vbnet'),
+        vbscript: () => import('highlight.js/lib/languages/vbscript'),
+        verilog: () => import('highlight.js/lib/languages/verilog'),
+        vhdl: () => import('highlight.js/lib/languages/vhdl'),
+        xml: () => import('highlight.js/lib/languages/xml'),
+        yaml: () => import('highlight.js/lib/languages/yaml'),
+    };
 
-    if (!language) {
+    if (!languageImports[languageName]) {
         return;
     }
+
+    const language = (await languageImports[languageName]()).default;
+
     hlJS.registerLanguage(languageName, language);
 }

--- a/utils/syntax_highlighting.tsx
+++ b/utils/syntax_highlighting.tsx
@@ -1,137 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {LanguageFn} from 'highlight.js';
 import hlJS from 'highlight.js/lib/core';
-import oneC from 'highlight.js/lib/languages/1c';
-import actionscript from 'highlight.js/lib/languages/actionscript';
-import applescript from 'highlight.js/lib/languages/applescript';
-import bash from 'highlight.js/lib/languages/bash';
-import clojure from 'highlight.js/lib/languages/clojure';
-import coffeescript from 'highlight.js/lib/languages/coffeescript';
-import cpp from 'highlight.js/lib/languages/cpp';
-import csharp from 'highlight.js/lib/languages/csharp';
-import css from 'highlight.js/lib/languages/css';
-import d from 'highlight.js/lib/languages/d';
-import dart from 'highlight.js/lib/languages/dart';
-import delphi from 'highlight.js/lib/languages/delphi';
-import diff from 'highlight.js/lib/languages/diff';
-import django from 'highlight.js/lib/languages/django';
-import dockerfile from 'highlight.js/lib/languages/dockerfile';
-import elixir from 'highlight.js/lib/languages/elixir';
-import erlang from 'highlight.js/lib/languages/erlang';
-import fortran from 'highlight.js/lib/languages/fortran';
-import fsharp from 'highlight.js/lib/languages/fsharp';
-import gcode from 'highlight.js/lib/languages/gcode';
-import go from 'highlight.js/lib/languages/go';
-import groovy from 'highlight.js/lib/languages/groovy';
-import handlebars from 'highlight.js/lib/languages/handlebars';
-import haskell from 'highlight.js/lib/languages/haskell';
-import haxe from 'highlight.js/lib/languages/haxe';
-import java from 'highlight.js/lib/languages/java';
-import javascript from 'highlight.js/lib/languages/javascript';
-import json from 'highlight.js/lib/languages/json';
-import julia from 'highlight.js/lib/languages/julia';
-import kotlin from 'highlight.js/lib/languages/kotlin';
-import latex from 'highlight.js/lib/languages/latex';
-import less from 'highlight.js/lib/languages/less';
-import lisp from 'highlight.js/lib/languages/lisp';
-import lua from 'highlight.js/lib/languages/lua';
-import makefile from 'highlight.js/lib/languages/makefile';
-import markdown from 'highlight.js/lib/languages/markdown';
-import matlab from 'highlight.js/lib/languages/matlab';
-import objectivec from 'highlight.js/lib/languages/objectivec';
-import ocaml from 'highlight.js/lib/languages/ocaml';
-import perl from 'highlight.js/lib/languages/perl';
-import pgsql from 'highlight.js/lib/languages/pgsql';
-import php from 'highlight.js/lib/languages/php';
-import powershell from 'highlight.js/lib/languages/powershell';
-import puppet from 'highlight.js/lib/languages/puppet';
-import python from 'highlight.js/lib/languages/python';
-import r from 'highlight.js/lib/languages/r';
-import ruby from 'highlight.js/lib/languages/ruby';
-import rust from 'highlight.js/lib/languages/rust';
-import scala from 'highlight.js/lib/languages/scala';
-import scheme from 'highlight.js/lib/languages/scheme';
-import scss from 'highlight.js/lib/languages/scss';
-import smalltalk from 'highlight.js/lib/languages/smalltalk';
-import sql from 'highlight.js/lib/languages/sql';
-import stylus from 'highlight.js/lib/languages/stylus';
-import swift from 'highlight.js/lib/languages/swift';
-import plaintext from 'highlight.js/lib/languages/plaintext';
-import typescript from 'highlight.js/lib/languages/typescript';
-import vbnet from 'highlight.js/lib/languages/vbnet';
-import vbscript from 'highlight.js/lib/languages/vbscript';
-import verilog from 'highlight.js/lib/languages/verilog';
-import vhdl from 'highlight.js/lib/languages/vhdl';
-import xml from 'highlight.js/lib/languages/xml';
-import yaml from 'highlight.js/lib/languages/yaml';
 
-hlJS.registerLanguage('1c', oneC);
-hlJS.registerLanguage('actionscript', actionscript);
-hlJS.registerLanguage('applescript', applescript);
-hlJS.registerLanguage('bash', bash);
-hlJS.registerLanguage('clojure', clojure);
-hlJS.registerLanguage('coffeescript', coffeescript);
-hlJS.registerLanguage('cpp', cpp);
-hlJS.registerLanguage('csharp', csharp);
-hlJS.registerLanguage('css', css);
-hlJS.registerLanguage('d', d);
-hlJS.registerLanguage('dart', dart);
-hlJS.registerLanguage('delphi', delphi);
-hlJS.registerLanguage('diff', diff);
-hlJS.registerLanguage('django', django);
-hlJS.registerLanguage('dockerfile', dockerfile);
-hlJS.registerLanguage('elixir', elixir);
-hlJS.registerLanguage('erlang', erlang);
-hlJS.registerLanguage('fortran', fortran);
-hlJS.registerLanguage('fsharp', fsharp);
-hlJS.registerLanguage('gcode', gcode);
-hlJS.registerLanguage('go', go);
-hlJS.registerLanguage('groovy', groovy);
-hlJS.registerLanguage('handlebars', handlebars);
-hlJS.registerLanguage('haskell', haskell);
-hlJS.registerLanguage('haxe', haxe);
-hlJS.registerLanguage('java', java);
-hlJS.registerLanguage('javascript', javascript);
-hlJS.registerLanguage('json', json);
-hlJS.registerLanguage('julia', julia);
-hlJS.registerLanguage('kotlin', kotlin);
-hlJS.registerLanguage('latex', latex);
-hlJS.registerLanguage('less', less);
-hlJS.registerLanguage('lisp', lisp);
-hlJS.registerLanguage('lua', lua);
-hlJS.registerLanguage('makefile', makefile);
-hlJS.registerLanguage('markdown', markdown);
-hlJS.registerLanguage('matlab', matlab);
-hlJS.registerLanguage('objectivec', objectivec);
-hlJS.registerLanguage('ocaml', ocaml);
-hlJS.registerLanguage('perl', perl);
-hlJS.registerLanguage('pgsql', pgsql);
-hlJS.registerLanguage('php', php);
-hlJS.registerLanguage('plaintext', plaintext);
-hlJS.registerLanguage('powershell', powershell);
-hlJS.registerLanguage('puppet', puppet);
-hlJS.registerLanguage('python', python);
-hlJS.registerLanguage('r', r);
-hlJS.registerLanguage('ruby', ruby);
-hlJS.registerLanguage('rust', rust);
-hlJS.registerLanguage('scala', scala);
-hlJS.registerLanguage('scheme', scheme);
-hlJS.registerLanguage('scss', scss);
-hlJS.registerLanguage('smalltalk', smalltalk);
-hlJS.registerLanguage('sql', sql);
-hlJS.registerLanguage('stylus', stylus);
-hlJS.registerLanguage('swift', swift);
-hlJS.registerLanguage('typescript', typescript);
-hlJS.registerLanguage('vbnet', vbnet);
-hlJS.registerLanguage('vbscript', vbscript);
-hlJS.registerLanguage('verilog', verilog);
-hlJS.registerLanguage('vhdl', vhdl);
-hlJS.registerLanguage('xml', xml);
-hlJS.registerLanguage('yaml', yaml);
+import * as TextFormatting from 'utils/text_formatting';
 
 import Constants from './constants';
-import * as TextFormatting from './text_formatting';
 
 type LanguageObject = {
     [key: string]: {
@@ -143,11 +18,12 @@ type LanguageObject = {
 
 const HighlightedLanguages: LanguageObject = Constants.HighlightedLanguages;
 
-export function highlight(lang: string, code: string) {
+export async function highlight(lang: string, code: string) {
     const language = getLanguageFromNameOrAlias(lang);
 
     if (language) {
         try {
+            await registerLanguage(language);
             return hlJS.highlight(code, {language}).value;
         } catch (e) {
             // fall through if highlighting fails and handle below
@@ -203,4 +79,204 @@ function getLanguageFromNameOrAlias(name: string) {
         const aliases = HighlightedLanguages[key].aliases;
         return aliases && aliases.find((a) => a === langName);
     });
+}
+
+async function registerLanguage(languageName: string) {
+    let language: LanguageFn | undefined;
+    switch (languageName) {
+    case '1c':
+        language = (await import('highlight.js/lib/languages/1c')).default;
+        break;
+    case 'actionscript':
+        language = (await import('highlight.js/lib/languages/actionscript')).default;
+        break;
+    case 'applescript':
+        language = (await import('highlight.js/lib/languages/applescript')).default;
+        break;
+    case 'bash':
+        language = (await import('highlight.js/lib/languages/bash')).default;
+        break;
+    case 'clojure':
+        language = (await import('highlight.js/lib/languages/clojure')).default;
+        break;
+    case 'coffeescript':
+        language = (await import('highlight.js/lib/languages/coffeescript')).default;
+        break;
+    case 'cpp':
+        language = (await import('highlight.js/lib/languages/cpp')).default;
+        break;
+    case 'csharp':
+        language = (await import('highlight.js/lib/languages/csharp')).default;
+        break;
+    case 'css':
+        language = (await import('highlight.js/lib/languages/css')).default;
+        break;
+    case 'd':
+        language = (await import('highlight.js/lib/languages/d')).default;
+        break;
+    case 'dart':
+        language = (await import('highlight.js/lib/languages/dart')).default;
+        break;
+    case 'delphi':
+        language = (await import('highlight.js/lib/languages/delphi')).default;
+        break;
+    case 'diff':
+        language = (await import('highlight.js/lib/languages/diff')).default;
+        break;
+    case 'django':
+        language = (await import('highlight.js/lib/languages/django')).default;
+        break;
+    case 'dockerfile':
+        language = (await import('highlight.js/lib/languages/dockerfile')).default;
+        break;
+    case 'elixir':
+        language = (await import('highlight.js/lib/languages/elixir')).default;
+        break;
+    case 'erlang':
+        language = (await import('highlight.js/lib/languages/erlang')).default;
+        break;
+    case 'fortran':
+        language = (await import('highlight.js/lib/languages/fortran')).default;
+        break;
+    case 'fsharp':
+        language = (await import('highlight.js/lib/languages/fsharp')).default;
+        break;
+    case 'gcode':
+        language = (await import('highlight.js/lib/languages/gcode')).default;
+        break;
+    case 'go':
+        language = (await import('highlight.js/lib/languages/go')).default;
+        break;
+    case 'groovy':
+        language = (await import('highlight.js/lib/languages/groovy')).default;
+        break;
+    case 'handlebars':
+        language = (await import('highlight.js/lib/languages/handlebars')).default;
+        break;
+    case 'haskell':
+        language = (await import('highlight.js/lib/languages/haskell')).default;
+        break;
+    case 'haxe':
+        language = (await import('highlight.js/lib/languages/haxe')).default;
+        break;
+    case 'java':
+        language = (await import('highlight.js/lib/languages/java')).default;
+        break;
+    case 'javascript':
+        language = (await import('highlight.js/lib/languages/javascript')).default;
+        break;
+    case 'json':
+        language = (await import('highlight.js/lib/languages/json')).default;
+        break;
+    case 'julia':
+        language = (await import('highlight.js/lib/languages/julia')).default;
+        break;
+    case 'kotlin':
+        language = (await import('highlight.js/lib/languages/kotlin')).default;
+        break;
+    case 'latex':
+        language = (await import('highlight.js/lib/languages/latex')).default;
+        break;
+    case 'less':
+        language = (await import('highlight.js/lib/languages/less')).default;
+        break;
+    case 'lisp':
+        language = (await import('highlight.js/lib/languages/lisp')).default;
+        break;
+    case 'lua':
+        language = (await import('highlight.js/lib/languages/lua')).default;
+        break;
+    case 'makefile':
+        language = (await import('highlight.js/lib/languages/makefile')).default;
+        break;
+    case 'markdown':
+        language = (await import('highlight.js/lib/languages/markdown')).default;
+        break;
+    case 'matlab':
+        language = (await import('highlight.js/lib/languages/matlab')).default;
+        break;
+    case 'objectivec':
+        language = (await import('highlight.js/lib/languages/objectivec')).default;
+        break;
+    case 'ocaml':
+        language = (await import('highlight.js/lib/languages/ocaml')).default;
+        break;
+    case 'perl':
+        language = (await import('highlight.js/lib/languages/perl')).default;
+        break;
+    case 'pgsql':
+        language = (await import('highlight.js/lib/languages/pgsql')).default;
+        break;
+    case 'php':
+        language = (await import('highlight.js/lib/languages/php')).default;
+        break;
+    case 'plaintext':
+        language = (await import('highlight.js/lib/languages/plaintext')).default;
+        break;
+    case 'powershell':
+        language = (await import('highlight.js/lib/languages/powershell')).default;
+        break;
+    case 'puppet':
+        language = (await import('highlight.js/lib/languages/puppet')).default;
+        break;
+    case 'python':
+        language = (await import('highlight.js/lib/languages/python')).default;
+        break;
+    case 'r':
+        language = (await import('highlight.js/lib/languages/r')).default;
+        break;
+    case 'ruby':
+        language = (await import('highlight.js/lib/languages/ruby')).default;
+        break;
+    case 'rust':
+        language = (await import('highlight.js/lib/languages/rust')).default;
+        break;
+    case 'scala':
+        language = (await import('highlight.js/lib/languages/scala')).default;
+        break;
+    case 'scheme':
+        language = (await import('highlight.js/lib/languages/scheme')).default;
+        break;
+    case 'scss':
+        language = (await import('highlight.js/lib/languages/scss')).default;
+        break;
+    case 'smalltalk':
+        language = (await import('highlight.js/lib/languages/smalltalk')).default;
+        break;
+    case 'sql':
+        language = (await import('highlight.js/lib/languages/sql')).default;
+        break;
+    case 'stylus':
+        language = (await import('highlight.js/lib/languages/stylus')).default;
+        break;
+    case 'swift':
+        language = (await import('highlight.js/lib/languages/swift')).default;
+        break;
+    case 'typescript':
+        language = (await import('highlight.js/lib/languages/typescript')).default;
+        break;
+    case 'vbnet':
+        language = (await import('highlight.js/lib/languages/vbnet')).default;
+        break;
+    case 'vbscript':
+        language = (await import('highlight.js/lib/languages/vbscript')).default;
+        break;
+    case 'verilog':
+        language = (await import('highlight.js/lib/languages/verilog')).default;
+        break;
+    case 'vhdl':
+        language = (await import('highlight.js/lib/languages/vhdl')).default;
+        break;
+    case 'xml':
+        language = (await import('highlight.js/lib/languages/xml')).default;
+        break;
+    case 'yaml':
+        language = (await import('highlight.js/lib/languages/yaml')).default;
+        break;
+    }
+
+    if (!language) {
+        return;
+    }
+    hlJS.registerLanguage(languageName, language);
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Load language libraries of highlight.js on demands to reduce bundle size.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/14029
Jira: https://mattermost.atlassian.net/browse/MM-22249

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
No related PRs.

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

No UI changes.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
