### PR TITLE
[#21315]: migrated custom status tests to typescript

### DIFF
--- a/e2e/cypress/package-lock.json
+++ b/e2e/cypress/package-lock.json
@@ -45,6 +45,7 @@
         "localforage": "1.10.0",
         "lodash.intersection": "4.4.0",
         "lodash.mapkeys": "4.6.0",
+        "lodash.set": "^4.3.2",
         "lodash.without": "4.4.0",
         "lodash.xor": "4.5.0",
         "mattermost-redux": "5.33.1",
@@ -8603,6 +8604,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true
     },
     "node_modules/lodash.throttle": {
@@ -21014,6 +21021,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true
     },
     "lodash.throttle": {

--- a/e2e/cypress/package.json
+++ b/e2e/cypress/package.json
@@ -40,6 +40,7 @@
     "localforage": "1.10.0",
     "lodash.intersection": "4.4.0",
     "lodash.mapkeys": "4.6.0",
+    "lodash.set": "^4.3.2",
     "lodash.without": "4.4.0",
     "lodash.xor": "4.5.0",
     "mattermost-redux": "5.33.1",

--- a/e2e/cypress/package.json
+++ b/e2e/cypress/package.json
@@ -40,7 +40,7 @@
     "localforage": "1.10.0",
     "lodash.intersection": "4.4.0",
     "lodash.mapkeys": "4.6.0",
-    "lodash.set": "^4.3.2",
+    "lodash.set": "4.3.2",
     "lodash.without": "4.4.0",
     "lodash.xor": "4.5.0",
     "mattermost-redux": "5.33.1",

--- a/e2e/cypress/tests/integration/custom_status/custom_status_1_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_1_spec.ts
@@ -10,13 +10,18 @@
 // Stage: @prod
 // Group: @custom_status
 
+import {set} from 'lodash';
+
 describe('Custom Status - CTAs for New Users', () => {
     before(() => {
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+        cy.apiGetConfig().then((config) => {
+            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
+            cy.apiUpdateConfig(config);
 
-        // # Login as test user and visit channel
-        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
-            cy.visit(`/${team.name}/channels/${channel.name}`);
+            // # Login as test user and visit channel
+            cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+                cy.visit(`/${team.name}/channels/${channel.name}`);
+            });
         });
     });
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_1_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_1_spec.ts
@@ -10,11 +10,11 @@
 // Stage: @prod
 // Group: @custom_status
 
-import {set} from 'lodash';
+import set from 'lodash.set';
 
 describe('Custom Status - CTAs for New Users', () => {
     before(() => {
-        cy.apiGetConfig().then((config) => {
+        cy.apiGetConfig().then(({config}) => {
             set(config, 'TeamSettings.EnableCustomUserStatuses', true);
             cy.apiUpdateConfig(config);
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_2_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_2_spec.ts
@@ -10,11 +10,11 @@
 // Stage: @prod
 // Group: @custom_status
 
-import {set} from 'lodash';
+import set from 'lodash.set';
 
 describe('Custom Status - Setting a Custom Status', () => {
     before(() => {
-        cy.apiGetConfig().then((config) => {
+        cy.apiGetConfig().then(({config}) => {
             set(config, 'TeamSettings.EnableCustomUserStatuses', true);
             cy.apiUpdateConfig(config);
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_2_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_2_spec.ts
@@ -10,13 +10,18 @@
 // Stage: @prod
 // Group: @custom_status
 
+import {set} from 'lodash';
+
 describe('Custom Status - Setting a Custom Status', () => {
     before(() => {
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+        cy.apiGetConfig().then((config) => {
+            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
+            cy.apiUpdateConfig(config);
 
-        // # Login as test user and visit channel
-        cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
-            cy.visit(channelUrl);
+            // # Login as test user and visit channel
+            cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
+                cy.visit(channelUrl);
+            });
         });
     });
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_3_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_3_spec.ts
@@ -10,13 +10,18 @@
 // Stage: @prod
 // Group: @custom_status
 
+import {set} from 'lodash';
+
 describe('Custom Status - Setting Your Own Custom Status', () => {
     before(() => {
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+        cy.apiGetConfig().then((config) => {
+            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
+            cy.apiUpdateConfig(config);
 
-        // # Login as test user and visit channel
-        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
-            cy.visit(`/${team.name}/channels/${channel.name}`);
+            // # Login as test user and visit channel
+            cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+                cy.visit(`/${team.name}/channels/${channel.name}`);
+            });
         });
     });
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_3_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_3_spec.ts
@@ -10,11 +10,11 @@
 // Stage: @prod
 // Group: @custom_status
 
-import {set} from 'lodash';
+import set from 'lodash.set';
 
 describe('Custom Status - Setting Your Own Custom Status', () => {
     before(() => {
-        cy.apiGetConfig().then((config) => {
+        cy.apiGetConfig().then(({config}) => {
             set(config, 'TeamSettings.EnableCustomUserStatuses', true);
             cy.apiUpdateConfig(config);
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_4_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_4_spec.ts
@@ -10,11 +10,11 @@
 // Stage: @prod
 // Group: @custom_status
 
-import {set} from 'lodash';
+import set from 'lodash.set';
 
 describe('Custom Status - Recent Statuses', () => {
     before(() => {
-        cy.apiGetConfig().then((config) => {
+        cy.apiGetConfig().then(({config}) => {
             set(config, 'TeamSettings.EnableCustomUserStatuses', true);
             cy.apiUpdateConfig(config);
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_4_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_4_spec.ts
@@ -10,13 +10,18 @@
 // Stage: @prod
 // Group: @custom_status
 
+import {set} from 'lodash';
+
 describe('Custom Status - Recent Statuses', () => {
     before(() => {
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+        cy.apiGetConfig().then((config) => {
+            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
+            cy.apiUpdateConfig(config);
 
-        // # Login as test user and visit channel
-        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
-            cy.visit(`/${team.name}/channels/${channel.name}`);
+            // # Login as test user and visit channel
+            cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+                cy.visit(`/${team.name}/channels/${channel.name}`);
+            });
         });
     });
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_5_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_5_spec.ts
@@ -9,7 +9,7 @@
 
 // Group: @custom_status
 
-import {set} from 'lodash';
+import set from 'lodash.set';
 
 describe('Custom Status - Verifying Where Custom Status Appears', () => {
     const customStatus = {
@@ -19,7 +19,7 @@ describe('Custom Status - Verifying Where Custom Status Appears', () => {
     let currentUser;
 
     before(() => {
-        cy.apiGetConfig().then((config) => {
+        cy.apiGetConfig().then(({config}) => {
             set(config, 'TeamSettings.EnableCustomUserStatuses', true);
             cy.apiUpdateConfig(config);
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_5_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_5_spec.ts
@@ -9,6 +9,8 @@
 
 // Group: @custom_status
 
+import {set} from 'lodash';
+
 describe('Custom Status - Verifying Where Custom Status Appears', () => {
     const customStatus = {
         emoji: 'grinning',
@@ -17,12 +19,15 @@ describe('Custom Status - Verifying Where Custom Status Appears', () => {
     let currentUser;
 
     before(() => {
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+        cy.apiGetConfig().then((config) => {
+            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
+            cy.apiUpdateConfig(config);
 
-        // # Login as test user and visit channel
-        cy.apiInitSetup({loginAfter: true}).then(({team, user, channel}) => {
-            cy.visit(`/${team.name}/channels/${channel.name}`);
-            currentUser = user;
+            // # Login as test user and visit channel
+            cy.apiInitSetup({loginAfter: true}).then(({team, user, channel}) => {
+                cy.visit(`/${team.name}/channels/${channel.name}`);
+                currentUser = user;
+            });
         });
     });
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_6_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_6_spec.ts
@@ -10,11 +10,11 @@
 // Stage: @prod
 // Group: @custom_status
 
-import {set} from 'lodash';
+import set from 'lodash.set';
 
 describe('Custom Status - Slash Commands', () => {
     before(() => {
-        cy.apiGetConfig().then((config) => {
+        cy.apiGetConfig().then(({config}) => {
             set(config, 'TeamSettings.EnableCustomUserStatuses', true);
             cy.apiUpdateConfig(config);
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_6_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_6_spec.ts
@@ -10,13 +10,18 @@
 // Stage: @prod
 // Group: @custom_status
 
+import {set} from 'lodash';
+
 describe('Custom Status - Slash Commands', () => {
     before(() => {
-        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+        cy.apiGetConfig().then((config) => {
+            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
+            cy.apiUpdateConfig(config);
 
-        // # Login as test user and visit channel
-        cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
-            cy.visit(channelUrl);
+            // # Login as test user and visit channel
+            cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
+                cy.visit(channelUrl);
+            });
         });
     });
 

--- a/e2e/cypress/tests/support/api/system.d.ts
+++ b/e2e/cypress/tests/support/api/system.d.ts
@@ -122,7 +122,7 @@ declare namespace Cypress {
          *       // do something with config
          *   });
          */
-        apiGetConfig(): Chainable<AdminConfig>;
+        apiGetConfig(): Chainable<{config: AdminConfig}>;
 
         /**
          * Get analytics.

--- a/e2e/cypress/tests/support/extended_commands.d.ts
+++ b/e2e/cypress/tests/support/extended_commands.d.ts
@@ -27,5 +27,16 @@ declare namespace Cypress {
          *   cy.visit('url');
          */
         visit(url: string, options?: Partial<Cypress.VisitOptions>, duration?: number): Chainable;
+
+        /**
+         * types the given string with `TypeOption.force` set to true
+         *
+         * @param text - the string that should be force-typed
+         * @param [options] - optional TypeOptions object (`force` option is omitted because it is manually set on the command)
+         *
+         * @example
+         *   cy.get('#emailInput').typeWithForce('john.doe@example.com');
+         */
+        typeWithForce(text: string, options?: Omit<Partial<TypeOptions>, 'force'>): Chainable;
     }
 }

--- a/e2e/cypress/tests/support/extended_commands.js
+++ b/e2e/cypress/tests/support/extended_commands.js
@@ -16,5 +16,5 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options, duration = TIMEOU
 });
 
 Cypress.Commands.add('typeWithForce', {prevSubject: true}, (subject, text, options = {}) => {
-    cy.get(subject).type(text, {force: true, options});
+    cy.get(subject).type(text, {force: true, ...options});
 });

--- a/e2e/cypress/tests/support/ui/global_header.d.ts
+++ b/e2e/cypress/tests/support/ui/global_header.d.ts
@@ -105,12 +105,12 @@ declare namespace Cypress {
         /**
          * Open user menu
          *
-         * @param {string} item - menu item ex. Profile, Logout, etc.
+         * @param {string} [item] - menu item ex. Profile, Logout, etc.
          *
          * @example
          *   cy.uiOpenUserMenu();
          */
-        uiOpenUserMenu(option: Record<string, boolean>): Chainable;
+        uiOpenUserMenu(item?: string): Chainable;
 
         /**
          * Get search form container


### PR DESCRIPTION
#### Summary
migrated following files to typescript:
- e2e/cypress/tests/integration/custom_status/custom_status_1_spec.ts
- e2e/cypress/tests/integration/custom_status/custom_status_2_spec.ts
- e2e/cypress/tests/integration/custom_status/custom_status_3_spec.ts
- e2e/cypress/tests/integration/custom_status/custom_status_4_spec.ts
- e2e/cypress/tests/integration/custom_status/custom_status_5_spec.ts
- e2e/cypress/tests/integration/custom_status/custom_status_6_spec.ts

also added a type-definition for the custom `typeWithForce` command and changed the definition for `uiOpenUserMenu` since the existing definition was incorrect

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/21315

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
