### PR TITLE
MM-47284: Migrate /autocomplete/ tests to TypeScript

### DIFF
--- a/e2e/cypress/tests/integration/autocomplete/common_test.ts
+++ b/e2e/cypress/tests/integration/autocomplete/common_test.ts
@@ -10,24 +10,25 @@
 import {
     getPostTextboxInput,
     getQuickChannelSwitcherInput,
+    SimpleUser,
     startAtMention,
     verifySuggestionAtChannelSwitcher,
     verifySuggestionAtPostTextbox,
 } from './helpers';
 
-export function doTestPostextbox(mention, ...suggestion) {
+export function doTestPostextbox(mention: string, ...suggestion: Cypress.UserProfile[]) {
     getPostTextboxInput();
     startAtMention(mention);
     verifySuggestionAtPostTextbox(...suggestion);
 }
 
-export function doTestQuickChannelSwitcher(mention, ...suggestion) {
+export function doTestQuickChannelSwitcher(mention: string, ...suggestion: Cypress.UserProfile[]) {
     getQuickChannelSwitcherInput();
     startAtMention(mention);
     verifySuggestionAtChannelSwitcher(...suggestion);
 }
 
-export function doTestUserChannelSection(prefix, testTeam, testUsers) {
+export function doTestUserChannelSection(prefix: string, testTeam: Cypress.Team, testUsers: Record<string, SimpleUser>) {
     const thor = testUsers.thor;
     const loki = testUsers.loki;
 
@@ -48,13 +49,13 @@ export function doTestUserChannelSection(prefix, testTeam, testUsers) {
         type(`@${prefix}odinson`);
 
     // * Thor should be a channel member
-    cy.uiVerifyAtMentionInSuggestionList(thor, true);
+    cy.uiVerifyAtMentionInSuggestionList(thor as Cypress.UserProfile, true);
 
     // * Loki should NOT be a channel member
-    cy.uiVerifyAtMentionInSuggestionList(loki, false);
+    cy.uiVerifyAtMentionInSuggestionList(loki as Cypress.UserProfile, false);
 }
 
-export function doTestDMChannelSidebar(testUsers) {
+export function doTestDMChannelSidebar(testUsers: Record<string, SimpleUser>) {
     const thor = testUsers.thor;
 
     // # Open of the add direct message modal

--- a/e2e/cypress/tests/integration/autocomplete/common_test.ts
+++ b/e2e/cypress/tests/integration/autocomplete/common_test.ts
@@ -34,7 +34,7 @@ export function doTestUserChannelSection(prefix, testTeam, testUsers) {
     // # Create new channel and add user to channel
     const channelName = 'new-channel';
     cy.apiCreateChannel(testTeam.id, channelName, channelName).then(({channel}) => {
-        cy.apiGetUserByEmail(thor.email).then((user) => {
+        cy.apiGetUserByEmail(thor.email).then(({user}) => {
             cy.apiAddUserToChannel(channel.id, user.id);
         });
 

--- a/e2e/cypress/tests/integration/autocomplete/common_test.ts
+++ b/e2e/cypress/tests/integration/autocomplete/common_test.ts
@@ -34,7 +34,7 @@ export function doTestUserChannelSection(prefix, testTeam, testUsers) {
     // # Create new channel and add user to channel
     const channelName = 'new-channel';
     cy.apiCreateChannel(testTeam.id, channelName, channelName).then(({channel}) => {
-        cy.apiGetUserByEmail(thor.email).then(({user}) => {
+        cy.apiGetUserByEmail(thor.email).then((user) => {
             cy.apiAddUserToChannel(channel.id, user.id);
         });
 

--- a/e2e/cypress/tests/integration/autocomplete/helpers.ts
+++ b/e2e/cypress/tests/integration/autocomplete/helpers.ts
@@ -1,9 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {AdminConfig} from '@mattermost/types/lib/config';
-import {UserProfile} from '@mattermost/types/lib/users';
-
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {getAdminAccount} from '../../support/env';
 
@@ -23,17 +20,19 @@ export {
     verifySuggestionAtPostTextbox,
 };
 
-function createPrivateChannel(teamId, userToAdd = null) {
+export type SimpleUser = Pick<Cypress.UserProfile, 'username' | 'first_name' | 'last_name' | 'nickname' | 'password' | 'email'>;
+
+function createPrivateChannel(teamId: string, userToAdd: Cypress.UserProfile = null) {
     // # Create a private channel as sysadmin
     return createChannel('P', teamId, userToAdd);
 }
 
-function createPublicChannel(teamId, userToAdd = null) {
+function createPublicChannel(teamId: string, userToAdd: Cypress.UserProfile = null) {
     // # Create a public channel as sysadmin
     return createChannel('O', teamId, userToAdd);
 }
 
-function createSearchData(prefix) {
+function createSearchData(prefix: string) {
     return cy.apiCreateCustomAdmin({loginAfter: true, hideAdminTrialModal: true}).then(({sysadmin}) => {
         const users = getTestUsers(prefix);
 
@@ -62,7 +61,7 @@ function enableElasticSearch() {
             EnableSearching: true,
             Sniff: false,
         },
-    } as AdminConfig);
+    } as Cypress.AdminConfig);
 
     // # Navigate to the elastic search setting page
     cy.visit('/admin_console/environment/elasticsearch');
@@ -91,7 +90,7 @@ function enableElasticSearch() {
     cy.waitUntil(checkFirstRow, options);
 }
 
-function getTestUsers(prefix = '') {
+function getTestUsers(prefix = ''): Record<string, SimpleUser & {email: string; password: string}> {
     if (Cypress.env('searchTestUsers')) {
         return JSON.parse(Cypress.env('searchTestUsers'));
     }
@@ -180,7 +179,7 @@ function getQuickChannelSwitcherInput() {
         clear();
 }
 
-function searchAndVerifyChannel(channel, shouldExist = true) {
+function searchAndVerifyChannel(channel: Cypress.Channel, shouldExist = true) {
     const name = channel.display_name;
     searchForChannel(name);
 
@@ -194,7 +193,7 @@ function searchAndVerifyChannel(channel, shouldExist = true) {
     }
 }
 
-function searchAndVerifyUser(user) {
+function searchAndVerifyUser(user: Cypress.UserProfile) {
     // # Start @ mentions autocomplete with username
     cy.uiGetPostTextBox().
         as('input').
@@ -208,7 +207,7 @@ function searchAndVerifyUser(user) {
     return cy.uiVerifyAtMentionSuggestion(user);
 }
 
-function searchForChannel(name) {
+function searchForChannel(name: string) {
     // # Open up channel switcher
     cy.typeCmdOrCtrl().type('k').wait(TIMEOUTS.ONE_SEC);
 
@@ -220,7 +219,7 @@ function searchForChannel(name) {
         type(name);
 }
 
-function startAtMention(string) {
+function startAtMention(string: string) {
     // # Get the expected input
     cy.get('@input').clear().type(string);
 
@@ -228,14 +227,14 @@ function startAtMention(string) {
     cy.get('#suggestionList').should('be.visible');
 }
 
-function verifySuggestionAtPostTextbox(...expectedUsers) {
+function verifySuggestionAtPostTextbox(...expectedUsers: Cypress.UserProfile[]) {
     expectedUsers.forEach((user) => {
         cy.wait(TIMEOUTS.HALF_SEC);
         cy.uiVerifyAtMentionSuggestion(user);
     });
 }
 
-function verifySuggestionAtChannelSwitcher(...expectedUsers) {
+function verifySuggestionAtChannelSwitcher(...expectedUsers: Cypress.UserProfile[]) {
     expectedUsers.forEach((user) => {
         cy.findByTestId(user.username).
             should('be.visible').
@@ -243,7 +242,7 @@ function verifySuggestionAtChannelSwitcher(...expectedUsers) {
     });
 }
 
-function createChannel(channelType, teamId, userToAdd = null) {
+function createChannel(channelType: string, teamId: string, userToAdd: Cypress.UserProfile = null) {
     // # Create a channel as sysadmin
     return cy.externalRequest({
         user: getAdminAccount(),
@@ -281,7 +280,7 @@ function createChannel(channelType, teamId, userToAdd = null) {
     });
 }
 
-function generatePrefixedUser(user: Pick<UserProfile, 'username' | 'first_name' | 'last_name' | 'nickname'>, prefix) {
+function generatePrefixedUser(user: Omit<SimpleUser, 'password' | 'email'>, prefix: string) {
     return {
         username: withPrefix(user.username, prefix),
         password: 'passwd',
@@ -292,10 +291,10 @@ function generatePrefixedUser(user: Pick<UserProfile, 'username' | 'first_name' 
     };
 }
 
-function withPrefix(name, prefix) {
+function withPrefix(name: string, prefix: string) {
     return prefix + name;
 }
 
-function createEmail(name, prefix) {
+function createEmail(name: string, prefix: string) {
     return `${prefix}${name}@sample.mattermost.com`;
 }

--- a/e2e/cypress/tests/integration/autocomplete/helpers.ts
+++ b/e2e/cypress/tests/integration/autocomplete/helpers.ts
@@ -266,7 +266,7 @@ function createChannel(channelType, teamId, userToAdd = null) {
     }).then(({data: channel}) => {
         if (userToAdd) {
             // # Get user profile by email
-            return cy.apiGetUserByEmail(userToAdd.email).then((user) => {
+            return cy.apiGetUserByEmail(userToAdd.email).then(({user}) => {
                 // # Add user to team
                 cy.externalRequest({
                     user: getAdminAccount(),

--- a/e2e/cypress/tests/integration/autocomplete/helpers.ts
+++ b/e2e/cypress/tests/integration/autocomplete/helpers.ts
@@ -90,7 +90,7 @@ function enableElasticSearch() {
     cy.waitUntil(checkFirstRow, options);
 }
 
-function getTestUsers(prefix = ''): Record<string, SimpleUser & {email: string; password: string}> {
+function getTestUsers(prefix = ''): Record<string, SimpleUser> {
     if (Cypress.env('searchTestUsers')) {
         return JSON.parse(Cypress.env('searchTestUsers'));
     }

--- a/e2e/cypress/tests/integration/autocomplete/helpers.ts
+++ b/e2e/cypress/tests/integration/autocomplete/helpers.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {AdminConfig} from '@mattermost/types/lib/config';
+import {UserProfile} from '@mattermost/types/lib/users';
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {getAdminAccount} from '../../support/env';
@@ -20,13 +21,6 @@ export {
     startAtMention,
     verifySuggestionAtChannelSwitcher,
     verifySuggestionAtPostTextbox,
-};
-
-type UserInfo = {
-    username: string;
-    firstName: string;
-    lastName: string;
-    nickname: string;
 };
 
 function createPrivateChannel(teamId, userToAdd = null) {
@@ -105,68 +99,68 @@ function getTestUsers(prefix = '') {
     return {
         ironman: generatePrefixedUser({
             username: 'ironman',
-            firstName: 'Tony',
-            lastName: 'Stark',
+            first_name: 'Tony',
+            last_name: 'Stark',
             nickname: 'protoncannon',
         }, prefix),
         hulk: generatePrefixedUser({
             username: 'hulk',
-            firstName: 'Bruce',
-            lastName: 'Banner',
+            first_name: 'Bruce',
+            last_name: 'Banner',
             nickname: 'gammaray',
         }, prefix),
         hawkeye: generatePrefixedUser({
             username: 'hawkeye',
-            firstName: 'Clint',
-            lastName: 'Barton',
+            first_name: 'Clint',
+            last_name: 'Barton',
             nickname: 'ronin',
         }, prefix),
         deadpool: generatePrefixedUser({
             username: 'deadpool',
-            firstName: 'Wade',
-            lastName: 'Wilson',
+            first_name: 'Wade',
+            last_name: 'Wilson',
             nickname: 'merc',
         }, prefix),
         captainamerica: generatePrefixedUser({
             username: 'captainamerica',
-            firstName: 'Steve',
-            lastName: 'Rogers',
+            first_name: 'Steve',
+            last_name: 'Rogers',
             nickname: 'professional',
         }, prefix),
         doctorstrange: generatePrefixedUser({
             username: 'doctorstrange',
-            firstName: 'Stephen',
-            lastName: 'Strange',
+            first_name: 'Stephen',
+            last_name: 'Strange',
             nickname: 'sorcerersupreme',
         }, prefix),
         thor: generatePrefixedUser({
             username: 'thor',
-            firstName: 'Thor',
-            lastName: 'Odinson',
+            first_name: 'Thor',
+            last_name: 'Odinson',
             nickname: 'mjolnir',
         }, prefix),
         loki: generatePrefixedUser({
             username: 'loki',
-            firstName: 'Loki',
-            lastName: 'Odinson',
+            first_name: 'Loki',
+            last_name: 'Odinson',
             nickname: 'trickster',
         }, prefix),
         dot: generatePrefixedUser({
             username: 'dot.dot',
-            firstName: 'z1First',
-            lastName: 'z1Last',
+            first_name: 'z1First',
+            last_name: 'z1Last',
             nickname: 'z1Nick',
         }, prefix),
         dash: generatePrefixedUser({
             username: 'dash-dash',
-            firstName: 'z2First',
-            lastName: 'z2Last',
+            first_name: 'z2First',
+            last_name: 'z2Last',
             nickname: 'z2Nick',
         }, prefix),
         underscore: generatePrefixedUser({
             username: 'under_score',
-            firstName: 'z3First',
-            lastName: 'z3Last',
+            first_name: 'z3First',
+            last_name: 'z3Last',
             nickname: 'z3Nick',
         }, prefix),
     };
@@ -287,12 +281,12 @@ function createChannel(channelType, teamId, userToAdd = null) {
     });
 }
 
-function generatePrefixedUser(user: UserInfo, prefix) {
+function generatePrefixedUser(user: Pick<UserProfile, 'username' | 'first_name' | 'last_name' | 'nickname'>, prefix) {
     return {
         username: withPrefix(user.username, prefix),
         password: 'passwd',
-        first_name: withPrefix(user.firstName, prefix),
-        last_name: withPrefix(user.lastName, prefix),
+        first_name: withPrefix(user.first_name, prefix),
+        last_name: withPrefix(user.last_name, prefix),
         email: createEmail(user.username, prefix),
         nickname: withPrefix(user.nickname, prefix),
     };

--- a/e2e/cypress/tests/integration/autocomplete/helpers.ts
+++ b/e2e/cypress/tests/integration/autocomplete/helpers.ts
@@ -46,7 +46,7 @@ function createSearchData(prefix) {
         cy.apiLogin(sysadmin);
 
         // # Create new team for tests
-        return cy.apiCreateTeam('search', 'Search').then((team) => {
+        return cy.apiCreateTeam('search', 'Search').then(({team}) => {
             // # Create pool of users for tests
             Cypress._.forEach(users, (testUser) => {
                 cy.apiCreateUser({user: testUser}).then(({user}) => {

--- a/e2e/cypress/tests/integration/autocomplete/helpers.ts
+++ b/e2e/cypress/tests/integration/autocomplete/helpers.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {AdminConfig} from '@mattermost/types/lib/config';
+
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {getAdminAccount} from '../../support/env';
 
@@ -20,6 +22,13 @@ export {
     verifySuggestionAtPostTextbox,
 };
 
+type UserInfo = {
+    username: string;
+    firstName: string;
+    lastName: string;
+    nickname: string;
+};
+
 function createPrivateChannel(teamId, userToAdd = null) {
     // # Create a private channel as sysadmin
     return createChannel('P', teamId, userToAdd);
@@ -31,13 +40,13 @@ function createPublicChannel(teamId, userToAdd = null) {
 }
 
 function createSearchData(prefix) {
-    return cy.apiCreateCustomAdmin().then(({sysadmin}) => {
+    return cy.apiCreateCustomAdmin({loginAfter: true, hideAdminTrialModal: true}).then(({sysadmin}) => {
         const users = getTestUsers(prefix);
 
         cy.apiLogin(sysadmin);
 
         // # Create new team for tests
-        return cy.apiCreateTeam('search', 'Search').then(({team}) => {
+        return cy.apiCreateTeam('search', 'Search').then((team) => {
             // # Create pool of users for tests
             Cypress._.forEach(users, (testUser) => {
                 cy.apiCreateUser({user: testUser}).then(({user}) => {
@@ -59,7 +68,7 @@ function enableElasticSearch() {
             EnableSearching: true,
             Sniff: false,
         },
-    });
+    } as AdminConfig);
 
     // # Navigate to the elastic search setting page
     cy.visit('/admin_console/environment/elasticsearch');
@@ -257,7 +266,7 @@ function createChannel(channelType, teamId, userToAdd = null) {
     }).then(({data: channel}) => {
         if (userToAdd) {
             // # Get user profile by email
-            return cy.apiGetUserByEmail(userToAdd.email).then(({user}) => {
+            return cy.apiGetUserByEmail(userToAdd.email).then((user) => {
                 // # Add user to team
                 cy.externalRequest({
                     user: getAdminAccount(),
@@ -278,7 +287,7 @@ function createChannel(channelType, teamId, userToAdd = null) {
     });
 }
 
-function generatePrefixedUser(user = {}, prefix) {
+function generatePrefixedUser(user: UserInfo, prefix) {
     return {
         username: withPrefix(user.username, prefix),
         password: 'passwd',

--- a/e2e/cypress/tests/support/api/team.d.ts
+++ b/e2e/cypress/tests/support/api/team.d.ts
@@ -33,7 +33,7 @@ declare namespace Cypress {
          *       // do something with team
          *   });
          */
-        apiCreateTeam(name: string, displayName: string, type?: string, unique?: boolean, options?: Partial<Team>): Chainable<Team>;
+        apiCreateTeam(name: string, displayName: string, type?: string, unique?: boolean, options?: Partial<Team>): Chainable<{team: Team}>;
 
         /**
          * Delete a team.

--- a/e2e/cypress/tests/support/api/user.d.ts
+++ b/e2e/cypress/tests/support/api/user.d.ts
@@ -110,7 +110,7 @@ declare namespace Cypress {
          *       // do something with user
          *   });
          */
-        apiGetUserByEmail(email: string): Chainable<UserProfile>;
+        apiGetUserByEmail(email: string): Chainable<{user: UserProfile}>;
 
         /**
          * Get users by usernames.

--- a/e2e/cypress/tests/support/ui/common.d.ts
+++ b/e2e/cypress/tests/support/ui/common.d.ts
@@ -55,7 +55,7 @@ declare namespace Cypress {
          * @example
          *   cy.uiGetButton('Save');
          */
-        uiGetButton(): Chainable;
+        uiGetButton(label: string): Chainable;
 
         /**
          * Get save button

--- a/e2e/cypress/tests/support/ui/suggestion_list.d.ts
+++ b/e2e/cypress/tests/support/ui/suggestion_list.d.ts
@@ -26,7 +26,7 @@ declare namespace Cypress {
          * @example
          *   cy.uiVerifyAtMentionInSuggestionList(user, true, 'Channel Members');
          */
-        uiVerifyAtMentionInSuggestionList(user: UserProfile, isSelected: boolean, sectionDividerName: string): Chainable;
+        uiVerifyAtMentionInSuggestionList(user: UserProfile, isSelected: boolean, sectionDividerName?: string): Chainable;
 
         /**
          * Verify user's at-mention suggestion
@@ -36,6 +36,6 @@ declare namespace Cypress {
          * @example
          *   cy.uiVerifyAtMentionSuggestion(user, true);
          */
-        uiVerifyAtMentionSuggestion(user: UserProfile, isSelected: boolean): Chainable;
+        uiVerifyAtMentionSuggestion(user: UserProfile, isSelected?: boolean): Chainable;
     }
 }


### PR DESCRIPTION
#### Summary
Following files under /integration/autocomplete are converted to Typescript

helpers.js
common_test.js

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21291
JIRA: https://mattermost.atlassian.net/browse/MM-47284

#### Release Note
```release-note
NONE
```
