### PR TITLE
[MM-44031] add system console SMTP link to invitation error

### DIFF
--- a/components/invitation_modal/result_table.scss
+++ b/components/invitation_modal/result_table.scss
@@ -92,7 +92,6 @@
     }
 
     .reason {
-        display: flex;
         width: 50%;
         align-items: center;
         padding: 12px;

--- a/components/invitation_modal/result_table.tsx
+++ b/components/invitation_modal/result_table.tsx
@@ -2,9 +2,10 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 
 import {UserProfile} from '@mattermost/types/users';
+
 import {imageURLForUser, getLongDisplayName} from 'utils/utils';
 import {isGuest} from 'mattermost-redux/utils/user_utils';
 
@@ -36,6 +37,7 @@ type I18nLike = {
 
 export type InviteResult = (InviteNotSent | InviteEmail | InviteUser) & {
     reason: string | I18nLike;
+    path?: string;
 }
 
 export type Props = {
@@ -44,6 +46,7 @@ export type Props = {
 }
 
 export default function ResultTable(props: Props) {
+    const intl = useIntl();
     let wrapperClass = 'invitation-modal-confirm invitation-modal-confirm--not-sent';
     let header = (
         <h2>
@@ -65,6 +68,27 @@ export default function ResultTable(props: Props) {
         );
     }
 
+    function messageWithLink(reason: any, link: any) {
+        return intl.formatMessage(
+            {
+                id: reason.id,
+                defaultMessage: reason.message,
+            },
+            {
+                a: (chunks: React.ReactNode | React.ReactNodeArray) => (
+                    <a
+                        href={link}
+                        onClick={(e: React.MouseEvent) => {
+                            e.preventDefault();
+                            window.open(link);
+                        }}
+                    >
+                        {chunks}
+                    </a>
+                ),
+            },
+        );
+    }
     return (
         <div className={wrapperClass}>
             {header}
@@ -138,6 +162,8 @@ export default function ResultTable(props: Props) {
                                     values={invitation.reason.values}
                                 />
                             );
+                        } else if (invitation.path && invitation.reason) {
+                            reason = messageWithLink(invitation.reason, invitation.path);
                         }
 
                         return (

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -819,6 +819,7 @@
   "admin.environment.smtp.smtpAuth.description": "When true, SMTP Authentication is enabled.",
   "admin.environment.smtp.smtpAuth.title": "Enable SMTP Authentication:",
   "admin.environment.smtp.smtpFail": "Connection unsuccessful: {error}",
+  "admin.environment.smtp.smtpFailure": "SMTP is not configured in System Console. Can be configured <a>here</a>.",
   "admin.environment.smtp.smtpPassword.description": "Obtain this credential from administrator setting up your email server.",
   "admin.environment.smtp.smtpPassword.placeholder": "Ex: \"yourpassword\", \"jcuS8PuvcpGhpgHhlcpT1Mx42pnqMxQY\"",
   "admin.environment.smtp.smtpPassword.title": "SMTP Server Password:",

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1901,6 +1901,7 @@ export const ConsolePages = {
     SESSION_LENGTHS: '/admin_console/environment/session_lengths',
     WEB_SERVER: '/admin_console/environment/web_server',
     PUSH_NOTIFICATION_CENTER: '/admin_console/environment/push_notification_server',
+    SMTP: '/admin_console/environment/smtp',
 };
 
 export const WindowSizes = {


### PR DESCRIPTION
#### Summary
Add system console SMPT config link to the invitation error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44031

#### Screenshots

|  before  |  after  |
|----|----|
| ![Screenshot 2022-10-08 at 16 45 15](https://user-images.githubusercontent.com/841955/194710648-d77ec1a0-6931-4e13-a7f0-6cef4e67c370.png) | ![Screenshot 2022-10-08 at 16 22 29](https://user-images.githubusercontent.com/841955/194709762-6654aede-ec28-4aeb-8662-fc475ba5065a.png) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
