### PR TITLE
MM-28362 : Implement Progressive Image Loading in Webapp

### DIFF
--- a/components/single_image_view/single_image_view.tsx
+++ b/components/single_image_view/single_image_view.tsx
@@ -39,14 +39,13 @@ type State = {
 }
 
 export default class SingleImageView extends React.PureComponent<Props, State> {
-    private mounted: boolean;
+    private mounted = false;
     static defaultProps = {
         compactDisplay: false,
     };
 
     constructor(props: Props) {
         super(props);
-        this.mounted = true;
         this.state = {
             loaded: false,
             dimensions: {

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -13,6 +13,7 @@ import {t} from 'utils/i18n';
 import LoadingImagePreview from 'components/loading_image_preview';
 import Tooltip from 'components/tooltip';
 import OverlayTrigger from 'components/overlay_trigger';
+import {getFileMiniPreviewUrl} from 'mattermost-redux/utils/file_utils';
 
 const MIN_IMAGE_SIZE = 48;
 const MIN_IMAGE_SIZE_FOR_INTERNAL_BUTTONS = 100;
@@ -361,34 +362,64 @@ export default class SizeAwareImage extends React.PureComponent {
         );
     }
 
-    renderImageOrPlaceholder = () => {
+    renderImageOrFallback = () => {
         const {
             dimensions,
+            fileInfo,
         } = this.props;
 
-        let placeHolder;
+        let ariaLabelImage = localizeMessage('file_attachment.thumbnail', 'file thumbnail');
+        if (fileInfo) {
+            ariaLabelImage += ` ${fileInfo.name}`.toLowerCase();
+        }
+
+        let fallback;
 
         if (this.dimensionsAvailable(dimensions) && !this.state.loaded) {
-            placeHolder = (
-                <div
-                    className={`image-loading__container ${this.props.className}`}
-                    style={{maxWidth: dimensions.width}}
-                >
-                    {this.renderImageLoaderIfNeeded()}
-                    <svg
-                        xmlns='http://www.w3.org/2000/svg'
-                        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
-                        style={{maxHeight: dimensions.height, maxWidth: dimensions.width, verticalAlign: 'middle'}}
-                    />
-                </div>
-            );
+            const ratio = dimensions.height > 350 ? 350 / dimensions.height : 1;
+            const height = dimensions.height * ratio;
+            const width = dimensions.width * ratio;
+
+            const miniPreview = getFileMiniPreviewUrl(fileInfo);
+
+            if (miniPreview) {
+                fallback = (
+                    <div
+                        className={`image-loading__container ${this.props.className}`}
+                        style={{maxWidth: dimensions.width}}
+                    >
+                        <img
+                            aria-label={ariaLabelImage}
+                            className={this.props.className}
+                            src={miniPreview}
+                            tabIndex='0'
+                            height={height}
+                            width={width}
+                        />
+                    </div>
+                );
+            } else {
+                fallback = (
+                    <div
+                        className={`image-loading__container ${this.props.className}`}
+                        style={{maxWidth: width}}
+                    >
+                        {this.renderImageLoaderIfNeeded()}
+                        <svg
+                            xmlns='http://www.w3.org/2000/svg'
+                            viewBox={`0 0 ${width} ${height}`}
+                            style={{maxHeight: height, maxWidth: width, verticalAlign: 'middle'}}
+                        />
+                    </div>
+                );
+            }
         }
 
         const shouldShowImg = !this.dimensionsAvailable(dimensions) || this.state.loaded;
 
         return (
             <React.Fragment>
-                {placeHolder}
+                {fallback}
                 <div
                     className='file-preview__button'
                     style={{display: shouldShowImg ? 'inline' : 'none'}}
@@ -436,7 +467,7 @@ export default class SizeAwareImage extends React.PureComponent {
 
     render() {
         return (
-            this.renderImageOrPlaceholder()
+            this.renderImageOrFallback()
         );
     }
 }

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -17,6 +17,7 @@ import {getFileMiniPreviewUrl} from 'mattermost-redux/utils/file_utils';
 
 const MIN_IMAGE_SIZE = 48;
 const MIN_IMAGE_SIZE_FOR_INTERNAL_BUTTONS = 100;
+const MAX_IMAGE_HEIGHT = 350;
 
 // SizeAwareImage is a component used for rendering images where the dimensions of the image are important for
 // ensuring that the page is laid out correctly.
@@ -376,7 +377,7 @@ export default class SizeAwareImage extends React.PureComponent {
         let fallback;
 
         if (this.dimensionsAvailable(dimensions) && !this.state.loaded) {
-            const ratio = dimensions.height > 350 ? 350 / dimensions.height : 1;
+            const ratio = dimensions.height > MAX_IMAGE_HEIGHT ? MAX_IMAGE_HEIGHT / dimensions.height : 1;
             const height = dimensions.height * ratio;
             const width = dimensions.width * ratio;
 

--- a/components/size_aware_image.test.jsx
+++ b/components/size_aware_image.test.jsx
@@ -52,6 +52,24 @@ describe('components/SizeAwareImage', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should render a mini preview when showLoader is true and preview is set', () => {
+        const props = {
+            ...baseProps,
+            fileInfo: {
+                ...baseProps.fileInfo,
+                mime_type: 'mime_type',
+                mini_preview: 'mini_preview',
+            },
+        };
+
+        const wrapper = mount(<SizeAwareImage {...props}/>);
+
+        wrapper.setState({loaded: false, error: false});
+
+        const src = wrapper.find('.image-loading__container img').prop('src');
+        expect(src).toEqual('data:mime_type;base64,mini_preview');
+    });
+
     test('should have display set to initial in loaded state', () => {
         const wrapper = mount(<SizeAwareImage {...baseProps}/>);
         wrapper.setState({loaded: true, error: false});

--- a/packages/mattermost-redux/src/utils/file_utils.test.js
+++ b/packages/mattermost-redux/src/utils/file_utils.test.js
@@ -37,6 +37,11 @@ describe('FileUtils', () => {
         assert.deepEqual(FileUtils.getFilePreviewUrl('id2'), 'localhost/api/v4/files/id2/preview');
     });
 
+    it('getFileMiniPreviewUrl', () => {
+        assert.deepEqual(FileUtils.getFileMiniPreviewUrl({}), undefined);
+        assert.deepEqual(FileUtils.getFileMiniPreviewUrl({mime_type: 'mime_type', mini_preview: 'mini_preview'}), 'data:mime_type;base64,mini_preview');
+    });
+
     it('sortFileInfos', () => {
         const testCases = [
             {inputFileInfos: [{name: 'aaa', create_at: 100}, {name: 'bbb', create_at: 200}], outputFileInfos: [{name: 'aaa', create_at: 100}, {name: 'bbb', create_at: 200}]},

--- a/packages/mattermost-redux/src/utils/file_utils.ts
+++ b/packages/mattermost-redux/src/utils/file_utils.ts
@@ -66,8 +66,8 @@ export function getFilePreviewUrl(fileId: string): string {
     return `${Client4.getFileRoute(fileId)}/preview`;
 }
 
-export function getFileMiniPreviewUrl(fileInfo: FileInfo): string | undefined {
-    if (!fileInfo.mini_preview || !fileInfo.mime_type) {
+export function getFileMiniPreviewUrl(fileInfo?: FileInfo): string | undefined {
+    if (!fileInfo?.mini_preview || !fileInfo?.mime_type) {
         return undefined;
     }
     return `data:${fileInfo.mime_type};base64,${fileInfo.mini_preview}`;

--- a/packages/mattermost-redux/src/utils/file_utils.ts
+++ b/packages/mattermost-redux/src/utils/file_utils.ts
@@ -66,6 +66,13 @@ export function getFilePreviewUrl(fileId: string): string {
     return `${Client4.getFileRoute(fileId)}/preview`;
 }
 
+export function getFileMiniPreviewUrl(fileInfo: FileInfo): string | undefined {
+    if (!fileInfo.mini_preview || !fileInfo.mime_type) {
+        return undefined;
+    }
+    return `data:${fileInfo.mime_type};base64,${fileInfo.mini_preview}`;
+}
+
 export function sortFileInfos(fileInfos: FileInfo[] = [], locale: string = General.DEFAULT_LOCALE): FileInfo[] {
     return fileInfos.sort((a, b) => {
         if (a.create_at !== b.create_at) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Implement Progressive Image Loading

I didn't use any transition animation as there wasn't any for placeholder to image one.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes  https://github.com/mattermost/mattermost-server/issues/15641
Fixes https://mattermost.atlassian.net/browse/MM-28362

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

https://user-images.githubusercontent.com/60970/194752364-64704b8a-8296-4148-a6d7-2ce82b1f4ee8.mov

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Implemented Progressive Image Loading in Webapp
```
