### PR TITLE
Bump @mattermost/compass-icons to 0.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@floating-ui/react-dom": "0.7.2",
     "@floating-ui/react-dom-interactions": "0.9.1",
     "@mattermost/compass-components": "^0.2.12",
-    "@mattermost/compass-icons": "0.1.27",
+    "@mattermost/compass-icons": "0.1.28",
     "@stripe/react-stripe-js": "1.6.0",
     "@stripe/stripe-js": "1.20.3",
     "@tippyjs/react": "4.2.6",


### PR DESCRIPTION
#### Summary

This PR will upgrade `@mattermost/compass-icons` to 0.1.28. A new `icon-shuffle-variant` which is added in compass-icons wasn't rendering in plugin mode. This will fix that. Linking related PR below.

#### Related Pull Requests

https://github.com/mattermost/focalboard/pull/3924


```release-note
Bump compass-icons to "0.1.28"
```