### PR TITLE
[MM-47299] Migrated enterprise/permissions tests to Typescript

### DIFF
--- a/e2e/cypress/tests/integration/enterprise/channel/channel_groups_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/channel/channel_groups_spec.ts
@@ -31,7 +31,7 @@ describe('channel groups', () => {
         cy.apiUpdateConfig({LdapSettings: {Enable: true}, ServiceSettings: {EnableTutorial: false}});
 
         // # Create a new team and associate one group to the team
-        cy.apiCreateTeam('team', 'Team').then((team) => {
+        cy.apiCreateTeam('team', 'Team').then(({team}) => {
             testTeam = team;
             cy.apiLinkGroupTeam(groups[0].id, team.id);
 

--- a/e2e/cypress/tests/integration/enterprise/channel/channel_groups_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/channel/channel_groups_spec.ts
@@ -31,7 +31,7 @@ describe('channel groups', () => {
         cy.apiUpdateConfig({LdapSettings: {Enable: true}, ServiceSettings: {EnableTutorial: false}});
 
         // # Create a new team and associate one group to the team
-        cy.apiCreateTeam('team', 'Team').then(({team}) => {
+        cy.apiCreateTeam('team', 'Team').then((team) => {
             testTeam = team;
             cy.apiLinkGroupTeam(groups[0].id, team.id);
 

--- a/e2e/cypress/tests/support/api/channel.d.ts
+++ b/e2e/cypress/tests/support/api/channel.d.ts
@@ -103,7 +103,7 @@ declare namespace Cypress {
          * @example
          *   cy.apiPatchChannel('channel-id', {name: 'new-name', display_name: 'New Display Name'});
          */
-        apiPatchChannel(channelId: string, channel: Channel): Chainable<{channel: Channel}>;
+        apiPatchChannel(channelId: string, channel: Partial<Channel>): Chainable<{channel: Channel}>;
 
         /**
          * Updates channel's privacy allowing changing a channel from Public to Private and back.

--- a/e2e/cypress/tests/support/api/system.d.ts
+++ b/e2e/cypress/tests/support/api/system.d.ts
@@ -97,7 +97,7 @@ declare namespace Cypress {
          *       // do something with config
          *   });
          */
-        apiUpdateConfig(newConfig: AdminConfig): Chainable<{config: AdminConfig}>;
+        apiUpdateConfig(newConfig: DeepPartial<AdminConfig>): Chainable<{config: AdminConfig}>;
 
         /**
          * Reload the configuration file to pick up on any changes made to it.

--- a/e2e/cypress/tests/support/api/team.d.ts
+++ b/e2e/cypress/tests/support/api/team.d.ts
@@ -81,7 +81,7 @@ declare namespace Cypress {
          *       // do something with team
          *   });
          */
-        apiPatchTeam(teamId: string, patch: Team): Chainable<Team>;
+        apiPatchTeam(teamId: string, patch: Partial<Team>): Chainable<Team>;
 
         /**
          * Get a team based on provided name string.

--- a/e2e/cypress/tests/support/index.d.ts
+++ b/e2e/cypress/tests/support/index.d.ts
@@ -32,6 +32,7 @@ declare namespace Cypress {
     type UserStatus = import('@mattermost/types/users').UserStatus;
     type UserCustomStatus = import('@mattermost/types/users').UserCustomStatus;
     type UserAccessToken = import('@mattermost/types/users').UserAccessToken;
+    type DeepPartial = import('@mattermost/types/utilities').DeepPartial;
     interface Chainable {
         tab: (options?: {shift?: boolean}) => Chainable<JQuery>;
     }


### PR DESCRIPTION
#### Summary
Converted the following spec files under /integration/enterprise/channel to Typescript

1. channel_groups_spec.js

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/21309

#### Release Note

```release-note
NONE
```
