### PR TITLE
[MM-47412] Check if delinquency since is not null before to calculate…

### DIFF
--- a/components/delinquency_modal/delinquency_modal_controller.test.tsx
+++ b/components/delinquency_modal/delinquency_modal_controller.test.tsx
@@ -201,6 +201,28 @@ describe('components/delinquency_modal/delinquency_modal_controller', () => {
         expect(screen.queryByText('Your workspace has been downgraded')).not.toBeInTheDocument();
     });
 
+    it('Shouldn\'t show the modal if the subscription isn\'t in delinquency state', () => {
+        const state = JSON.parse(JSON.stringify(initialState));
+        state.entities.cloud.subscription = {
+            ...state.entities.cloud.subscription,
+            delinquent_since: null,
+        };
+
+        jest.useFakeTimers().setSystemTime(new Date('2022-12-20'));
+
+        const store = configureStore(state);
+
+        renderWithIntl(
+            <reactRedux.Provider store={store}>
+                <div id='root-portal'/>
+                <ModalController/>
+                <DelinquencyModalController/>
+            </reactRedux.Provider>,
+        );
+
+        expect(screen.queryByText('Your workspace has been downgraded')).not.toBeInTheDocument();
+    });
+
     it('Should show the modal if the user is an admin', () => {
         jest.useFakeTimers().setSystemTime(new Date('2022-08-17'));
 

--- a/components/delinquency_modal/useDelinquencyModalController.tsx
+++ b/components/delinquency_modal/useDelinquencyModalController.tsx
@@ -66,9 +66,11 @@ export const useDelinquencyModalController = (props: UseDelinquencyModalControll
             return;
         }
 
-        const delinquencyDate = new Date(
-            (subscription.delinquent_since || 0) * 1000,
-        );
+        if (subscription.delinquent_since == null) {
+            return;
+        }
+
+        const delinquencyDate = new Date(subscription.delinquent_since * 1000);
 
         const oneDay = 24 * 60 * 60 * 1000; // hours*minutes*seconds*milliseconds
         const today = new Date();


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Hide the modal when delinquency since is null. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-47412

#### Release Note
```release-note
NONE
```
