### PR TITLE
[MM-47369] Remove mention counts of muted channels on the browser and desktop tabs

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/channels.test.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.test.ts
@@ -1,17 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {General, Permissions} from 'mattermost-redux/constants';
+
+import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
+
+import {sortChannelsByDisplayName, getDirectChannelName} from 'mattermost-redux/utils/channel_utils';
+
+import deepFreezeAndThrowOnMutation from 'mattermost-redux/utils/deep_freeze';
+
 import {Channel} from '@mattermost/types/channels';
 import {GlobalState} from '@mattermost/types/store';
 
-import {General, Permissions} from 'mattermost-redux/constants';
-import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
-
 import mergeObjects from '../../../test/merge_objects';
 import TestHelper from '../../..//test/test_helper';
-
-import {sortChannelsByDisplayName, getDirectChannelName} from 'mattermost-redux/utils/channel_utils';
-import deepFreezeAndThrowOnMutation from 'mattermost-redux/utils/deep_freeze';
 
 import * as Selectors from './channels';
 
@@ -2364,7 +2366,7 @@ describe('Selectors.Channels.getUnreadStatus', () => {
         const unreadMeta = Selectors.basicUnreadMeta(unreadStatus);
 
         expect(unreadMeta.isUnread).toBe(true); // channelA and channelB are unread, but only channelB is counted because of its mark_unread
-        expect(unreadStatus).toBe(myMemberA.mention_count + myMemberB.mention_count);
+        expect(unreadStatus).toBe(myMemberB.mention_count); // channelA and channelB are unread, but only channelB is counted because of its mark_unread
     });
 
     test('should count mentions from DM channels', () => {

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -34,6 +34,25 @@ import {
 } from 'mattermost-redux/selectors/entities/users';
 
 import {
+    calculateUnreadCount,
+    completeDirectChannelDisplayName,
+    completeDirectChannelInfo,
+    completeDirectGroupInfo,
+    filterChannelsMatchingTerm,
+    getChannelByName as getChannelByNameHelper,
+    getUserIdFromChannelName,
+    isChannelMuted,
+    isDefault,
+    isDirectChannel,
+    newCompleteDirectChannelInfo,
+    sortChannelsByDisplayName,
+} from 'mattermost-redux/utils/channel_utils';
+
+import {createIdsSelector} from 'mattermost-redux/utils/helpers';
+
+import {createSelector} from 'reselect';
+
+import {
     Channel,
     ChannelMemberCountsByGroup,
     ChannelMembership,
@@ -51,23 +70,6 @@ import {
     RelationOneToManyUnique,
     RelationOneToOne,
 } from '@mattermost/types/utilities';
-
-import {
-    calculateUnreadCount,
-    completeDirectChannelDisplayName,
-    completeDirectChannelInfo,
-    completeDirectGroupInfo,
-    filterChannelsMatchingTerm,
-    getChannelByName as getChannelByNameHelper,
-    getUserIdFromChannelName,
-    isChannelMuted,
-    isDefault,
-    isDirectChannel,
-    newCompleteDirectChannelInfo,
-    sortChannelsByDisplayName,
-} from 'mattermost-redux/utils/channel_utils';
-import {createIdsSelector} from 'mattermost-redux/utils/helpers';
-import {createSelector} from 'reselect';
 
 import {getThreadCounts, getThreadCountsIncludingDirect} from './threads';
 import {isPostPriorityEnabled} from './posts';
@@ -611,7 +613,7 @@ export const getUnreadStatus: (state: GlobalState) => BasicUnreadStatus = create
             }
 
             const mentions = collapsedThreads ? membership.mention_count_root : membership.mention_count;
-            if (mentions) {
+            if (mentions && !isChannelMuted(membership)) {
                 counts.mentions += mentions;
             }
 

--- a/packages/mattermost-redux/src/selectors/entities/channels.ts
+++ b/packages/mattermost-redux/src/selectors/entities/channels.ts
@@ -562,6 +562,7 @@ export function basicUnreadMeta(unreadStatus: BasicUnreadStatus): BasicUnreadMet
     };
 }
 
+// muted channel will not be counted towards unreads
 export const getUnreadStatus: (state: GlobalState) => BasicUnreadStatus = createSelector(
     'getUnreadStatus',
     getAllChannels,


### PR DESCRIPTION
#### Summary
Remove mention counts of muted channels on the browser and desktop tabs

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/21229
  Fixes https://mattermost.atlassian.net/browse/MM-47369

#### Related Pull Requests
NA

#### Screenshots
https://user-images.githubusercontent.com/16203333/195066884-84e7382a-7545-4452-a36e-82abc958c8b9.mov

#### Release Note
```release-note
NONE
```
