### PR TITLE
MM-47400/MM-47410 Fix subpaths with module federation

### DIFF
--- a/entry.tsx
+++ b/entry.tsx
@@ -24,19 +24,6 @@ declare global {
     }
 }
 
-// Allow overriding the path used by webpack to dynamically resolve assets. This is driven by
-// an environment variable in development, or by a window variable defined in root.html in
-// production. The window variable is updated by the server after configuring SiteURL and
-// restarting or by running the `mattermost config subpath` command.
-window.publicPath = process.env.PUBLIC_PATH || window.publicPath || '/static/'; // eslint-disable-line no-process-env
-__webpack_public_path__ = window.publicPath; // eslint-disable-line camelcase, @typescript-eslint/naming-convention, no-undef
-
-// Define the subpath at which Mattermost is running. Extract this from the publicPath above to
-// avoid depending on Redux state before it is even loaded. This actual global export is used
-// in a minimum of places, as it is preferred to leverage react-router, configured to use this
-// basename accordingly.
-window.basename = window.publicPath.substr(0, window.publicPath.length - '/static/'.length);
-
 // This is for anything that needs to be done for ALL react components.
 // This runs before we start to render anything.
 function preRenderSetup(callwhendone: () => void) {

--- a/root.tsx
+++ b/root.tsx
@@ -1,6 +1,19 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// Allow overriding the path used by webpack to dynamically resolve assets. This is driven by
+// an environment variable in development, or by a window variable defined in root.html in
+// production. The window variable is updated by the server after configuring SiteURL and
+// restarting or by running the `mattermost config subpath` command.
+window.publicPath = process.env.PUBLIC_PATH || window.publicPath || '/static/'; // eslint-disable-line no-process-env
+__webpack_public_path__ = window.publicPath; // eslint-disable-line camelcase, @typescript-eslint/naming-convention, no-undef
+
+// Define the subpath at which Mattermost is running. Extract this from the publicPath above to
+// avoid depending on Redux state before it is even loaded. This actual global export is used
+// in a minimum of places, as it is preferred to leverage react-router, configured to use this
+// basename accordingly.
+window.basename = window.publicPath.substr(0, window.publicPath.length - '/static/'.length);
+
 import('./entry');
 
 // This empty export forces this to be treated as a module by the TS compiler

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -270,6 +270,12 @@ var config = {
             filename: 'root.html',
             inject: 'head',
             template: 'root.html',
+            meta: {
+                csp: {
+                    'http-equiv': 'Content-Security-Policy',
+                    content: generateCSP(),
+                },
+            },
         }),
         new CopyWebpackPlugin({
             patterns: [
@@ -379,6 +385,20 @@ var config = {
         // }),
     ],
 };
+
+function generateCSP() {
+    let csp = 'script-src \'self\' cdn.rudderlabs.com/ js.stripe.com/v3';
+
+    if (DEV) {
+        // react-hot-loader and development source maps require eval
+        csp += ' \'unsafe-eval\'';
+
+        // Focalboard runs on http://localhost:9006
+        csp += ' http://localhost:9006';
+    }
+
+    return csp;
+}
 
 async function initializeModuleFederation() {
     function makeSingletonSharedModules(packageNames) {


### PR DESCRIPTION
So there's two issues that prevent subpaths from working currently:
1. The server's subpath rewriting logic silently fails (with an error message in the logs) when it can't find the CSP meta tag in the HTML. While that isn't needed for most cases, it's probably needed if people deploy MM using a CDN since that wouldn't load static files through the MM server which is responsible for adding the CSP HTML header. This PR fixes that by re-adding the CSP meta tag.
2. Since we're using module federation to load web app files now, we need to set the `__webpack_public_path__` sooner in the process before module federation is initialized. That's fixed by moving that stuff to happen in `root.tsx` before `entry.tsx` is loaded.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47400
https://mattermost.atlassian.net/browse/MM-47410

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/21324

#### Release Note
```release-note
NONE
```
