### PR TITLE
[MM-47499] Add UTM Tracking

### DIFF
--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -380,9 +380,8 @@ export default class Root extends React.PureComponent<Props, State> {
 
         if (Object.keys(campaign).length > 0) {
             trackEvent('utm_params', 'utm_params', campaign);
+            this.props.history.replace({search: qs.toString()});
         }
-
-        this.props.history.replace({search: qs.toString()});
     }
 
     initiateMeRequests = async () => {

--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -262,6 +262,9 @@ export default class Root extends React.PureComponent<Props, State> {
             });
         }
 
+        // This needs to be called as early as possible to ensure that a redirect won't remove the query string
+        this.trackUTMCampain();
+
         if (this.props.location.pathname === '/' && this.props.noAccounts) {
             this.props.history.push('/signup_user_complete');
         }
@@ -300,8 +303,6 @@ export default class Root extends React.PureComponent<Props, State> {
             this.props.history.push('/landing#' + this.props.location.pathname + this.props.location.search);
             BrowserStore.setLandingPageSeen(true);
         }
-
-        this.trackUTMCampain();
 
         Utils.applyTheme(this.props.theme);
     }

--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -367,7 +367,11 @@ export default class Root extends React.PureComponent<Props, State> {
             const utmMedium = qs.get('utm_medium');
             const utmCampaign = qs.get('utm_campaign');
 
-            trackEvent('onboarding', 'track_campain', {utm_source: utmSource, utm_medium: utmMedium, utm_campaign: utmCampaign});
+            trackEvent('utm_params', 'utm_params', {
+                utm_source: utmSource,
+                utm_medium: utmMedium,
+                utm_campaign: utmCampaign,
+            });
 
             qs.delete('utm_source');
             qs.delete('utm_medium');

--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -363,23 +363,26 @@ export default class Root extends React.PureComponent<Props, State> {
 
     trackUTMCampaign() {
         const qs = new URLSearchParams(window.location.search);
-        if (qs.has('utm_source')) {
-            const utmSource = qs.get('utm_source');
-            const utmMedium = qs.get('utm_medium');
-            const utmCampaign = qs.get('utm_campaign');
 
-            trackEvent('utm_params', 'utm_params', {
-                utm_source: utmSource,
-                utm_medium: utmMedium,
-                utm_campaign: utmCampaign,
-            });
+        // list of key that we want to track
+        const keys = ['utm_source', 'utm_medium', 'utm_campaign'];
 
-            qs.delete('utm_source');
-            qs.delete('utm_medium');
-            qs.delete('utm_campaign');
+        const campaign = keys.reduce((acc, key) => {
+            if (qs.has(key)) {
+                const value = qs.get(key);
+                if (value) {
+                    acc[key] = value;
+                }
+                qs.delete(key);
+            }
+            return acc;
+        }, {} as Record<string, string>);
 
-            this.props.history.replace({search: qs.toString()});
+        if (Object.keys(campaign).length > 0) {
+            trackEvent('utm_params', 'utm_params', campaign);
         }
+
+        this.props.history.replace({search: qs.toString()});
     }
 
     initiateMeRequests = async () => {

--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -22,7 +22,7 @@ import {getCurrentUser, isCurrentUserSystemAdmin, checkIsFirstAdmin} from 'matte
 
 import {loadRecentlyUsedCustomEmojis} from 'actions/emoji_actions';
 import * as GlobalActions from 'actions/global_actions';
-import {measurePageLoadTelemetry, trackSelectorMetrics} from 'actions/telemetry_actions.jsx';
+import {measurePageLoadTelemetry, trackEvent, trackSelectorMetrics} from 'actions/telemetry_actions.jsx';
 
 import {makeAsyncComponent} from 'components/async_load';
 import CompassThemeProvider from 'components/compass_theme_provider/compass_theme_provider';
@@ -301,6 +301,8 @@ export default class Root extends React.PureComponent<Props, State> {
             BrowserStore.setLandingPageSeen(true);
         }
 
+        this.trackUTMCampain();
+
         Utils.applyTheme(this.props.theme);
     }
 
@@ -356,6 +358,23 @@ export default class Root extends React.PureComponent<Props, State> {
         }
 
         GlobalActions.redirectUserToDefaultTeam();
+    }
+
+    trackUTMCampain() {
+        const qs = new URLSearchParams(window.location.search);
+        if (qs.has('utm_source')) {
+            const utmSource = qs.get('utm_source');
+            const utmMedium = qs.get('utm_medium');
+            const utmCampaign = qs.get('utm_campaign');
+
+            trackEvent('onboarding', 'track_campain', {utm_source: utmSource, utm_medium: utmMedium, utm_campaign: utmCampaign});
+
+            qs.delete('utm_source');
+            qs.delete('utm_medium');
+            qs.delete('utm_campaign');
+
+            this.props.history.replace({search: qs.toString()});
+        }
     }
 
     initiateMeRequests = async () => {

--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -263,7 +263,7 @@ export default class Root extends React.PureComponent<Props, State> {
         }
 
         // This needs to be called as early as possible to ensure that a redirect won't remove the query string
-        this.trackUTMCampain();
+        this.trackUTMCampaign();
 
         if (this.props.location.pathname === '/' && this.props.noAccounts) {
             this.props.history.push('/signup_user_complete');
@@ -361,7 +361,7 @@ export default class Root extends React.PureComponent<Props, State> {
         GlobalActions.redirectUserToDefaultTeam();
     }
 
-    trackUTMCampain() {
+    trackUTMCampaign() {
         const qs = new URLSearchParams(window.location.search);
         if (qs.has('utm_source')) {
             const utmSource = qs.get('utm_source');


### PR DESCRIPTION
#### Summary
Add UTM tracking on the webapp.

The PR reads the params from the URL, fires a trackEvent, and then removes the params from the URL to prevent re-triggering the event upon refresh.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47499

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
