### PR TITLE
MM-47534 : Remove the 'channelRolesLoading' check in "channel_view"

### DIFF
--- a/components/channel_view/__snapshots__/channel_view.test.tsx.snap
+++ b/components/channel_view/__snapshots__/channel_view.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`components/channel_view Should match snapshot if channel is archived 1`
   <withRouter(Connect(injectIntl(ChannelHeader)))
     channelId="channelId"
     channelIsArchived={true}
-    channelRolesLoading={false}
     deactivatedChannel={false}
     enableOnboardingFlow={true}
     goToLastViewedChannel={[MockFunction]}
@@ -70,7 +69,6 @@ exports[`components/channel_view Should match snapshot if channel is deactivated
   <withRouter(Connect(injectIntl(ChannelHeader)))
     channelId="channelId"
     channelIsArchived={false}
-    channelRolesLoading={false}
     deactivatedChannel={true}
     enableOnboardingFlow={true}
     goToLastViewedChannel={[MockFunction]}
@@ -128,7 +126,6 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
   <withRouter(Connect(injectIntl(ChannelHeader)))
     channelId="channelId"
     channelIsArchived={false}
-    channelRolesLoading={false}
     deactivatedChannel={false}
     enableOnboardingFlow={true}
     goToLastViewedChannel={[MockFunction]}

--- a/components/channel_view/__snapshots__/channel_view.test.tsx.snap
+++ b/components/channel_view/__snapshots__/channel_view.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/channel_view Should match snapshot if channel is archived with roles loading 1`] = `
+exports[`components/channel_view Should match snapshot if channel is archived 1`] = `
 <div
   className="app__content"
   id="app-content"
@@ -9,20 +9,17 @@ exports[`components/channel_view Should match snapshot if channel is archived wi
     overlayType="center"
   />
   <withRouter(Connect(injectIntl(ChannelHeader)))
-    actions={
-      Object {
-        "getProfiles": [MockFunction],
-        "goToLastViewedChannel": [MockFunction],
-      }
-    }
     channelId="channelId"
     channelIsArchived={true}
-    channelRolesLoading={true}
+    channelRolesLoading={false}
     deactivatedChannel={false}
     enableOnboardingFlow={true}
+    goToLastViewedChannel={[MockFunction]}
+    history={Object {}}
     isCloud={false}
     isFirstAdmin={false}
     isOnboardingHidden={true}
+    location={Object {}}
     match={
       Object {
         "params": Object {},
@@ -62,7 +59,7 @@ exports[`components/channel_view Should match snapshot if channel is archived wi
 </div>
 `;
 
-exports[`components/channel_view Should match snapshot if channel roles loading 1`] = `
+exports[`components/channel_view Should match snapshot if channel is deactivated 1`] = `
 <div
   className="app__content"
   id="app-content"
@@ -71,20 +68,17 @@ exports[`components/channel_view Should match snapshot if channel roles loading 
     overlayType="center"
   />
   <withRouter(Connect(injectIntl(ChannelHeader)))
-    actions={
-      Object {
-        "getProfiles": [MockFunction],
-        "goToLastViewedChannel": [MockFunction],
-      }
-    }
     channelId="channelId"
     channelIsArchived={false}
-    channelRolesLoading={true}
-    deactivatedChannel={false}
+    channelRolesLoading={false}
+    deactivatedChannel={true}
     enableOnboardingFlow={true}
+    goToLastViewedChannel={[MockFunction]}
+    history={Object {}}
     isCloud={false}
     isFirstAdmin={false}
     isOnboardingHidden={true}
+    location={Object {}}
     match={
       Object {
         "params": Object {},
@@ -98,6 +92,28 @@ exports[`components/channel_view Should match snapshot if channel roles loading 
   <DeferredRenderWrapper
     channelId="channelId"
   />
+  <div
+    className="post-create__container"
+    id="post-create"
+  >
+    <div
+      className="channel-archived__message"
+    >
+      <FormattedMarkdownMessage
+        defaultMessage="You are viewing an archived channel with a **deactivated user**. New messages cannot be posted."
+        id="create_post.deactivated"
+      />
+      <button
+        className="btn btn-primary channel-archived__close-btn"
+        onClick={[Function]}
+      >
+        <MemoizedFormattedMessage
+          defaultMessage="Close Channel"
+          id="center_panel.archived.closeChannel"
+        />
+      </button>
+    </div>
+  </div>
 </div>
 `;
 
@@ -110,20 +126,17 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
     overlayType="center"
   />
   <withRouter(Connect(injectIntl(ChannelHeader)))
-    actions={
-      Object {
-        "getProfiles": [MockFunction],
-        "goToLastViewedChannel": [MockFunction],
-      }
-    }
     channelId="channelId"
     channelIsArchived={false}
     channelRolesLoading={false}
     deactivatedChannel={false}
     enableOnboardingFlow={true}
+    goToLastViewedChannel={[MockFunction]}
+    history={Object {}}
     isCloud={false}
     isFirstAdmin={false}
     isOnboardingHidden={true}
+    location={Object {}}
     match={
       Object {
         "params": Object {},

--- a/components/channel_view/__snapshots__/channel_view.test.tsx.snap
+++ b/components/channel_view/__snapshots__/channel_view.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`components/channel_view Should match snapshot if channel is archived 1`
     history={Object {}}
     isCloud={false}
     isFirstAdmin={false}
-    isOnboardingHidden={true}
     location={Object {}}
     match={
       Object {
@@ -25,7 +24,6 @@ exports[`components/channel_view Should match snapshot if channel is archived 1`
         "url": "/team/channel/channelId",
       }
     }
-    showTutorial={false}
     teamUrl="/team"
     viewArchivedChannels={false}
   />
@@ -75,7 +73,6 @@ exports[`components/channel_view Should match snapshot if channel is deactivated
     history={Object {}}
     isCloud={false}
     isFirstAdmin={false}
-    isOnboardingHidden={true}
     location={Object {}}
     match={
       Object {
@@ -83,7 +80,6 @@ exports[`components/channel_view Should match snapshot if channel is deactivated
         "url": "/team/channel/channelId",
       }
     }
-    showTutorial={false}
     teamUrl="/team"
     viewArchivedChannels={false}
   />
@@ -132,7 +128,6 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
     history={Object {}}
     isCloud={false}
     isFirstAdmin={false}
-    isOnboardingHidden={true}
     location={Object {}}
     match={
       Object {
@@ -140,7 +135,6 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
         "url": "/team/channel/channelId",
       }
     }
-    showTutorial={false}
     teamUrl="/team"
     viewArchivedChannels={false}
   />

--- a/components/channel_view/channel_view.test.tsx
+++ b/components/channel_view/channel_view.test.tsx
@@ -16,8 +16,6 @@ describe('components/channel_view', () => {
             url: '/team/channel/channelId',
             params: {},
         } as Props['match'],
-        showTutorial: false,
-        isOnboardingHidden: true,
         enableOnboardingFlow: true,
         teamUrl: '/team',
         channelIsArchived: false,

--- a/components/channel_view/channel_view.test.tsx
+++ b/components/channel_view/channel_view.test.tsx
@@ -7,9 +7,8 @@ import {shallow} from 'enzyme';
 import ChannelView, {Props} from './channel_view';
 
 describe('components/channel_view', () => {
-    const baseProps = {
+    const baseProps: Props = {
         channelId: 'channelId',
-        channelRolesLoading: false,
         deactivatedChannel: false,
         history: {} as Props['history'],
         location: {} as Props['location'],

--- a/components/channel_view/channel_view.test.tsx
+++ b/components/channel_view/channel_view.test.tsx
@@ -4,17 +4,19 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import ChannelView from './channel_view';
+import ChannelView, {Props} from './channel_view';
 
 describe('components/channel_view', () => {
     const baseProps = {
         channelId: 'channelId',
         channelRolesLoading: false,
         deactivatedChannel: false,
+        history: {} as Props['history'],
+        location: {} as Props['location'],
         match: {
             url: '/team/channel/channelId',
             params: {},
-        },
+        } as Props['match'],
         showTutorial: false,
         isOnboardingHidden: true,
         enableOnboardingFlow: true,
@@ -22,10 +24,7 @@ describe('components/channel_view', () => {
         channelIsArchived: false,
         viewArchivedChannels: false,
         isCloud: false,
-        actions: {
-            goToLastViewedChannel: jest.fn(),
-            getProfiles: jest.fn(),
-        },
+        goToLastViewedChannel: jest.fn(),
         isFirstAdmin: false,
     };
 
@@ -34,22 +33,21 @@ describe('components/channel_view', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('Should match snapshot if channel roles loading', () => {
+    it('Should match snapshot if channel is archived', () => {
         const wrapper = shallow(
             <ChannelView
                 {...baseProps}
-                channelRolesLoading={true}
+                channelIsArchived={true}
             />,
         );
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('Should match snapshot if channel is archived with roles loading', () => {
+    it('Should match snapshot if channel is deactivated', () => {
         const wrapper = shallow(
             <ChannelView
                 {...baseProps}
-                channelRolesLoading={true}
-                channelIsArchived={true}
+                deactivatedChannel={true}
             />,
         );
         expect(wrapper).toMatchSnapshot();

--- a/components/channel_view/channel_view.tsx
+++ b/components/channel_view/channel_view.tsx
@@ -14,7 +14,7 @@ import AdvancedCreatePost from 'components/advanced_create_post';
 
 import type {PropsFromRedux} from './index';
 
-type Props = PropsFromRedux & RouteComponentProps<{
+export type Props = PropsFromRedux & RouteComponentProps<{
     postid?: string;
 }>;
 
@@ -94,7 +94,6 @@ export default class ChannelView extends React.PureComponent<Props, State> {
     }
 
     render() {
-        const {channelIsArchived} = this.props;
         let createPost;
         if (this.props.deactivatedChannel) {
             createPost = (
@@ -121,7 +120,7 @@ export default class ChannelView extends React.PureComponent<Props, State> {
                     </div>
                 </div>
             );
-        } else if (channelIsArchived) {
+        } else if (this.props.channelIsArchived) {
             createPost = (
                 <div
                     className='post-create__container'

--- a/components/channel_view/channel_view.tsx
+++ b/components/channel_view/channel_view.tsx
@@ -1,38 +1,22 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable react/no-string-refs */
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
+import {RouteComponentProps} from 'react-router-dom';
 
 import deferComponentRender from 'components/deferComponentRender';
 import ChannelHeader from 'components/channel_header';
 import FileUploadOverlay from 'components/file_upload_overlay';
 import PostView from 'components/post_view';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
-
 import AdvancedCreatePost from 'components/advanced_create_post';
 
-type Props = {
-    channelId: string;
-    deactivatedChannel: boolean;
-    channelRolesLoading: boolean;
-    enableOnboardingFlow: boolean;
-    teamUrl: string;
-    match: {
-        url: string;
-        params: {
-            postid?: string;
-        };
-    };
-    channelIsArchived: boolean;
-    viewArchivedChannels: boolean;
-    isCloud: boolean;
-    isFirstAdmin: boolean;
-    actions: {
-        goToLastViewedChannel: () => void;
-    };
-};
+import type {PropsFromRedux} from './index';
+
+type Props = PropsFromRedux & RouteComponentProps<{
+    postid?: string;
+}>;
 
 type State = {
     channelId: string;
@@ -77,7 +61,9 @@ export default class ChannelView extends React.PureComponent<Props, State> {
 
         return null;
     }
+
     channelViewRef: React.RefObject<HTMLDivElement>;
+
     constructor(props: Props) {
         super(props);
 
@@ -96,13 +82,13 @@ export default class ChannelView extends React.PureComponent<Props, State> {
     }
 
     onClickCloseChannel = () => {
-        this.props.actions.goToLastViewedChannel();
+        this.props.goToLastViewedChannel();
     }
 
     componentDidUpdate(prevProps: Props) {
         if (prevProps.channelId !== this.props.channelId || prevProps.channelIsArchived !== this.props.channelIsArchived) {
             if (this.props.channelIsArchived && !this.props.viewArchivedChannels) {
-                this.props.actions.goToLastViewedChannel();
+                this.props.goToLastViewedChannel();
             }
         }
     }
@@ -161,7 +147,7 @@ export default class ChannelView extends React.PureComponent<Props, State> {
                     </div>
                 </div>
             );
-        } else if (!this.props.channelRolesLoading) {
+        } else {
             createPost = (
                 <div
                     className='post-create__container AdvancedTextEditor__ctr'
@@ -193,4 +179,3 @@ export default class ChannelView extends React.PureComponent<Props, State> {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/channel_view/index.ts
+++ b/components/channel_view/index.ts
@@ -32,7 +32,6 @@ function mapStateToProps(state: GlobalState) {
     return {
         channelId: channel ? channel.id : '',
         deactivatedChannel: channel ? isDeactivatedChannel(state, channel.id) : false,
-        focusedPostId: state.views.channel.focusedPostId,
         enableOnboardingFlow,
         channelIsArchived: channel ? channel.delete_at !== 0 : false,
         viewArchivedChannels,

--- a/components/channel_view/index.ts
+++ b/components/channel_view/index.ts
@@ -1,16 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
-import {connect} from 'react-redux';
+import {connect, ConnectedProps} from 'react-redux';
 import {withRouter} from 'react-router-dom';
 
 import {getCurrentChannel, getDirectTeammate} from 'mattermost-redux/selectors/entities/channels';
-import {getMyChannelRoles} from 'mattermost-redux/selectors/entities/roles';
-import {getRoles} from 'mattermost-redux/selectors/entities/roles_helpers';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
-
-import {Action} from 'mattermost-redux/types/actions';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 
@@ -19,10 +14,6 @@ import {goToLastViewedChannel} from 'actions/views/channel';
 import {GlobalState} from 'types/store';
 
 import ChannelView from './channel_view';
-
-type Actions = {
-    goToLastViewedChannel: () => void;
-}
 
 function isDeactivatedChannel(state: GlobalState, channelId: string) {
     const teammate = getDirectTeammate(state, channelId);
@@ -38,24 +29,8 @@ function mapStateToProps(state: GlobalState) {
     const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
     const enableOnboardingFlow = config.EnableOnboardingFlow === 'true';
 
-    let channelRolesLoading = true;
-    if (channel && channel.id) {
-        const roles = getRoles(state);
-        const myChannelRoles = getMyChannelRoles(state);
-        if (myChannelRoles[channel.id]) {
-            const channelRoles = myChannelRoles[channel.id].values();
-            for (const roleName of channelRoles) {
-                if (roles[roleName]) {
-                    channelRolesLoading = false;
-                    break;
-                }
-            }
-        }
-    }
-
     return {
         channelId: channel ? channel.id : '',
-        channelRolesLoading,
         deactivatedChannel: channel ? isDeactivatedChannel(state, channel.id) : false,
         focusedPostId: state.views.channel.focusedPostId,
         enableOnboardingFlow,
@@ -67,12 +42,12 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch) {
-    return {
-        actions: bindActionCreators<ActionCreatorsMapObject<Action>, Actions>({
-            goToLastViewedChannel,
-        }, dispatch),
-    };
-}
+const mapDispatchToProps = ({
+    goToLastViewedChannel,
+});
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ChannelView));
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+export type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default withRouter(connector(ChannelView));


### PR DESCRIPTION
#### Summary

The situation was that the create post will be briefly in [disabled state](https://mattermost.atlassian.net/browse/MM-22801) until the permissions are resolved from the network  . To counter this flash a fix https://github.com/mattermost/mattermost-webapp/pull/5337 was to keeping checking the permission state until the relevant permission for the channel is found. It worked as a kind of [loading mechanism](https://github.com/mattermost/mattermost-webapp/pull/5417/files#r417472909). Fortunately things have changed [after that](https://github.com/mattermost/mattermost-redux/blob/3d1028034d7677adfda58e91b9a5dcaf1bc0ff99/src/selectors/entities/roles.ts#L187) and we have improved the IPermission selector https://github.com/mattermost/mattermost-webapp/pull/10058 and brought the permission resolution inside a promise https://github.com/mattermost/mattermost-webapp/pull/10052. Hence this check is no necessary anymore.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47534

#### Related Pull Requests
none

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
