### PR TITLE
MM-47497 - remove invite task from guest users

### DIFF
--- a/components/onboarding_tasks/onboarding_tasks_manager.test.tsx
+++ b/components/onboarding_tasks/onboarding_tasks_manager.test.tsx
@@ -21,6 +21,7 @@ const WrapperComponent = (): JSX.Element => {
 describe('onboarding tasks manager', () => {
     const user1 = 'user1';
     const user2 = 'user2';
+    const user3 = 'user3';
 
     const initialState = {
         entities: {
@@ -40,6 +41,7 @@ describe('onboarding tasks manager', () => {
                 profiles: {
                     [user1]: {id: user1, username: user1, roles: 'system_admin'},
                     [user2]: {id: user2, username: user2, roles: 'system_user'},
+                    [user3]: {id: user3, username: user3, roles: 'system_guest'},
                 },
             },
             roles: {},
@@ -76,5 +78,20 @@ describe('onboarding tasks manager', () => {
         // verify visit_system_console and start_trial were removed
         expect(wrapper.findWhere((node) => node.key() === 'visit_system_console')).toHaveLength(0);
         expect(wrapper.findWhere((node) => node.key() === 'start_trial')).toHaveLength(0);
+    });
+
+    it('Removes invite people task item when user is GUEST user', () => {
+        const endUserState = {...initialState, entities: {...initialState.entities, users: {...initialState.entities.users, currentUserId: user3}}};
+        const store = configureStore(endUserState);
+
+        const wrapper = mount(
+            <Provider store={store}>
+                <WrapperComponent/>
+            </Provider>,
+        );
+        expect(wrapper.find('li')).toHaveLength(3);
+
+        // verify visit_system_console and start_trial were removed
+        expect(wrapper.findWhere((node) => node.key() === 'invite_people')).toHaveLength(0);
     });
 });

--- a/components/onboarding_tasks/onboarding_tasks_manager.tsx
+++ b/components/onboarding_tasks/onboarding_tasks_manager.tsx
@@ -23,7 +23,7 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 
 import {makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
-import {isCurrentUserSystemAdmin, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
+import {isCurrentUserGuestUser, isCurrentUserSystemAdmin, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 
 import {GlobalState} from 'types/store';
 import {browserHistory} from 'utils/browser_history';
@@ -104,6 +104,7 @@ export const useTasksList = () => {
     const isPrevLicensed = prevTrialLicense?.IsLicensed;
     const isCurrentLicensed = license?.IsLicensed;
     const isUserAdmin = useSelector((state: GlobalState) => isCurrentUserSystemAdmin(state));
+    const isGuestUser = useSelector((state: GlobalState) => isCurrentUserGuestUser(state));
     const isUserFirstAdmin = useSelector(isFirstAdmin);
 
     // Cloud conditions
@@ -138,6 +139,11 @@ export const useTasksList = () => {
     // explore other tools tour is only shown to subsequent admins and end users
     if (isUserFirstAdmin || (!pluginsList.playbooks && !pluginsList.focalboard)) {
         delete list.EXPLORE_OTHER_TOOLS;
+    }
+
+    // invite other users is hidden for guest users
+    if (isGuestUser) {
+        delete list.INVITE_PEOPLE;
     }
 
     return Object.values(list);

--- a/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -23,6 +23,7 @@ import {
     includesAnAdminRole,
     profileListToMap,
     sortByUsername,
+    isGuest,
     applyRolesFilters,
 } from 'mattermost-redux/utils/user_utils';
 
@@ -142,6 +143,15 @@ export const isCurrentUserSystemAdmin: (state: GlobalState) => boolean = createS
     (user) => {
         const roles = user?.roles || '';
         return isSystemAdmin(roles);
+    },
+);
+
+export const isCurrentUserGuestUser: (state: GlobalState) => boolean = createSelector(
+    'isCurrentUserGuestUser',
+    getCurrentUser,
+    (user) => {
+        const roles = user?.roles || '';
+        return isGuest(roles);
     },
 );
 


### PR DESCRIPTION
#### Summary
This PR adds code to hide the invite team members onboarding task list item to guest users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47497

#### Related Pull Requests
n/a

#### Screenshots
Before:
<img width="645" alt="Captura de Pantalla 2022-10-13 a las 16 27 34" src="https://user-images.githubusercontent.com/10082627/195624524-9264b0f6-c330-4b30-8553-c018338e1513.png">

After:
<img width="1295" alt="Captura de Pantalla 2022-10-13 a las 16 26 36" src="https://user-images.githubusercontent.com/10082627/195624371-d7adf9b1-89fc-403e-b243-4fbc01408ac0.png">


#### Release Note
```release-note
NONE
```
