### PR TITLE
MM-47442 : Avoid passing global state into post_actions.ts in Mattermost webapp

### DIFF
--- a/actions/post_actions.ts
+++ b/actions/post_actions.ts
@@ -278,12 +278,13 @@ export function markPostAsUnread(post: Post, location: string) {
 
 export function deleteAndRemovePost(post: Post) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const {error} = await dispatch(PostActions.deletePost(post));
         if (error) {
             return {error};
         }
 
-        if (post.id === getSelectedPostId(getState() as GlobalState)) {
+        if (post.id === getSelectedPostId(state as GlobalState)) {
             dispatch({
                 type: ActionTypes.SELECT_POST,
                 postId: '',
@@ -292,7 +293,7 @@ export function deleteAndRemovePost(post: Post) {
             });
         }
 
-        if (post.id === getSelectedPostCardId(getState() as GlobalState)) {
+        if (post.id === getSelectedPostCardId(state as GlobalState)) {
             dispatch({
                 type: ActionTypes.SELECT_POST_CARD,
                 postId: '',


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Avoid calling `getState()` as much as possible.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21334

```release-note
NONE
```

