### PR TITLE
MM-47449 : Avoid passing global state into actions/views/create_comment.tsx in mattermost webapp

### DIFF
--- a/actions/views/create_comment.tsx
+++ b/actions/views/create_comment.tsx
@@ -61,8 +61,9 @@ export function makeOnMoveHistoryIndex(rootId: string, direction: number) {
     const getMessageInHistory = makeGetMessageInHistoryItem(Posts.MESSAGE_TYPES.COMMENT as 'comment');
 
     return () => (dispatch: DispatchFunc, getState: () => GlobalState) => {
-        const draft = getPostDraft(getState(), StoragePrefixes.COMMENT_DRAFT, rootId);
-        if (draft.message !== '' && draft.message !== getMessageInHistory(getState())) {
+        const state = getState();
+        const draft = getPostDraft(state, StoragePrefixes.COMMENT_DRAFT, rootId);
+        if (draft.message !== '' && draft.message !== getMessageInHistory(state)) {
             return {data: true};
         }
 
@@ -72,7 +73,7 @@ export function makeOnMoveHistoryIndex(rootId: string, direction: number) {
             dispatch(moveHistoryIndexForward(Posts.MESSAGE_TYPES.COMMENT as 'comment'));
         }
 
-        const nextMessageInHistory = getMessageInHistory(getState());
+        const nextMessageInHistory = getMessageInHistory(state);
 
         dispatch(updateCommentDraft(rootId, {...draft, message: nextMessageInHistory}));
         return {data: true};
@@ -162,6 +163,7 @@ export function submitCommand(channelId: string, rootId: string, draft: PostDraf
 export function makeOnSubmit(channelId: string, rootId: string, latestPostId: string) {
     return (draft: PostDraft, options: {ignoreSlash?: boolean} = {}) => async (dispatch: DispatchFunc, getState: () => GlobalState) => {
         const {message} = draft;
+        const state = getState();
 
         dispatch(addMessageIntoHistory(message));
 
@@ -169,7 +171,7 @@ export function makeOnSubmit(channelId: string, rootId: string, latestPostId: st
 
         const isReaction = Utils.REACTION_PATTERN.exec(message);
 
-        const emojis = getCustomEmojisByName(getState());
+        const emojis = getCustomEmojisByName(state);
         const emojiMap = new EmojiMap(emojis);
 
         if (isReaction && emojiMap.has(isReaction[2])) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
avoid multiple getState calls in `actions/views/create_comment.tsx`

#### Ticket Link
Fixes - https://github.com/mattermost/mattermost-server/issues/21348

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
