### PR TITLE
Cypress/E2E: Revert changes using lodash.set and mattermost types imports

### DIFF
--- a/e2e/cypress/package-lock.json
+++ b/e2e/cypress/package-lock.json
@@ -45,7 +45,6 @@
         "localforage": "1.10.0",
         "lodash.intersection": "4.4.0",
         "lodash.mapkeys": "4.6.0",
-        "lodash.set": "^4.3.2",
         "lodash.without": "4.4.0",
         "lodash.xor": "4.5.0",
         "mattermost-redux": "5.33.1",
@@ -8604,12 +8603,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "dev": true
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true
     },
     "node_modules/lodash.throttle": {
@@ -21021,12 +21014,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "dev": true
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true
     },
     "lodash.throttle": {

--- a/e2e/cypress/package.json
+++ b/e2e/cypress/package.json
@@ -40,7 +40,6 @@
     "localforage": "1.10.0",
     "lodash.intersection": "4.4.0",
     "lodash.mapkeys": "4.6.0",
-    "lodash.set": "4.3.2",
     "lodash.without": "4.4.0",
     "lodash.xor": "4.5.0",
     "mattermost-redux": "5.33.1",

--- a/e2e/cypress/tests/integration/custom_status/custom_status_1_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_1_spec.ts
@@ -10,18 +10,13 @@
 // Stage: @prod
 // Group: @custom_status
 
-import set from 'lodash.set';
-
 describe('Custom Status - CTAs for New Users', () => {
     before(() => {
-        cy.apiGetConfig().then(({config}) => {
-            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
-            cy.apiUpdateConfig(config);
+        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
 
-            // # Login as test user and visit channel
-            cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
-                cy.visit(`/${team.name}/channels/${channel.name}`);
-            });
+        // # Login as test user and visit channel
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            cy.visit(`/${team.name}/channels/${channel.name}`);
         });
     });
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_2_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_2_spec.ts
@@ -10,26 +10,21 @@
 // Stage: @prod
 // Group: @custom_status
 
-import set from 'lodash.set';
-
 describe('Custom Status - Setting a Custom Status', () => {
-    before(() => {
-        cy.apiGetConfig().then(({config}) => {
-            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
-            cy.apiUpdateConfig(config);
-
-            // # Login as test user and visit channel
-            cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
-                cy.visit(channelUrl);
-            });
-        });
-    });
-
     const defaultCustomStatuses = ['In a meeting', 'Out for lunch', 'Out sick', 'Working from home', 'On a vacation'];
     const customStatus = {
         emoji: 'calendar',
         text: 'In a meeting',
     };
+
+    before(() => {
+        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+
+        // # Login as test user and visit channel
+        cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
+            cy.visit(channelUrl);
+        });
+    });
 
     it('MM-T3836_1 should open status dropdown', () => {
         // # Click on the sidebar header to open status dropdown

--- a/e2e/cypress/tests/integration/custom_status/custom_status_3_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_3_spec.ts
@@ -10,25 +10,20 @@
 // Stage: @prod
 // Group: @custom_status
 
-import set from 'lodash.set';
-
 describe('Custom Status - Setting Your Own Custom Status', () => {
-    before(() => {
-        cy.apiGetConfig().then(({config}) => {
-            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
-            cy.apiUpdateConfig(config);
-
-            // # Login as test user and visit channel
-            cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
-                cy.visit(`/${team.name}/channels/${channel.name}`);
-            });
-        });
-    });
-
     const customStatus = {
         emoji: 'grinning',
         text: 'Busy',
     };
+
+    before(() => {
+        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+
+        // # Login as test user and visit channel
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+        });
+    });
 
     it('MM-T3846_1 should change the emoji to speech balloon when typed in the input', () => {
         // # Open the custom status modal

--- a/e2e/cypress/tests/integration/custom_status/custom_status_4_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_4_spec.ts
@@ -10,21 +10,7 @@
 // Stage: @prod
 // Group: @custom_status
 
-import set from 'lodash.set';
-
 describe('Custom Status - Recent Statuses', () => {
-    before(() => {
-        cy.apiGetConfig().then(({config}) => {
-            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
-            cy.apiUpdateConfig(config);
-
-            // # Login as test user and visit channel
-            cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
-                cy.visit(`/${team.name}/channels/${channel.name}`);
-            });
-        });
-    });
-
     const customStatus = {
         emoji: 'grinning',
         text: 'Busy',
@@ -34,6 +20,15 @@ describe('Custom Status - Recent Statuses', () => {
         emoji: 'calendar',
         text: 'In a meeting',
     };
+
+    before(() => {
+        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+
+        // # Login as test user and visit channel
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+        });
+    });
 
     it('MM-T3847_1 set a status', () => {
         // # Open the custom status modal

--- a/e2e/cypress/tests/integration/custom_status/custom_status_5_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_5_spec.ts
@@ -9,8 +9,6 @@
 
 // Group: @custom_status
 
-import set from 'lodash.set';
-
 describe('Custom Status - Verifying Where Custom Status Appears', () => {
     const customStatus = {
         emoji: 'grinning',
@@ -19,15 +17,12 @@ describe('Custom Status - Verifying Where Custom Status Appears', () => {
     let currentUser;
 
     before(() => {
-        cy.apiGetConfig().then(({config}) => {
-            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
-            cy.apiUpdateConfig(config);
+        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
 
-            // # Login as test user and visit channel
-            cy.apiInitSetup({loginAfter: true}).then(({team, user, channel}) => {
-                cy.visit(`/${team.name}/channels/${channel.name}`);
-                currentUser = user;
-            });
+        // # Login as test user and visit channel
+        cy.apiInitSetup({loginAfter: true}).then(({team, user, channel}) => {
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+            currentUser = user;
         });
     });
 

--- a/e2e/cypress/tests/integration/custom_status/custom_status_6_spec.ts
+++ b/e2e/cypress/tests/integration/custom_status/custom_status_6_spec.ts
@@ -10,25 +10,20 @@
 // Stage: @prod
 // Group: @custom_status
 
-import set from 'lodash.set';
-
 describe('Custom Status - Slash Commands', () => {
-    before(() => {
-        cy.apiGetConfig().then(({config}) => {
-            set(config, 'TeamSettings.EnableCustomUserStatuses', true);
-            cy.apiUpdateConfig(config);
-
-            // # Login as test user and visit channel
-            cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
-                cy.visit(channelUrl);
-            });
-        });
-    });
-
     const customStatus = {
         emoji: 'laughing',
         text: 'Feeling happy',
     };
+
+    before(() => {
+        cy.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+
+        // # Login as test user and visit channel
+        cy.apiInitSetup({loginAfter: true}).then(({channelUrl}) => {
+            cy.visit(channelUrl);
+        });
+    });
 
     it('MM-T3852_1 should set custom status by slash command', () => {
         // # Set the custom status using slash command

--- a/e2e/cypress/tests/integration/enterprise/oauth/oauth_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/oauth/oauth_spec.ts
@@ -10,8 +10,6 @@
 // Stage: @prod
 // Group: @enterprise @integrations
 
-import set from 'lodash.set';
-
 import {getRandomId} from '../../../utils';
 import {checkboxesTitleToIdMap} from '../system_console/channel_moderation/constants';
 
@@ -32,10 +30,7 @@ describe('Integrations page', () => {
         cy.requireWebhookServer();
 
         // # Set ServiceSettings to expected values
-        cy.apiGetConfig().then(({config}) => {
-            set(config, 'ServiceSettings.EnableOAuthServiceProvider', true);
-            cy.apiUpdateConfig(config);
-        });
+        cy.apiUpdateConfig({ServiceSettings: {EnableOAuthServiceProvider: true}});
 
         cy.apiInitSetup().then(({team, user}) => {
             user1 = user;

--- a/e2e/cypress/tests/support/api/setup.ts
+++ b/e2e/cypress/tests/support/api/setup.ts
@@ -1,16 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {UserProfile} from '@mattermost/types/users';
-import {Team} from '@mattermost/types/teams';
-import {Channel} from '@mattermost/types/channels';
-
 import {ChainableT} from '../../types';
 
 interface SetupResult {
-    user: UserProfile;
-    team: Team;
-    channel: Channel;
+    user: Cypress.UserProfile;
+    team: Cypress.Team;
+    channel: Cypress.Channel;
     channelUrl: string;
     offTopicUrl: string;
     townSquareUrl: string;
@@ -89,9 +85,9 @@ declare global {
              * @param {string} options.teamPrefix - {name: 'team', displayName: 'Team'} (default) or any prefix to easily identify a team
              * @param {string} options.channelPrefix - {name: 'team', displayName: 'Team'} (default) or any prefix to easily identify a channel
              * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
-             * @returns {UserProfile} `out.user` as `UserProfile` object
-             * @returns {Team} `out.team` as `Team` object
-             * @returns {Channel} `out.channel` as `Channel` object
+             * @returns {Cypress.UserProfile} `out.user` as `UserProfile` object
+             * @returns {Cypress.Team} `out.team` as `Team` object
+             * @returns {Cypress.Channel} `out.channel` as `Channel` object
              * @returns {string} `out.channelUrl` as channel URL
              * @returns {string} `out.offTopicUrl` as off-topic URL
              * @returns {string} `out.townSquareUrl` as town-square URL


### PR DESCRIPTION
#### Summary
- Revert changes using lodash.set
- Use Mattermost [types under `Cypress` namespace](https://github.com/mattermost/mattermost-webapp/blob/master/e2e/cypress/tests/support/index.d.ts#L7-L35) to keep imports in one place only.

#### Release Note
```release-note
NONE
```
