### PR TITLE
MM-37606: Queue sending message after file upload finishes

### DIFF
--- a/actions/file_actions.ts
+++ b/actions/file_actions.ts
@@ -14,9 +14,7 @@ import {Client4} from 'mattermost-redux/client';
 
 import {localizeMessage} from 'utils/utils';
 
-import {postRemoved, storePost} from 'mattermost-redux/actions/posts';
-
-import {storePendingPosts} from './post_actions';
+import {postRemoved, storePendingPosts, storePost} from 'mattermost-redux/actions/posts';
 
 export interface UploadFile {
     file: File;

--- a/actions/file_actions.ts
+++ b/actions/file_actions.ts
@@ -160,6 +160,7 @@ export function cancelUploadingFile(clientId: string) {
             clientId,
         });
 
+        // If this is the last uploading file, immediately send the message or delete it.
         if (pendingPostEntry[1].length !== 1) {
             return;
         }
@@ -170,8 +171,10 @@ export function cancelUploadingFile(clientId: string) {
         }
 
         if (pendingPost.message.length === 0) {
+            // If this post doesn't have message, then delete it.
             await dispatch(postRemoved(pendingPost));
         } else {
+            // otherwise send it.
             await dispatch(storePost(pendingPost, []));
         }
     };

--- a/actions/post_actions.test.ts
+++ b/actions/post_actions.test.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Post} from '@mattermost/types/posts';
-import {FileInfo} from '@mattermost/types/files';
+import {FileInfo, FilePreviewInfo} from '@mattermost/types/files';
 
 import {GlobalState} from 'types/store';
 import {ChannelTypes, SearchTypes} from 'mattermost-redux/action_types';
@@ -343,6 +343,7 @@ describe('Actions.Posts', () => {
             const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message'} as Post;
             const newReply = {id: 'reply_post_id', channel_id: 'current_channel_id', message: 'new message', root_id: 'new_post_id'} as Post;
             const files: FileInfo[] = [];
+            const filePreviews: FilePreviewInfo[] = [];
 
             const immediateExpectedState = [{
                 args: [newPost, files],
@@ -358,7 +359,7 @@ describe('Actions.Posts', () => {
             const finalExpectedState = [
                 ...immediateExpectedState,
                 {
-                    args: [newReply, files],
+                    args: [newReply, files, filePreviews],
                     type: 'MOCK_CREATE_POST',
                 }, {
                     args: ['comment_draft_new_post_id', null],
@@ -366,7 +367,7 @@ describe('Actions.Posts', () => {
                 },
             ];
 
-            await testStore.dispatch(Actions.createPost(newReply, files));
+            await testStore.dispatch(Actions.createPost(newReply, files, filePreviews));
             expect(testStore.getActions()).toEqual(finalExpectedState);
         });
 
@@ -374,12 +375,13 @@ describe('Actions.Posts', () => {
             const testStore = mockStore(initialState);
             const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message :+1:'} as Post;
             const files: FileInfo[] = [];
+            const filePreviews: FilePreviewInfo[] = [];
 
             const immediateExpectedState = [{
                 args: ['+1'],
                 type: 'MOCK_ADD_RECENT_EMOJI',
             }, {
-                args: [newPost, files],
+                args: [newPost, files, filePreviews],
                 type: 'MOCK_CREATE_POST',
             }, {
                 args: ['draft_current_channel_id', null],
@@ -394,12 +396,13 @@ describe('Actions.Posts', () => {
             const testStore = mockStore(initialState);
             const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message :cake:'} as Post;
             const files: FileInfo[] = [];
+            const filePreviews: FilePreviewInfo[] = [];
 
             const immediateExpectedState = [{
                 args: ['cake'],
                 type: 'MOCK_ADD_RECENT_EMOJI',
             }, {
-                args: [newPost, files],
+                args: [newPost, files, filePreviews],
                 type: 'MOCK_CREATE_POST',
             }, {
                 args: ['draft_current_channel_id', null],
@@ -414,6 +417,7 @@ describe('Actions.Posts', () => {
             const testStore = mockStore(initialState);
             const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message :cake: :+1:'} as Post;
             const files: FileInfo[] = [];
+            const filePreviews: FilePreviewInfo[] = [];
 
             const immediateExpectedState = [{
                 args: ['cake'],
@@ -422,7 +426,7 @@ describe('Actions.Posts', () => {
                 args: ['+1'],
                 type: 'MOCK_ADD_RECENT_EMOJI',
             }, {
-                args: [newPost, files],
+                args: [newPost, files, filePreviews],
                 type: 'MOCK_CREATE_POST',
             }, {
                 args: ['draft_current_channel_id', null],

--- a/actions/post_actions.ts
+++ b/actions/post_actions.ts
@@ -128,6 +128,7 @@ export function createPost(post: Post, files: FileInfo[], filePreviews: FilePrev
 export function storePendingPosts() {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
+        // Send posts when their uploading files are all uploaded.
         await Promise.all(Object.entries(state.entities.files.filePreviews).map(async (entry) => {
             const pendingPostId = entry[0];
             let pendingPost = state.entities.posts.posts[pendingPostId];
@@ -140,6 +141,7 @@ export function storePendingPosts() {
             }
             const clientIds = filePreviewInfos.map((f) => f.clientId);
             const files = Object.values(state.entities.files.files).filter((f) => clientIds.includes(f.clientId));
+            // If post‘s uploading files are all uploaded, then send it.
             if (filePreviewInfos.length !== files.length) {
                 return;
             }

--- a/actions/post_actions.ts
+++ b/actions/post_actions.ts
@@ -128,6 +128,7 @@ export function createPost(post: Post, files: FileInfo[], filePreviews: FilePrev
 export function storePendingPosts() {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
+
         // Send posts when their uploading files are all uploaded.
         await Promise.all(Object.entries(state.entities.files.filePreviews).map(async (entry) => {
             const pendingPostId = entry[0];
@@ -141,6 +142,7 @@ export function storePendingPosts() {
             }
             const clientIds = filePreviewInfos.map((f) => f.clientId);
             const files = Object.values(state.entities.files.files).filter((f) => clientIds.includes(f.clientId));
+
             // If post‘s uploading files are all uploaded, then send it.
             if (filePreviewInfos.length !== files.length) {
                 return;

--- a/actions/views/create_comment.test.jsx
+++ b/actions/views/create_comment.test.jsx
@@ -183,7 +183,7 @@ describe('rhs view actions', () => {
             // make sure callback is a function which clears uploadsInProgress
             expect(typeof callback).toBe('function');
 
-            const draft = {message: 'test msg', channelId, rootId, uploadsProgressPercent: {'3': undefined, '4': undefined}, fileInfos: [{id: 1}, {id: 2}]};
+            const draft = {message: 'test msg', channelId, rootId, uploadsProgressPercent: {3: undefined, 4: undefined}, fileInfos: [{id: 1}, {id: 2}]};
 
             expect(callback(null, draft)).toEqual({...draft, uploadsProgressPercent: {}});
 

--- a/actions/views/create_comment.test.jsx
+++ b/actions/views/create_comment.test.jsx
@@ -151,7 +151,7 @@ describe('rhs view actions', () => {
                     value: {
                         message: '',
                         fileInfos: [],
-                        uploadsInProgress: [],
+                        uploadsProgressPercent: {},
                         channelId,
                         rootId,
                     },
@@ -183,9 +183,9 @@ describe('rhs view actions', () => {
             // make sure callback is a function which clears uploadsInProgress
             expect(typeof callback).toBe('function');
 
-            const draft = {message: 'test msg', channelId, rootId, uploadsInProgress: [3, 4], fileInfos: [{id: 1}, {id: 2}]};
+            const draft = {message: 'test msg', channelId, rootId, uploadsProgressPercent: {'3': undefined, '4': undefined}, fileInfos: [{id: 1}, {id: 2}]};
 
-            expect(callback(null, draft)).toEqual({...draft, uploadsInProgress: []});
+            expect(callback(null, draft)).toEqual({...draft, uploadsProgressPercent: {}});
 
             const testStore = mockStore(initialState);
 
@@ -248,7 +248,7 @@ describe('rhs view actions', () => {
 
             const testStore = mockStore(initialState);
 
-            testStore.dispatch(updateCommentDraft(rootId, {message: 'test message', channelId, rootId, fileInfos: [], uploadsInProgress: []}));
+            testStore.dispatch(updateCommentDraft(rootId, {message: 'test message', channelId, rootId, fileInfos: [], uploadsProgressPercent: {}}));
 
             expect(store.getActions()).toEqual(
                 expect.arrayContaining(testStore.getActions()),
@@ -259,7 +259,7 @@ describe('rhs view actions', () => {
     });
 
     describe('submitPost', () => {
-        const draft = {message: '', channelId, rootId, fileInfos: []};
+        const draft = {message: '', channelId, rootId, fileInfos: [], uploadsProgressPercent: {}};
 
         const post = {
             file_ids: [],

--- a/actions/views/create_comment.tsx
+++ b/actions/views/create_comment.tsx
@@ -32,9 +32,10 @@ import {getPostDraft} from 'selectors/rhs';
 
 import * as Utils from 'utils/utils';
 import {Constants, StoragePrefixes} from 'utils/constants';
-import type {PostDraft} from 'types/store/draft';
-import type {GlobalState} from 'types/store';
-import type {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {PostDraft} from 'types/store/draft';
+import {GlobalState} from 'types/store';
+import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
+import {FilePreviewInfo} from '@mattermost/types/files';
 
 export function clearCommentDraftUploads() {
     return actionOnGlobalItemsWithPrefix(StoragePrefixes.COMMENT_DRAFT, (_key: string, draft: PostDraft) => {
@@ -75,7 +76,7 @@ export function makeOnMoveHistoryIndex(rootId: string, direction: number) {
     };
 }
 
-export function submitPost(channelId: string, rootId: string, draft: PostDraft) {
+export function submitPost(channelId: string, rootId: string, draft: PostDraft, filePreviewInfos: FilePreviewInfo[] = []) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
 
@@ -102,7 +103,7 @@ export function submitPost(channelId: string, rootId: string, draft: PostDraft) 
 
         post = hookResult.data;
 
-        return dispatch(PostActions.createPost(post, draft.fileInfos));
+        return dispatch(PostActions.createPost(post, draft.fileInfos, filePreviewInfos));
     };
 }
 
@@ -156,7 +157,7 @@ export function submitCommand(channelId: string, rootId: string, draft: PostDraf
 }
 
 export function makeOnSubmit(channelId: string, rootId: string, latestPostId: string) {
-    return (draft: PostDraft, options: {ignoreSlash?: boolean} = {}) => async (dispatch: DispatchFunc, getState: () => GlobalState) => {
+    return (draft: PostDraft, filePreviewInfos: FilePreviewInfo[], options: {ignoreSlash?: boolean} = {}) => async (dispatch: DispatchFunc, getState: () => GlobalState) => {
         const {message} = draft;
 
         dispatch(addMessageIntoHistory(message));
@@ -179,7 +180,7 @@ export function makeOnSubmit(channelId: string, rootId: string, latestPostId: st
                 throw err;
             }
         } else {
-            dispatch(submitPost(channelId, rootId, draft));
+            dispatch(submitPost(channelId, rootId, draft, filePreviewInfos));
         }
         return {data: true};
     };

--- a/actions/views/drafts.ts
+++ b/actions/views/drafts.ts
@@ -177,7 +177,7 @@ export function transformServerDraft(draft: ServerDraft): Draft {
             message: draft.message,
             fileInfos,
             props: draft.props,
-            uploadsInProgress: [],
+            uploadsProgressPercent: {},
             channelId: draft.channel_id,
             rootId: draft.root_id,
             createAt: draft.create_at,

--- a/components/advanced_create_comment/__snapshots__/advanced_create_comment.test.jsx.snap
+++ b/components/advanced_create_comment/__snapshots__/advanced_create_comment.test.jsx.snap
@@ -19,9 +19,7 @@ exports[`components/AdvancedCreateComment should match snapshot when cannot post
           Object {},
         ],
         "message": "Test message",
-        "uploadsInProgress": Array [
-          Object {},
-        ],
+        "uploadsProgressPercent": Object {},
       }
     }
     emitTypingEvent={[Function]}
@@ -88,7 +86,7 @@ exports[`components/AdvancedCreateComment should match snapshot, comment with me
       Object {
         "fileInfos": Array [],
         "message": "Test message",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {},
       }
     }
     emitTypingEvent={[Function]}
@@ -160,9 +158,7 @@ exports[`components/AdvancedCreateComment should match snapshot, emoji picker di
           Object {},
         ],
         "message": "Test message",
-        "uploadsInProgress": Array [
-          Object {},
-        ],
+        "uploadsProgressPercent": Object {},
       }
     }
     emitTypingEvent={[Function]}
@@ -229,7 +225,7 @@ exports[`components/AdvancedCreateComment should match snapshot, empty comment 1
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {},
       }
     }
     emitTypingEvent={[Function]}
@@ -301,9 +297,7 @@ exports[`components/AdvancedCreateComment should match snapshot, non-empty messa
           Object {},
         ],
         "message": "Test message",
-        "uploadsInProgress": Array [
-          Object {},
-        ],
+        "uploadsProgressPercent": Object {},
       }
     }
     emitTypingEvent={[Function]}

--- a/components/advanced_create_comment/advanced_create_comment.test.jsx
+++ b/components/advanced_create_comment/advanced_create_comment.test.jsx
@@ -74,7 +74,7 @@ describe('components/AdvancedCreateComment', () => {
         useLDAPGroupMentions: true,
         useCustomGroupMentions: true,
         openModal: jest.fn(),
-        cancelUploadingFile: jest.fn()
+        cancelUploadingFile: jest.fn(),
     };
 
     const emptyDraft = {

--- a/components/advanced_create_comment/advanced_create_comment.test.jsx
+++ b/components/advanced_create_comment/advanced_create_comment.test.jsx
@@ -286,9 +286,9 @@ describe('components/AdvancedCreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsProgressPercent: {
-                '1': undefined,
-                '2': undefined,
-                '3': undefined
+                1: undefined,
+                2: undefined,
+                3: undefined,
             },
             fileInfos: [{}, {}, {}],
         };
@@ -309,14 +309,14 @@ describe('components/AdvancedCreateComment', () => {
         expect(updateCommentDraftWithRootId.mock.calls[0][0]).toEqual(props.rootId);
         expect(updateCommentDraftWithRootId.mock.calls[0][1]).toEqual(
             expect.objectContaining({uploadsProgressPercent: {
-                '2': undefined,
-                '3': undefined
+                2: undefined,
+                3: undefined,
             }}),
         );
         expect(wrapper.state().serverError.message).toBe(testError1);
         expect(wrapper.state().draft.uploadsProgressPercent).toEqual({
-            '2': undefined,
-            '3': undefined
+            2: undefined,
+            3: undefined,
         });
 
         // clientId = -1
@@ -343,9 +343,9 @@ describe('components/AdvancedCreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsProgressPercent: {
-                '1': undefined,
-                '2': undefined,
-                '3': undefined
+                1: undefined,
+                2: undefined,
+                3: undefined,
             },
             fileInfos: [{}, {}, {}],
         };
@@ -363,20 +363,20 @@ describe('components/AdvancedCreateComment', () => {
         expect(onUpdateCommentDraft).toHaveBeenCalled();
         expect(onUpdateCommentDraft.mock.calls[0][0]).toEqual(
             expect.objectContaining({uploadsProgressPercent: {
-                '1': undefined,
-                '2': undefined,
-                '3': undefined,
-                '4': undefined,
-                '5': undefined
+                1: undefined,
+                2: undefined,
+                3: undefined,
+                4: undefined,
+                5: undefined,
             }}),
         );
 
         expect(wrapper.state().draft.uploadsProgressPercent).toStrictEqual({
-            '1': undefined,
-            '2': undefined,
-            '3': undefined,
-            '4': undefined,
-            '5': undefined
+            1: undefined,
+            2: undefined,
+            3: undefined,
+            4: undefined,
+            5: undefined,
         });
         expect(focusTextbox).toHaveBeenCalled();
     });
@@ -387,9 +387,9 @@ describe('components/AdvancedCreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsProgressPercent: {
-                '1': undefined,
-                '2': undefined,
-                '3': undefined
+                1: undefined,
+                2: undefined,
+                3: undefined,
             },
             fileInfos,
         };
@@ -418,16 +418,16 @@ describe('components/AdvancedCreateComment', () => {
         expect(updateCommentDraftWithRootId.mock.calls[0][1]).toEqual(
             expect.objectContaining({
                 uploadsProgressPercent: {
-                    '1': undefined,
-                    '2': undefined
+                    1: undefined,
+                    2: undefined,
                 },
-                fileInfos: expectedNewFileInfos
+                fileInfos: expectedNewFileInfos,
             }),
         );
 
         expect(wrapper.state().draft.uploadsProgressPercent).toEqual({
-            '1': undefined,
-            '2': undefined
+            1: undefined,
+            2: undefined,
         });
         expect(wrapper.state().draft.fileInfos).toEqual(expectedNewFileInfos);
     });
@@ -479,9 +479,9 @@ describe('components/AdvancedCreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsProgressPercent: {
-                '1': undefined,
-                '2': undefined,
-                '3': undefined
+                1: undefined,
+                2: undefined,
+                3: undefined,
             },
             fileInfos: [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'bbb', create_at: 200}],
         };
@@ -498,7 +498,7 @@ describe('components/AdvancedCreateComment', () => {
             const newProps = {
                 ...props,
                 rootId: 'testid123',
-                uploadsProgressPercent: {}
+                uploadsProgressPercent: {},
             };
 
             // Note that setProps doesn't actually trigger componentDidUpdate
@@ -519,7 +519,7 @@ describe('components/AdvancedCreateComment', () => {
             const newProps = {
                 ...props,
                 selectedPostFocussedAt: 2000,
-                uploadsProgressPercent: {}
+                uploadsProgressPercent: {},
             };
 
             // Note that setProps doesn't actually trigger componentDidUpdate
@@ -586,9 +586,9 @@ describe('components/AdvancedCreateComment', () => {
         const draft = {
             message: '/fakecommand other text',
             uploadsProgressPercent: {
-                '1': undefined,
-                '2': undefined,
-                '3': undefined
+                1: undefined,
+                2: undefined,
+                3: undefined,
             },
             fileInfos: [{}, {}, {}],
         };
@@ -623,9 +623,9 @@ describe('components/AdvancedCreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsProgressPercent: {
-                '1': undefined,
-                '2': undefined,
-                '3': undefined
+                1: undefined,
+                2: undefined,
+                3: undefined,
             },
             fileInfos: [{}, {}, {}],
         };
@@ -1140,9 +1140,9 @@ describe('components/AdvancedCreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsProgressPercent: {
-                '4': undefined,
-                '5': undefined,
-                '6': undefined
+                4: undefined,
+                5: undefined,
+                6: undefined,
             },
             fileInfos: [{id: 1}, {id: 2}, {id: 3}],
         };
@@ -1168,13 +1168,13 @@ describe('components/AdvancedCreateComment', () => {
         jest.advanceTimersByTime(Constants.SAVE_DRAFT_TIMEOUT);
         expect(onUpdateCommentDraft.mock.calls[1][0]).toEqual(
             expect.objectContaining({uploadsProgressPercent: {
-                '4': undefined,
-                '6': undefined
+                4: undefined,
+                6: undefined,
             }}),
         );
         expect(wrapper.state().draft.uploadsProgressPercent).toEqual({
-            '4': undefined,
-            '6': undefined
+            4: undefined,
+            6: undefined,
         });
     });
 
@@ -1199,9 +1199,9 @@ describe('components/AdvancedCreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsProgressPercent: {
-                '4': undefined,
-                '5': undefined,
-                '6': undefined
+                4: undefined,
+                5: undefined,
+                6: undefined,
             },
             fileInfos: [{id: 1}, {id: 2}, {id: 3}],
         };
@@ -1375,13 +1375,13 @@ describe('components/AdvancedCreateComment', () => {
 
         expect(scrollToBottom).toBeCalledTimes(0);
 
-        wrapper.setState({draft: {...draft, uploadsProgressPercent: { '1': undefined }}});
+        wrapper.setState({draft: {...draft, uploadsProgressPercent: {1: undefined}}});
         expect(scrollToBottom).toBeCalledTimes(1);
 
-        wrapper.setState({draft: {...draft, uploadsProgressPercent: { '1': undefined, '2': undefined }}});
+        wrapper.setState({draft: {...draft, uploadsProgressPercent: {1: undefined, 2: undefined}}});
         expect(scrollToBottom).toBeCalledTimes(2);
 
-        wrapper.setState({draft: {...draft, uploadsProgressPercent: { '2': undefined }}});
+        wrapper.setState({draft: {...draft, uploadsProgressPercent: {2: undefined}}});
         expect(scrollToBottom).toBeCalledTimes(2);
     });
 
@@ -1730,7 +1730,7 @@ describe('components/AdvancedCreateComment', () => {
         wrapper.setState({
             draft: {
                 message: '',
-                uploadsProgressPercent: { [clientId]: {} },
+                uploadsProgressPercent: {[clientId]: {}},
             },
         });
 
@@ -1776,7 +1776,7 @@ describe('components/AdvancedCreateComment', () => {
             <AdvancedCreateComment {...baseProps}/>,
         );
 
-        const uploadsProgressPercent = {'a': undefined};
+        const uploadsProgressPercent = {a: undefined};
         wrapper.setState({
             uploadsProgressPercent,
         });

--- a/components/advanced_create_comment/advanced_create_comment.test.jsx
+++ b/components/advanced_create_comment/advanced_create_comment.test.jsx
@@ -37,7 +37,7 @@ describe('components/AdvancedCreateComment', () => {
         channelMembersCount: 3,
         draft: {
             message: 'Test message',
-            uploadsInProgress: [{}],
+            uploadsProgressPercent: {},
             fileInfos: [{}, {}, {}],
         },
         enableAddButton: true,
@@ -79,7 +79,7 @@ describe('components/AdvancedCreateComment', () => {
 
     const emptyDraft = {
         message: '',
-        uploadsInProgress: [],
+        uploadsProgressPercent: {},
         fileInfos: [],
     };
 
@@ -102,7 +102,7 @@ describe('components/AdvancedCreateComment', () => {
         const getChannelMemberCountsByGroup = jest.fn();
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [],
+            uploadsProgressPercent: {},
             fileInfos: [],
         };
         const ctrlSend = true;
@@ -127,7 +127,7 @@ describe('components/AdvancedCreateComment', () => {
     test('should call searchAssociatedGroupsForReference if there is one mention in the draft', () => {
         const draft = {
             message: '@group',
-            uploadsInProgress: [],
+            uploadsProgressPercent: {},
             fileInfos: [],
         };
 
@@ -142,7 +142,7 @@ describe('components/AdvancedCreateComment', () => {
     test('should call getChannelMemberCountsByGroup if there is more than one mention in the draft', () => {
         const draft = {
             message: '@group @othergroup',
-            uploadsInProgress: [],
+            uploadsProgressPercent: {},
             fileInfos: [],
         };
         const getChannelMemberCountsByGroup = jest.fn();
@@ -158,7 +158,7 @@ describe('components/AdvancedCreateComment', () => {
         const useCustomGroupMentions = false;
         const draft = {
             message: '@group @othergroup',
-            uploadsInProgress: [],
+            uploadsProgressPercent: {},
             fileInfos: [],
         };
 
@@ -174,7 +174,7 @@ describe('components/AdvancedCreateComment', () => {
     test('should match snapshot, non-empty message and uploadsInProgress + fileInfos', () => {
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [{}],
+            uploadsProgressPercent: {},
             fileInfos: [{}, {}, {}],
         };
 
@@ -242,7 +242,7 @@ describe('components/AdvancedCreateComment', () => {
         );
         expect(wrapper.state().draft.message).toBe(':smile: ');
 
-        wrapper.setState({draft: {message: 'test', uploadsInProgress: [], fileInfos: []},
+        wrapper.setState({draft: {message: 'test', uploadsProgressPercent: {}, fileInfos: []},
             caretPosition: 'test'.length, // cursor is at the end
         });
         wrapper.instance().handleEmojiClick({name: 'smile'});
@@ -254,7 +254,7 @@ describe('components/AdvancedCreateComment', () => {
         );
         expect(wrapper.state().draft.message).toBe('test :smile:  ');
 
-        wrapper.setState({draft: {message: 'test ', uploadsInProgress: [], fileInfos: []},
+        wrapper.setState({draft: {message: 'test ', uploadsProgressPercent: {}, fileInfos: []},
             caretPosition: 'test '.length, // cursor is at the end
         });
         wrapper.instance().handleEmojiClick({name: 'smile'});
@@ -285,7 +285,11 @@ describe('components/AdvancedCreateComment', () => {
         const updateCommentDraftWithRootId = jest.fn();
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [1, 2, 3],
+            uploadsProgressPercent: {
+                '1': undefined,
+                '2': undefined,
+                '3': undefined
+            },
             fileInfos: [{}, {}, {}],
         };
         const props = {...baseProps, draft, updateCommentDraftWithRootId};
@@ -304,10 +308,16 @@ describe('components/AdvancedCreateComment', () => {
         expect(updateCommentDraftWithRootId).toHaveBeenCalled();
         expect(updateCommentDraftWithRootId.mock.calls[0][0]).toEqual(props.rootId);
         expect(updateCommentDraftWithRootId.mock.calls[0][1]).toEqual(
-            expect.objectContaining({uploadsInProgress: [2, 3]}),
+            expect.objectContaining({uploadsProgressPercent: {
+                '2': undefined,
+                '3': undefined
+            }}),
         );
         expect(wrapper.state().serverError.message).toBe(testError1);
-        expect(wrapper.state().draft.uploadsInProgress).toEqual([2, 3]);
+        expect(wrapper.state().draft.uploadsProgressPercent).toEqual({
+            '2': undefined,
+            '3': undefined
+        });
 
         // clientId = -1
         const testError2 = 'test error 2';
@@ -332,7 +342,11 @@ describe('components/AdvancedCreateComment', () => {
         const onUpdateCommentDraft = jest.fn();
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [1, 2, 3],
+            uploadsProgressPercent: {
+                '1': undefined,
+                '2': undefined,
+                '3': undefined
+            },
             fileInfos: [{}, {}, {}],
         };
         const props = {...baseProps, onUpdateCommentDraft, draft};
@@ -348,10 +362,22 @@ describe('components/AdvancedCreateComment', () => {
 
         expect(onUpdateCommentDraft).toHaveBeenCalled();
         expect(onUpdateCommentDraft.mock.calls[0][0]).toEqual(
-            expect.objectContaining({uploadsInProgress: [1, 2, 3, 4, 5]}),
+            expect.objectContaining({uploadsProgressPercent: {
+                '1': undefined,
+                '2': undefined,
+                '3': undefined,
+                '4': undefined,
+                '5': undefined
+            }}),
         );
 
-        expect(wrapper.state().draft.uploadsInProgress === [1, 2, 3, 4, 5]);
+        expect(wrapper.state().draft.uploadsProgressPercent).toStrictEqual({
+            '1': undefined,
+            '2': undefined,
+            '3': undefined,
+            '4': undefined,
+            '5': undefined
+        });
         expect(focusTextbox).toHaveBeenCalled();
     });
 
@@ -360,7 +386,11 @@ describe('components/AdvancedCreateComment', () => {
         const fileInfos = [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'bbb', create_at: 200}];
         const draft = {
             message: 'Test message',
-            uploadsInProgress: ['1', '2', '3'],
+            uploadsProgressPercent: {
+                '1': undefined,
+                '2': undefined,
+                '3': undefined
+            },
             fileInfos,
         };
         const props = {...baseProps, updateCommentDraftWithRootId, draft};
@@ -380,18 +410,26 @@ describe('components/AdvancedCreateComment', () => {
 
         const uploadCompleteFileInfo = [{id: '3', name: 'ccc', create_at: 300}];
         const expectedNewFileInfos = fileInfos.concat(uploadCompleteFileInfo);
-        instance.handleFileUploadComplete(uploadCompleteFileInfo, [3], null, props.rootId);
+        instance.handleFileUploadComplete(uploadCompleteFileInfo, ['3'], null, props.rootId);
 
         jest.advanceTimersByTime(Constants.SAVE_DRAFT_TIMEOUT);
         expect(updateCommentDraftWithRootId).toHaveBeenCalled();
         expect(updateCommentDraftWithRootId.mock.calls[0][0]).toEqual(props.rootId);
         expect(updateCommentDraftWithRootId.mock.calls[0][1]).toEqual(
-            expect.objectContaining({uploadsInProgress: ['1', '2'], fileInfos: expectedNewFileInfos}),
+            expect.objectContaining({
+                uploadsProgressPercent: {
+                    '1': undefined,
+                    '2': undefined
+                },
+                fileInfos: expectedNewFileInfos
+            }),
         );
 
-        expect(wrapper.state().draft.uploadsInProgress).toEqual(['1', '2']);
+        expect(wrapper.state().draft.uploadsProgressPercent).toEqual({
+            '1': undefined,
+            '2': undefined
+        });
         expect(wrapper.state().draft.fileInfos).toEqual(expectedNewFileInfos);
-        expect(wrapper.state().uploadsProgressPercent).toStrictEqual({});
     });
 
     test('should open PostDeletedModal when createPostErrorId === api.post.create_post.root_id.app_error', () => {
@@ -440,7 +478,11 @@ describe('components/AdvancedCreateComment', () => {
     describe('focusTextbox', () => {
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [1, 2, 3],
+            uploadsProgressPercent: {
+                '1': undefined,
+                '2': undefined,
+                '3': undefined
+            },
             fileInfos: [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'bbb', create_at: 200}],
         };
 
@@ -456,6 +498,7 @@ describe('components/AdvancedCreateComment', () => {
             const newProps = {
                 ...props,
                 rootId: 'testid123',
+                uploadsProgressPercent: {}
             };
 
             // Note that setProps doesn't actually trigger componentDidUpdate
@@ -476,6 +519,7 @@ describe('components/AdvancedCreateComment', () => {
             const newProps = {
                 ...props,
                 selectedPostFocussedAt: 2000,
+                uploadsProgressPercent: {}
             };
 
             // Note that setProps doesn't actually trigger componentDidUpdate
@@ -541,7 +585,11 @@ describe('components/AdvancedCreateComment', () => {
 
         const draft = {
             message: '/fakecommand other text',
-            uploadsInProgress: [1, 2, 3],
+            uploadsProgressPercent: {
+                '1': undefined,
+                '2': undefined,
+                '3': undefined
+            },
             fileInfos: [{}, {}, {}],
         };
         const props = {...baseProps, onUpdateCommentDraft, draft, onSubmit};
@@ -554,7 +602,7 @@ describe('components/AdvancedCreateComment', () => {
 
         expect(onSubmit).toHaveBeenCalledWith({
             message: '/fakecommand other text',
-            uploadsInProgress: [],
+            uploadsProgressPercent: {},
             fileInfos: [{}, {}, {}],
         }, [], {ignoreSlash: false});
 
@@ -566,7 +614,7 @@ describe('components/AdvancedCreateComment', () => {
 
         expect(onSubmit).toHaveBeenCalledWith({
             message: 'some valid text',
-            uploadsInProgress: [],
+            uploadsProgressPercent: {},
             fileInfos: [{}, {}, {}],
         }, [], {ignoreSlash: false});
     });
@@ -574,7 +622,11 @@ describe('components/AdvancedCreateComment', () => {
     test('should scroll to bottom when uploadsInProgress increase', () => {
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [1, 2, 3],
+            uploadsProgressPercent: {
+                '1': undefined,
+                '2': undefined,
+                '3': undefined
+            },
             fileInfos: [{}, {}, {}],
         };
         const scrollToBottom = jest.fn();
@@ -960,7 +1012,7 @@ describe('components/AdvancedCreateComment', () => {
                 ...baseProps,
                 draft: {
                     message: '/fakecommand other text',
-                    uploadsInProgress: [],
+                    uploadsProgressPercent: {},
                     fileInfos: [{}, {}, {}],
                 },
                 onSubmit: onSubmitWithError,
@@ -974,7 +1026,7 @@ describe('components/AdvancedCreateComment', () => {
 
             expect(onSubmitWithError).toHaveBeenCalledWith({
                 message: '/fakecommand other text',
-                uploadsInProgress: [],
+                uploadsProgressPercent: {},
                 fileInfos: [{}, {}, {}],
             }, [], {ignoreSlash: false});
             expect(preventDefault).toHaveBeenCalled();
@@ -984,7 +1036,7 @@ describe('components/AdvancedCreateComment', () => {
 
             expect(onSubmit).toHaveBeenCalledWith({
                 message: '/fakecommand other text',
-                uploadsInProgress: [],
+                uploadsProgressPercent: {},
                 fileInfos: [{}, {}, {}],
             }, [], {ignoreSlash: true});
             expect(wrapper.find('[id="postServerError"]').exists()).toBe(false);
@@ -999,7 +1051,7 @@ describe('components/AdvancedCreateComment', () => {
                 ...baseProps,
                 draft: {
                     message: '/fakecommand other text',
-                    uploadsInProgress: [],
+                    uploadsProgressPercent: {},
                     fileInfos: [{}, {}, {}],
                 },
                 onSubmit: onSubmitWithError,
@@ -1087,7 +1139,11 @@ describe('components/AdvancedCreateComment', () => {
         const onUpdateCommentDraft = jest.fn();
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [4, 5, 6],
+            uploadsProgressPercent: {
+                '4': undefined,
+                '5': undefined,
+                '6': undefined
+            },
             fileInfos: [{id: 1}, {id: 2}, {id: 3}],
         };
         const props = {...baseProps, draft, onUpdateCommentDraft};
@@ -1111,15 +1167,21 @@ describe('components/AdvancedCreateComment', () => {
 
         jest.advanceTimersByTime(Constants.SAVE_DRAFT_TIMEOUT);
         expect(onUpdateCommentDraft.mock.calls[1][0]).toEqual(
-            expect.objectContaining({uploadsInProgress: [4, 6]}),
+            expect.objectContaining({uploadsProgressPercent: {
+                '4': undefined,
+                '6': undefined
+            }}),
         );
-        expect(wrapper.state().draft.uploadsInProgress).toEqual([4, 6]);
+        expect(wrapper.state().draft.uploadsProgressPercent).toEqual({
+            '4': undefined,
+            '6': undefined
+        });
     });
 
     test('should match draft state on componentWillReceiveProps with change in messageInHistory', () => {
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [],
+            uploadsProgressPercent: {},
             fileInfos: [{}, {}, {}],
         };
 
@@ -1136,7 +1198,11 @@ describe('components/AdvancedCreateComment', () => {
     test('should match draft state on componentWillReceiveProps with new rootId', () => {
         const draft = {
             message: 'Test message',
-            uploadsInProgress: [4, 5, 6],
+            uploadsProgressPercent: {
+                '4': undefined,
+                '5': undefined,
+                '6': undefined
+            },
             fileInfos: [{id: 1}, {id: 2}, {id: 3}],
         };
 
@@ -1147,7 +1213,7 @@ describe('components/AdvancedCreateComment', () => {
         expect(wrapper.state('draft')).toEqual(draft);
 
         wrapper.setProps({rootId: 'new_root_id'});
-        expect(wrapper.state('draft')).toEqual({...draft, uploadsInProgress: [], fileInfos: [{}, {}, {}]});
+        expect(wrapper.state('draft')).toEqual({...draft, uploadsProgressPercent: {}, fileInfos: [{}, {}, {}]});
     });
 
     test('should match snapshot when cannot post', () => {
@@ -1252,7 +1318,7 @@ describe('components/AdvancedCreateComment', () => {
         expect(downKey.preventDefault).toHaveBeenCalledTimes(1);
         expect(onMoveHistoryIndexForward).toHaveBeenCalledTimes(1);
 
-        wrapper.setState({draft: {message: '', fileInfos: [], uploadsInProgress: []}});
+        wrapper.setState({draft: {message: '', fileInfos: [], uploadsProgressPercent: {}}});
         const upKeyForEdit = {
             preventDefault: jest.fn(),
             ctrlKey: false,
@@ -1309,13 +1375,13 @@ describe('components/AdvancedCreateComment', () => {
 
         expect(scrollToBottom).toBeCalledTimes(0);
 
-        wrapper.setState({draft: {...draft, uploadsInProgress: [1]}});
+        wrapper.setState({draft: {...draft, uploadsProgressPercent: { '1': undefined }}});
         expect(scrollToBottom).toBeCalledTimes(1);
 
-        wrapper.setState({draft: {...draft, uploadsInProgress: [1, 2]}});
+        wrapper.setState({draft: {...draft, uploadsProgressPercent: { '1': undefined, '2': undefined }}});
         expect(scrollToBottom).toBeCalledTimes(2);
 
-        wrapper.setState({draft: {...draft, uploadsInProgress: [2]}});
+        wrapper.setState({draft: {...draft, uploadsProgressPercent: { '2': undefined }}});
         expect(scrollToBottom).toBeCalledTimes(2);
     });
 
@@ -1662,10 +1728,9 @@ describe('components/AdvancedCreateComment', () => {
             [clientId]: {},
         };
         wrapper.setState({
-            uploadsProgressPercent,
             draft: {
                 message: '',
-                uploadsInProgress: [clientId],
+                uploadsProgressPercent: { [clientId]: {} },
             },
         });
 
@@ -1679,7 +1744,7 @@ describe('components/AdvancedCreateComment', () => {
             expect.anything(),
         );
 
-        expect(wrapper.state().uploadsProgressPercent).toStrictEqual({});
+        expect(wrapper.state().draft.uploadsProgressPercent).toStrictEqual({});
     });
 
     it('should call cancelUploadingFile when draft has no corresponding fileInfo', () => {
@@ -1698,7 +1763,7 @@ describe('components/AdvancedCreateComment', () => {
             draft: {
                 message: '',
                 fileInfos: [],
-                uploadsInProgress: [id],
+                uploadsProgressPercent: {[id]: undefined},
             },
         });
 
@@ -1711,7 +1776,7 @@ describe('components/AdvancedCreateComment', () => {
             <AdvancedCreateComment {...baseProps}/>,
         );
 
-        const uploadsProgressPercent = ['a'];
+        const uploadsProgressPercent = {'a': undefined};
         wrapper.setState({
             uploadsProgressPercent,
         });

--- a/components/advanced_create_comment/advanced_create_comment.test.jsx
+++ b/components/advanced_create_comment/advanced_create_comment.test.jsx
@@ -74,6 +74,7 @@ describe('components/AdvancedCreateComment', () => {
         useLDAPGroupMentions: true,
         useCustomGroupMentions: true,
         openModal: jest.fn(),
+        cancelUploadingFile: jest.fn()
     };
 
     const emptyDraft = {

--- a/components/advanced_create_comment/advanced_create_comment.test.jsx
+++ b/components/advanced_create_comment/advanced_create_comment.test.jsx
@@ -549,7 +549,7 @@ describe('components/AdvancedCreateComment', () => {
             message: '/fakecommand other text',
             uploadsInProgress: [],
             fileInfos: [{}, {}, {}],
-        }, {ignoreSlash: false});
+        }, [], {ignoreSlash: false});
 
         wrapper.instance().handleChange({
             target: {value: 'some valid text'},
@@ -561,7 +561,7 @@ describe('components/AdvancedCreateComment', () => {
             message: 'some valid text',
             uploadsInProgress: [],
             fileInfos: [{}, {}, {}],
-        }, {ignoreSlash: false});
+        }, [], {ignoreSlash: false});
     });
 
     test('should scroll to bottom when uploadsInProgress increase', () => {
@@ -969,7 +969,7 @@ describe('components/AdvancedCreateComment', () => {
                 message: '/fakecommand other text',
                 uploadsInProgress: [],
                 fileInfos: [{}, {}, {}],
-            }, {ignoreSlash: false});
+            }, [], {ignoreSlash: false});
             expect(preventDefault).toHaveBeenCalled();
 
             wrapper.setProps({onSubmit});
@@ -979,7 +979,7 @@ describe('components/AdvancedCreateComment', () => {
                 message: '/fakecommand other text',
                 uploadsInProgress: [],
                 fileInfos: [{}, {}, {}],
-            }, {ignoreSlash: true});
+            }, [], {ignoreSlash: true});
             expect(wrapper.find('[id="postServerError"]').exists()).toBe(false);
         });
 

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -1032,8 +1032,8 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
             const uploadsProgressPercent = {...draft.uploadsProgressPercent, [filePreviewInfo.clientId]: filePreviewInfo};
             const modifiedDraft = {
                 ...draft,
-                uploadsProgressPercent
-            }
+                uploadsProgressPercent,
+            };
             this.handleDraftChange(modifiedDraft);
             this.setState({draft: modifiedDraft});
         }

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -1116,9 +1116,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
             if (index !== -1) {
                 uploadsInProgress.splice(index, 1);
 
-                if (this.fileUploadRef.current) {
-                    this.props.cancelUploadingFile(id);
-                }
+                this.props.cancelUploadingFile(id);
             }
         } else {
             fileInfos.splice(index, 1);
@@ -1171,7 +1169,8 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         if (draft) {
             const message = draft.message ? draft.message.trim() : '';
             const fileInfos = draft.fileInfos ? draft.fileInfos : [];
-            if (message.trim().length !== 0 || fileInfos.length !== 0) {
+            const uploadsInProgress = draft.uploadsInProgress ? draft.uploadsInProgress : [];
+            if (message.trim().length !== 0 || fileInfos.length !== 0 || uploadsInProgress.length !== 0) {
                 return true;
             }
         }

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -656,11 +656,6 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
             return;
         }
 
-        if (draft.uploadsInProgress.length > 0) {
-            this.isDraftSubmitting = false;
-            return;
-        }
-
         if (this.state.postError) {
             this.setState({errorClass: 'animation--highlight'});
             setTimeout(() => {

--- a/components/advanced_create_comment/index.ts
+++ b/components/advanced_create_comment/index.ts
@@ -156,7 +156,6 @@ function makeMapDispatchToProps() {
     let updateCommentDraftWithRootId: (rootID: string, draft: PostDraft, save?: boolean) => void;
     let onSubmit: (
         draft: PostDraft,
-        filePreviewInfos: FilePreviewInfo[],
         options: {ignoreSlash: boolean},
     ) => (dispatch: DispatchFunc, getState: () => GlobalState) => Promise<ActionResult | ActionResult[]> | ActionResult;
     let onMoveHistoryIndexBack: () => (

--- a/components/advanced_create_comment/index.ts
+++ b/components/advanced_create_comment/index.ts
@@ -49,6 +49,9 @@ import {searchAssociatedGroupsForReference} from 'actions/views/group';
 import {getEmojiMap} from 'selectors/emojis';
 import {canUploadFiles} from 'utils/file_utils';
 
+import {cancelUploadingFile} from 'actions/file_actions';
+import {FilePreviewInfo} from '@mattermost/types/files';
+
 import AdvancedCreateComment from './advanced_create_comment';
 
 type OwnProps = {
@@ -132,7 +135,7 @@ type Actions = {
     clearCommentDraftUploads: () => void;
     onUpdateCommentDraft: (draft?: PostDraft, save?: boolean) => void;
     updateCommentDraftWithRootId: (rootID: string, draft: PostDraft, save?: boolean) => void;
-    onSubmit: (draft: PostDraft, options: {ignoreSlash: boolean}) => void;
+    onSubmit: (draft: PostDraft, filePreviewInfos: FilePreviewInfo[], options: {ignoreSlash: boolean}) => void;
     onResetHistoryIndex: () => void;
     onMoveHistoryIndexBack: () => void;
     onMoveHistoryIndexForward: () => void;
@@ -145,6 +148,7 @@ type Actions = {
     openModal: <P>(modalData: ModalData<P>) => void;
     savePreferences: (userId: string, preferences: PreferenceType[]) => ActionResult;
     searchAssociatedGroupsForReference: (prefix: string, teamId: string, channelId: string | undefined) => Promise<{ data: any }>;
+    cancelUploadingFile: (clientId: string) => void;
 };
 
 function makeMapDispatchToProps() {
@@ -152,6 +156,7 @@ function makeMapDispatchToProps() {
     let updateCommentDraftWithRootId: (rootID: string, draft: PostDraft, save?: boolean) => void;
     let onSubmit: (
         draft: PostDraft,
+        filePreviewInfos: FilePreviewInfo[],
         options: {ignoreSlash: boolean},
     ) => (dispatch: DispatchFunc, getState: () => GlobalState) => Promise<ActionResult | ActionResult[]> | ActionResult;
     let onMoveHistoryIndexBack: () => (
@@ -213,6 +218,7 @@ function makeMapDispatchToProps() {
                 openModal,
                 savePreferences,
                 searchAssociatedGroupsForReference,
+                cancelUploadingFile,
             },
             dispatch,
         );

--- a/components/advanced_create_post/__snapshots__/advanced_create_post.test.jsx.snap
+++ b/components/advanced_create_post/__snapshots__/advanced_create_post.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`components/advanced_create_post Show tutorial 1`] = `
   id="create_post"
   onSubmit={[Function]}
 >
+  <FileLimitStickyBanner />
   <AdvanceTextEditor
     additionalControls={Array []}
     applyMarkdown={[Function]}
@@ -24,7 +25,9 @@ exports[`components/advanced_create_post Show tutorial 1`] = `
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -102,7 +105,7 @@ exports[`components/advanced_create_post should match snapshot for center textbo
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {},
       }
     }
     emitTypingEvent={[Function]}
@@ -180,7 +183,9 @@ exports[`components/advanced_create_post should match snapshot when cannot post 
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -240,6 +245,7 @@ exports[`components/advanced_create_post should match snapshot when file upload 
   id="create_post"
   onSubmit={[Function]}
 >
+  <FileLimitStickyBanner />
   <AdvanceTextEditor
     additionalControls={Array []}
     applyMarkdown={[Function]}
@@ -258,7 +264,9 @@ exports[`components/advanced_create_post should match snapshot when file upload 
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -318,6 +326,7 @@ exports[`components/advanced_create_post should match snapshot, can post; previe
   id="create_post"
   onSubmit={[Function]}
 >
+  <FileLimitStickyBanner />
   <AdvanceTextEditor
     additionalControls={Array []}
     applyMarkdown={[Function]}
@@ -336,7 +345,9 @@ exports[`components/advanced_create_post should match snapshot, can post; previe
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -396,6 +407,7 @@ exports[`components/advanced_create_post should match snapshot, can post; previe
   id="create_post"
   onSubmit={[Function]}
 >
+  <FileLimitStickyBanner />
   <AdvanceTextEditor
     additionalControls={Array []}
     applyMarkdown={[Function]}
@@ -414,7 +426,9 @@ exports[`components/advanced_create_post should match snapshot, can post; previe
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -492,7 +506,9 @@ exports[`components/advanced_create_post should match snapshot, cannot post; pre
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -570,7 +586,9 @@ exports[`components/advanced_create_post should match snapshot, cannot post; pre
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -648,7 +666,7 @@ exports[`components/advanced_create_post should match snapshot, init 1`] = `
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {},
       }
     }
     emitTypingEvent={[Function]}
@@ -708,6 +726,7 @@ exports[`components/advanced_create_post should match snapshot, post priority di
   id="create_post"
   onSubmit={[Function]}
 >
+  <FileLimitStickyBanner />
   <AdvanceTextEditor
     additionalControls={Array []}
     applyMarkdown={[Function]}
@@ -731,7 +750,9 @@ exports[`components/advanced_create_post should match snapshot, post priority di
             "priority": "important",
           },
         },
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -791,6 +812,7 @@ exports[`components/advanced_create_post should match snapshot, post priority en
   id="create_post"
   onSubmit={[Function]}
 >
+  <FileLimitStickyBanner />
   <AdvanceTextEditor
     additionalControls={
       Array [
@@ -866,7 +888,9 @@ exports[`components/advanced_create_post should match snapshot, post priority en
       Object {
         "fileInfos": Array [],
         "message": "",
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}
@@ -926,6 +950,7 @@ exports[`components/advanced_create_post should match snapshot, post priority en
   id="create_post"
   onSubmit={[Function]}
 >
+  <FileLimitStickyBanner />
   <AdvanceTextEditor
     additionalControls={
       Array [
@@ -1011,7 +1036,9 @@ exports[`components/advanced_create_post should match snapshot, post priority en
             "priority": "important",
           },
         },
-        "uploadsInProgress": Array [],
+        "uploadsProgressPercent": Object {
+          "a": undefined,
+        },
       }
     }
     emitTypingEvent={[Function]}

--- a/components/advanced_create_post/advanced_create_post.test.jsx
+++ b/components/advanced_create_post/advanced_create_post.test.jsx
@@ -867,14 +867,14 @@ describe('components/advanced_create_post', () => {
         instance.draftsForChannel[currentChannelProp.id] = uploadsInProgressDraft;
 
         wrapper.setProps({draft: uploadsInProgressDraft});
-        const fileInfos = {
-            id: 'a',
-        };
+        const fileInfos = [{
+            clientId: 'a',
+        }];
         const expectedDraft = {
             ...draftProp,
             fileInfos: [
                 ...draftProp.fileInfos,
-                fileInfos,
+                fileInfos[0],
             ],
         };
 
@@ -1217,6 +1217,7 @@ describe('components/advanced_create_post', () => {
                 message: '/fakecommand some text',
             }),
             expect.anything(),
+            expect.anything(),
         );
     });
 
@@ -1256,6 +1257,7 @@ describe('components/advanced_create_post', () => {
             expect.objectContaining({
                 message: 'some valid text',
             }),
+            expect.anything(),
             expect.anything(),
         );
     });

--- a/components/advanced_create_post/advanced_create_post.test.jsx
+++ b/components/advanced_create_post/advanced_create_post.test.jsx
@@ -833,8 +833,8 @@ describe('components/advanced_create_post', () => {
         const draft = {
             ...draftProp,
             uploadsProgressPercent: Object.assign(draftProp.uploadsProgressPercent, {
-                'a': undefined
-            })
+                a: undefined,
+            }),
         };
 
         instance.handleUploadStart(clientIds, currentChannelProp.id);
@@ -858,8 +858,8 @@ describe('components/advanced_create_post', () => {
         const uploadsProgressPercentDraft = {
             ...draftProp,
             uploadsProgressPercent: Object.assign(draftProp.uploadsProgressPercent, {
-                'a': undefined
-            })
+                a: undefined,
+            }),
         };
 
         instance.draftsForChannel[currentChannelProp.id] = uploadsProgressPercentDraft;
@@ -875,7 +875,7 @@ describe('components/advanced_create_post', () => {
                 ...draftProp.fileInfos,
                 fileInfos[0],
             ],
-            uploadsProgressPercent: {}
+            uploadsProgressPercent: {},
         };
 
         instance.handleFileUploadComplete(fileInfos, clientIds, currentChannelProp.id);
@@ -900,8 +900,8 @@ describe('components/advanced_create_post', () => {
         const uploadsInProgressDraft = {
             ...draftProp,
             uploadsProgressPercent: Object.assign(draftProp.uploadsProgressPercent, {
-                'a': undefined
-            })
+                a: undefined,
+            }),
         };
 
         wrapper.setProps({draft: uploadsInProgressDraft});
@@ -1665,7 +1665,7 @@ describe('components/advanced_create_post', () => {
             draft: {
                 ...draftProp,
                 uploadsProgressPercent: {
-                    "id": undefined
+                    id: undefined,
                 },
             },
         }));

--- a/components/advanced_create_post/advanced_create_post.test.jsx
+++ b/components/advanced_create_post/advanced_create_post.test.jsx
@@ -44,7 +44,7 @@ const currentChannelProp = {
 const currentChannelMembersCountProp = 9;
 const draftProp = {
     message: '',
-    uploadsInProgress: [],
+    uploadsProgressPercent: {},
     fileInfos: [],
 };
 
@@ -832,10 +832,9 @@ describe('components/advanced_create_post', () => {
         const clientIds = ['a'];
         const draft = {
             ...draftProp,
-            uploadsInProgress: [
-                ...draftProp.uploadsInProgress,
-                ...clientIds,
-            ],
+            uploadsProgressPercent: Object.assign(draftProp.uploadsProgressPercent, {
+                'a': undefined
+            })
         };
 
         instance.handleUploadStart(clientIds, currentChannelProp.id);
@@ -856,18 +855,18 @@ describe('components/advanced_create_post', () => {
 
         const instance = wrapper.instance();
         const clientIds = ['a'];
-        const uploadsInProgressDraft = {
+        const uploadsProgressPercentDraft = {
             ...draftProp,
-            uploadsInProgress: [
-                ...draftProp.uploadsInProgress,
-                'a',
-            ],
+            uploadsProgressPercent: Object.assign(draftProp.uploadsProgressPercent, {
+                'a': undefined
+            })
         };
 
-        instance.draftsForChannel[currentChannelProp.id] = uploadsInProgressDraft;
+        instance.draftsForChannel[currentChannelProp.id] = uploadsProgressPercentDraft;
 
-        wrapper.setProps({draft: uploadsInProgressDraft});
+        wrapper.setProps({draft: uploadsProgressPercentDraft});
         const fileInfos = [{
+            name: 'a',
             clientId: 'a',
         }];
         const expectedDraft = {
@@ -876,6 +875,7 @@ describe('components/advanced_create_post', () => {
                 ...draftProp.fileInfos,
                 fileInfos[0],
             ],
+            uploadsProgressPercent: {}
         };
 
         instance.handleFileUploadComplete(fileInfos, clientIds, currentChannelProp.id);
@@ -899,10 +899,9 @@ describe('components/advanced_create_post', () => {
         const instance = wrapper.instance();
         const uploadsInProgressDraft = {
             ...draftProp,
-            uploadsInProgress: [
-                ...draftProp.uploadsInProgress,
-                'a',
-            ],
+            uploadsProgressPercent: Object.assign(draftProp.uploadsProgressPercent, {
+                'a': undefined
+            })
         };
 
         wrapper.setProps({draft: uploadsInProgressDraft});
@@ -1665,7 +1664,9 @@ describe('components/advanced_create_post', () => {
             },
             draft: {
                 ...draftProp,
-                uploadsInProgress: [clientId],
+                uploadsProgressPercent: {
+                    "id": undefined
+                },
             },
         }));
 
@@ -1701,7 +1702,7 @@ describe('components/advanced_create_post', () => {
                 },
                 draft: {
                     ...draftProp,
-                    uploadsInProgress: [id],
+                    uploadsProgressPercent: {[id]: undefined},
                 },
             }),
         );

--- a/components/advanced_create_post/advanced_create_post.test.jsx
+++ b/components/advanced_create_post/advanced_create_post.test.jsx
@@ -1654,4 +1654,73 @@ describe('components/advanced_create_post', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    it('should be able to send post which is uploading file without message', async () => {
+        const clientId = 'clientId';
+        const onSubmitPost = jest.fn();
+        const wrapper = shallow(advancedCreatePost({
+            actions: {
+                ...actionsProp,
+                onSubmitPost,
+            },
+            draft: {
+                ...draftProp,
+                uploadsInProgress: [clientId],
+            },
+        }));
+
+        const uploadsProgressPercent = {
+            [clientId]: {},
+        };
+        wrapper.setState({
+            message: '',
+            uploadsProgressPercent,
+        });
+
+        await wrapper.instance().handleSubmit({preventDefault: jest.fn()});
+
+        expect(onSubmitPost).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: '',
+            }),
+            [],
+            Object.values(uploadsProgressPercent),
+        );
+
+        expect(wrapper.state().uploadsProgressPercent).toStrictEqual({});
+    });
+
+    it('should call cancelUploadingFile when draft has no corresponding fileInfo', () => {
+        const id = 'a';
+        const cancelUploadingFile = jest.fn();
+        const wrapper = shallow(
+            advancedCreatePost({
+                actions: {
+                    ...actionsProp,
+                    cancelUploadingFile,
+                },
+                draft: {
+                    ...draftProp,
+                    uploadsInProgress: [id],
+                },
+            }),
+        );
+
+        wrapper.instance().removePreview(id);
+        expect(cancelUploadingFile).toHaveBeenCalled();
+    });
+
+    it("should ignore already submitted file's progoress", () => {
+        const wrapper = shallow(
+            advancedCreatePost(),
+        );
+
+        const uploadsProgressPercent = ['a'];
+        wrapper.setState({
+            uploadsProgressPercent,
+        });
+
+        wrapper.instance().handleUploadProgress({clientId: 'b'});
+        expect(wrapper.state().uploadsProgressPercent).toStrictEqual(uploadsProgressPercent);
+    });
 });

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -1017,7 +1017,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
 
         this.handleDraftChange(draft, true);
         this.draftsForChannel[channelId] = draft;
-        this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft);
+        this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft, channelId);
     }
 
     handleUploadError = (err: string | ServerError, clientId?: string, channelId?: string) => {

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -71,7 +71,7 @@ import FileLimitStickyBanner from '../file_limit_sticky_banner';
 const KeyCodes = Constants.KeyCodes;
 
 function isDraftEmpty(draft: PostDraft): boolean {
-    return !draft || (!draft.message && draft.fileInfos.length === 0);
+    return !draft || (!draft.message && (!draft.fileInfos || draft.fileInfos.length === 0));
 }
 
 // Temporary fix for IE-11, see MM-13423

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -491,7 +491,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         post.props = this.props.draft.props || {};
         post.metadata = (this.props.draft.metadata || {}) as PostMetadata;
 
-        if (post.message.trim().length === 0 && this.props.draft.fileInfos.length === 0) {
+        if (post.message.trim().length === 0 && this.props.draft.fileInfos.length === 0 && Object.keys(this.state.uploadsProgressPercent).length === 0) {
             return;
         }
 

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -1016,8 +1016,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         }
 
         this.handleDraftChange(draft, true);
-        this.draftsForChannel[channelId] = draft;
-        this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft, channelId);
     }
 
     handleUploadError = (err: string | ServerError, clientId?: string, channelId?: string) => {

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -36,8 +36,6 @@ import {getTable, hasHtmlLink, formatMarkdownMessage, formatGithubCodePaste, isG
 import * as UserAgent from 'utils/user_agent';
 import {isMac} from 'utils/utils';
 import * as Utils from 'utils/utils';
-import EmojiMap from 'utils/emoji_map';
-import {applyMarkdown, ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
 
 import Tooltip from 'components/tooltip';
 import OverlayTrigger from 'components/overlay_trigger';
@@ -50,6 +48,8 @@ import ResetStatusModal from 'components/reset_status_modal';
 import TextboxClass from 'components/textbox/textbox';
 import PostPriorityPickerOverlay from 'components/post_priority/post_priority_picker_overlay';
 import PriorityLabel from 'components/post_priority/post_priority_label';
+import {ApplyMarkdownOptions, applyMarkdown} from 'utils/markdown/apply_markdown';
+import EmojiMap from 'utils/emoji_map';
 
 import {PostDraft} from 'types/store/draft';
 

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -1011,10 +1011,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             }
         }
 
-        if (draft.fileInfos) {
-            draft.fileInfos = sortFileInfos(draft.fileInfos.concat(fileInfos), this.props.locale);
-        }
-
         this.handleDraftChange(draft, true);
     }
 

--- a/components/advanced_create_post/index.ts
+++ b/components/advanced_create_post/index.ts
@@ -201,7 +201,7 @@ function setDraft(key: string, value: PostDraft, draftChannelId: string, save = 
 
 function clearDraftUploads() {
     return actionOnGlobalItemsWithPrefix(StoragePrefixes.DRAFT, (_key: string, draft: PostDraft) => {
-        if (!draft || !draft.uploadsInProgress || draft.uploadsInProgress.length === 0) {
+        if (!draft || !draft.uploadsProgressPercent || Object.keys(draft.uploadsProgressPercent).length === 0) {
             return draft;
         }
 

--- a/components/advanced_create_post/index.ts
+++ b/components/advanced_create_post/index.ts
@@ -8,7 +8,7 @@ import {GlobalState} from 'types/store/index.js';
 
 import {Post} from '@mattermost/types/posts.js';
 
-import {FileInfo} from '@mattermost/types/files.js';
+import {FileInfo, FilePreviewInfo} from '@mattermost/types/files.js';
 
 import {ActionResult, GetStateFunc, DispatchFunc} from 'mattermost-redux/types/actions.js';
 
@@ -64,6 +64,8 @@ import {canUploadFiles} from 'utils/file_utils';
 import {OnboardingTourSteps, TutorialTourName, OnboardingTourStepsForGuestUsers} from 'components/tours';
 
 import {PreferenceType} from '@mattermost/types/preferences';
+
+import {cancelUploadingFile} from 'actions/file_actions';
 
 import AdvancedCreatePost from './advanced_create_post';
 
@@ -145,9 +147,9 @@ function makeMapStateToProps() {
     };
 }
 
-function onSubmitPost(post: Post, fileInfos: FileInfo[]) {
+function onSubmitPost(post: Post, fileInfos: FileInfo[], filePreviewInfos: FilePreviewInfo[]) {
     return (dispatch: Dispatch) => {
-        dispatch(createPost(post, fileInfos) as any);
+        dispatch(createPost(post, fileInfos, filePreviewInfos) as any);
     };
 }
 
@@ -157,7 +159,7 @@ type Actions = {
     moveHistoryIndexBack: (index: string) => Promise<void>;
     moveHistoryIndexForward: (index: string) => Promise<void>;
     addReaction: (postId: string, emojiName: string) => void;
-    onSubmitPost: (post: Post, fileInfos: FileInfo[]) => void;
+    onSubmitPost: (post: Post, fileInfos: FileInfo[], filePreviewInfos: FilePreviewInfo[]) => void;
     removeReaction: (postId: string, emojiName: string) => void;
     clearDraftUploads: () => void;
     runMessageWillBePostedHooks: (originalPost: Post) => ActionResult;
@@ -174,6 +176,7 @@ type Actions = {
     getChannelMemberCountsByGroup: (channelId: string, includeTimezones: boolean) => void;
     savePreferences: (userId: string, preferences: PreferenceType[]) => ActionResult;
     searchAssociatedGroupsForReference: (prefix: string, teamId: string, channelId: string | undefined) => Promise<{ data: any }>;
+    cancelUploadingFile: (clientId: string) => void;
 }
 
 function setDraft(key: string, value: PostDraft, draftChannelId: string, save = false) {
@@ -230,6 +233,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
             getChannelMemberCountsByGroup,
             savePreferences,
             searchAssociatedGroupsForReference,
+            cancelUploadingFile,
         }, dispatch),
     };
 }

--- a/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/components/advanced_text_editor/advanced_text_editor.tsx
@@ -6,6 +6,10 @@ import classNames from 'classnames';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {EmoticonHappyOutlineIcon} from '@mattermost/compass-icons/components';
 
+import {Emoji} from '@mattermost/types/emojis';
+import {FileInfo, FilePreviewInfo} from '@mattermost/types/files';
+import {ServerError} from '@mattermost/types/errors';
+import {Channel} from '@mattermost/types/channels';
 import {PostDraft} from 'types/store/draft';
 
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay';
@@ -15,8 +19,7 @@ import MsgTyping from 'components/msg_typing';
 import Textbox, {TextboxElement} from 'components/textbox';
 import TextboxClass from 'components/textbox/textbox';
 import MessageSubmitError from 'components/message_submit_error';
-import {FilePreviewInfo} from 'components/file_preview/file_preview';
-import {SendMessageTour} from 'components/tours/onboarding_tour';
+import {SendMessageTour} from 'components/onboarding_tour';
 import {FileUpload as FileUploadClass} from 'components/file_upload/file_upload';
 import OverlayTrigger from 'components/overlay_trigger';
 import KeyboardShortcutSequence, {KEYBOARD_SHORTCUTS} from 'components/keyboard_shortcuts/keyboard_shortcuts_sequence';

--- a/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/components/advanced_text_editor/advanced_text_editor.tsx
@@ -6,10 +6,7 @@ import classNames from 'classnames';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {EmoticonHappyOutlineIcon} from '@mattermost/compass-icons/components';
 
-import {Emoji} from '@mattermost/types/emojis';
-import {FileInfo, FilePreviewInfo} from '@mattermost/types/files';
-import {ServerError} from '@mattermost/types/errors';
-import {Channel} from '@mattermost/types/channels';
+import {FilePreviewInfo, FileInfo} from '@mattermost/types/files';
 import {PostDraft} from 'types/store/draft';
 
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay';
@@ -19,7 +16,7 @@ import MsgTyping from 'components/msg_typing';
 import Textbox, {TextboxElement} from 'components/textbox';
 import TextboxClass from 'components/textbox/textbox';
 import MessageSubmitError from 'components/message_submit_error';
-import {SendMessageTour} from 'components/onboarding_tour';
+import {SendMessageTour} from 'components/tours/onboarding_tour';
 import {FileUpload as FileUploadClass} from 'components/file_upload/file_upload';
 import OverlayTrigger from 'components/overlay_trigger';
 import KeyboardShortcutSequence, {KEYBOARD_SHORTCUTS} from 'components/keyboard_shortcuts/keyboard_shortcuts_sequence';
@@ -30,7 +27,7 @@ import Constants, {Locations} from 'utils/constants';
 
 import {Channel} from '@mattermost/types/channels';
 import {ServerError} from '@mattermost/types/errors';
-import {FileInfo} from '@mattermost/types/files';
+
 import {Emoji} from '@mattermost/types/emojis';
 import AutoHeightSwitcher from '../common/auto_height_switcher';
 import RhsSuggestionList from '../suggestion/rhs_suggestion_list';

--- a/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/components/advanced_text_editor/advanced_text_editor.tsx
@@ -53,7 +53,7 @@ type Props = {
     currentUserId: string;
     message: string;
     showEmojiPicker: boolean;
-    uploadsProgressPercent: { [clientID: string]: FilePreviewInfo };
+    uploadsProgressPercent: { [clientID: string]: FilePreviewInfo | undefined };
     currentChannel?: Channel;
     errorClass: string | null;
     serverError: (ServerError & { submittedMessage?: string }) | null;
@@ -199,19 +199,20 @@ const AdvanceTextEditor = ({
     }
 
     let attachmentPreview = null;
-    if (!readOnlyChannel && (draft.fileInfos.length > 0 || draft.uploadsInProgress.length > 0)) {
+    if (!readOnlyChannel && (draft.fileInfos.length > 0 || Object.keys(draft.uploadsProgressPercent).length > 0)) {
         attachmentPreview = (
-            <FilePreview
-                fileInfos={draft.fileInfos}
-                onRemove={removePreview}
-                uploadsInProgress={draft.uploadsInProgress}
-                uploadsProgressPercent={uploadsProgressPercent}
-            />
+            <div>
+                <FilePreview
+                    fileInfos={draft.fileInfos}
+                    onRemove={removePreview}
+                    uploadsProgressPercent={uploadsProgressPercent}
+                />
+            </div>
         );
     }
 
     const getFileCount = () => {
-        return draft.fileInfos.length + draft.uploadsInProgress.length;
+        return draft.fileInfos.length + Object.keys(draft.uploadsProgressPercent).length;
     };
 
     let postType = 'post';

--- a/components/drafts/channel_draft/channel_draft.tsx
+++ b/components/drafts/channel_draft/channel_draft.tsx
@@ -110,7 +110,7 @@ function ChannelDraft({
                         message={value.message}
                         status={status}
                         priority={value.metadata?.priority}
-                        uploadsInProgress={value.uploadsInProgress}
+                        uploadsProgressPercent={value.uploadsProgressPercent}
                         userId={user.id}
                         username={user.username}
                     />

--- a/components/drafts/panel/__snapshots__/panel_body.test.tsx.snap
+++ b/components/drafts/panel/__snapshots__/panel_body.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`components/drafts/panel/panel_body should have called handleFormattedTe
     fileInfos={Array []}
     message="message"
     status="status"
-    uploadsInProgress={Array []}
+    uploadsProgressPercent={Object {}}
     userId="user_id"
     username="username"
   >
@@ -297,7 +297,7 @@ exports[`components/drafts/panel/panel_body should match snapshot 1`] = `
     fileInfos={Array []}
     message="message"
     status="status"
-    uploadsInProgress={Array []}
+    uploadsProgressPercent={Object {}}
     userId="user_id"
     username="username"
   >

--- a/components/drafts/panel/__snapshots__/panel_body.test.tsx.snap
+++ b/components/drafts/panel/__snapshots__/panel_body.test.tsx.snap
@@ -581,7 +581,7 @@ exports[`components/drafts/panel/panel_body should match snapshot for priority 1
       }
     }
     status="status"
-    uploadsInProgress={Array []}
+    uploadsProgressPercent={Object {}}
     userId="user_id"
     username="username"
   >
@@ -935,7 +935,7 @@ exports[`components/drafts/panel/panel_body should match snapshot for requested_
       }
     }
     status="status"
-    uploadsInProgress={Array []}
+    uploadsProgressPercent={Object {}}
     userId="user_id"
     username="username"
   >

--- a/components/drafts/panel/panel_body.test.tsx
+++ b/components/drafts/panel/panel_body.test.tsx
@@ -24,7 +24,7 @@ describe('components/drafts/panel/panel_body', () => {
         fileInfos: [] as PostDraft['fileInfos'],
         message: 'message',
         status: 'status' as UserStatus['status'],
-        uploadsInProgress: [] as PostDraft['uploadsInProgress'],
+        uploadsProgressPercent: {} as PostDraft['uploadsProgressPercent'],
         userId: 'user_id' as UserProfile['id'],
         username: 'username' as UserProfile['username'],
     };

--- a/components/drafts/panel/panel_body.tsx
+++ b/components/drafts/panel/panel_body.tsx
@@ -29,7 +29,7 @@ type Props = {
     message: string;
     priority?: PostPriorityMetadata;
     status: UserStatus['status'];
-    uploadsInProgress: PostDraft['uploadsInProgress'];
+    uploadsProgressPercent: PostDraft['uploadsProgressPercent'];
     userId: UserProfile['id'];
     username: UserProfile['username'];
 }
@@ -46,7 +46,7 @@ function PanelBody({
     message,
     priority,
     status,
-    uploadsInProgress,
+    uploadsProgressPercent,
     userId,
     username,
 }: Props) {
@@ -104,10 +104,10 @@ function PanelBody({
                             message={message}
                         />
                     </div>
-                    {(fileInfos.length > 0 || uploadsInProgress?.length > 0) && (
+                    {(fileInfos.length > 0 || Object.keys(uploadsProgressPercent).length > 0) && (
                         <FilePreview
                             fileInfos={fileInfos}
-                            uploadsInProgress={uploadsInProgress}
+                            uploadsProgressPercent={uploadsProgressPercent}
                         />
                     )}
                 </div>

--- a/components/drafts/thread_draft/thread_draft.tsx
+++ b/components/drafts/thread_draft/thread_draft.tsx
@@ -115,7 +115,7 @@ function ThreadDraft({
                         fileInfos={value.fileInfos}
                         message={value.message}
                         status={status}
-                        uploadsInProgress={value.uploadsInProgress}
+                        uploadsProgressPercent={value.uploadsProgressPercent}
                         userId={user.id}
                         username={user.username}
                     />

--- a/components/file_attachment_list/file_attachment_list.test.tsx
+++ b/components/file_attachment_list/file_attachment_list.test.tsx
@@ -137,7 +137,7 @@ describe('FileAttachmentList', () => {
         );
 
         expect(wrapper.find(FilePreview)).toHaveLength(1);
-        expect(wrapper.find(FilePreview).first().props().uploadsInProgress).toStrictEqual(['a']);
+        expect(Object.keys(wrapper.find(FilePreview).first().props().uploadsProgressPercent!)).toStrictEqual(['a']);
 
         expect(wrapper.find(FileAttachment).last().props().fileInfo.id).toBe('file_id_3');
     });

--- a/components/file_attachment_list/file_attachment_list.test.tsx
+++ b/components/file_attachment_list/file_attachment_list.test.tsx
@@ -9,6 +9,8 @@ import {TestHelper} from 'utils/test_helper';
 import FileAttachment from 'components/file_attachment';
 import SingleImageView from 'components/single_image_view';
 
+import {FilePreviewInfo} from '@mattermost/types/files';
+
 import FileAttachmentList from './file_attachment_list';
 
 describe('FileAttachmentList', () => {
@@ -21,6 +23,7 @@ describe('FileAttachmentList', () => {
         TestHelper.getFileInfoMock({id: 'file_id_2', name: 'image_2.png', extension: 'png', create_at: 2}),
         TestHelper.getFileInfoMock({id: 'file_id_1', name: 'image_1.png', extension: 'png', create_at: 1}),
     ];
+    const filePreviews: FilePreviewInfo[] = [];
     const baseProps = {
         post,
         fileCount: 3,
@@ -32,7 +35,9 @@ describe('FileAttachmentList', () => {
         handleFileDropdownOpened: jest.fn(),
         actions: {
             openModal: jest.fn(),
+            cancelUploadingFile: jest.fn(),
         },
+        filePreviews,
     };
 
     test('should render a FileAttachment for a single file', () => {

--- a/components/file_attachment_list/file_attachment_list.test.tsx
+++ b/components/file_attachment_list/file_attachment_list.test.tsx
@@ -9,7 +9,9 @@ import {TestHelper} from 'utils/test_helper';
 import FileAttachment from 'components/file_attachment';
 import SingleImageView from 'components/single_image_view';
 
-import {FilePreviewInfo} from '@mattermost/types/files';
+import {FileInfo, FilePreviewInfo} from '@mattermost/types/files';
+
+import FilePreview from 'components/file_preview';
 
 import FileAttachmentList from './file_attachment_list';
 
@@ -118,5 +120,25 @@ describe('FileAttachmentList', () => {
 
         expect(wrapper.find(SingleImageView).exists()).toBe(false);
         expect(wrapper.find(FileAttachment).exists()).toBe(true);
+    });
+
+    test('should render FilePreview', () => {
+        const filePreviews: FileInfo[] = [
+            TestHelper.getFileInfoMock({
+                clientId: 'a',
+            }),
+        ];
+        const props = {
+            ...baseProps,
+            filePreviews,
+        };
+        const wrapper = shallow(
+            <FileAttachmentList {...props}/>,
+        );
+
+        expect(wrapper.find(FilePreview)).toHaveLength(1);
+        expect(wrapper.find(FilePreview).first().props().uploadsInProgress).toStrictEqual(['a']);
+
+        expect(wrapper.find(FileAttachment).last().props().fileInfo.id).toBe('file_id_3');
     });
 });

--- a/components/file_attachment_list/file_attachment_list.tsx
+++ b/components/file_attachment_list/file_attachment_list.tsx
@@ -70,7 +70,6 @@ export default function FileAttachmentList(props: Props) {
             <FilePreview
                 key='KEY'
                 fileInfos={[]}
-                uploadsInProgress={filePreviews.map((f) => f.clientId)}
                 uploadsProgressPercent={filePreviews.reduce((s, f) => {
                     return {
                         ...s,

--- a/components/file_attachment_list/file_attachment_list.tsx
+++ b/components/file_attachment_list/file_attachment_list.tsx
@@ -12,6 +12,9 @@ import FileAttachment from 'components/file_attachment';
 import SingleImageView from 'components/single_image_view';
 import FilePreviewModal from 'components/file_preview_modal';
 
+import FilePreview from 'components/file_preview';
+import {FilePreviewInfo} from '@mattermost/types/files';
+
 import type {OwnProps, PropsFromRedux} from './index';
 
 type Props = OwnProps & PropsFromRedux;
@@ -60,6 +63,26 @@ export default function FileAttachmentList(props: Props) {
     }
 
     const postFiles = [];
+
+    const filePreviews = sortFileInfos(props.filePreviews.slice().filter((f) => !sortedFileInfos.map((s) => s.clientId).includes(f.clientId)));
+    if (filePreviews.length !== 0) {
+        postFiles.push(
+            <FilePreview
+                key='KEY'
+                fileInfos={[]}
+                uploadsInProgress={filePreviews.map((f) => f.clientId)}
+                uploadsProgressPercent={filePreviews.reduce((s, f) => {
+                    return {
+                        ...s,
+                        [f.clientId]: f,
+                    };
+                }, {} as {[clientID: string]: FilePreviewInfo})}
+                onRemove={(id) => {
+                    props.actions.cancelUploadingFile(id);
+                }}
+            />,
+        );
+    }
     if (sortedFileInfos && sortedFileInfos.length > 0) {
         for (let i = 0; i < sortedFileInfos.length; i++) {
             const fileInfo = sortedFileInfos[i];

--- a/components/file_attachment_list/index.ts
+++ b/components/file_attachment_list/index.ts
@@ -4,7 +4,7 @@
 import {connect, ConnectedProps} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
 
-import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
+import {getFilePreviews, makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {Post} from '@mattermost/types/posts';
 import {GenericAction} from 'mattermost-redux/types/actions';
@@ -15,6 +15,8 @@ import {getCurrentLocale} from 'selectors/i18n';
 import {isEmbedVisible} from 'selectors/posts';
 
 import {openModal} from 'actions/views/modals';
+
+import {cancelUploadingFile} from 'actions/file_actions';
 
 import FileAttachmentList from './file_attachment_list';
 
@@ -44,6 +46,7 @@ function makeMapStateToProps() {
         return {
             enableSVGs: getConfig(state).EnableSVGs === 'true',
             fileInfos,
+            filePreviews: getFilePreviews(state, ownProps.post.pending_post_id),
             fileCount,
             isEmbedVisible: isEmbedVisible(state, ownProps.post.id),
             locale: getCurrentLocale(state),
@@ -55,6 +58,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators({
             openModal,
+            cancelUploadingFile,
         }, dispatch),
     };
 }

--- a/components/file_preview/__snapshots__/file_preview.test.tsx.snap
+++ b/components/file_preview/__snapshots__/file_preview.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`FilePreview should match snapshot 1`] = `
     </div>
   </div>
   <FileProgressPreview
-    clientId="clientID_1"
+    clientId=""
     fileInfo={
       Object {
         "archived": false,
@@ -99,7 +99,7 @@ exports[`FilePreview should match snapshot 1`] = `
       }
     }
     handleRemove={[Function]}
-    key="clientID_1"
+    key=""
   />
 </div>
 `;
@@ -182,7 +182,7 @@ exports[`FilePreview should match snapshot when props are changed 1`] = `
     </div>
   </div>
   <FileProgressPreview
-    clientId="clientID_1"
+    clientId=""
     fileInfo={
       Object {
         "archived": false,
@@ -203,7 +203,7 @@ exports[`FilePreview should match snapshot when props are changed 1`] = `
       }
     }
     handleRemove={[Function]}
-    key="clientID_1"
+    key=""
   />
 </div>
 `;
@@ -348,5 +348,29 @@ exports[`FilePreview should match snapshot when props are changed 2`] = `
       </div>
     </div>
   </div>
+  <FileProgressPreview
+    clientId=""
+    fileInfo={
+      Object {
+        "archived": false,
+        "clientId": "",
+        "create_at": 0,
+        "delete_at": 0,
+        "extension": "image/png",
+        "has_preview_image": true,
+        "height": 100,
+        "id": "file_id_1",
+        "mime_type": "",
+        "name": "file",
+        "percent": 50,
+        "size": 100,
+        "update_at": 0,
+        "user_id": "",
+        "width": 100,
+      }
+    }
+    handleRemove={[Function]}
+    key=""
+  />
 </div>
 `;

--- a/components/file_preview/__snapshots__/file_preview.test.tsx.snap
+++ b/components/file_preview/__snapshots__/file_preview.test.tsx.snap
@@ -77,30 +77,6 @@ exports[`FilePreview should match snapshot 1`] = `
       </div>
     </div>
   </div>
-  <FileProgressPreview
-    clientId=""
-    fileInfo={
-      Object {
-        "archived": false,
-        "clientId": "",
-        "create_at": 0,
-        "delete_at": 0,
-        "extension": "image/png",
-        "has_preview_image": true,
-        "height": 100,
-        "id": "file_id_1",
-        "mime_type": "",
-        "name": "file",
-        "percent": 50,
-        "size": 100,
-        "update_at": 0,
-        "user_id": "",
-        "width": 100,
-      }
-    }
-    handleRemove={[Function]}
-    key=""
-  />
 </div>
 `;
 
@@ -181,30 +157,6 @@ exports[`FilePreview should match snapshot when props are changed 1`] = `
       </div>
     </div>
   </div>
-  <FileProgressPreview
-    clientId=""
-    fileInfo={
-      Object {
-        "archived": false,
-        "clientId": "",
-        "create_at": 0,
-        "delete_at": 0,
-        "extension": "image/png",
-        "has_preview_image": true,
-        "height": 100,
-        "id": "file_id_1",
-        "mime_type": "",
-        "name": "file",
-        "percent": 50,
-        "size": 100,
-        "update_at": 0,
-        "user_id": "",
-        "width": 100,
-      }
-    }
-    handleRemove={[Function]}
-    key=""
-  />
 </div>
 `;
 
@@ -348,29 +300,5 @@ exports[`FilePreview should match snapshot when props are changed 2`] = `
       </div>
     </div>
   </div>
-  <FileProgressPreview
-    clientId=""
-    fileInfo={
-      Object {
-        "archived": false,
-        "clientId": "",
-        "create_at": 0,
-        "delete_at": 0,
-        "extension": "image/png",
-        "has_preview_image": true,
-        "height": 100,
-        "id": "file_id_1",
-        "mime_type": "",
-        "name": "file",
-        "percent": 50,
-        "size": 100,
-        "update_at": 0,
-        "user_id": "",
-        "width": 100,
-      }
-    }
-    handleRemove={[Function]}
-    key=""
-  />
 </div>
 `;

--- a/components/file_preview/file_preview.tsx
+++ b/components/file_preview/file_preview.tsx
@@ -4,20 +4,13 @@
 import React, {ReactNode} from 'react';
 
 import {getFileThumbnailUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
-import {FileInfo} from '@mattermost/types/files';
+import {FilePreviewInfo} from '@mattermost/types/files';
 
 import FilenameOverlay from 'components/file_attachment/filename_overlay';
 import Constants, {FileTypes} from 'utils/constants';
 import * as Utils from 'utils/utils';
 
 import FileProgressPreview from './file_progress_preview';
-
-type UploadInfo = {
-    name: string;
-    percent?: number;
-    type?: string;
-}
-export type FilePreviewInfo = FileInfo & UploadInfo;
 
 type Props = {
     enableSVGs: boolean;

--- a/components/file_preview/file_preview.tsx
+++ b/components/file_preview/file_preview.tsx
@@ -16,14 +16,12 @@ type Props = {
     enableSVGs: boolean;
     onRemove?: (id: string) => void;
     fileInfos: FilePreviewInfo[];
-    uploadsInProgress?: string[];
-    uploadsProgressPercent?: {[clientID: string]: FilePreviewInfo};
+    uploadsProgressPercent?: {[clientID: string]: FilePreviewInfo | undefined};
 }
 
 export default class FilePreview extends React.PureComponent<Props> {
     static defaultProps = {
         fileInfos: [],
-        uploadsInProgress: [],
         uploadsProgressPercent: {},
     };
 
@@ -110,15 +108,14 @@ export default class FilePreview extends React.PureComponent<Props> {
             );
         });
 
-        if (this.props.uploadsInProgress && this.props.uploadsProgressPercent) {
-            const uploadsProgressPercent = this.props.uploadsProgressPercent;
-            this.props.uploadsInProgress.forEach((clientId) => {
-                const fileInfo = uploadsProgressPercent[clientId];
+        const uploadsProgressPercent = this.props.uploadsProgressPercent;
+        if (uploadsProgressPercent) {
+            Object.values(uploadsProgressPercent).filter((filePreviewInfo): filePreviewInfo is FilePreviewInfo => filePreviewInfo !== undefined).forEach((fileInfo) => {
                 if (fileInfo) {
                     previews.push(
                         <FileProgressPreview
-                            key={clientId}
-                            clientId={clientId}
+                            key={fileInfo.clientId}
+                            clientId={fileInfo.clientId}
                             fileInfo={fileInfo}
                             handleRemove={this.handleRemove}
                         />,

--- a/components/file_preview/file_preview.tsx
+++ b/components/file_preview/file_preview.tsx
@@ -32,6 +32,7 @@ export default class FilePreview extends React.PureComponent<Props> {
     render() {
         const previews: ReactNode[] = [];
 
+        const fileInfoClientIds = this.props.fileInfos.map((f) => f.clientId);
         this.props.fileInfos.forEach((info) => {
             const type = Utils.getFileType(info.extension);
 
@@ -110,18 +111,20 @@ export default class FilePreview extends React.PureComponent<Props> {
 
         const uploadsProgressPercent = this.props.uploadsProgressPercent;
         if (uploadsProgressPercent) {
-            Object.values(uploadsProgressPercent).filter((filePreviewInfo): filePreviewInfo is FilePreviewInfo => filePreviewInfo !== undefined).forEach((fileInfo) => {
-                if (fileInfo) {
-                    previews.push(
-                        <FileProgressPreview
-                            key={fileInfo.clientId}
-                            clientId={fileInfo.clientId}
-                            fileInfo={fileInfo}
-                            handleRemove={this.handleRemove}
-                        />,
-                    );
-                }
-            });
+            Object.values(uploadsProgressPercent).
+                filter((filePreviewInfo): filePreviewInfo is FilePreviewInfo => filePreviewInfo !== undefined && !fileInfoClientIds.includes(filePreviewInfo.clientId)).
+                forEach((fileInfo) => {
+                    if (fileInfo) {
+                        previews.push(
+                            <FileProgressPreview
+                                key={fileInfo.clientId}
+                                clientId={fileInfo.clientId}
+                                fileInfo={fileInfo}
+                                handleRemove={this.handleRemove}
+                            />,
+                        );
+                    }
+                });
         }
 
         return (

--- a/components/file_preview/file_progress_preview.tsx
+++ b/components/file_preview/file_progress_preview.tsx
@@ -8,8 +8,7 @@ import {ProgressBar} from 'react-bootstrap';
 import FilenameOverlay from 'components/file_attachment/filename_overlay';
 import {getFileTypeFromMime} from 'utils/file_utils';
 import * as Utils from 'utils/utils';
-
-import {FilePreviewInfo} from './file_preview';
+import {FilePreviewInfo} from '@mattermost/types/files';
 
 type Props = {
     handleRemove: (id: string) => void;

--- a/components/file_upload/file_upload.test.tsx
+++ b/components/file_upload/file_upload.test.tsx
@@ -166,7 +166,7 @@ describe('components/FileUpload', () => {
 
     test('should props.onFileUpload when fileUploadSuccess is called', () => {
         const data = {
-            file_infos: [{id: 'file_info1'} as FileInfo],
+            file_infos: [{id: 'file_info1', clientId: 'id1'} as FileInfo],
             client_ids: ['id1'],
         };
 

--- a/components/file_upload/file_upload.test.tsx
+++ b/components/file_upload/file_upload.test.tsx
@@ -176,7 +176,7 @@ describe('components/FileUpload', () => {
 
         const instance = wrapper.instance() as FileUploadClass;
 
-        instance.fileUploadSuccess(data, 'channel_id', 'root_id');
+        instance.fileUploadSuccess(data.file_infos, 'channel_id', 'root_id');
 
         expect(baseProps.onFileUpload).toHaveBeenCalledTimes(1);
         expect(baseProps.onFileUpload).toHaveBeenCalledWith(data.file_infos, data.client_ids, 'channel_id', 'root_id');

--- a/components/post/index.tsx
+++ b/components/post/index.tsx
@@ -44,9 +44,9 @@ import {General} from 'mattermost-redux/constants';
 import {getDisplayNameByUser} from 'utils/utils';
 import {getDirectTeammate} from 'mattermost-redux/selectors/entities/channels';
 
-import PostComponent from './post_component';
-
 import {getFilePreviews} from 'mattermost-redux/selectors/entities/files';
+
+import PostComponent from './post_component';
 
 interface OwnProps {
     post?: Post | UserActivityPost;
@@ -234,7 +234,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         isPostPriorityEnabled: isPostPriorityEnabled(state),
         isCardOpen: selectedCard && selectedCard.id === post.id,
         shouldShowDotMenu: shouldShowDotMenu(state, post, channel),
-        filePreviews: getFilePreviews(state, ownProps.post?.pending_post_id),
+        filePreviews: getFilePreviews(state, post.pending_post_id),
     };
 }
 

--- a/components/post/index.tsx
+++ b/components/post/index.tsx
@@ -46,6 +46,8 @@ import {getDirectTeammate} from 'mattermost-redux/selectors/entities/channels';
 
 import PostComponent from './post_component';
 
+import {getFilePreviews} from 'mattermost-redux/selectors/entities/files';
+
 interface OwnProps {
     post?: Post | UserActivityPost;
     previousPostId?: string;
@@ -232,6 +234,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         isPostPriorityEnabled: isPostPriorityEnabled(state),
         isCardOpen: selectedCard && selectedCard.id === post.id,
         shouldShowDotMenu: shouldShowDotMenu(state, post, channel),
+        filePreviews: getFilePreviews(state, ownProps.post?.pending_post_id),
     };
 }
 

--- a/components/post/post_component.tsx
+++ b/components/post/post_component.tsx
@@ -8,7 +8,8 @@ import classNames from 'classnames';
 import {Posts} from 'mattermost-redux/constants/index';
 import {
     isMeMessage as checkIsMeMessage,
-    isPostPendingOrFailed} from 'mattermost-redux/utils/post_utils';
+    isPostPendingOrFailed,
+} from 'mattermost-redux/utils/post_utils';
 
 import Constants, {A11yCustomEventTypes, AppEvents, Locations} from 'utils/constants';
 
@@ -48,11 +49,10 @@ import {UserProfile} from '@mattermost/types/users';
 import {Post} from '@mattermost/types/posts';
 import {Emoji} from '@mattermost/types/emojis';
 
+import {FilePreviewInfo} from '@mattermost/types/files';
+
 import PostUserProfile from './user_profile';
 import PostOptions from './post_options';
-
-import {FilePreviewInfo} from '@mattermost/types/files';
-import {isPostUploadingFile} from 'mattermost-redux/utils/post_utils';
 
 export type Props = {
     post: Post;
@@ -600,7 +600,7 @@ const PostComponent = (props: Props): JSX.Element => {
                                 slot2={<EditPost/>}
                                 onTransitionEnd={() => document.dispatchEvent(new Event(AppEvents.FOCUS_EDIT_TEXTBOX))}
                             />
-                            {post.file_ids && post.file_ids.length > 0 && filePreviews.length > 0 &&
+                            {((post.file_ids && post.file_ids.length > 0) || filePreviews.length > 0) &&
                             <FileAttachmentListContainer
                                 post={post}
                                 compactDisplay={props.compactDisplay}

--- a/components/post/post_component.tsx
+++ b/components/post/post_component.tsx
@@ -51,6 +51,9 @@ import {Emoji} from '@mattermost/types/emojis';
 import PostUserProfile from './user_profile';
 import PostOptions from './post_options';
 
+import {FilePreviewInfo} from '@mattermost/types/files';
+import {isPostUploadingFile} from 'mattermost-redux/utils/post_utils';
+
 export type Props = {
     post: Post;
     teamId: string;
@@ -116,10 +119,11 @@ export type Props = {
     isCardOpen?: boolean;
     shouldShowDotMenu: boolean;
     tourTipsEnabled: boolean;
+    filePreviews: FilePreviewInfo[];
 };
 
 const PostComponent = (props: Props): JSX.Element => {
-    const {post, togglePostMenu} = props;
+    const {post, filePreviews, togglePostMenu} = props;
 
     const isSearchResultItem = (props.matches && props.matches.length > 0) || props.isMentionSearch || (props.term && props.term.length > 0);
     const isRHS = props.location === Locations.RHS_ROOT || props.location === Locations.RHS_COMMENT || props.location === Locations.SEARCH;
@@ -596,7 +600,7 @@ const PostComponent = (props: Props): JSX.Element => {
                                 slot2={<EditPost/>}
                                 onTransitionEnd={() => document.dispatchEvent(new Event(AppEvents.FOCUS_EDIT_TEXTBOX))}
                             />
-                            {post.file_ids && post.file_ids.length > 0 &&
+                            {post.file_ids && post.file_ids.length > 0 && filePreviews.length > 0 &&
                             <FileAttachmentListContainer
                                 post={post}
                                 compactDisplay={props.compactDisplay}

--- a/components/post_view/failed_post_options/failed_post_options.tsx
+++ b/components/post_view/failed_post_options/failed_post_options.tsx
@@ -10,7 +10,7 @@ import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import {ExtendedPost} from 'mattermost-redux/actions/posts';
 
 type CreatePostAction =
-    (post: Post, files: FileInfo[]) => (dispatch: DispatchFunc) => Promise<{data?: boolean}>;
+    (post: Post, files: FileInfo[]) => (dispatch: DispatchFunc, getState: GetStateFunc) => Promise<{data?: boolean}>;
 type RemovePostAction =
     (post: ExtendedPost) => (dispatch: DispatchFunc, getState: GetStateFunc) => void;
 

--- a/components/post_view/post_message_preview/post_message_preview.tsx
+++ b/components/post_view/post_message_preview/post_message_preview.tsx
@@ -103,7 +103,7 @@ const PostMessagePreview = (props: Props) => {
 
     let fileAttachmentPreview = null;
 
-    if (((previewPost.file_ids && previewPost.file_ids.length > 0) || (previewPost.filenames && previewPost.filenames.length > 0))) {
+    if (((previewPost.file_ids && previewPost.file_ids.length > 0) || (previewPost.filenames && previewPost.filenames.length > 0)) || (previewPost.file_client_ids && previewPost.file_client_ids.length > 0)) {
         fileAttachmentPreview = (
             <FileAttachmentListContainer
                 post={previewPost}

--- a/components/sidebar/sidebar_channel/channel_pencil_icon/index.ts
+++ b/components/sidebar/sidebar_channel/channel_pencil_icon/index.ts
@@ -22,7 +22,7 @@ function hasDraft(draft: PostDraft|null, id: Channel['id'], currentChannelId?: s
         return false;
     }
 
-    return Boolean(draft.message.trim() || draft.fileInfos.length || draft.uploadsInProgress.length) && currentChannelId !== id;
+    return Boolean(draft.message.trim() || draft.fileInfos.length || Object.keys(draft.uploadsProgressPercent).length) && currentChannelId !== id;
 }
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {

--- a/components/threading/thread_viewer/thread_viewer.tsx
+++ b/components/threading/thread_viewer/thread_viewer.tsx
@@ -84,7 +84,7 @@ export default class ThreadViewer extends React.PureComponent<Props, State> {
             return;
         }
 
-        const selectedChanged = this.props.selected.id !== prevProps.selected.id;
+        const selectedChanged = prevProps.selected && this.props.selected.id !== prevProps.selected.id;
 
         if (reconnected || selectedChanged) {
             this.onInit(reconnected);

--- a/packages/mattermost-redux/src/action_types/files.ts
+++ b/packages/mattermost-redux/src/action_types/files.ts
@@ -13,4 +13,9 @@ export default keyMirror({
     RECEIVED_FILES_FOR_POST: null,
     RECEIVED_UPLOAD_FILES: null,
     RECEIVED_FILE_PUBLIC_LINK: null,
+    RECEIVED_FILE_PREVIEWS: null,
+
+    START_UPLOADING_FILE: null,
+    UPDATE_FILE_UPLOAD_PROGRESS: null,
+    REMOVE_FILE_PREVIEWS: null,
 });

--- a/packages/mattermost-redux/src/actions/posts.ts
+++ b/packages/mattermost-redux/src/actions/posts.ts
@@ -249,7 +249,7 @@ export function storePost(post: Post, files: FileInfo[]) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const crtEnabled = isCollapsedThreadsEnabled(getState());
         try {
-            const created = await Client4.createPost({...post/* TODO: , create_at: 0*/});
+            const created = await Client4.createPost({...post, id: ''});
 
             const actions: AnyAction[] = [
                 receivedPost(created, crtEnabled),

--- a/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -363,6 +363,14 @@ function handlePostReceived(nextState: any, post: Post, nestedPermalinkLevel?: n
         currentState[post.root_id] = nextRootPost;
     }
 
+    const childPosts = (Object.values(currentState) as Post[]).filter((p) => p.root_id && p.root_id === post.pending_post_id);
+    childPosts.forEach((childPost) => {
+        currentState[childPost.id] = {
+            ...childPost,
+            root_id: post.id,
+        };
+    });
+
     return currentState;
 }
 

--- a/packages/mattermost-redux/src/selectors/entities/files.ts
+++ b/packages/mattermost-redux/src/selectors/entities/files.ts
@@ -61,7 +61,7 @@ export const getSearchFilesResults: (state: GlobalState) => FileSearchResultItem
     },
 );
 
-export function getFilePreviews(state: GlobalState, pendingPostId: string | undefined) {
+export function getFilePreviews(state: GlobalState, pendingPostId?: string) {
     if (!pendingPostId) {
         return [];
     }

--- a/packages/mattermost-redux/src/selectors/entities/files.ts
+++ b/packages/mattermost-redux/src/selectors/entities/files.ts
@@ -61,3 +61,9 @@ export const getSearchFilesResults: (state: GlobalState) => FileSearchResultItem
     },
 );
 
+export function getFilePreviews(state: GlobalState, pendingPostId: string | undefined) {
+    if (!pendingPostId) {
+        return [];
+    }
+    return state.entities.files.filePreviews[pendingPostId] ?? [];
+}

--- a/packages/mattermost-redux/src/store/initial_state.ts
+++ b/packages/mattermost-redux/src/store/initial_state.ts
@@ -126,6 +126,7 @@ const state: GlobalState = {
             files: {},
             filesFromSearch: {},
             fileIdsByPostId: {},
+            filePreviews: {},
         },
         emojis: {
             customEmoji: {},

--- a/packages/mattermost-redux/src/utils/post_utils.test.ts
+++ b/packages/mattermost-redux/src/utils/post_utils.test.ts
@@ -18,6 +18,7 @@ import {
     getEmbedFromMetadata,
     shouldUpdatePost,
     isPermalink,
+    isPostUploadingFile,
 } from 'mattermost-redux/utils/post_utils';
 
 describe('PostUtils', () => {
@@ -648,6 +649,25 @@ describe('PostUtils', () => {
             const storedPostSansMetadata = {...storedPost};
             delete (storedPostSansMetadata as any).metadata;
             expect(shouldUpdatePost(post, storedPostSansMetadata)).toBe(true);
+        });
+    });
+
+    describe('isPostUploadingFile', () => {
+        it('should return true when post which has file being uploaded passed in argument', () => {
+            const post = TestHelper.getPostMock({
+                id: 'pending',
+                pending_post_id: 'pending',
+                file_client_ids: ['a'],
+            });
+            expect(isPostUploadingFile(post)).toBe(true);
+        });
+
+        it('should return false when post which has no file being uploaded passed in argument', () => {
+            const post = TestHelper.getPostMock({
+                id: 'id',
+                pending_post_id: 'pending',
+            });
+            expect(isPostUploadingFile(post)).toBe(false);
         });
     });
 });

--- a/packages/mattermost-redux/src/utils/post_utils.ts
+++ b/packages/mattermost-redux/src/utils/post_utils.ts
@@ -140,16 +140,22 @@ function isJoinLeavePostForUsername(post: Post, currentUsername: string): boolea
         post.props.removedUsername === currentUsername;
 }
 
+export function isPostUploadingFile(post: Post): boolean {
+    return post.id === post.pending_post_id && post.file_client_ids !== undefined && post.file_client_ids.length !== 0;
+}
+
 export function isPostPendingOrFailed(post: Post): boolean {
     return post.failed || post.id === post.pending_post_id;
 }
 
 export function comparePosts(a: Post, b: Post): number {
+    const aIsUploadingFile = isPostUploadingFile(a);
+    const bIsUploadingFile = isPostUploadingFile(b);
     const aIsPendingOrFailed = isPostPendingOrFailed(a);
     const bIsPendingOrFailed = isPostPendingOrFailed(b);
-    if (aIsPendingOrFailed && !bIsPendingOrFailed) {
+    if (!aIsUploadingFile && aIsPendingOrFailed && !bIsPendingOrFailed) {
         return -1;
-    } else if (!aIsPendingOrFailed && bIsPendingOrFailed) {
+    } else if (!bIsUploadingFile && !aIsPendingOrFailed && bIsPendingOrFailed) {
         return 1;
     }
 

--- a/packages/mattermost-redux/src/utils/post_utils.ts
+++ b/packages/mattermost-redux/src/utils/post_utils.ts
@@ -144,8 +144,17 @@ export function isPostUploadingFile(post: Post): boolean {
     return post.id === post.pending_post_id && post.file_client_ids !== undefined && post.file_client_ids.length !== 0;
 }
 
+export function isPostDangling(state: GlobalState, post: Post) {
+    const rootPost = state.entities.posts.posts[post.root_id];
+    return rootPost && isPostPending(rootPost);
+}
+
+export function isPostPending(post: Post) {
+    return post.id === post.pending_post_id;
+}
+
 export function isPostPendingOrFailed(post: Post): boolean {
-    return post.failed || post.id === post.pending_post_id;
+    return post.failed || isPostPending(post);
 }
 
 export function comparePosts(a: Post, b: Post): number {

--- a/packages/types/src/files.ts
+++ b/packages/types/src/files.ts
@@ -20,11 +20,20 @@ export type FileInfo = {
     archived: boolean;
     link?: string;
 };
+
+export type UploadInfo = {
+    name: string;
+    percent?: number;
+    type?: string;
+}
+export type FilePreviewInfo = FileInfo & UploadInfo;
+
 export type FilesState = {
     files: Record<string, FileInfo>;
     filesFromSearch: Record<string, FileSearchResultItem>;
     fileIdsByPostId: Record<string, string[]>;
     filePublicLink?: {link: string};
+    filePreviews: Record<string, FilePreviewInfo[]>;
 };
 
 export type FileUploadResponse = {

--- a/packages/types/src/posts.ts
+++ b/packages/types/src/posts.ts
@@ -87,6 +87,7 @@ export type Post = {
     pending_post_id: string;
     reply_count: number;
     file_ids?: string[];
+    file_client_ids?: string[];
     metadata: PostMetadata;
     failed?: boolean;
     user_activity_posts?: Post[];

--- a/selectors/rhs.ts
+++ b/selectors/rhs.ts
@@ -130,14 +130,14 @@ export function getIsSearchGettingMore(state: GlobalState): boolean {
 }
 
 export function makeGetChannelDraft() {
-    const defaultDraft = Object.freeze({message: '', fileInfos: [], uploadsInProgress: [], createAt: 0, updateAt: 0, channelId: '', rootId: ''});
+    const defaultDraft = Object.freeze({message: '', fileInfos: [], uploadsProgressPercent: {}, createAt: 0, updateAt: 0, channelId: '', rootId: ''});
     const getDraft = makeGetGlobalItemWithDefault(defaultDraft);
 
     return (state: GlobalState, channelId: string): PostDraft => {
         const draft = getDraft(state, StoragePrefixes.DRAFT + channelId);
         if (
             typeof draft.message !== 'undefined' &&
-            typeof draft.uploadsInProgress !== 'undefined' &&
+            typeof draft.uploadsProgressPercent !== 'undefined' &&
             typeof draft.fileInfos !== 'undefined'
         ) {
             return draft;

--- a/selectors/rhs.ts
+++ b/selectors/rhs.ts
@@ -148,7 +148,7 @@ export function makeGetChannelDraft() {
 }
 
 export function getPostDraft(state: GlobalState, prefixId: string, suffixId: string): PostDraft {
-    const defaultDraft = {message: '', fileInfos: [], uploadsInProgress: [], createAt: 0, updateAt: 0, channelId: '', rootId: ''};
+    const defaultDraft = {message: '', fileInfos: [], uploadsProgressPercent: {}, createAt: 0, updateAt: 0, channelId: '', rootId: ''};
 
     if (prefixId === StoragePrefixes.COMMENT_DRAFT) {
         defaultDraft.rootId = suffixId;
@@ -157,7 +157,7 @@ export function getPostDraft(state: GlobalState, prefixId: string, suffixId: str
 
     if (
         typeof draft.message !== 'undefined' &&
-        typeof draft.uploadsInProgress !== 'undefined' &&
+        typeof draft.uploadsProgressPercent !== 'undefined' &&
         typeof draft.fileInfos !== 'undefined'
     ) {
         return draft;

--- a/types/store/draft.ts
+++ b/types/store/draft.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {FileInfo} from '@mattermost/types/files';
+import {FileInfo, FilePreviewInfo} from '@mattermost/types/files';
 import {PostPriority} from '@mattermost/types/posts';
 
 export type DraftInfo = {
@@ -12,7 +12,7 @@ export type DraftInfo = {
 export type PostDraft = {
     message: string;
     fileInfos: FileInfo[];
-    uploadsInProgress: string[];
+    uploadsProgressPercent: {[clientID: string]: FilePreviewInfo | undefined};
     props?: any;
     caretPosition?: number;
     channelId: string;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Queue sending message when files are being uploaded so that users can send next message.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/21264
Jira: https://mattermost.atlassian.net/browse/MM-37606

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
No related PRs.

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

add later...

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Message can be uploaded when files are being uploaded.
```
