### PR TITLE
MM-47611 : Change tsconfig value of module to 'es2020'

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "commonjs",
+    "module": "es2020",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "noEmit": true,


### PR DESCRIPTION
#### Summary
The purpose of this change is to incorporate ts check support for `import.meta`. Currently [webpack already handles ](https://github.com/webpack/webpack/issues/6719)it without any configuration change https://webpack.js.org/api/module-variables/#importmetaurl. But the ts compiler throws error `The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'esnext', or 'system'.`. We cannot directly go to `esnext` as ts 4.7+ is needed for that change. For context "import.meta" is required to add WASM support in the app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47611

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
