### PR TITLE
MM-47238 Add MM_BOARDS_DEV_SERVER_URL environment variable for MPA

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,8 @@ const targetIsEslint = NPM_TARGET === 'check' || NPM_TARGET === 'fix' || process
 
 const DEV = targetIsRun || targetIsStats || targetIsDevServer;
 
+const boardsDevServerUrl = process.env.MM_BOARDS_DEV_SERVER_URL ?? 'http://localhost:9006';
+
 const STANDARD_EXCLUDE = [
     path.join(__dirname, 'node_modules'),
 ];
@@ -394,8 +396,7 @@ function generateCSP() {
         // react-hot-loader and development source maps require eval
         csp += ' \'unsafe-eval\'';
 
-        // Focalboard runs on http://localhost:9006
-        csp += ' http://localhost:9006';
+        csp += ' ' + boardsDevServerUrl;
     }
 
     return csp;
@@ -440,7 +441,7 @@ async function initializeModuleFederation() {
 
     async function getRemoteContainers() {
         const products = [
-            {name: 'boards', baseUrl: 'http://localhost:9006'},
+            {name: 'boards', baseUrl: boardsDevServerUrl},
         ];
 
         if (!DEV) {


### PR DESCRIPTION
This PR is based on https://github.com/mattermost/mattermost-webapp/pull/11355. Changes specific to it are here: https://github.com/mattermost/mattermost-webapp/compare/MM-46981_production-mpa...MM-47238_boards-dev-server-url

This makes it so that people who develop MM on a URL other than `http://localhost` can redefine the URL, port, and protocol that the Boards Webpack dev server runs on for MPA development. Without it sets, it still defaults to running the dev server on `http://localhost:9006`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47238

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/11355
https://github.com/mattermost/focalboard/pull/4026
https://github.com/mattermost/mattermost-server/pull/21435

#### Release Note
```release-note
NONE
```
