### PR TITLE
MM-47679 - add id to feature discovery cloud trial start telemetry id

### DIFF
--- a/components/admin_console/feature_discovery/__snapshots__/feature_discovery.test.tsx.snap
+++ b/components/admin_console/feature_discovery/__snapshots__/feature_discovery.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`components/feature_discovery FeatureDiscovery should match snapshot whe
     <CloudStartTrialButton
       extraClass="btn btn-primary"
       message="Try free for 30 days"
-      telemetryId="start_cloud_trial_feature_discovery"
+      telemetryId="start_cloud_trial_from_test"
     />
     <a
       className="btn btn-secondary"

--- a/components/admin_console/feature_discovery/feature_discovery.tsx
+++ b/components/admin_console/feature_discovery/feature_discovery.tsx
@@ -190,7 +190,7 @@ export default class FeatureDiscovery extends React.PureComponent<Props, State> 
                             'Try free for {trialLength} days',
                             {trialLength: FREEMIUM_TO_ENTERPRISE_TRIAL_LENGTH_DAYS},
                         )}
-                        telemetryId={'start_cloud_trial_feature_discovery'}
+                        telemetryId={`start_cloud_trial_from_${this.props.featureName}`}
                         extraClass='btn btn-primary'
                     />
                 );


### PR DESCRIPTION
#### Summary
This PR attaches the id of the feature guarded by the feature discovery page to the telemetry id used to know where cloud trial starts from.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47679

#### Related Pull Requests
n/a

#### Screenshots


#### Release Note
```release-note
NONE
```
