### PR TITLE
MM-47111 : Migrate "components/emoji_picker/emoji_picker_tabs" to typescript

### DIFF
--- a/components/emoji_picker/emoji_picker_overlay.tsx
+++ b/components/emoji_picker/emoji_picker_overlay.tsx
@@ -10,12 +10,12 @@ import {Constants} from 'utils/constants';
 
 import {Emoji} from '@mattermost/types/emojis';
 
-import EmojiPickerTabs from './emoji_picker_tabs.jsx';
+import EmojiPickerTabs from './emoji_picker_tabs';
 
 type Props = {
     show: boolean;
-    container?: () => ReactNode | ReactNode;
-    target: () => ReactNode | ReactNode;
+    container?: () => ReactNode;
+    target: () => ReactNode;
     onEmojiClick: (emoji: Emoji) => void;
     onGifClick?: (gif: string) => void;
     onHide: () => void;
@@ -39,7 +39,7 @@ export default class EmojiPickerOverlay extends React.PureComponent<Props> {
     static RHS_SPACE_REQUIRED_ABOVE = 420;
     static RHS_SPACE_REQUIRED_BELOW = 420;
 
-    // Reasonable defaults calculated from from the center channel
+    // Reasonable defaults calculated from the center channel
     static defaultProps = {
         spaceRequiredAbove: EmojiPickerOverlay.CENTER_SPACE_REQUIRED_ABOVE,
         spaceRequiredBelow: EmojiPickerOverlay.CENTER_SPACE_REQUIRED_BELOW,

--- a/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/components/emoji_picker/emoji_picker_tabs.tsx
@@ -81,13 +81,10 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                 pickerStyle = {...this.props.style};
             }
 
-            let offset = 0;
-            if (pickerStyle.top) {
-                offset = (this.props.topOffset || 0) + (pickerStyle.top as number);
-            } else {
-                offset = (this.props.topOffset || 0);
+            pickerStyle.top = this.props.topOffset || 0;
+            if (pickerStyle.top && this.props.topOffset) {
+                pickerStyle.top = this.props.topOffset + (pickerStyle.top as number);
             }
-            pickerStyle.top = offset;
 
             if (pickerStyle.left && this.props.leftOffset) {
                 (pickerStyle.left as number) += this.props.leftOffset;

--- a/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/components/emoji_picker/emoji_picker_tabs.tsx
@@ -128,6 +128,7 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                             visible={this.state.emojiTabVisible}
                             onEmojiClick={this.props.onEmojiClick}
                             handleFilterChange={this.handleFilterChange}
+                            handleEmojiPickerClose={this.handleEmojiPickerClose}
                         />
                     </Tab>
                     <Tab

--- a/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/components/emoji_picker/emoji_picker_tabs.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {PureComponent} from 'react';
+import React, {CSSProperties, PureComponent} from 'react';
 import {Tab, Tabs} from 'react-bootstrap';
 
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
@@ -15,7 +15,7 @@ import {Emoji} from '@mattermost/types/emojis';
 const GifPicker = makeAsyncComponent('GifPicker', React.lazy(() => import('components/gif_picker/gif_picker')));
 
 export interface Props {
-    style?: React.CSSProperties;
+    style?: CSSProperties;
     rightOffset?: number;
     topOffset?: number;
     leftOffset?: number;

--- a/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/components/emoji_picker/emoji_picker_tabs.tsx
@@ -81,13 +81,14 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                 pickerStyle = {...this.props.style};
             }
 
-            pickerStyle.top = this.props.topOffset || 0;
-            if (pickerStyle.top && this.props.topOffset) {
-                pickerStyle.top = this.props.topOffset + (pickerStyle.top as number);
+            if (pickerStyle.top) {
+                pickerStyle.top = (this.props.topOffset || 0) + (pickerStyle.top as number);
+            } else {
+                pickerStyle.top = this.props.topOffset;
             }
 
-            if (pickerStyle.left && this.props.leftOffset) {
-                (pickerStyle.left as number) += this.props.leftOffset;
+            if (pickerStyle.left) {
+                (pickerStyle.left as number) += (this.props.leftOffset || 0);
             }
         }
 

--- a/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/components/emoji_picker/emoji_picker_tabs.tsx
@@ -18,14 +18,14 @@ type PickerStyle = {
     top: number;
     bottom: number;
     left?: number;
-    right: number;
+    right?: number;
 }
 
 export interface Props {
     style?: PickerStyle;
-    rightOffset: number;
-    topOffset: number;
-    leftOffset: number;
+    rightOffset?: number;
+    topOffset?: number;
+    leftOffset?: number;
     placement?: ('top' | 'bottom' | 'left' | 'right');
     customEmojis?: Emoji[];
     onEmojiClose: () => void;
@@ -38,6 +38,7 @@ type State = {
     emojiTabVisible: boolean;
     filter: string;
 }
+
 export default class EmojiPickerTabs extends PureComponent<Props, State> {
     static defaultProps = {
         rightOffset: 0,
@@ -82,15 +83,21 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
                 pickerStyle = {
                     top: this.props.style.top,
                     bottom: this.props.style.bottom,
-                    right: this.props.rightOffset,
+                    right: this.props?.rightOffset,
                 };
             } else {
                 pickerStyle = {...this.props.style};
             }
 
-            pickerStyle.top = pickerStyle.top ? pickerStyle.top + this.props.topOffset : this.props.topOffset;
+            let offset = 0;
+            if (pickerStyle.top) {
+                offset = pickerStyle.top + (this.props.topOffset || 0);
+            } else {
+                offset = (this.props.topOffset || 0);
+            }
+            pickerStyle.top = offset;
 
-            if (pickerStyle.left) {
+            if (pickerStyle.left && this.props.leftOffset) {
                 pickerStyle.left += this.props.leftOffset;
             }
         }

--- a/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/components/emoji_picker/emoji_picker_tabs.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
 import {Tab, Tabs} from 'react-bootstrap';
 
@@ -11,29 +10,42 @@ import {makeAsyncComponent} from 'components/async_load';
 import EmojiPicker from 'components/emoji_picker';
 import EmojiPickerHeader from 'components/emoji_picker/components/emoji_picker_header';
 
+import {Emoji} from '@mattermost/types/emojis';
+
 const GifPicker = makeAsyncComponent('GifPicker', React.lazy(() => import('components/gif_picker/gif_picker')));
 
-export default class EmojiPickerTabs extends PureComponent {
-    static propTypes = {
-        style: PropTypes.object,
-        rightOffset: PropTypes.number,
-        topOffset: PropTypes.number,
-        leftOffset: PropTypes.number,
-        placement: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
-        customEmojis: PropTypes.object,
-        onEmojiClose: PropTypes.func.isRequired,
-        onEmojiClick: PropTypes.func.isRequired,
-        onGifClick: PropTypes.func,
-        enableGifPicker: PropTypes.bool,
-    };
+type PickerStyle = {
+    top: number;
+    bottom: number;
+    left?: number;
+    right: number;
+}
 
+export interface Props {
+    style?: PickerStyle;
+    rightOffset: number;
+    topOffset: number;
+    leftOffset: number;
+    placement?: ('top' | 'bottom' | 'left' | 'right');
+    customEmojis?: Emoji[];
+    onEmojiClose: () => void;
+    onEmojiClick: (emoji: Emoji) => void;
+    onGifClick?: (gif: string) => void;
+    enableGifPicker?: boolean;
+}
+
+type State = {
+    emojiTabVisible: boolean;
+    filter: string;
+}
+export default class EmojiPickerTabs extends PureComponent<Props, State> {
     static defaultProps = {
         rightOffset: 0,
         topOffset: 0,
         leftOffset: 0,
     };
 
-    constructor(props) {
+    constructor(props: Props) {
         super(props);
 
         this.state = {
@@ -58,7 +70,7 @@ export default class EmojiPickerTabs extends PureComponent {
         this.props.onEmojiClose();
     };
 
-    handleFilterChange = (filter) => {
+    handleFilterChange = (filter: string) => {
         this.setState({filter});
     };
 
@@ -124,7 +136,6 @@ export default class EmojiPickerTabs extends PureComponent {
                     <Tab
                         eventKey={2}
                         title={<GfycatIcon/>}
-                        mountOnEnter={true}
                         unmountOnExit={true}
                         tabClassName={'custom-emoji-tab'}
                     >

--- a/components/emoji_picker/emoji_picker_tabs.tsx
+++ b/components/emoji_picker/emoji_picker_tabs.tsx
@@ -14,20 +14,12 @@ import {Emoji} from '@mattermost/types/emojis';
 
 const GifPicker = makeAsyncComponent('GifPicker', React.lazy(() => import('components/gif_picker/gif_picker')));
 
-type PickerStyle = {
-    top: number;
-    bottom: number;
-    left?: number;
-    right?: number;
-}
-
 export interface Props {
-    style?: PickerStyle;
+    style?: React.CSSProperties;
     rightOffset?: number;
     topOffset?: number;
     leftOffset?: number;
     placement?: ('top' | 'bottom' | 'left' | 'right');
-    customEmojis?: Emoji[];
     onEmojiClose: () => void;
     onEmojiClick: (emoji: Emoji) => void;
     onGifClick?: (gif: string) => void;
@@ -91,14 +83,14 @@ export default class EmojiPickerTabs extends PureComponent<Props, State> {
 
             let offset = 0;
             if (pickerStyle.top) {
-                offset = pickerStyle.top + (this.props.topOffset || 0);
+                offset = (this.props.topOffset || 0) + (pickerStyle.top as number);
             } else {
                 offset = (this.props.topOffset || 0);
             }
             pickerStyle.top = offset;
 
             if (pickerStyle.left && this.props.leftOffset) {
-                pickerStyle.left += this.props.leftOffset;
+                (pickerStyle.left as number) += this.props.leftOffset;
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Migrates components/emoji_picker/emoji_picker_tabs to Typescript.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.



Otherwise, link the JIRA ticket.
-->
  Fixes https://github.com/mattermost/mattermost-server/issues/21059
Jira: https://mattermost.atlassian.net/browse/MM-47111
#### Related Pull Requests


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
