### PR TITLE
[MM-475584]: fix channel name not showing up in search results

### DIFF
--- a/components/search_results_item/index.ts
+++ b/components/search_results_item/index.ts
@@ -82,7 +82,7 @@ export function mapStateToProps() {
             teamDisplayName,
             teamName,
             channelId: channel.id,
-            channelName: channel.display_name,
+            channelDisplayName: channel.display_name,
             channelType: channel.type,
             channelIsArchived: channel.delete_at !== 0,
             enablePostUsernameOverride,


### PR DESCRIPTION
#### Summary
Fixes Channel name is not shown for recent mentions or search results.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-47584

#### Related Pull Requests
NONE

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="387" alt="Screenshot at Oct 14 09-25-12" src="https://user-images.githubusercontent.com/16203333/196959391-089e3e28-7beb-41b7-816c-9fa54862d608.png"> | <img width="507" alt="Screenshot 2022-10-20 at 6 46 14 PM" src="https://user-images.githubusercontent.com/16203333/196959417-21afbbb3-7884-4279-b3b7-c75bdb6502af.png"> |


#### Release Note
```release-note
* Fixes Channel name is not shown for recent mentions or search results.
```
