### PR TITLE
Adding total count to the people directory

### DIFF
--- a/components/people/directory/directory.tsx
+++ b/components/people/directory/directory.tsx
@@ -51,7 +51,9 @@ const Directory = () => {
         }
     }, []);
 
-    useEffect(() => {initialLoad()}, [initialLoad]);
+    useEffect(() => {
+        initialLoad();
+    }, [initialLoad]);
 
     const loadMore = async () => {
         setIsNextPageLoading(true);

--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -104,6 +104,7 @@ import {
     UserStatus,
     GetFilteredUsersStatsOpts,
     UserCustomStatus,
+    UserProfilesWithTotalCount,
 } from '@mattermost/types/users';
 import {DeepPartial, RelationOneToOne} from '@mattermost/types/utilities';
 import {ProductNotices} from '@mattermost/types/product_notices';
@@ -780,7 +781,7 @@ export default class Client4 {
     };
 
     getProfiles = (page = 0, perPage = PER_PAGE_DEFAULT, options: Record<string, any> = {}) => {
-        return this.doFetch<UserProfile[]>(
+        return this.doFetch<UserProfile[] | UserProfilesWithTotalCount>(
             `${this.getUsersRoute()}${buildQueryString({page, per_page: perPage, ...options})}`,
             {method: 'get'},
         );

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -140,3 +140,8 @@ export type GetFilteredUsersStatsOpts = {
 export type AuthChangeResponse = {
     follow_link: string;
 };
+
+export type UserProfilesWithTotalCount = {
+    users: UserProfile[];
+    total_count: number;
+};


### PR DESCRIPTION
#### Summary
Adding total count  parameter when fetching users

#### Related Pull Requests
- server change: https://github.com/mattermost/mattermost-server/pull/21362

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
