### PR TITLE
Automated cherry pick of #11140

### DIFF
--- a/components/multiselect/multiselect_list.tsx
+++ b/components/multiselect/multiselect_list.tsx
@@ -6,7 +6,8 @@ import React from 'react';
 
 import {getOptionValue} from 'react-select/src/builtins';
 
-import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+import {FormattedMessage} from 'react-intl';
+
 import Constants from 'utils/constants';
 import {cmdOrCtrlPressed} from 'utils/utils';
 
@@ -185,13 +186,15 @@ export default class MultiSelectList<T extends Value> extends React.PureComponen
                     <div
                         key='no-users-found'
                         className='no-channel-message'
+                        tabIndex={0}
                     >
                         <p className='primary-message'>
-                            <FormattedMarkdownMessage
+                            <FormattedMessage
                                 id='multiselect.list.notFound'
-                                defaultMessage='No results found matching **{searchQuery}**'
+                                defaultMessage='No results found matching <b>{searchQuery}</b>'
                                 values={{
                                     searchQuery: this.props.query,
+                                    b: (value: string) => <b>{value}</b>,
                                 }}
                             />
                         </p>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3892,7 +3892,7 @@
   "multiselect.createGroup": "Create Group",
   "multiselect.creating": "Creating...",
   "multiselect.go": "Go",
-  "multiselect.list.notFound": "No results found matching **{searchQuery}**",
+  "multiselect.list.notFound": "No results found matching <b>{searchQuery}</b>",
   "multiselect.loading": "Loading...",
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",


### PR DESCRIPTION
Cherry pick of #11140 on release-7.1.

/cc  @babinderrathi

```release-note
NONE
```