### PR TITLE
Fix missing field from master

### DIFF
--- a/utils/test_helper.ts
+++ b/utils/test_helper.ts
@@ -449,6 +449,7 @@ export class TestHelper {
             sku: '',
             billing_scheme: '',
             recurring_interval: '',
+            cross_sells_to: '',
             ...override,
         };
     }


### PR DESCRIPTION
We had 2 PRs that went in around the same time that conflicted without actually conflicting because one used a type in a new place and another added a field to that type.

#### Release Note
```release-note
NONE
```
