### PR TITLE
MM-47316 Update client and types packages to 7.4.0 (release-7.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mattermost-webapp",
-  "version": "7.3.0-0",
+  "version": "7.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mattermost-webapp",
-      "version": "7.3.0-0",
+      "version": "7.4.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/client",
@@ -30961,7 +30961,7 @@
     },
     "packages/client": {
       "name": "@mattermost/client",
-      "version": "7.1.0",
+      "version": "7.4.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -32896,7 +32896,7 @@
     },
     "packages/types": {
       "name": "@mattermost/types",
-      "version": "7.1.0",
+      "version": "7.4.0",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "7.3.0-0",
+  "version": "7.4.0",
   "private": true,
   "engines": {
     "npm": ">=7.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "7.1.0",
+  "version": "7.4.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "7.1.0",
+  "version": "7.4.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"


### PR DESCRIPTION
Some day, I'll remember to update these versions on master and then cherry-pick them to the release branch before it's been cut.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47316

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/11431

#### Release Note
```release-note
NONE
```
