### PR TITLE
[MM-47622] minor upgrade of emoji-regex from 10.1.0 to 10.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#77a0cb4c565bc239bab1ce5414b95bdd9a570963",
         "emoji-datasource": "6.1.1",
         "emoji-datasource-apple": "6.0.1",
-        "emoji-regex": "10.1.0",
+        "emoji-regex": "10.2.1",
         "exif2css": "1.3.0",
         "fast-deep-equal": "3.1.3",
         "flexsearch": "0.6.32",
@@ -10835,9 +10835,9 @@
       "integrity": "sha512-Aqj3Km5e4Q8an0cOASP0T1S/+StnIrPQc9Y7Mg2x2LtkwvmoVQO3UaaF9Cj8yi4o8yOPc6GoIKeg95WJTzWzhw=="
     },
     "node_modules/emoji-regex": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
-      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg=="
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -42540,9 +42540,9 @@
       "integrity": "sha512-Aqj3Km5e4Q8an0cOASP0T1S/+StnIrPQc9Y7Mg2x2LtkwvmoVQO3UaaF9Cj8yi4o8yOPc6GoIKeg95WJTzWzhw=="
     },
     "emoji-regex": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
-      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg=="
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
     },
     "emojis-list": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dynamic-virtualized-list": "github:mattermost/dynamic-virtualized-list#77a0cb4c565bc239bab1ce5414b95bdd9a570963",
     "emoji-datasource": "6.1.1",
     "emoji-datasource-apple": "6.0.1",
-    "emoji-regex": "10.1.0",
+    "emoji-regex": "10.2.1",
     "exif2css": "1.3.0",
     "fast-deep-equal": "3.1.3",
     "flexsearch": "0.6.32",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
As part of regular dependency upgrades, this PR upgrades emoji-regex from version 10.1.0 to 10.2.1.

| From version | To version | Changelog | Notes|
|--------------|------------|------------|------|
| 10.1.0             | 10.2.1          | https://github.com/mathiasbynens/emoji-regex/commits/main | There are no release notes just tags added. The changes introduced from 10.1.0 to 10.2.1 are support for js modules and some style code changes |

I've tested emojis locally and work properly.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-47622

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
