### PR TITLE
MM-47361 : Remove global state & dispatch from logged_in.tsx

### DIFF
--- a/components/logged_in/index.ts
+++ b/components/logged_in/index.ts
@@ -11,6 +11,7 @@ import {Channel} from '@mattermost/types/channels';
 import {DispatchFunc, GenericAction} from 'mattermost-redux/types/actions';
 
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
+import {viewChannel} from 'mattermost-redux/actions/channels';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser, shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
@@ -58,6 +59,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
         actions: bindActionCreators({
             autoUpdateTimezone,
             getChannelURLAction,
+            viewChannel,
         }, dispatch),
     };
 }

--- a/components/logged_in/logged_in.test.tsx
+++ b/components/logged_in/logged_in.test.tsx
@@ -24,6 +24,7 @@ describe('components/logged_in/LoggedIn', () => {
         actions: {
             autoUpdateTimezone: jest.fn(),
             getChannelURLAction: jest.fn(),
+            viewChannel: jest.fn(),
         },
         showTermsOfService: false,
         location: {

--- a/components/logged_in/logged_in.tsx
+++ b/components/logged_in/logged_in.tsx
@@ -6,21 +6,15 @@ import {Redirect} from 'react-router-dom';
 
 import semver from 'semver';
 
-import {viewChannel} from 'mattermost-redux/actions/channels';
-
 import * as GlobalActions from 'actions/global_actions';
 import * as WebSocketActions from 'actions/websocket_actions.jsx';
 import * as UserAgent from 'utils/user_agent';
 import LoadingScreen from 'components/loading_screen';
 import {getBrowserTimezone} from 'utils/timezone';
-import store from 'stores/redux_store.jsx';
 import WebSocketClient from 'client/web_websocket_client.jsx';
 import BrowserStore from 'stores/browser_store';
 import {UserProfile} from '@mattermost/types/users';
 import {Channel} from '@mattermost/types/channels';
-
-const dispatch = store.dispatch;
-const getState = store.getState;
 
 const BACKSPACE_CHAR = 8;
 
@@ -41,6 +35,7 @@ export type Props = {
     actions: {
         autoUpdateTimezone: (deviceTimezone: string) => void;
         getChannelURLAction: (channel: Channel, teamId: string, url: string) => void;
+        viewChannel: (channelId: string, prevChannelId?: string) => void;
     };
     showTermsOfService: boolean;
     location: {
@@ -218,7 +213,7 @@ export default class LoggedIn extends React.PureComponent<Props> {
         // remove the event listener to prevent getting stuck in a loop
         window.removeEventListener('beforeunload', this.handleBeforeUnload);
         if (document.cookie.indexOf('MMUSERID=') > -1) {
-            viewChannel('', this.props.currentChannelId || '')(dispatch, getState);
+            this.props.actions.viewChannel('', this.props.currentChannelId || '');
         }
         WebSocketActions.close();
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Included `viewChannel` in `mapDispatchToProps` so that we don't have to call it with `state` and `dispatch` inside the component

#### Ticket Link
fixes https://github.com/mattermost/mattermost-server/issues/21248

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
~- Has server changes (please link here)~
~- Has mobile changes (please link here)~

```release-note
NONE
```
