### PR TITLE
[MM-47890] Upgrade p-queue from 7.1.0 to 7.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "marked": "github:mattermost/marked#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008",
         "memoize-one": "5.2.1",
         "moment-timezone": "0.5.38",
-        "p-queue": "7.1.0",
+        "p-queue": "7.3.0",
         "pdfjs-dist": "2.15.349",
         "popper.js": "1.16.1",
         "process": "0.11.10",
@@ -22428,12 +22428,12 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.1.0.tgz",
-      "integrity": "sha512-V+0vPJbhYkBqknPp0qnaz+dWcj8cNepfXZcsVIVEHPbFQXMPwrzCNIiM4FoxGtwHXtPzVCPHDvqCr1YrOJX2Gw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
+      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
       "dependencies": {
         "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.0"
+        "p-timeout": "^5.0.2"
       },
       "engines": {
         "node": ">=12"
@@ -51521,12 +51521,12 @@
       "dev": true
     },
     "p-queue": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.1.0.tgz",
-      "integrity": "sha512-V+0vPJbhYkBqknPp0qnaz+dWcj8cNepfXZcsVIVEHPbFQXMPwrzCNIiM4FoxGtwHXtPzVCPHDvqCr1YrOJX2Gw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
+      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
       "requires": {
         "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.0"
+        "p-timeout": "^5.0.2"
       },
       "dependencies": {
         "p-timeout": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "marked": "github:mattermost/marked#2ef7f28cc7718e3f551c4ce9ea75fdd7580c2008",
     "memoize-one": "5.2.1",
     "moment-timezone": "0.5.38",
-    "p-queue": "7.1.0",
+    "p-queue": "7.3.0",
     "pdfjs-dist": "2.15.349",
     "popper.js": "1.16.1",
     "process": "0.11.10",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
In the context of regularly upgrading dependencies in web app, this PR upgrades p-queue to latest version.

| From version | To version | changelog | Notes |
|--------------|-----------|------------|-------|
| 7.1.0               | 7.3.0          | [releases](https://github.com/sindresorhus/p-queue/releases) | Only some new functionality added without breaking changes. Namely, new "empty" queue event emitted in v7.3.0, as well as an abort task signal and controller added in v7.2.0.|

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-47890

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
