### PR TITLE
MM-20820: add a help button to right controls on global header

### DIFF
--- a/components/global_header/right_controls/right_controls.tsx
+++ b/components/global_header/right_controls/right_controls.tsx
@@ -12,6 +12,8 @@ import {
 } from 'components/onboarding_tour';
 import StatusDropdown from 'components/status_dropdown';
 
+import UserGuideDropdown from '../center_controls/user_guide_dropdown';
+
 import AtMentionsButton from './at_mentions_button/at_mentions_button';
 import SavedPostsButton from './saved_posts_button/saved_posts_button';
 import SettingsButton from './settings_button';
@@ -55,6 +57,7 @@ const RightControls = ({productId = null}: Props): JSX.Element => {
                     pluggableId={productId}
                 />
             )}
+            {productId === null ? '' : <UserGuideDropdown/>}
             <StatusDropdown/>
         </RightControlsContainer>
     );

--- a/components/global_header/right_controls/right_controls.tsx
+++ b/components/global_header/right_controls/right_controls.tsx
@@ -12,6 +12,13 @@ import {
 } from 'components/onboarding_tour';
 import StatusDropdown from 'components/status_dropdown';
 
+import {GlobalState} from 'types/store';
+
+import {useLocation} from 'react-router-dom';
+import {useSelector} from 'react-redux';
+
+import {getCurrentProduct} from 'selectors/products';
+
 import UserGuideDropdown from '../center_controls/user_guide_dropdown';
 
 import AtMentionsButton from './at_mentions_button/at_mentions_button';
@@ -37,6 +44,8 @@ export type Props = {
 
 const RightControls = ({productId = null}: Props): JSX.Element => {
     const showCustomizeTip = useShowOnboardingTutorialStep(OnboardingTourSteps.CUSTOMIZE_EXPERIENCE);
+    const {pathname} = useLocation();
+    const currentProduct = useSelector((state: GlobalState) => getCurrentProduct(state.plugins.components.Product, pathname));
 
     return (
         <RightControlsContainer
@@ -57,7 +66,7 @@ const RightControls = ({productId = null}: Props): JSX.Element => {
                     pluggableId={productId}
                 />
             )}
-            {productId === null ? '' : <UserGuideDropdown/>}
+            {currentProduct?.pluginId === 'playbooks' ? <UserGuideDropdown/> : ''}
             <StatusDropdown/>
         </RightControlsContainer>
     );


### PR DESCRIPTION
#### Summary
Add a help button for playbooks as feedback button was removed.

I am in doubt if the Keyboard shortcuts button is needed for this scenario?

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/20820

#### Screenshots
![Screenshot 2022-10-25 at 9 58 24 PM](https://user-images.githubusercontent.com/45600289/197831595-971c5cb5-4b55-4209-9055-cad2453e7e83.png)
![Screenshot 2022-10-25 at 9 58 17 PM](https://user-images.githubusercontent.com/45600289/197831603-24ff72ca-4af4-46ae-8d7d-170d37f37f80.png)

#### Release Note

NA
