### PR TITLE
[MM-45789] Don't update redux state unless something has actually changed

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -533,10 +533,15 @@ function membersInChannel(state: RelationOneToOne<Channel, Record<string, Channe
     case ChannelTypes.RECEIVED_CHANNEL_MEMBER: {
         const member = action.data;
         const members = {...(state[member.channel_id] || {})};
-        members[member.user_id] = member;
+        if (member.last_update_at > members[member.user_id]?.last_update_at) {
+            members[member.user_id] = member;
+            return {
+                ...state,
+                [member.channel_id]: members,
+            };
+        }
         return {
             ...state,
-            [member.channel_id]: members,
         };
     }
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS:

--- a/packages/mattermost-redux/src/reducers/entities/channels.ts
+++ b/packages/mattermost-redux/src/reducers/entities/channels.ts
@@ -533,7 +533,9 @@ function membersInChannel(state: RelationOneToOne<Channel, Record<string, Channe
     case ChannelTypes.RECEIVED_CHANNEL_MEMBER: {
         const member = action.data;
         const members = {...(state[member.channel_id] || {})};
-        if (member.last_update_at > members[member.user_id]?.last_update_at) {
+        if ((!members[member.user_id]) ||
+            (member.last_update_at > members[member.user_id]?.last_update_at) ||
+            (member.roles !== members[member.user_id]?.roles)) {
             members[member.user_id] = member;
             return {
                 ...state,


### PR DESCRIPTION
#### Summary
We are currently unable to open the profile popover from the Channel member RHS list because opening the popover triggers a request to fetch channel member information which causes the RHS list to re-render and close the popover immediately.

I tried to refactor the RHS list like Caleb suggested in the ticket and I moved the selector for the member information into the child component (`Member`). This solved the render issue but it meant that we couldn't order/sort the list correctly and I was unable to work around that without having the channel member info present in the parent components. From what I can tell, the selectors are functioning correctly and memoizing the components didn't impact the outcome.

I decided to make this change in the reducer, this means that when we open the popover we will only update the member information if something has changed. We use this approach for posts as well in order to cut down on re-renders. This means that the only edge case for the popover not opening will be if I have the RHS open in my app, someone else changes something about that members info (i.e change their channel role), and then I click their profile to open the popover. This isn't the ideal solution but it's good enough for now.

Refactoring the RHS list is a much bigger task that would likely involve server and possibly redux tree changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45789

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed a bug that wouldn't allow the user to open the profile popover from the RHS channel member list
```
