### PR TITLE
MM47242 - add icon to explore other tools in the platform task list item

### DIFF
--- a/components/onboarding_tasks/onboarding_tasks_manager.tsx
+++ b/components/onboarding_tasks/onboarding_tasks_manager.tsx
@@ -73,7 +73,7 @@ const taskLabels = {
     ),
     [OnboardingTasksName.EXPLORE_OTHER_TOOLS]: (
         <FormattedMessage
-            id='onboardingTask.checklist.explore_other_tools'
+            id='onboardingTask.checklist.explore_other_tools_in_platform'
             defaultMessage='⛰️ Explore other tools in the platform'
         />
     ),

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4161,7 +4161,7 @@
   "onboardingTask.checklist.disclaimer": "By clicking “Start trial”, I agree to the <linkEvaluation>Mattermost Software Evaluation Agreement,</linkEvaluation> <linkPrivacy>privacy policy,</linkPrivacy> and receiving product emails.",
   "onboardingTask.checklist.dismiss_link": "No thanks, I’ll figure it out myself",
   "onboardingTask.checklist.downloads": "Now that you’re all set up, <link>download our apps.</link>",
-  "onboardingTask.checklist.explore_other_tools": "Explore other tools in the platform",
+  "onboardingTask.checklist.explore_other_tools_in_platform": "⛰️ Explore other tools in the platform",
   "onboardingTask.checklist.higher_security_features": "Interested in our higher-security features?",
   "onboardingTask.checklist.main_subtitle": "Let's get up and running.",
   "onboardingTask.checklist.plan_sprint_with_kanban_style_boards": "🎯 Plan a sprint with Kanban-style boards",


### PR DESCRIPTION
#### Summary
In a previous PR done for adding icons to the onboarding task list items, there was a scenario that was missing for the "explore other tools item task" that is only shown to non-admin end users. This small PR adds the icon to that onboarding task list.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-47242

#### Related Pull Requests
Original PR: https://github.com/mattermost/mattermost-webapp/pull/11335

#### Screenshots
Before: (no icon)
<img width="1074" alt="Captura de Pantalla 2022-10-26 a las 12 30 49" src="https://user-images.githubusercontent.com/10082627/198004104-e8e58088-146c-4817-a702-dff4e0fc3220.png">


After:
<img width="1017" alt="Captura de Pantalla 2022-10-26 a las 14 23 42" src="https://user-images.githubusercontent.com/10082627/198025203-1a08f855-d223-43de-9e14-12aee18aae59.png">



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
