### PR TITLE
Migrate to ts,

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "hoist-non-react-statics": "3.3.2",
         "html-to-react": "1.5.0",
         "inobounce": "0.2.1",
+        "json-decoder": "1.4.0",
         "katex": "0.13.11",
         "key-mirror": "1.0.1",
         "localforage": "1.10.0",
@@ -18765,6 +18766,11 @@
       "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/json-decoder": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/json-decoder/-/json-decoder-1.4.0.tgz",
+      "integrity": "sha512-rZ5c/+IDcNH+PcaCcOcNEFZr6K7wFfjUa2FEeu21/YqHso4fA43uXEEDIayJQovwdPdPVPCVNe5tEJIWhKzNcQ=="
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -48587,6 +48593,11 @@
       "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
       "dev": true,
       "optional": true
+    },
+    "json-decoder": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/json-decoder/-/json-decoder-1.4.0.tgz",
+      "integrity": "sha512-rZ5c/+IDcNH+PcaCcOcNEFZr6K7wFfjUa2FEeu21/YqHso4fA43uXEEDIayJQovwdPdPVPCVNe5tEJIWhKzNcQ=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "hoist-non-react-statics": "3.3.2",
     "html-to-react": "1.5.0",
     "inobounce": "0.2.1",
+    "json-decoder": "1.4.0",
     "katex": "0.13.11",
     "key-mirror": "1.0.1",
     "localforage": "1.10.0",

--- a/utils/policy_roles_adapter.test.jsx
+++ b/utils/policy_roles_adapter.test.jsx
@@ -78,10 +78,10 @@ describe('PolicyRolesAdapter', () => {
 
     describe('PolicyRolesAdapter.rolesFromMapping', () => {
         test('unknown value throws an exception', () => {
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
             policies.enableTeamCreation = 'sometimesmaybe';
-            expect(() => {
-                rolesFromMapping(policies, roles);
-            }).toThrowError(/not present in mapping/i);
+            rolesFromMapping(policies, roles);
+            expect(consoleSpy).toHaveBeenCalled();
         });
 
         // // That way you can pass in the whole state if you want.
@@ -130,6 +130,31 @@ describe('PolicyRolesAdapter', () => {
                 value = mappingValueFromRoles('enableTeamCreation', roles);
                 expect(value).toEqual('false');
             });
+        });
+    });
+
+    describe('editOthersPosts', () => {
+        test('Returns the expected policy value for a editOthersPosts policy', () => {
+            addPermissionToRole(
+                Permissions.EDIT_OTHERS_POSTS,
+                roles.system_admin,
+            );
+            addPermissionToRole(Permissions.EDIT_OTHERS_POSTS, roles.team_admin);
+
+            let value = mappingValueFromRoles('editOthersPosts', roles);
+            expect(value).toEqual('true');
+
+            removePermissionFromRole(
+                Permissions.EDIT_OTHERS_POSTS,
+                roles.system_admin,
+            );
+            removePermissionFromRole(
+                Permissions.EDIT_OTHERS_POSTS,
+                roles.team_admin,
+            );
+
+            value = mappingValueFromRoles('editOthersPosts', roles);
+            expect(value).toEqual('false');
         });
     });
 });

--- a/utils/policy_roles_adapter.ts
+++ b/utils/policy_roles_adapter.ts
@@ -1,165 +1,509 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+import * as D from 'json-decoder';
 
 import {Role} from '@mattermost/types/roles';
+
 import {Permissions} from 'mattermost-redux/constants/index';
 
-const trueString = 'true';
-const falseString = 'false';
+// enumeration of possible values for Mapping type
+enum MMPermission {
+    CREATE_TEAM = 'create_team',
+    EDIT_OTHERS_POSTS = 'edit_others_posts',
+    MANAGE_INCOMING_WEBHOOKS = 'manage_incoming_webhooks',
+    MANAGE_OUTGOING_WEBHOOKS = 'manage_outgoing_webhooks',
+    MANAGE_SLASH_COMMANDS = 'manage_slash_commands',
+    MANAGE_OAUTH = 'manage_oauth',
+}
 
-const MAPPING = {
-    enableTeamCreation: {
-        [trueString]: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: true}],
-        [falseString]: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: false}],
-    },
+// Mapping types
+// ------------
 
-    editOthersPosts: {
-        [trueString]: [
-            {roleName: 'system_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
-            {roleName: 'team_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
-        ],
-        [falseString]: [
-            {roleName: 'team_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: false},
-            {roleName: 'system_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
-        ],
-    },
+type MappingKey =
+  | 'enableTeamCreation'
+  | 'editOthersPosts'
+  | 'enableOnlyAdminIntegrations';
 
-    enableOnlyAdminIntegrations: {
-        [trueString]: [
-            {roleName: 'team_user', permission: Permissions.MANAGE_INCOMING_WEBHOOKS, shouldHave: false},
-            {roleName: 'team_user', permission: Permissions.MANAGE_OUTGOING_WEBHOOKS, shouldHave: false},
-            {roleName: 'team_user', permission: Permissions.MANAGE_SLASH_COMMANDS, shouldHave: false},
-            {roleName: 'system_user', permission: Permissions.MANAGE_OAUTH, shouldHave: false},
-        ],
-        [falseString]: [
-            {roleName: 'team_user', permission: Permissions.MANAGE_INCOMING_WEBHOOKS, shouldHave: true},
-            {roleName: 'team_user', permission: Permissions.MANAGE_OUTGOING_WEBHOOKS, shouldHave: true},
-            {roleName: 'team_user', permission: Permissions.MANAGE_SLASH_COMMANDS, shouldHave: true},
-            {roleName: 'system_user', permission: Permissions.MANAGE_OAUTH, shouldHave: true},
-        ],
-    },
-};
-type MappingKeyTypes = 'enableTeamCreation' | 'editOthersPosts' | 'enableOnlyAdminIntegrations';
-type MappingValueTypes = {roleName: string;
-    permission: string;
+type MappingOption = 'true' | 'false';
+
+type MappingRoleName =
+  | 'team_user'
+  | 'team_admin'
+  | 'system_admin'
+  | 'system_user';
+
+type MappingRole = {
+    roleName: MappingRoleName;
+    permission: MMPermission;
     shouldHave: boolean;
 };
 
-/**
- * Get the roles that were changed (but unsaved) for given mapping key/values.
- *
- * @param {object} mappingValues key/value to indicate which mapping items to use to update the roles.
- * @param {object} roles same structure as returned by mattermost-redux `getRoles`.
- * @return {object} the updated roles (only) in the same structure as returned by mattermost-redux `getRoles`.
- */
-export function rolesFromMapping(mappingValues: Record<string, any>, roles: Record<string, Role>): Record<string, Role> {
-    const rolesClone: Record<string, Role> = JSON.parse(JSON.stringify(roles));
+type MappingValue = {
+    true: MappingRole[];
+    false: MappingRole[];
+};
 
-    // Purge roles that aren't present in MAPPING, we don't care about them.
-    purgeNonPertinentRoles(rolesClone);
+type Mapping = {
+    enableTeamCreation: MappingValue;
+    editOthersPosts: MappingValue;
+    enableOnlyAdminIntegrations: MappingValue;
+};
 
-    Object.keys(MAPPING).forEach((mappingKey) => {
-        const value = mappingValues[mappingKey];
-        if (value) {
-            mutateRolesBasedOnMapping(mappingKey as MappingKeyTypes, value, rolesClone);
-        }
-    });
+type MMPermissions = {
+    CREATE_TEAM: string;
+    EDIT_OTHERS_POSTS: string;
+    MANAGE_INCOMING_WEBHOOKS: string;
+    MANAGE_OUTGOING_WEBHOOKS: string;
+    MANAGE_SLASH_COMMANDS: string;
+    MANAGE_OAUTH: string;
+};
 
-    // Purge roles that didn't have permissions changes, we don't care about them.
-    Object.entries(rolesClone).forEach(([roleName, roleClone]) => {
-        const originalPermissionSet = new Set(roles[roleName].permissions);
-        const newPermissionSet = new Set(roleClone.permissions);
-        const difference = [...newPermissionSet].filter((x) => !originalPermissionSet.has(x));
+// Policy types
+// ------------
 
-        if (originalPermissionSet.size === newPermissionSet.size && difference.length === 0) {
-            delete rolesClone[roleName];
-        }
-    });
+type Policy = {
+    editOthersPosts?: string;
+    enableTeamCreation?: string;
+    enableOnlyAdminIntegrations?: string;
+};
 
-    return rolesClone;
+// Role types
+// ----------
+
+type Roles = {
+    system_user: Role;
+    system_admin: Role;
+    team_admin: Role;
+    team_user: Role;
+};
+
+// Decoders, to check if unknown object is valid,
+// also usefull to check the validity of types
+// after JSON has been decoded
+// -------------------------------------------
+
+const policyTrueDecoder = D.exactDecoder('true');
+const policyFalseDecoder = D.exactDecoder('false');
+const policyValueDecoder = D.oneOfDecoders(
+    policyTrueDecoder,
+    policyFalseDecoder,
+    D.undefinedDecoder,
+);
+
+const policyDecoder = D.objectDecoder<Policy>({
+    editOthersPosts: policyValueDecoder,
+    enableTeamCreation: policyValueDecoder,
+    enableOnlyAdminIntegrations: policyValueDecoder,
+});
+
+//  Decode mattremost Permissions.
+//  To check if MMPermission have the correct values
+const mattermostPermissionsDecoder = D.objectDecoder<MMPermissions>({
+    CREATE_TEAM: D.exactDecoder(MMPermission.CREATE_TEAM),
+    EDIT_OTHERS_POSTS: D.exactDecoder(MMPermission.EDIT_OTHERS_POSTS),
+    MANAGE_INCOMING_WEBHOOKS: D.exactDecoder(
+        MMPermission.MANAGE_INCOMING_WEBHOOKS,
+    ),
+    MANAGE_OUTGOING_WEBHOOKS: D.exactDecoder(
+        MMPermission.MANAGE_OUTGOING_WEBHOOKS,
+    ),
+    MANAGE_SLASH_COMMANDS: D.exactDecoder(MMPermission.MANAGE_SLASH_COMMANDS),
+    MANAGE_OAUTH: D.exactDecoder(MMPermission.MANAGE_OAUTH),
+});
+
+// Check JSON valid types
+// ---------------------------
+
+// Given Policy should remove undefined properties
+//
+// Policy => Policy
+function removeUndefinedPropertiesPolicy(policy: Policy): Policy {
+    return Object.fromEntries(
+        Object.entries(policy).filter(([, value]) => value !== undefined),
+    );
 }
 
-/**
- * Get the mapping value that matches for a given set of roles.
- *
- * @param {string} key to match under in the mapping.
- * @param {object} roles same structure as returned by mattermost-redux `getRoles`.
- * @return {string} the value that the roles/permissions assignment match in the mapping.
- */
-export function mappingValueFromRoles(key: MappingKeyTypes, roles: Record<string, Role>): string {
-    for (const o of mappingPartIterator(MAPPING[key], roles)) {
-        if (o.allConditionsAreMet) {
-            return o.value;
-        }
+// Given JSON object, should remove undefined values from decoded policies
+//
+// (unknown) => D.Result<Policy>
+function decodePolicies(policies: unknown): D.Result<Policy> {
+    return policyDecoder.decode(policies).map(removeUndefinedPropertiesPolicy);
+}
+
+// Given D.Result<Policy> should check Result.type === 'OK' and return Policy
+// else show an error and return empty object
+//
+// D.Result<Policy> => Policy
+function checkPolicies(policies: D.Result<Policy>): Policy {
+    switch (policies.type) {
+    case 'OK':
+        return policies.value;
+    case 'ERR':
+        console.error( //eslint-disable-line no-console
+            policies.message,
+            'values for Policy should be \'true\', \'false\' ',
+        );
+        return {} as Policy;
+    default:
+        return {} as Policy;
     }
-    throw new Error(`No matching mapping value found for key '${key}' with the given roles.`);
 }
 
-function purgeNonPertinentRoles(roles: Record<string, Role>) {
-    const pertinentRoleNames = roleNamesInMapping();
+// Given permissions object, should return true if key/value are valid,
+// else show an error return false
+// we need to validate MMPermission, to match mattermost permissions keys/values
+//
+// unknown => boolean
+function isValidPermissions(permissions: unknown = {}): boolean {
+    const result = mattermostPermissionsDecoder.decode(permissions);
+    switch (result.type) {
+    case 'OK':
+        return true;
+    case 'ERR':
+        console.error( //eslint-disable-line no-console
+            result.message,
+            '. MMPermission should match with mattermost Permissions, same keys and values',
+        );
+        return false;
+    default:
+        return false;
+    }
+}
 
-    Object.keys(roles).forEach((key) => {
-        if (!pertinentRoleNames.includes(key)) {
-            delete roles[key];
+// Roles data
+// ------------
+
+// Given Mapping, MappingKey, MappingOption, should return a list of MappingRole
+//
+// Mapping => MappingKey => MappingOption => MappingRole[]
+function getMappingRoles(
+    mapping: Mapping,
+    key: MappingKey,
+    value: MappingOption,
+): MappingRole[] {
+    return mapping[key][value];
+}
+
+// Given MMPermission, Role, should
+// add to role.permissions permission value
+// role permissions list should contain unique values
+//
+// MMPermission => Role => Role
+function addPermissionToRolePermissions(
+    permission: MMPermission,
+    role: Role,
+): Role {
+    return {
+        ...role,
+        permissions: [...new Set([...role.permissions, permission])],
+    };
+}
+
+// Given MMPermission, Role, should remove the permission
+// from role.permissions list
+//
+// MMPermission => RoleValue => RoleValue
+function removePermissionFromRolePermissions(
+    permission: MMPermission,
+    role: Role,
+): Role {
+    return {
+        ...role,
+        permissions: role.permissions.filter(
+            (rolePermission) => rolePermission !== permission,
+        ),
+    };
+}
+
+// Given list MappingRole, Roles, iterate over MappingRole comparing
+// MappingRole.name with Roles keys, if equals add or remove permission from role,
+// based on shouldHave value
+//
+// MappingRole[] => Roles => Roles
+function addOrRemovePermissions(
+    mappingRoles: MappingRole[],
+    roles: Roles,
+): Roles {
+    return mappingRoles.reduce((acc, mappingRole) => {
+        const {roleName, permission, shouldHave} = mappingRole;
+        const roleValue = acc[roleName];
+        if (roleValue) {
+            const newRoleValue =
+            shouldHave ? addPermissionToRolePermissions(permission, roleValue) : removePermissionFromRolePermissions(permission, roleValue);
+            return {...acc, [roleName]: newRoleValue};
         }
-    });
+        return acc;
+    }, roles);
 }
 
-function mutateRolesBasedOnMapping(mappingKey: MappingKeyTypes, value: 'true' | 'false', roles: Record<string, Role>) {
-    const roleRules = MAPPING[mappingKey][value];
+// Policy data
+// ------------
 
-    if (typeof roleRules === 'undefined') {
-        throw new Error(`Value '${value}' not present in MAPPING for key '${mappingKey}'.`);
+// Given Policy, Mapping should getMappingRoles for each key and value
+// return a list of MappingRole.
+// If policy is empty, return an empty list
+//
+// Policy => Mapping => MappingRole[]
+function getPolicyMappingRoles(
+    policy: Policy,
+    mapping: Mapping,
+): MappingRole[] {
+    if (Object.keys(policy).length === 0) {
+        return [] as MappingRole[];
     }
 
-    roleRules.forEach((item) => {
-        const role = roles[item.roleName];
-        if (item.shouldHave) {
-            addPermissionToRole(item.permission, role);
-        } else {
-            removePermissionFromRole(item.permission, role);
-        }
-    });
+    return Object.entries(policy).flatMap(([key, value]) =>
+        getMappingRoles(mapping, key as MappingKey, value as MappingOption),
+    );
 }
 
-// Returns a set of the role names present in MAPPING.
-function roleNamesInMapping() {
-    let roleNames: string[] = [];
+// Should return a Mapping type object
+//
+// () => Mapping
+function getMapping(): Mapping {
+    return {
+        enableTeamCreation: {
+            true: [
+                {
+                    roleName: 'system_user',
+                    permission: MMPermission.CREATE_TEAM,
+                    shouldHave: true,
+                },
+            ],
+            false: [
+                {
+                    roleName: 'system_user',
+                    permission: MMPermission.CREATE_TEAM,
+                    shouldHave: false,
+                },
+            ],
+        },
 
-    Object.values(MAPPING).forEach((v1) => {
-        Object.values(v1).forEach((v2) => {
-            const names = v2.map((item) => item.roleName); // eslint-disable-line max-nested-callbacks
-            roleNames = roleNames.concat(names);
+        editOthersPosts: {
+            true: [
+                {
+                    roleName: 'system_admin',
+                    permission: MMPermission.EDIT_OTHERS_POSTS,
+                    shouldHave: true,
+                },
+                {
+                    roleName: 'team_admin',
+                    permission: MMPermission.EDIT_OTHERS_POSTS,
+                    shouldHave: true,
+                },
+            ],
+            false: [
+                {
+                    roleName: 'team_admin',
+                    permission: MMPermission.EDIT_OTHERS_POSTS,
+                    shouldHave: false,
+                },
+                {
+                    roleName: 'system_admin',
+                    permission: MMPermission.EDIT_OTHERS_POSTS,
+                    shouldHave: true,
+                },
+            ],
+        },
+
+        enableOnlyAdminIntegrations: {
+            true: [
+                {
+                    roleName: 'team_user',
+                    permission: MMPermission.MANAGE_INCOMING_WEBHOOKS,
+                    shouldHave: false,
+                },
+                {
+                    roleName: 'team_user',
+                    permission: MMPermission.MANAGE_OUTGOING_WEBHOOKS,
+                    shouldHave: false,
+                },
+                {
+                    roleName: 'team_user',
+                    permission: MMPermission.MANAGE_SLASH_COMMANDS,
+                    shouldHave: false,
+                },
+                {
+                    roleName: 'system_user',
+                    permission: MMPermission.MANAGE_OAUTH,
+                    shouldHave: false,
+                },
+            ],
+            false: [
+                {
+                    roleName: 'team_user',
+                    permission: MMPermission.MANAGE_INCOMING_WEBHOOKS,
+                    shouldHave: true,
+                },
+                {
+                    roleName: 'team_user',
+                    permission: MMPermission.MANAGE_OUTGOING_WEBHOOKS,
+                    shouldHave: true,
+                },
+                {
+                    roleName: 'team_user',
+                    permission: MMPermission.MANAGE_SLASH_COMMANDS,
+                    shouldHave: true,
+                },
+                {
+                    roleName: 'system_user',
+                    permission: MMPermission.MANAGE_OAUTH,
+                    shouldHave: true,
+                },
+            ],
+        },
+    };
+}
+
+// Should return default Roles
+//
+// () => Roles
+function getDefaultRoles(): Roles {
+    const role: Role = {
+        id: '',
+        name: '',
+        display_name: '',
+        description: '',
+        create_at: 0,
+        update_at: 0,
+        delete_at: 0,
+        permissions: [],
+        scheme_managed: false,
+        built_in: false,
+    };
+
+    return {
+        system_admin: role,
+        system_user: role,
+        team_admin: role,
+        team_user: role,
+    };
+}
+
+// Given Record<string, Role>, MappingRoleName list,
+// if MappingRoleName is in MappingRoleName list,
+// should merge the current role with the default role
+//
+// Record<string, Role> => MappingRoleName[] => Roles
+function updateWithDefaultRoles(
+    roles: Record<string, Role>,
+    mappingRoleNames: MappingRoleName[],
+): Roles {
+    const defaultRoles = getDefaultRoles();
+
+    return mappingRoleNames.reduce((acc, mappingRoleName) => {
+        const role = roles[mappingRoleName];
+        if (role) {
+            const defaultRole = defaultRoles[mappingRoleName];
+            const mergedRole = {...defaultRole, ...role};
+            return {...acc, [mappingRoleName]: mergedRole};
+        }
+        return {...acc, [mappingRoleName]: defaultRoles[mappingRoleName]};
+    }, defaultRoles);
+}
+
+// Given unknown policies, unknown roles,
+// ckeck that roles and policies are valid.If yes should
+// return a new Roles with the updated permissions for each role
+//
+// unnown => unknown =>  Roles
+function getUpdatedRoles(
+    policies: unknown = {},
+    roles: Record<string, Role> = {},
+): Roles {
+    if (!isValidPermissions(Permissions)) {
+        return getDefaultRoles();
+    }
+
+    const decodedPolicies = decodePolicies(policies);
+    const checkedPolicies = checkPolicies(decodedPolicies);
+
+    if (Object.keys(checkedPolicies).length === 0) {
+        return getDefaultRoles();
+    }
+
+    const mappingRoles = getPolicyMappingRoles(checkedPolicies, getMapping());
+
+    const mappingRoleNames = mappingRoles.reduce(
+        (acc, {roleName}) => {
+            return (acc.includes(roleName) ? acc : [...acc, roleName]);
+        }, [] as MappingRoleName[]);
+
+    const updatedWithDefaultRoles = updateWithDefaultRoles(
+        roles,
+        mappingRoleNames,
+    );
+
+    return addOrRemovePermissions(mappingRoles, updatedWithDefaultRoles);
+}
+
+// Given unknown policies object, and Record<string,Role>,
+// should the return the updated part of the roles object
+//
+// unnown => unknown => Record<string, Role>
+export function rolesFromMapping(
+    policies: unknown = {},
+    roles: Record<string, Role> = {},
+): Record<string, Role> {
+    const updatedRoles: Roles = getUpdatedRoles(policies, roles);
+    return Object.entries(updatedRoles).reduce((acc, [key, value]) => {
+        if (value.name !== '') {
+            return {...acc, [key]: value};
+        }
+        return acc;
+    }, {});
+}
+
+// Mappings values from Role
+// -------------------------
+
+// Given MappingKey, Roles, should
+// get the mapping value that matches for a given set of roles
+//
+// if matches for 'true' should return 'true'
+// if matches for 'false' should return 'false'
+// if not matches should print a warning and return ''
+//
+// MappingKey => Record<string, Role> => string
+export function mappingValueFromRoles(
+    mappingKey: MappingKey,
+    roles: Record<string, Role>,
+): string {
+    const mapping = getMapping();
+    const mappingRolesTrue = getMappingRoles(mapping, mappingKey, 'true');
+    const mappingRolesFalse = getMappingRoles(mapping, mappingKey, 'false');
+
+    let value = '';
+
+    ['true', 'false'].forEach((v) => {
+        const mappingRoles = v === 'true' ? mappingRolesTrue : mappingRolesFalse;
+
+        mappingRoles.forEach((mappingRole) => {
+            const {roleName, permission, shouldHave} = mappingRole;
+            const role = roles[roleName];
+
+            if (role) {
+                const hasPermission = role.permissions.includes(permission);
+                const conditionTrue = shouldHave && hasPermission;
+                const conditionFalse = !shouldHave && !hasPermission;
+
+                switch (true) {
+                case conditionTrue:
+                    value = 'true';
+                    break;
+                case conditionFalse:
+                    value = 'false';
+                    break;
+                }
+            }
         });
     });
 
-    return [...new Set(roleNames.map((item) => item))];
-}
-
-function* mappingPartIterator(mappingPart: Record<string, MappingValueTypes[]>, roles: Record<string, Role>) {
-    for (const value in mappingPart) {
-        if (mappingPart.hasOwnProperty(value)) {
-            const roleRules = mappingPart[value];
-
-            const hasUnmetCondition = roleRules.some((item: MappingValueTypes) => {
-                const role = roles[item.roleName];
-                return (item.shouldHave && !role.permissions.includes(item.permission)) || (!item.shouldHave && role.permissions.includes(item.permission));
-            });
-
-            yield {value, allConditionsAreMet: !hasUnmetCondition};
-        }
+    if (value === '') {
+        console.warn( // eslint-disable-line no-console
+            `Warning: No matching mapping value found for key '${mappingKey}' with the given roles.`,
+        );
     }
-}
 
-function addPermissionToRole(permission: string, role: Role) {
-    if (!role.permissions.includes(permission)) {
-        role.permissions.push(permission);
-    }
-}
-
-function removePermissionFromRole(permission: string, role: Role) {
-    const permissionIndex = role.permissions.indexOf(permission);
-    if (permissionIndex !== -1) {
-        role.permissions.splice(permissionIndex, 1);
-    }
+    return value;
 }


### PR DESCRIPTION
proposal for migration to ts, providing robustness with typing

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

proposal for migration to ts, providing robustness with typing
 - strongly data types.
 - every function get an input and returns an output.
 - no data mutation.
-  each unknown datatype object it's checked.

#### Ticket Link

[JIRA ticket 21167](https://github.com/mattermost/mattermost-server/issues/21167)
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note

Bug is fixed, (You can copy the test proposed in these changes and test it on master)

If we add a new test, to the current file in master branch
utils/policy_roles_adapter.test.jsx, 

```
describe('editOthersPosts', () => {... 
```

the test doesn't pass it should return "false", but it throws an Error


<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
