### PR TITLE
Z index for dropdown selector collide with modals

### DIFF
--- a/components/admin_console/billing/company_info_edit.scss
+++ b/components/admin_console/billing/company_info_edit.scss
@@ -5,6 +5,8 @@
     background-color: var(--sys-center-channel-bg);
     border-radius: 4px;
     box-shadow: 0 2px 3px rgba(0, 0, 0, 0.08);
+    // Just in case I can't fix the dropdown component
+    isolation: isolate;
 
     .checkbox {
         margin-top: 0;

--- a/components/admin_console/billing/company_info_edit.scss
+++ b/components/admin_console/billing/company_info_edit.scss
@@ -5,7 +5,6 @@
     background-color: var(--sys-center-channel-bg);
     border-radius: 4px;
     box-shadow: 0 2px 3px rgba(0, 0, 0, 0.08);
-    // Just in case I can't fix the dropdown component
     isolation: isolate;
 
     .checkbox {


### PR DESCRIPTION
#### Summary
Fixing a z-index issue with dropdown selector and modal with z-index. Ideally we should use this property at input level, instead of form, but the fix it's much bigger and require more investigation, as the z index levels are complex to follow. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47802

#### Screenshots
before
![AlwaysOnTop](https://user-images.githubusercontent.com/713534/198005030-c0fde171-8442-42ba-98aa-3594efa1afde.gif)

After
![bug_fixed](https://user-images.githubusercontent.com/713534/198005576-d5bee6ea-319e-4a0c-9394-cccecc208a92.gif)

#### Release Note

```release-note
NONE
```
