### PR TITLE
MM-47959, MM-47960 - fix text in dark theme; show cursor as hand in text

### DIFF
--- a/components/new_channel_modal/new_channel_modal.scss
+++ b/components/new_channel_modal/new_channel_modal.scss
@@ -79,8 +79,8 @@
             label {
                 display: flex;
                 color: var(--center-channel-color);
-                font-weight: 400;
                 cursor: pointer;
+                font-weight: 400;
 
                 input[type=checkbox] {
                     margin-top: 0 !important;

--- a/components/new_channel_modal/new_channel_modal.scss
+++ b/components/new_channel_modal/new_channel_modal.scss
@@ -78,8 +78,9 @@
 
             label {
                 display: flex;
-                color: var(--center-channel-text);
+                color: var(--center-channel-color);
                 font-weight: 400;
+                cursor: pointer;
 
                 input[type=checkbox] {
                     margin-top: 0 !important;


### PR DESCRIPTION
#### Summary
This PR addressed some styles for the text shown in the add channels modal to create a new board. Modifies the color so it looks well in light and dark themes and adds the hand cursor when hovering over the text.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47959

https://mattermost.atlassian.net/browse/MM-47960

#### Related Pull Requests
n/a

#### Screenshots
![cursor_pointer_light](https://user-images.githubusercontent.com/10082627/198100884-fd6d122d-2fbc-4771-a483-99f83174c4e8.gif)
![cursor_pointer_dark](https://user-images.githubusercontent.com/10082627/198101033-01e73be2-e4e5-453e-a2c4-7264456be683.gif)


#### Release Note
```release-note
NONE
```
