### PR TITLE
[MM-46112] Allowing special characters in group name

### DIFF
--- a/components/at_mention/at_mention.tsx
+++ b/components/at_mention/at_mention.tsx
@@ -12,7 +12,7 @@ import {Group} from '@mattermost/types/groups';
 import ProfilePopover from 'components/profile_popover';
 
 import {popOverOverlayPosition} from 'utils/position_utils';
-import {getUserFromMentionName} from 'utils/post_utils';
+import {getUserOrGroupFromMentionName} from 'utils/post_utils';
 
 const spaceRequiredForPopOver = 300;
 
@@ -69,18 +69,12 @@ export default class AtMention extends React.PureComponent<Props, State> {
         this.setState({show: false});
     }
 
-    getGroupFromMentionName() {
-        const {groupsByName, mentionName} = this.props;
-        const mentionNameTrimmed = mentionName.toLowerCase().replace(/[._-]*$/, '');
-        return groupsByName?.[mentionNameTrimmed] || {};
-    }
-
     render() {
-        const user = getUserFromMentionName(this.props.usersByUsername, this.props.mentionName);
+        const user = getUserOrGroupFromMentionName(this.props.usersByUsername, this.props.mentionName) as UserProfile | '';
 
         if (!this.props.disableGroupHighlight && !user) {
-            const group = this.getGroupFromMentionName();
-            if (group.allow_reference) {
+            const group = getUserOrGroupFromMentionName(this.props.groupsByName, this.props.mentionName) as Group | '';
+            if (group && group.allow_reference) {
                 return <span className='group-mention-link'>{'@' + group.name}</span>;
             }
         }

--- a/components/create_user_groups_modal/create_user_groups_modal.test.tsx
+++ b/components/create_user_groups_modal/create_user_groups_modal.test.tsx
@@ -83,6 +83,21 @@ describe('component/create_user_groups_modal', () => {
         });
     });
 
+    test('create a mention with special characters', () => {
+        const wrapper = shallow<CreateUserGroupsModal>(
+            <CreateUserGroupsModal
+                {...baseProps}
+            />,
+        );
+        wrapper.setState({name: 'Ursa', mention: 'ursa.-_'});
+        wrapper.instance().createGroup(users);
+        expect(wrapper.instance().props.actions.createGroupWithUserIds).toHaveBeenCalledTimes(1);
+        process.nextTick(() => {
+            expect(wrapper.state('showUnknownError')).toEqual(false);
+            expect(wrapper.state('mentionInputErrorText')).toEqual('');
+        });
+    });
+
     test('fail to create with empty name', () => {
         const wrapper = shallow<CreateUserGroupsModal>(
             <CreateUserGroupsModal

--- a/components/create_user_groups_modal/create_user_groups_modal.tsx
+++ b/components/create_user_groups_modal/create_user_groups_modal.tsx
@@ -73,7 +73,7 @@ export default class CreateUserGroupsModal extends React.PureComponent<Props, St
         const value = e.target.value;
         let mention = this.state.mention;
         if (!this.state.mentionUpdatedManually) {
-            mention = value.replace(/[^A-Za-z0-9@]/g, '').toLowerCase();
+            mention = value.replace(/[^A-Za-z0-9.\-_@]/g, '').toLowerCase();
             if (mention.substring(0, 1) !== '@') {
                 mention = `@${mention}`;
             }
@@ -129,8 +129,8 @@ export default class CreateUserGroupsModal extends React.PureComponent<Props, St
             return;
         }
 
-        const mentionRegEx = new RegExp(/[^A-Za-z0-9]/g);
-        if (mentionRegEx.test(mention)) {
+        const mentionRegEx = new RegExp(/^[a-z0-9.\-_]+$/);
+        if (!mentionRegEx.test(mention)) {
             this.setState({mentionInputErrorText: Utils.localizeMessage('user_groups_modal.mentionInvalidError', 'Invalid character in mention.'), saving: false});
             return;
         }

--- a/components/update_user_group_modal/update_user_group_modal.tsx
+++ b/components/update_user_group_modal/update_user_group_modal.tsx
@@ -66,7 +66,7 @@ const UpdateUserGroupModal = (props: Props) => {
         const value = e.target.value;
         let newMention = mention;
         if (!mentionUpdatedManually) {
-            newMention = value.replace(/[^A-Za-z0-9@]/g, '').toLowerCase();
+            newMention = value.replace(/[^A-Za-z0-9.\-_@]/g, '').toLowerCase();
             if (newMention.substring(0, 1) !== '@') {
                 newMention = `@${newMention}`;
             }
@@ -115,8 +115,8 @@ const UpdateUserGroupModal = (props: Props) => {
             return;
         }
 
-        const mentionRegEx = new RegExp(/[^A-Za-z0-9]/g);
-        if (mentionRegEx.test(newMention)) {
+        const mentionRegEx = new RegExp(/^[a-z0-9.\-_]+$/);
+        if (!mentionRegEx.test(newMention)) {
             setMentionInputErrorText(Utils.localizeMessage('user_groups_modal.mentionInvalidError', 'Invalid character in mention.'));
             setSaving(false);
             return;

--- a/utils/post_utils.ts
+++ b/utils/post_utils.ts
@@ -431,7 +431,7 @@ export function makeGetMentionsFromMessage(): (state: GlobalState, post: Post) =
             const mentionsArray = post.message.match(Constants.MENTIONS_REGEX) || [];
             for (let i = 0; i < mentionsArray.length; i++) {
                 const mention = mentionsArray[i];
-                const user = getUserFromMentionName(users, mention.substring(1));
+                const user = getUserOrGroupFromMentionName(users, mention.substring(1)) as UserProfile | '';
 
                 if (user) {
                     mentions[mention] = user;
@@ -687,7 +687,7 @@ export function makeGetUniqueReactionsToPost(): (state: GlobalState, postId: Pos
     );
 }
 
-export function getUserFromMentionName(usersByUsername: Record<string, UserProfile>, mentionName: string) {
+export function getUserOrGroupFromMentionName(usersByUsername: Record<string, UserProfile | Group>, mentionName: string) {
     let mentionNameToLowerCase = mentionName.toLowerCase();
 
     while (mentionNameToLowerCase.length > 0) {


### PR DESCRIPTION
#### Summary
Allowing the same special characters as a user's username

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46112

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Allowing the same special characters in a group mention name as a user's username
```
