### PR TITLE
[MM-41906] Add max height and overflow to Multiselect

### DIFF
--- a/sass/components/_channel-invite-modal.scss
+++ b/sass/components/_channel-invite-modal.scss
@@ -96,6 +96,8 @@
     .react-select__control.react-select-auto {
         min-height: 48px;
         padding: 3px 0;
+        max-height: 125px;
+        overflow: auto;
     }
 
     .loading-screen {

--- a/sass/components/_channel-invite-modal.scss
+++ b/sass/components/_channel-invite-modal.scss
@@ -94,10 +94,10 @@
     }
 
     .react-select__control.react-select-auto {
-        min-height: 48px;
-        padding: 3px 0;
-        max-height: 125px;
         overflow: auto;
+        min-height: 48px;
+        max-height: 125px;
+        padding: 3px 0;
     }
 
     .loading-screen {


### PR DESCRIPTION
#### Summary
Multiselect height will no longer increase indefinitely. After 3 rows it will turn into a scrollable area

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41906

#### Screenshots
Before:
![Screen Shot 2022-10-27 at 9 45 09 AM](https://user-images.githubusercontent.com/14115924/198301652-bc2452c5-8712-4b79-9909-41a9a21184fc.png)

After:
![Screen Shot 2022-10-27 at 9 21 22 AM](https://user-images.githubusercontent.com/14115924/198301690-919a4928-0eae-4f2c-951c-1404cfd2deff.png)
 
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
