### PR TITLE
Fix Image Scaling for Tall Thin Images

### DIFF
--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -70,7 +70,7 @@ export default class SizeAwareImage extends React.PureComponent {
         handleSmallImageContainer: PropTypes.bool,
 
         /*
-         * Enables the logic of cropping large images to fit within container div
+         * Enables the logic of scaling large images to fit within container div
          */
         handleLargeImageContainer: PropTypes.bool,
 
@@ -196,6 +196,13 @@ export default class SizeAwareImage extends React.PureComponent {
             ariaLabelImage += ` ${fileInfo.name}`.toLowerCase();
         }
 
+        let imgClassName = this.props.className;
+        if (this.handleLargeImageContainer && this.state.isLargeImage) {
+            imgClassName += 'large-image--inside-container';
+        } else if (this.handleSmallImageContainer && this.state.isSmallImage) {
+            imgClassName += 'small-image-inside-container';
+        }
+
         const image = (
             <img
                 {...props}
@@ -204,11 +211,7 @@ export default class SizeAwareImage extends React.PureComponent {
                 onClick={this.handleImageClick}
                 onKeyDown={this.onEnterKeyDown}
                 className={
-                    this.props.className +
-                    (this.props.handleSmallImageContainer &&
-                        this.state.isSmallImage ? ' small-image--inside-container' : '') +
-                    (this.props.handleLargeImageContainer &&
-                        this.state.isLargeImage ? ' large-image--inside-container' : '')
+                    imgClassName
                 }
                 src={src}
                 onError={this.handleError}
@@ -395,8 +398,8 @@ export default class SizeAwareImage extends React.PureComponent {
                         {image}
                     </div>
                     <span
-                        className={classNames('image-preview-utility-buttons-container', 'image-preview-utility-buttons-container--large-image', {
-                            'image-preview-utility-buttons-container--large-image-no-copy-button': !enablePublicLink,
+                        className={classNames('image-preview-utility-buttons-container', 'image-preview-utility-buttons-container--small-image', {
+                            'image-preview-utility-buttons-container--small-image-no-copy-button': !enablePublicLink,
                         })}
                         style={leftStyle}
                     >

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -383,17 +383,17 @@ export default class SizeAwareImage extends React.PureComponent {
                 left: `min(${wideImageButtonsOffset + (modifierCopyButton - modifierLargerWidth)}px, calc(100% - ${31 - (modifierCopyButton - modifierLargerWidth)}px)`,
             } : {};
 
-            const wideLargeImageStyle = this.state.imageWidth > MAX_IMAGE_SIZE ? {
-                width: MAX_IMAGE_SIZE + 2, // 2px to account for the border
+            const tallLargeImageStyle = this.state.imageHeight > MAX_IMAGE_SIZE ? {
+                height: MAX_IMAGE_SIZE + 2, // 2px to account for the border
             } : {};
             return (
                 <div
-                    className='large-image-utility-buttons-wrapper'
+                    className='small-image-utility-buttons-wrapper'
                 >
                     <div
                         onClick={this.handleImageClick}
                         className={classNames(className)}
-                        style={wideLargeImageStyle}
+                        style={tallLargeImageStyle}
                     >
                         {image}
                     </div>

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -780,10 +780,10 @@
 
 .large-image__container {
     display: flex;
-    min-width: 100px;
+    min-width: 48px;
     max-width: calc(100% - 5px);
-    min-height: 350px;
-    max-height: inherit;
+    min-height: 48px;
+    max-height: 350px;
     align-items: center;
     justify-content: center;
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.32);
@@ -802,6 +802,6 @@
     }
 }
 
-.large-image__container--max-width {
-    width: 350px;
+.large-image__container--max-height {
+    height: 350px;
 }

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -777,3 +777,31 @@
 .small-image__container--min-width {
     width: 48px;
 }
+
+.large-image__container {
+    display: flex;
+    min-width: 100px;
+    max-width: calc(100% - 5px);
+    min-height: 350px;
+    max-height: inherit;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(var(--center-channel-color-rgb), 0.32);
+    margin: 5px 2px;
+    background: var(--center-channel-bg);
+    border-radius: 4px;
+
+    &:hover {
+        z-index: 2;
+        box-shadow: 0 2px 5px 0 rgba($black, 0.1), 0 2px 5px 0 rgba($black, 0.1);
+        transition: all 0.1s linear;
+    }
+
+    &:hover .image-preview-utility-buttons-container {
+        display: inline-block;
+    }
+}
+
+.large-image__container--max-width {
+    width: 350px;
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fixes Scaling of Tall single images with narrow width.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/21428

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
