### PR TITLE
Fix apiadminlogin ts spec

### DIFF
--- a/e2e/cypress/tests/integration/auth_sso/authentication_3_spec.ts
+++ b/e2e/cypress/tests/integration/auth_sso/authentication_3_spec.ts
@@ -17,8 +17,8 @@ describe('Authentication', () => {
     });
 
     after(() => {
-      cy.apiAdminLogin({failOnStatusCode: false});
-      cy.apiUpdateConfig({} as Cypress.AdminConfig);
+        cy.apiAdminLogin({failOnStatusCode: false});
+        cy.apiUpdateConfig({});
     });
 
     const testCases = [

--- a/e2e/cypress/tests/integration/auth_sso/authentication_3_spec.ts
+++ b/e2e/cypress/tests/integration/auth_sso/authentication_3_spec.ts
@@ -16,6 +16,11 @@ describe('Authentication', () => {
         cy.apiAdminLogin();
     });
 
+    after(() => {
+      cy.apiAdminLogin({failOnStatusCode: false});
+      cy.apiUpdateConfig({} as Cypress.AdminConfig);
+    });
+
     const testCases = [
         {
             title: 'MM-T1767 - Email signin false Username signin true',

--- a/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_identification_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_identification_spec.ts
@@ -41,7 +41,7 @@ describe('Guest Accounts', () => {
         });
 
         // # Log in as a team admin.
-        cy.apiAdminLogin().then(({user}) => {
+        cy.apiAdminLogin().then((user) => {
             sysadmin = user;
         });
     });

--- a/e2e/cypress/tests/support/api/user.d.ts
+++ b/e2e/cypress/tests/support/api/user.d.ts
@@ -52,7 +52,7 @@ declare namespace Cypress {
          * @example
          *   cy.apiAdminLogin();
          */
-        apiAdminLogin(requestOptions?: Object): Chainable<UserProfile>;
+        apiAdminLogin(requestOptions?: Record<string, any>): Chainable<UserProfile>;
 
         /**
          * Login as admin via API.

--- a/e2e/cypress/tests/support/api/user.d.ts
+++ b/e2e/cypress/tests/support/api/user.d.ts
@@ -46,12 +46,13 @@ declare namespace Cypress {
         /**
          * Login as admin via API.
          * See https://api.mattermost.com/#tag/users/paths/~1users~1login/post
+         * @param {Object} requestOptions - cypress' request options object, see https://docs.cypress.io/api/commands/request#Arguments
          * @returns {UserProfile} out.user: `UserProfile` object
          *
          * @example
          *   cy.apiAdminLogin();
          */
-        apiAdminLogin(): Chainable<{user: UserProfile}>;
+        apiAdminLogin(requestOptions?: Object): Chainable<UserProfile>;
 
         /**
          * Login as admin via API.


### PR DESCRIPTION
#### Summary

Fix the `apiAdminLogin()` function signature, in the Typescript declaration.

#### Ticket Link

None

#### Related Pull Requests

This is a small improvement over an already merged MR, where the `apiAdminLogin()` function signature issue was observed https://github.com/mattermost/mattermost-webapp/pull/11365

#### Release Note

```release-note
NONE
```
