### PR TITLE
Mm 47645 show license count activated users

### DIFF
--- a/components/admin_console/license_settings/__snapshots__/license_settings.test.tsx.snap
+++ b/components/admin_console/license_settings/__snapshots__/license_settings.test.tsx.snap
@@ -395,6 +395,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={false}
             />
           </div>
@@ -532,6 +533,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={false}
             />
           </div>
@@ -656,6 +658,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={false}
             />
           </div>
@@ -780,6 +783,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={false}
             />
           </div>
@@ -904,6 +908,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={false}
             />
           </div>
@@ -1028,6 +1033,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={true}
             />
           </div>
@@ -1141,6 +1147,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={false}
             />
           </div>
@@ -1787,6 +1794,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={false}
             />
           </div>
@@ -1912,6 +1920,7 @@ exports[`components/admin_console/license_settings/LicenseSettings should match 
               }
               openEELicenseModal={[Function]}
               removing={false}
+              statsActiveUsers={10}
               upgradedFromTE={false}
             />
           </div>

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition.scss
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition.scss
@@ -135,11 +135,29 @@
                     min-width: 150px;
                     color: rgba(var(--secondary-blue-rgb), 0.4);
                     font-weight: 600;
+
+                    &--warning-over-seats-purchased {
+                        color: var(--warning-text);
+                    }
+
+                    &--over-seats-purchased {
+                        color: var(--error-text);
+                    }
                 }
 
                 span.value {
                     margin-left: 10px;
                     color: var(--secondary-blue);
+
+                    &--warning-over-seats-purchased {
+                        color: var(--warning-text);
+                        font-weight: 600;
+                    }
+
+                    &--over-seats-purchased {
+                        color: var(--error-text);
+                        font-weight: 600;
+                    }
                 }
             }
 

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition.scss
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition.scss
@@ -136,11 +136,11 @@
                     color: rgba(var(--secondary-blue-rgb), 0.4);
                     font-weight: 600;
 
-                    &--warning-over-seats-purchased {
+                    &--warning-overage-purchased {
                         color: var(--warning-text);
                     }
 
-                    &--over-seats-purchased {
+                    &--overage-purchased {
                         color: var(--error-text);
                     }
                 }
@@ -149,12 +149,12 @@
                     margin-left: 10px;
                     color: var(--secondary-blue);
 
-                    &--warning-over-seats-purchased {
+                    &--warning-overage-purchased {
                         color: var(--warning-text);
                         font-weight: 600;
                     }
 
-                    &--over-seats-purchased {
+                    &--overage-purchased {
                         color: var(--error-text);
                         font-weight: 600;
                     }

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.test.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.test.tsx
@@ -2,8 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {screen} from '@testing-library/react';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
+import {renderWithIntl} from 'tests/react_testing_utils';
+import {OverActiveUserLimits} from 'utils/constants';
 
 import EnterpriseEditionLeftPanel, {EnterpriseEditionProps} from './enterprise_edition_left_panel';
 
@@ -32,6 +35,7 @@ describe('components/admin_console/license_settings/enterprise_edition/enterpris
         removing: false,
         handleChange: jest.fn(),
         fileInputRef: React.createRef(),
+        statsActiveUsers: 1,
     } as EnterpriseEditionProps;
 
     test('should format the Users field', () => {
@@ -42,9 +46,59 @@ describe('components/admin_console/license_settings/enterprise_edition/enterpris
         const item = wrapper.find('.item-element').filterWhere((n) => {
             return n.children().length === 2 &&
                    n.childAt(0).type() === 'span' &&
+                   !n.childAt(0).text().includes('ACTIVE') &&
                    n.childAt(0).text().includes('USERS');
         });
 
         expect(item.text()).toContain('1,000,000');
+    });
+
+    test('should not add any class if active users is lower than the minimal', () => {
+        renderWithIntl(
+            <EnterpriseEditionLeftPanel
+                {...props}
+            />,
+        );
+
+        expect(screen.getByText(Intl.NumberFormat('en').format(props.statsActiveUsers))).toHaveClass('value');
+        expect(screen.getByText(Intl.NumberFormat('en').format(props.statsActiveUsers))).not.toHaveClass('value--warning-over-seats-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(props.statsActiveUsers))).not.toHaveClass('value--over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend');
+        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--warning-over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--over-seats-purchased');
+    });
+
+    test('should add warning class to active users', () => {
+        const minWarning = Math.ceil(parseInt(license.Users, 10) * OverActiveUserLimits.MIN) + parseInt(license.Users, 10);
+        renderWithIntl(
+            <EnterpriseEditionLeftPanel
+                {...props}
+                statsActiveUsers={minWarning}
+            />,
+        );
+
+        expect(screen.getByText(Intl.NumberFormat('en').format(minWarning))).toHaveClass('value');
+        expect(screen.getByText(Intl.NumberFormat('en').format(minWarning))).toHaveClass('value--warning-over-seats-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(minWarning))).not.toHaveClass('value--over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend');
+        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend--warning-over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--over-seats-purchased');
+    });
+
+    test('should add over-seats-purchased class to active users', () => {
+        const exceedHighLimitExtraUsersError = Math.ceil(parseInt(license.Users, 10) * OverActiveUserLimits.MAX) + parseInt(license.Users, 10);
+        renderWithIntl(
+            <EnterpriseEditionLeftPanel
+                {...props}
+                statsActiveUsers={exceedHighLimitExtraUsersError}
+            />,
+        );
+
+        expect(screen.getByText(Intl.NumberFormat('en').format(exceedHighLimitExtraUsersError))).toHaveClass('value');
+        expect(screen.getByText(Intl.NumberFormat('en').format(exceedHighLimitExtraUsersError))).toHaveClass('value--over-seats-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(exceedHighLimitExtraUsersError))).not.toHaveClass('value--warning-over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend');
+        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--warning-over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend--over-seats-purchased');
     });
 });

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.test.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.test.tsx
@@ -61,11 +61,11 @@ describe('components/admin_console/license_settings/enterprise_edition/enterpris
         );
 
         expect(screen.getByText(Intl.NumberFormat('en').format(props.statsActiveUsers))).toHaveClass('value');
-        expect(screen.getByText(Intl.NumberFormat('en').format(props.statsActiveUsers))).not.toHaveClass('value--warning-over-seats-purchased');
-        expect(screen.getByText(Intl.NumberFormat('en').format(props.statsActiveUsers))).not.toHaveClass('value--over-seats-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(props.statsActiveUsers))).not.toHaveClass('value--warning-overage-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(props.statsActiveUsers))).not.toHaveClass('value--overage-purchased');
         expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend');
-        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--warning-over-seats-purchased');
-        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--warning-overage-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--overage-purchased');
     });
 
     test('should add warning class to active users', () => {
@@ -78,14 +78,14 @@ describe('components/admin_console/license_settings/enterprise_edition/enterpris
         );
 
         expect(screen.getByText(Intl.NumberFormat('en').format(minWarning))).toHaveClass('value');
-        expect(screen.getByText(Intl.NumberFormat('en').format(minWarning))).toHaveClass('value--warning-over-seats-purchased');
-        expect(screen.getByText(Intl.NumberFormat('en').format(minWarning))).not.toHaveClass('value--over-seats-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(minWarning))).toHaveClass('value--warning-overage-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(minWarning))).not.toHaveClass('value--overage-purchased');
         expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend');
-        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend--warning-over-seats-purchased');
-        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend--warning-overage-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--overage-purchased');
     });
 
-    test('should add over-seats-purchased class to active users', () => {
+    test('should add overage-purchased class to active users', () => {
         const exceedHighLimitExtraUsersError = Math.ceil(parseInt(license.Users, 10) * OverActiveUserLimits.MAX) + parseInt(license.Users, 10);
         renderWithIntl(
             <EnterpriseEditionLeftPanel
@@ -95,10 +95,10 @@ describe('components/admin_console/license_settings/enterprise_edition/enterpris
         );
 
         expect(screen.getByText(Intl.NumberFormat('en').format(exceedHighLimitExtraUsersError))).toHaveClass('value');
-        expect(screen.getByText(Intl.NumberFormat('en').format(exceedHighLimitExtraUsersError))).toHaveClass('value--over-seats-purchased');
-        expect(screen.getByText(Intl.NumberFormat('en').format(exceedHighLimitExtraUsersError))).not.toHaveClass('value--warning-over-seats-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(exceedHighLimitExtraUsersError))).toHaveClass('value--overage-purchased');
+        expect(screen.getByText(Intl.NumberFormat('en').format(exceedHighLimitExtraUsersError))).not.toHaveClass('value--warning-overage-purchased');
         expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend');
-        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--warning-over-seats-purchased');
-        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend--over-seats-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).not.toHaveClass('legend--warning-overage-purchased');
+        expect(screen.getByText('ACTIVE USERS:')).toHaveClass('legend--overage-purchased');
     });
 });

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {RefObject, useEffect, useState} from 'react';
+import classNames from 'classnames';
 import {FormattedDate, FormattedMessage, FormattedNumber, FormattedTime} from 'react-intl';
 
 import {ClientLicense} from '@mattermost/types/config';
@@ -9,7 +10,7 @@ import {ClientLicense} from '@mattermost/types/config';
 import {Client4} from 'mattermost-redux/client';
 
 import {getRemainingDaysFromFutureTimestamp, toTitleCase} from 'utils/utils';
-import {FileTypes, LicenseSkus} from 'utils/constants';
+import {FileTypes, LicenseSkus, OverActiveUserLimits} from 'utils/constants';
 
 import Badge from 'components/widgets/badges/badge';
 
@@ -25,6 +26,7 @@ export interface EnterpriseEditionProps {
     removing: boolean;
     fileInputRef: RefObject<HTMLInputElement>;
     handleChange: () => void;
+    statsActiveUsers: number;
 }
 
 export const getSkuDisplayName = (skuShortName: string, isGovSku: boolean): string => {
@@ -62,6 +64,7 @@ const EnterpriseEditionLeftPanel = ({
     removing,
     fileInputRef,
     handleChange,
+    statsActiveUsers,
 }: EnterpriseEditionProps) => {
     const [unsanitizedLicense, setUnsanitizedLicense] = useState(license);
     useEffect(() => {
@@ -115,6 +118,7 @@ const EnterpriseEditionLeftPanel = ({
                         skuName,
                         fileInputRef,
                         handleChange,
+                        statsActiveUsers,
                     )
                 }
             </div>
@@ -141,6 +145,48 @@ const EnterpriseEditionLeftPanel = ({
     );
 };
 
+type LegendValues = 'START DATE:' | 'EXPIRES:' | 'USERS:' | 'ACTIVE USERS:' | 'EDITION:' | 'LICENSE ISSUED:' | 'NAME:' | 'COMPANY / ORG:'
+
+const renderLicenseValues = (activeUsers: number, seatsPurchased: number) => ({legend, value}: {legend: LegendValues; value: string | JSX.Element | null}, index: number): React.ReactNode => {
+    if (legend === 'ACTIVE USERS:') {
+        const minimumOverSeats = Math.ceil(seatsPurchased * OverActiveUserLimits.MIN) + seatsPurchased;
+        const maximumOverSeats = Math.ceil(seatsPurchased * OverActiveUserLimits.MAX) + seatsPurchased;
+        const isBetween5PercerntAnd10PercentPurchasedSeats = minimumOverSeats <= activeUsers && activeUsers < maximumOverSeats;
+        const isOver10PercerntPurchasedSeats = maximumOverSeats <= activeUsers;
+        return (
+            <div
+                className='item-element'
+                key={value + index.toString()}
+            >
+                <span
+                    className={classNames({
+                        legend: true,
+                        'legend--warning-over-seats-purchased': isBetween5PercerntAnd10PercentPurchasedSeats,
+                        'legend--over-seats-purchased': isOver10PercerntPurchasedSeats,
+                    })}
+                >{legend}</span>
+                <span
+                    className={classNames({
+                        value: true,
+                        'value--warning-over-seats-purchased': isBetween5PercerntAnd10PercentPurchasedSeats,
+                        'value--over-seats-purchased': isOver10PercerntPurchasedSeats,
+                    })}
+                >{value}</span>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className='item-element'
+            key={value + index.toString()}
+        >
+            <span className='legend'>{legend}</span>
+            <span className='value'>{value}</span>
+        </div>
+    );
+};
+
 const renderLicenseContent = (
     license: ClientLicense,
     isTrialLicense: boolean,
@@ -150,12 +196,14 @@ const renderLicenseContent = (
     skuName: string,
     fileInputRef: RefObject<HTMLInputElement>,
     handleChange: () => void,
+    statsActiveUsers: number,
 ) => {
     // Note: DO NOT LOCALISE THESE STRINGS. Legally we can not since the license is in English.
 
     const sku = license.SkuShortName ? <>{`Mattermost ${toTitleCase(skuName)}${isTrialLicense ? ' License Trial' : ''}`}</> : null;
 
     const users = <FormattedNumber value={parseInt(license.Users, 10)}/>;
+    const activeUsers = <FormattedNumber value={statsActiveUsers}/>;
     const startsAt = <FormattedDate value={new Date(parseInt(license.StartsAt, 10))}/>;
     const expiresAt = <FormattedDate value={new Date(parseInt(license.ExpiresAt, 10))}/>;
 
@@ -168,15 +216,16 @@ const renderLicenseContent = (
     );
 
     const licenseValues: Array<{
-        legend: string;
+        legend: LegendValues;
         value: string;
     } | {
-        legend: string;
+        legend: LegendValues;
         value: JSX.Element | null;
     }> = [
         {legend: 'START DATE:', value: startsAt},
         {legend: 'EXPIRES:', value: expiresAt},
         {legend: 'USERS:', value: users},
+        {legend: 'ACTIVE USERS:', value: activeUsers},
         {legend: 'EDITION:', value: sku},
         {legend: 'LICENSE ISSUED:', value: issued},
         {legend: 'NAME:', value: license.Name},
@@ -185,17 +234,7 @@ const renderLicenseContent = (
 
     return (
         <div className='licenseElements'>
-            {licenseValues.map((item: {legend: string; value: JSX.Element | null | string}, i: number) => {
-                return (
-                    <div
-                        className='item-element'
-                        key={item.value + i.toString()}
-                    >
-                        <span className='legend'>{item.legend}</span>
-                        <span className='value'>{item.value}</span>
-                    </div>
-                );
-            })}
+            {licenseValues.map(renderLicenseValues(statsActiveUsers, parseInt(license.Users, 10)))}
             <hr/>
             {renderAddNewLicenseButton(fileInputRef, handleChange)}
             {renderRemoveButton(handleRemove, isDisabled, removing)}

--- a/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
+++ b/components/admin_console/license_settings/enterprise_edition/enterprise_edition_left_panel.tsx
@@ -161,15 +161,15 @@ const renderLicenseValues = (activeUsers: number, seatsPurchased: number) => ({l
                 <span
                     className={classNames({
                         legend: true,
-                        'legend--warning-over-seats-purchased': isBetween5PercerntAnd10PercentPurchasedSeats,
-                        'legend--over-seats-purchased': isOver10PercerntPurchasedSeats,
+                        'legend--warning-overage-purchased': isBetween5PercerntAnd10PercentPurchasedSeats,
+                        'legend--overage-purchased': isOver10PercerntPurchasedSeats,
                     })}
                 >{legend}</span>
                 <span
                     className={classNames({
                         value: true,
-                        'value--warning-over-seats-purchased': isBetween5PercerntAnd10PercentPurchasedSeats,
-                        'value--over-seats-purchased': isOver10PercerntPurchasedSeats,
+                        'value--warning-overage-purchased': isBetween5PercerntAnd10PercentPurchasedSeats,
+                        'value--overage-purchased': isOver10PercerntPurchasedSeats,
                     })}
                 >{value}</span>
             </div>

--- a/components/admin_console/license_settings/license_settings.tsx
+++ b/components/admin_console/license_settings/license_settings.tsx
@@ -16,7 +16,7 @@ import {trackEvent} from 'actions/telemetry_actions';
 
 import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header';
 
-import {AboutLinks, CloudLinks, ModalIdentifiers} from 'utils/constants';
+import {AboutLinks, CloudLinks, ModalIdentifiers, StatTypes} from 'utils/constants';
 
 import {ModalData} from 'types/actions';
 
@@ -317,6 +317,7 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
                     removing={this.state.removing}
                     fileInputRef={this.fileInputRef}
                     handleChange={this.handleChange}
+                    statsActiveUsers={this.props.stats[StatTypes.TOTAL_USERS]}
                 />
             );
 

--- a/sass/base/_css_variables.scss
+++ b/sass/base/_css_variables.scss
@@ -9,7 +9,7 @@
     --center-channel-color: #3d3c40;
     --dnd-indicator: #d24b4e;
     --error-text: #d24b4e;
-    --warning-text: #CC8F00;
+    --warning-text: #cc8f00;
     --link-color: #2389d7;
     --mention-bg: #fff;
     --mention-color: #145dbf;

--- a/sass/base/_css_variables.scss
+++ b/sass/base/_css_variables.scss
@@ -9,6 +9,7 @@
     --center-channel-color: #3d3c40;
     --dnd-indicator: #d24b4e;
     --error-text: #d24b4e;
+    --warning-text: #CC8F00;
     --link-color: #2389d7;
     --mention-bg: #fff;
     --mention-color: #145dbf;

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -2182,4 +2182,9 @@ export const DataSearchTypes = {
     MESSAGES_SEARCH_TYPE: 'messages',
 };
 
+export const OverActiveUserLimits = {
+    MIN: 0.05,
+    MAX: 0.1,
+} as const;
+
 export default Constants;


### PR DESCRIPTION
#### Summary
Display the number of active users on License Panel Detail and dynamically style based on some limits.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47645

#### Related Pull Requests
- Has server changes https://github.com/mattermost/mattermost-server/pull/21666

#### Screenshots
|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/713534/198987671-77e37730-91ea-4650-b747-a7ea84ffeda5.png) | ![image](https://user-images.githubusercontent.com/713534/198987727-0927434d-3f17-46fa-aae0-ed4f6d47c07c.png) |

Between 5% - 10% Overage.

![image](https://user-images.githubusercontent.com/713534/198988028-9e8f7dcc-861f-42a1-99bb-621e38dd04a4.png)

Over 10% Overage
![image](https://user-images.githubusercontent.com/713534/198988121-361fcc94-0e3c-406c-b71a-b8586631191f.png)

#### Release Note
```release-note
Self hosted license detail display the active users.
```
