### PR TITLE
[MM-48049] Including users who were removed from group in not_in_group response

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/users.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/users.test.js
@@ -578,4 +578,99 @@ describe('Reducers.users', () => {
             assert.deepEqual(newState.filteredStats, expectedState.filteredStats);
         });
     });
+    describe('profilesNotInGroup', () => {
+        it('initial state', () => {
+            const state = undefined;
+            const action = {};
+            const expectedState = {
+                profilesNotInGroup: {},
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesNotInGroup, expectedState.profilesNotInGroup);
+        });
+
+        it('UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_GROUP, no existing profiles', () => {
+            const state = {
+                profilesNotInGroup: {},
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_GROUP,
+                id: 'id',
+                data: [
+                    {
+                        id: 'user_id',
+                    },
+                    {
+                        id: 'user_id_2',
+                    },
+                ],
+            };
+            const expectedState = {
+                profilesNotInGroup: {
+                    id: new Set().add('user_id').add('user_id_2'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesNotInGroup, expectedState.profilesNotInGroup);
+        });
+
+        it('UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_GROUP, existing profiles', () => {
+            const state = {
+                profilesNotInGroup: {
+                    id: new Set().add('old_user_id'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_GROUP,
+                id: 'id',
+                data: [
+                    {
+                        id: 'user_id',
+                    },
+                    {
+                        id: 'user_id_2',
+                    },
+                ],
+            };
+            const expectedState = {
+                profilesNotInGroup: {
+                    id: new Set().add('old_user_id').add('user_id').add('user_id_2'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesNotInGroup, expectedState.profilesNotInGroup);
+        });
+
+        it('UserTypes.RECEIVED_PROFILES_FOR_GROUP, existing profiles', () => {
+            const state = {
+                profilesNotInGroup: {
+                    id: new Set().add('user_id').add('user_id_2'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILES_FOR_GROUP,
+                id: 'id',
+                data: [
+                    {
+                        user_id: 'user_id',
+                    },
+                ],
+            };
+            const expectedState = {
+                profilesNotInGroup: {
+                    id: new Set().add('user_id_2'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesNotInGroup, expectedState.profilesNotInGroup);
+        });
+    });
 });

--- a/packages/mattermost-redux/src/reducers/entities/users.ts
+++ b/packages/mattermost-redux/src/reducers/entities/users.ts
@@ -446,6 +446,21 @@ function profilesInGroup(state: RelationOneToMany<Group, UserProfile> = {}, acti
 
 function profilesNotInGroup(state: RelationOneToMany<Group, UserProfile> = {}, action: GenericAction) {
     switch (action.type) {
+    case UserTypes.RECEIVED_PROFILES_FOR_GROUP: {
+        const id = action.id;
+        const nextSet = new Set(state[id]);
+        if (action.data) {
+            action.data.forEach((profile: any) => {
+                nextSet.delete(profile.user_id);
+            });
+
+            return {
+                ...state,
+                [id]: nextSet,
+            };
+        }
+        return state;
+    }
     case UserTypes.RECEIVED_PROFILES_LIST_NOT_IN_GROUP: {
         return profileListToSet(state, action);
     }


### PR DESCRIPTION
#### Summary
Users who were removed from a group couldn't be added back in through the UI

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48049

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
