### PR TITLE
Fixed post pasteHandler not saving drafts

### DIFF
--- a/components/advanced_create_post/advanced_create_post.test.jsx
+++ b/components/advanced_create_post/advanced_create_post.test.jsx
@@ -1413,6 +1413,57 @@ describe('components/advanced_create_post', () => {
         expect(wrapper.state('message')).toBe(codeBlockMarkdown);
     });
 
+    it('should call handlePostPasteDraft to update the draft after pasting', () => {
+        const wrapper = shallow(advancedCreatePost());
+        const mockImpl = () => {
+            return {
+                setSelectionRange: jest.fn(),
+                focus: jest.fn(),
+            };
+        };
+        wrapper.instance().textboxRef.current = {getInputBox: jest.fn(mockImpl), focus: jest.fn(), blur: jest.fn()};
+        wrapper.instance().handlePostPasteDraft = jest.fn();
+
+        const event = {
+            target: {
+                id: 'post_textbox',
+            },
+            preventDefault: jest.fn(),
+            clipboardData: {
+                items: [1],
+                types: ['text/html'],
+                getData: () => {
+                    return '<a href="https://test.domain">link text</a>';
+                },
+            },
+        };
+
+        wrapper.instance().pasteHandler(event);
+        expect(wrapper.instance().handlePostPasteDraft).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update draft when handlePostPasteDraft is called', () => {
+        const setDraft = jest.fn();
+
+        const wrapper = shallow(
+            advancedCreatePost({
+                actions: {
+                    ...actionsProp,
+                    setDraft,
+                },
+            }),
+        );
+
+        const testMessage = 'test';
+        const expectedDraft = {
+            ...draftProp,
+            message: testMessage,
+        };
+
+        wrapper.instance().handlePostPasteDraft(testMessage);
+        expect(setDraft).toHaveBeenCalledWith(StoragePrefixes.DRAFT + currentChannelProp.id, expectedDraft);
+    });
+
     /**
      * TODO@all: move this test to advanced_text_editor.test.tsx and rewrite it according to the component
      *

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -856,7 +856,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
 
         e.preventDefault();
 
-        let message = this.state.message;
+        const message = this.state.message;
         if (table && isGitHubCodeBlock(table.className)) {
             const selectionStart = (e.target as any).selectionStart;
             const selectionEnd = (e.target as any).selectionEnd;
@@ -867,9 +867,21 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         }
 
         const originalSize = message.length;
-        message = formatMarkdownMessage(clipboardData, message.trim(), this.state.caretPosition);
-        const newCaretPosition = message.length - (originalSize - this.state.caretPosition);
-        this.setMessageAndCaretPostion(message, newCaretPosition);
+        const formattedMessage = formatMarkdownMessage(clipboardData, message.trim(), this.state.caretPosition);
+        const newCaretPosition = formattedMessage.length - (originalSize - this.state.caretPosition);
+        this.setMessageAndCaretPostion(formattedMessage, newCaretPosition);
+        this.handlePostPasteDraft(formattedMessage);
+    }
+
+    handlePostPasteDraft = (message: string) => {
+        const draft = {
+            ...this.props.draft,
+            message,
+        };
+
+        const channelId = this.props.currentChannel.id;
+        this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft);
+        this.draftsForChannel[channelId] = draft;
     }
 
     handleFileUploadChange = () => {


### PR DESCRIPTION
#### Summary
This ticket fixes a bug in which drafts are not saved after a paste that goes through the pasteHandler in the post textbox is processed (tables and hyperlinks, currently).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-47681


#### Release Note

```release-note
NONE
```
