### PR TITLE
MM-47793 Let products be developed using https

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@
 
 const childProcess = require('child_process');
 const http = require('http');
+const https = require('https');
 const path = require('path');
 
 const url = require('url');
@@ -427,7 +428,8 @@ async function initializeModuleFederation() {
                 return;
             }
 
-            const req = http.request(`${baseUrl}/remote_entry.js`, (response) => {
+            const requestModule = baseUrl.startsWith('https:') ? https : http;
+            const req = requestModule.request(`${baseUrl}/remote_entry.js`, (response) => {
                 return resolve(response.statusCode === 200);
             });
 


### PR DESCRIPTION
I have no idea why Node requires two separate packages for making http and https requests since most people wouldn't care about that

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47793

#### Release Note
```release-note
NONE
```
