### PR TITLE
MM-47042_Remove default text for "Custom Brand Text" in login-signup

### DIFF
--- a/components/login/login.tsx
+++ b/components/login/login.tsx
@@ -676,15 +676,15 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     };
 
     const getMessageSubtitle = () => {
-        if (enableCustomBrand && CustomBrandText) {
-            return (
+        if (enableCustomBrand) {
+            return CustomBrandText ? (
                 <div className='login-body-custom-branding-markdown'>
                     <Markdown
                         message={CustomBrandText}
                         options={{mentionHighlight: false}}
                     />
                 </div>
-            );
+            ) : null;
         }
 
         return (

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -352,15 +352,15 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
     };
 
     const getMessageSubtitle = () => {
-        if (enableCustomBrand && CustomBrandText) {
-            return (
+        if (enableCustomBrand) {
+            return CustomBrandText ? (
                 <div className='signup-body-custom-branding-markdown'>
                     <Markdown
                         message={CustomBrandText}
                         options={{mentionHighlight: false}}
                     />
                 </div>
-            );
+            ) : null;
         }
 
         return (


### PR DESCRIPTION
#### Summary
[UX] When leaving "Custom Brand Text" blank with Custom Branding enabled, we should remove the text altogether.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47042

#### Screenshots
|  before  |  after  |
|----|----|
| ![Screen Shot 2022-11-01 at 3 54 24 PM](https://user-images.githubusercontent.com/79058848/199339160-2d1b0558-de77-47c9-94b0-6948a4aff681.png) | ![Screen Shot 2022-11-01 at 3 50 12 PM](https://user-images.githubusercontent.com/79058848/199338692-9b9959ab-1470-4ffc-bf3d-769678dbfccc.png) |
| ![Screen Shot 2022-11-01 at 3 54 10 PM](https://user-images.githubusercontent.com/79058848/199339225-064bf512-6d65-4213-a644-3d70fd4c0450.png) | ![Screen Shot 2022-11-01 at 3 50 26 PM](https://user-images.githubusercontent.com/79058848/199338736-66638b1d-6d33-479a-ba1e-e84976724f49.png) |

#### Release Note
```release-note
NONE
```
