### PR TITLE
MM-45313_Cannot access the create account button on safari for iOS

### DIFF
--- a/components/header_footer_route/header_footer_route.scss
+++ b/components/header_footer_route/header_footer_route.scss
@@ -21,5 +21,7 @@
         background-repeat: no-repeat;
         background-size: cover;
         overflow-y: auto;
+        // Hack for issue in iOS Safari with scrolling
+        -webkit-overflow-scrolling: touch;
     }
 }

--- a/components/header_footer_route/header_footer_route.scss
+++ b/components/header_footer_route/header_footer_route.scss
@@ -20,8 +20,8 @@
         background-position: center;
         background-repeat: no-repeat;
         background-size: cover;
-        overflow-y: auto;
         // Hack for issue in iOS Safari with scrolling
         -webkit-overflow-scrolling: touch;
+        overflow-y: auto;
     }
 }

--- a/components/header_footer_route/header_footer_route.scss
+++ b/components/header_footer_route/header_footer_route.scss
@@ -20,7 +20,7 @@
         background-position: center;
         background-repeat: no-repeat;
         background-size: cover;
-        // Hack for issue in iOS Safari with scrolling
+        // MM-45313 - Hack for issue in iOS Safari with scrolling
         -webkit-overflow-scrolling: touch;
         overflow-y: auto;
     }


### PR DESCRIPTION
#### Summary
In Safari for iPhone, the Signup page now allows to scroll, so the Create Account button can be accessed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45313
https://github.com/mattermost/mattermost-server/issues/20536

#### Screenshots
https://user-images.githubusercontent.com/79058848/199356814-2882ab5f-35ca-4c2f-88fa-21e415ad4fe5.mp4

#### Release Note
```release-note
NONE
```
