### PR TITLE
[MM-48046] upgrade react-popper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "react-intl": "5.20.10",
         "react-is": "16.13.1",
         "react-overlays": "0.9.3",
-        "react-popper": "2.2.5",
+        "react-popper": "2.3.0",
         "react-redux": "7.2.4",
         "react-router-dom": "5.3.3",
         "react-select": "2.4.4",
@@ -24391,16 +24391,17 @@
       }
     },
     "node_modules/react-popper": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
       "dependencies": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
       },
       "peerDependencies": {
         "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-popper/node_modules/warning": {
@@ -53055,9 +53056,9 @@
       }
     },
     "react-popper": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-intl": "5.20.10",
     "react-is": "16.13.1",
     "react-overlays": "0.9.3",
-    "react-popper": "2.2.5",
+    "react-popper": "2.3.0",
     "react-redux": "7.2.4",
     "react-router-dom": "5.3.3",
     "react-select": "2.4.4",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Upgrade react-popper to latest version as part of dependency upgrades. The library is used in the onboarding task list component. Apart from checking the changelog of the library (from 2.2.5 to 2.3.0 only support for React 18 has been added, no breaking changes), I checked manually and the onboarding task popover continues to work as previously.

| From version | To version | Changelog | Notes |
|-------------|---------|-----------|---------|
| 2.2.5 | 2.3.0 | [changelog](https://github.com/floating-ui/react-popper/releases) | Add support for React 18 |


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48046

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
