### PR TITLE
[MM-44353] Increase number of people that can be added to a group at once

### DIFF
--- a/components/add_user_to_group_multiselect/add_user_to_group_multiselect.tsx
+++ b/components/add_user_to_group_multiselect/add_user_to_group_multiselect.tsx
@@ -16,7 +16,7 @@ import Constants from 'utils/constants';
 import MultiSelectOption from './multiselect_option/multiselect_option';
 
 const USERS_PER_PAGE = 50;
-const MAX_SELECTABLE_VALUES = 30;
+const MAX_SELECTABLE_VALUES = 256;
 
 type UserProfileValue = Value & UserProfile;
 
@@ -62,6 +62,8 @@ type State = {
     values: UserProfileValue[];
     term: string;
     loadingUsers: boolean;
+    maxValues: number | undefined;
+    numRemainingText: string | null;
 }
 
 export default class AddUserToGroupMultiSelect extends React.PureComponent<Props, State> {
@@ -80,6 +82,8 @@ export default class AddUserToGroupMultiSelect extends React.PureComponent<Props
             values: [],
             term: '',
             loadingUsers: true,
+            maxValues: undefined,
+            numRemainingText: null,
         } as State;
 
         this.selectedItemRef = React.createRef<HTMLDivElement>();
@@ -96,6 +100,11 @@ export default class AddUserToGroupMultiSelect extends React.PureComponent<Props
         }
 
         this.setState({values});
+
+        if (values.length >= MAX_SELECTABLE_VALUES) {
+            this.setState({maxValues: MAX_SELECTABLE_VALUES});
+            this.setState({numRemainingText: localizeMessage('multiselect.maxGroupMembers', 'No more than 256 members can be added to a group at once.')});
+        }
     };
 
     public componentDidMount(): void {
@@ -218,7 +227,6 @@ export default class AddUserToGroupMultiSelect extends React.PureComponent<Props
                 handleDelete={this.handleDelete}
                 handleAdd={this.addValue}
                 handleSubmit={this.handleSubmit}
-                maxValues={MAX_SELECTABLE_VALUES}
                 buttonSubmitText={buttonSubmitText}
                 buttonSubmitLoadingText={buttonSubmitLoadingText}
                 saving={this.props.saving}
@@ -230,6 +238,8 @@ export default class AddUserToGroupMultiSelect extends React.PureComponent<Props
                 backButtonClick={this.props.backButtonClick}
                 backButtonClass={this.props.backButtonClass}
                 backButtonText={this.props.backButtonText}
+                maxValues={this.state.maxValues}
+                numRemainingText={this.state.numRemainingText}
             />
         );
     }


### PR DESCRIPTION
#### Summary
Remove the counter below the the multiselect and only surface it when they have added 256 users to it

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44353

#### Screenshot
![Screen Shot 2022-11-02 at 11 41 13 AM](https://user-images.githubusercontent.com/14115924/199534454-a0609837-a411-4db0-9a1b-cdf0a9ea78a8.png)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Increasing the number of people that can be added to a group at once to 256
```
