### PR TITLE
Mm 30941 system roles shows license and environment should be hidden in cloud

### DIFF
--- a/components/admin_console/system_roles/system_role/__snapshots__/system_role_permissions.test.tsx.snap
+++ b/components/admin_console/system_roles/system_role/__snapshots__/system_role_permissions.test.tsx.snap
@@ -406,31 +406,6 @@ exports[`admin_console/system_role_permissions should match snapshot with isLice
     className="SystemRolePermissions"
   >
     <SystemRolePermission
-      key="about"
-      permissionsMap={Object {}}
-      permissionsToUpdate={
-        Object {
-          "environment": "read",
-          "plugins": "write",
-          "site": "write",
-        }
-      }
-      section={
-        Object {
-          "hasDescription": true,
-          "name": "about",
-          "subsections": Array [
-            Object {
-              "name": "about_edition_and_license",
-            },
-          ],
-        }
-      }
-      setSectionVisible={[Function]}
-      updatePermissions={[MockFunction]}
-      visibleSections={Object {}}
-    />
-    <SystemRolePermission
       key="reporting"
       permissionsMap={Object {}}
       permissionsToUpdate={
@@ -495,67 +470,6 @@ exports[`admin_console/system_role_permissions should match snapshot with isLice
             Object {
               "disabled": true,
               "name": "user_management_system_roles",
-            },
-          ],
-        }
-      }
-      setSectionVisible={[Function]}
-      updatePermissions={[MockFunction]}
-      visibleSections={Object {}}
-    />
-    <SystemRolePermission
-      key="environment"
-      permissionsMap={Object {}}
-      permissionsToUpdate={
-        Object {
-          "environment": "read",
-          "plugins": "write",
-          "site": "write",
-        }
-      }
-      section={
-        Object {
-          "hasDescription": true,
-          "name": "environment",
-          "subsections": Array [
-            Object {
-              "name": "environment_web_server",
-            },
-            Object {
-              "name": "environment_database",
-            },
-            Object {
-              "name": "environment_elasticsearch",
-            },
-            Object {
-              "name": "environment_file_storage",
-            },
-            Object {
-              "name": "environment_image_proxy",
-            },
-            Object {
-              "name": "environment_smtp",
-            },
-            Object {
-              "name": "environment_push_notification_server",
-            },
-            Object {
-              "name": "environment_high_availability",
-            },
-            Object {
-              "name": "environment_rate_limiting",
-            },
-            Object {
-              "name": "environment_logging",
-            },
-            Object {
-              "name": "environment_session_lengths",
-            },
-            Object {
-              "name": "environment_performance_monitoring",
-            },
-            Object {
-              "name": "environment_developer",
             },
           ],
         }

--- a/components/admin_console/system_roles/system_role/system_role_permissions.test.tsx
+++ b/components/admin_console/system_roles/system_role/system_role_permissions.test.tsx
@@ -48,7 +48,7 @@ describe('admin_console/system_role_permissions', () => {
                 {...props}
             />);
 
-        const expectedLength = 10;
+        const expectedLength = 8;
         let systemRolePermissionLength = wrapper.find(SystemRolePermission).length;
         expect(systemRolePermissionLength).toEqual(expectedLength);
         wrapper.setProps({permissionToUpdate: {

--- a/components/admin_console/system_roles/system_role/system_role_permissions.tsx
+++ b/components/admin_console/system_roles/system_role/system_role_permissions.tsx
@@ -176,6 +176,13 @@ export default class SystemRolePermissions extends React.PureComponent<Props, St
         };
     }
 
+    removeSection = (name: string) => {
+        const sectionIndex = sectionsList.findIndex((section) => section.name === name);
+        if (sectionIndex > -1) {
+            sectionsList.splice(sectionIndex, 1);
+        }
+    }
+
     updatePermissions = (permissions: PermissionToUpdate[]) => {
         this.props.updatePermissions(permissions);
     }
@@ -227,10 +234,13 @@ export default class SystemRolePermissions extends React.PureComponent<Props, St
 
         if (!isLicensedForCloud) {
             // Remove the billing section if it's not licensed for cloud
-            const billingSectionIndex = sectionsList.findIndex((section) => section.name === 'billing');
-            if (billingSectionIndex > -1) {
-                sectionsList.splice(billingSectionIndex, 1);
-            }
+            this.removeSection('billing');
+        }
+
+        if (isLicensedForCloud) {
+            // Remove the site configuration section if it's licensed for cloud
+            this.removeSection('site');
+            this.removeSection('about');
         }
 
         return getSectionsListForRole(sectionsList, this.props.role.name, editedSectionsByRole).map((section: SystemSection) => {

--- a/components/admin_console/system_roles/system_role/system_role_permissions.tsx
+++ b/components/admin_console/system_roles/system_role/system_role_permissions.tsx
@@ -239,8 +239,8 @@ export default class SystemRolePermissions extends React.PureComponent<Props, St
 
         if (isLicensedForCloud) {
             // Remove the site configuration section if it's licensed for cloud
-            this.removeSection('site');
             this.removeSection('about');
+            this.removeSection('environment');
         }
 
         return getSectionsListForRole(sectionsList, this.props.role.name, editedSectionsByRole).map((section: SystemSection) => {


### PR DESCRIPTION
#### Summary
Within the console, under `User Management > System Roles`, there exists options to grant/remove access to License and Environment. These options should not be shown for cloud servers.

#### Ticket Link
[MM-30941](https://mattermost.atlassian.net/browse/MM-30941)

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="1186" alt="Screen Shot 2022-11-02 at 2 49 28 PM" src="https://user-images.githubusercontent.com/116016004/199576690-7b3d0e98-d7ba-41c2-9ef0-07cfbb1f405e.png"> | <img width="1186" alt="Screen Shot 2022-11-02 at 2 50 40 PM" src="https://user-images.githubusercontent.com/116016004/199576757-60e58e29-d939-4b60-be0f-ce2bd58b34eb.png"> |

#### Test Plan
1. Sign onto the server under a role that can access the `System Console`.
2. Upload any cloud license
3. Navigate to `User Management > System Roles`, and click edit on the `System Admin Role`
4. Ensure the `Privileges` list does not contain the `About` (Edition and License) and the `Environment` sections.

#### Release Note

```release-note
NONE
```
