### PR TITLE
MM-45471 - Reveal "File Sharing and Download" System Console settings in Cloud.

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2946,7 +2946,6 @@ const AdminDefinition = {
             title: t('admin.sidebar.fileSharingDownloads'),
             title_default: 'File Sharing and Downloads',
             isHidden: it.any(
-                it.configIsTrue('ExperimentalSettings', 'RestrictSystemAdmin'),
                 it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.SITE.FILE_SHARING_AND_DOWNLOADS)),
             ),
             schema: {


### PR DESCRIPTION
#### Summary

In March, we hid file sharing and download options in Cloud ([link to PR](https://github.com/mattermost/mattermost-webapp/pull/9953)), including the following settings:

- EnableFileAttachments
- EnableMobileUpload
- EnableMobileDownload

File sharing and Download options in Cloud **_should_** be available, so we must reveal them in the system console now.

**Note**: In the ticket, it's mentioned that we should `Fix mobile upload and download settings, so that they honoured in Cloud when set to 'true'`. This has already been completed, and the settings are honoured.

#### Ticket Link

[MM-45471](https://mattermost.atlassian.net/browse/MM-45471)

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="1186" alt="Screen Shot 2022-11-02 at 4 51 50 PM" src="https://user-images.githubusercontent.com/116016004/199602039-ad8a1ef7-868f-4e4d-87e0-84d8ce30e58d.png"> | <img width="1186" alt="Screen Shot 2022-11-02 at 5 02 26 PM" src="https://user-images.githubusercontent.com/116016004/199602086-2af7f464-ab27-484d-93bf-61a8cc0c8de4.png"> |


#### Test Plan

1. Ensure you have at least 2 users (1 admin and 1 user works best).
2. Log in as the admin user.
3. Go to the `System Console` and navigate to the `System Roles` section.
4. Click the `edit` option for the `System Manager Role`.
5. Find the `Site Configuration` section under this role and expand it.
6. Sign out of the admin account and log in as the user.
7. Ensure you can see the `File Sharing and Downloads` subsection under the `Site Configuration` in the left-side bar
8. Log out of the user account and log back into the admin account.
9. Find the `File Sharing and Downloads` subsection and update the permission to `No access`.
10. Add the user in the `Assigned People` section and save your changes.
11. Log out from the admin account and log into the user.
12. Ensure the `File Sharing and Downloads` section under `Site Configuration` is hidden.


 #### Release Note

```release-note
NONE
```
