### PR TITLE
Fix `make node_modules` when running in production mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ node_modules: package.json package-lock.json
 ifeq ($(CI),false)
 	npm install
 else
-	npm ci
+	# This runs in CI with NODE_ENV=production which doesn't install devDependencies without this flag
+	npm ci --include=dev
 endif
 
 	touch $@


### PR DESCRIPTION
This is another case where running `npm install` or `npm ci` with NODE_ENV=production doesn't install the dev dependencies which was causing the GitLab builds of the web app to fail

#### Ticket Link


#### Release Note
```release-note
NONE
```
