### PR TITLE
MM-47715 : Update "package/readme" to reflect new jest config file

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -68,38 +68,38 @@ To set up a new package:
 1. Add an entry to the `workspaces` section of the root `package.json` so that NPM is aware of your package.
 1. Set up import aliases so that the package is visible from the web app to the following tools:
     1. TypeScript - In the root `tsconfig.json`, add an entry to the `compilerOptions.paths` section pointing to the `src` folder and an entry to the `references` section pointing to the root of your package which should contain its own `tsconfig.json`.
+    
+        Note that the `compilerOptions.paths` entry will differ based on if your package exports just a single module (ie a single `index.js` file) or if it exports multiple submodules.
 
-    Note that the `compilerOptions.paths` entry will differ based on if your package exports just a single module (ie a single `index.js` file) or if it exports multiple submodules.
-
-    ```json
-    {
-        "compilerOptions": {
-            "paths": {
-                "@mattermost/apple": ["packages/apple/lib"], // import * as Apple from '@mattermost/apple';
-                "@mattermost/banana/*": ["packages/banana/lib/*"], // import Yellow from '@mattermost/banana/yellow';
-            }
-        },
-        "references": [
-            {"path": "./packages/apple"},
-            {"path": "./packages/banana"},
-        ]
-    }
-    ```
+        ```json
+            {
+                "compilerOptions": {
+                "paths": {
+                    "@mattermost/apple": ["packages/apple/lib"], // import * as Apple from '@mattermost/apple';
+                    "@mattermost/banana/*": ["packages/banana/lib/*"], // import Yellow from    '@mattermost/banana/yellow';
+                }
+            },
+            "references": [
+                {"path": "./packages/apple"},
+                {"path": "./packages/banana"},
+            ]
+        }
+        ```
 
     1. Jest - Add an entry to the `jest.moduleNameMapper` section of the root `package.json` for your package. Since that setting supports regexes, you can add these to the existing patterns used by the `client` and `types` packages.
+    
+        Similar to TypeScript, this will differ based on if the package exports a single module or multiple modules.
 
-    Similar to TypeScript, this will differ based on if the package exports a single module or multiple modules.
-
-    ```json
-    {
-        "jest": {
-            "moduleNameMapper": {
-                "^@mattermost/(apple|client)$": "<rootDir>/packages/$1/src",
-                "^@mattermost/(banana|types)/(.*)$": "<rootDir>/packages/$1/src/$2",
+        ```json
+        {
+            "jest": {
+                "moduleNameMapper": {
+                    "^@mattermost/(apple|client)$": "<rootDir>/packages/$1/src",
+                    "^@mattermost/(banana|types)/(.*)$": "<rootDir>/packages/$1/src/$2",
+                }
             }
         }
-    }
-    ```
+        ```
 1. Add the compiled code to the CircleCI dependency cache. This is done by modifying the `paths` used by the `save_cache` step in `.circleci/config.yml`
     ```yml
     aliases:

--- a/packages/README.md
+++ b/packages/README.md
@@ -67,13 +67,13 @@ To set up a new package:
 1. Ensure all source files are located in `src` and all compiled files are built to `lib`.
 1. Add an entry to the `workspaces` section of the root `package.json` so that NPM is aware of your package.
 1. Set up import aliases so that the package is visible from the web app to the following tools:
-    1. TypeScript - In the root `tsconfig.json`, add an entry to the `compilerOptions.paths` section pointing to the `src` folder and an entry to the `references` section pointing to the root of your package which should contain its own `tsconfig.json`.
+    1. **TypeScript** - In the root `tsconfig.json`, add an entry to the `compilerOptions.paths` section pointing to the `src` folder and an entry to the `references` section pointing to the root of your package which should contain its own `tsconfig.json`.
     
         Note that the `compilerOptions.paths` entry will differ based on if your package exports just a single module (ie a single `index.js` file) or if it exports multiple submodules.
 
-        ```json
-            {
-                "compilerOptions": {
+        ```json5
+        {
+            "compilerOptions": {
                 "paths": {
                     "@mattermost/apple": ["packages/apple/lib"], // import * as Apple from '@mattermost/apple';
                     "@mattermost/banana/*": ["packages/banana/lib/*"], // import Yellow from    '@mattermost/banana/yellow';
@@ -86,7 +86,7 @@ To set up a new package:
         }
         ```
 
-    1. Jest - Add an entry to the `jest.moduleNameMapper` section of the root `package.json` for your package. Since that setting supports regexes, you can add these to the existing patterns used by the `client` and `types` packages.
+    1. **Jest** - Add an entry to the `jest.moduleNameMapper` section of the root `jest.config.js` for your package. Since that setting supports regexes, you can add these to the existing patterns used by the `client` and `types` packages.
     
         Similar to TypeScript, this will differ based on if the package exports a single module or multiple modules.
 


### PR DESCRIPTION
#### Summary
With the recent change to isolate jest config into [its own file](https://github.com/mattermost/mattermost-webapp/pull/11372), this pr updates document references in package readme. It also fixes indents in few paragraphs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47715

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
