### PR TITLE
Downgrade languages to Alpha

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -354,7 +354,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 13,
-                  "text": "Български (Beta)",
+                  "text": "Български (Alpha)",
                   "value": "bg",
                 },
                 Object {
@@ -369,7 +369,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 16,
-                  "text": "فارسی (Beta)",
+                  "text": "فارسی (Alpha)",
                   "value": "fa",
                 },
                 Object {
@@ -379,7 +379,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 18,
-                  "text": "中文 (简体)",
+                  "text": "中文 (简体) (Alpha)",
                   "value": "zh-CN",
                 },
                 Object {
@@ -485,7 +485,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 13,
-                  "text": "Български (Beta)",
+                  "text": "Български (Alpha)",
                   "value": "bg",
                 },
                 Object {
@@ -500,7 +500,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 16,
-                  "text": "فارسی (Beta)",
+                  "text": "فارسی (Alpha)",
                   "value": "fa",
                 },
                 Object {
@@ -510,7 +510,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 },
                 Object {
                   "order": 18,
-                  "text": "中文 (简体)",
+                  "text": "中文 (简体) (Alpha)",
                   "value": "zh-CN",
                 },
                 Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -109,7 +109,7 @@ const languages = {
     },
     bg: {
         value: 'bg',
-        name: 'Български (Beta)',
+        name: 'Български (Alpha)',
         order: 13,
         url: bg,
     },
@@ -127,7 +127,7 @@ const languages = {
     },
     fa: {
         value: 'fa',
-        name: 'فارسی (Beta)',
+        name: 'فارسی (Alpha)',
         order: 16,
         url: fa,
     },
@@ -139,7 +139,7 @@ const languages = {
     },
     'zh-CN': {
         value: 'zh-CN',
-        name: '中文 (简体)',
+        name: '中文 (简体) (Alpha)',
         order: 18,
         url: zhCN,
     },


### PR DESCRIPTION
#### Summary
Bulgarian, Persian, and Simplified Chinese product translations haven't been actively maintained, and with this reduction in translation quality, these languages are being downgraded to Alpha.

#### Release Note
```release-note
Downgraded Bulgarian, Persian, and Simplified Chinese language support to Alpha.
```
