### PR TITLE
[MM-48317] Wait for subscription to be loaded in cloud purchase modal

### DIFF
--- a/components/common/hocs/cloud/with_get_cloud_subscription.tsx
+++ b/components/common/hocs/cloud/with_get_cloud_subscription.tsx
@@ -1,25 +1,41 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, { ComponentType } from "react";
+import React, {ComponentType} from 'react';
 
-import {Subscription} from "@mattermost/types/cloud";
-import useGetSubscription from "components/common/hooks/useGetSubscription";
+import {isEmpty} from 'lodash';
 
+import {Subscription} from '@mattermost/types/cloud';
+
+interface Actions {
+    getCloudSubscription?: () => void;
+}
 
 interface UsedHocProps {
     subscription?: Subscription;
     isCloud: boolean;
+    actions: Actions;
     userIsAdmin?: boolean;
 }
 
-function withGetCloudSubscription<P>(Component: ComponentType<P>) {
-    return function WrappedComponent(props: P & UsedHocProps) {
-        const subscription = useGetSubscription();
-        if (!subscription) {
-            return null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function withGetCloudSubscription<P>(WrappedComponent: ComponentType<P>): ComponentType<any> {
+    return class extends React.Component<P & UsedHocProps> {
+        async componentDidMount() {
+            // if not is cloud, not even try to destructure values from props, just return
+            if (!this.props.isCloud) {
+                return;
+            }
+            const {subscription, actions, userIsAdmin} = this.props;
+
+            if (isEmpty(subscription) && userIsAdmin && actions?.getCloudSubscription) {
+                await actions.getCloudSubscription();
+            }
         }
-        return <Component {...props} />;
+
+        render(): JSX.Element {
+            return <WrappedComponent {...this.props}/>;
+        }
     };
 }
 

--- a/components/common/hocs/cloud/with_get_cloud_subscription.tsx
+++ b/components/common/hocs/cloud/with_get_cloud_subscription.tsx
@@ -1,41 +1,25 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {ComponentType} from 'react';
+import React, { ComponentType } from "react";
 
-import {isEmpty} from 'lodash';
+import {Subscription} from "@mattermost/types/cloud";
+import useGetSubscription from "components/common/hooks/useGetSubscription";
 
-import {Subscription} from '@mattermost/types/cloud';
-
-interface Actions {
-    getCloudSubscription?: () => void;
-}
 
 interface UsedHocProps {
     subscription?: Subscription;
     isCloud: boolean;
-    actions: Actions;
     userIsAdmin?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function withGetCloudSubscription<P>(WrappedComponent: ComponentType<P>): ComponentType<any> {
-    return class extends React.Component<P & UsedHocProps> {
-        async componentDidMount() {
-            // if not is cloud, not even try to destructure values from props, just return
-            if (!this.props.isCloud) {
-                return;
-            }
-            const {subscription, actions, userIsAdmin} = this.props;
-
-            if (isEmpty(subscription) && userIsAdmin && actions?.getCloudSubscription) {
-                await actions.getCloudSubscription();
-            }
+function withGetCloudSubscription<P>(Component: ComponentType<P>) {
+    return function WrappedComponent(props: P & UsedHocProps) {
+        const subscription = useGetSubscription();
+        if (!subscription) {
+            return null;
         }
-
-        render(): JSX.Element {
-            return <WrappedComponent {...this.props}/>;
-        }
+        return <Component {...props} />;
     };
 }
 

--- a/components/purchase_modal/index.ts
+++ b/components/purchase_modal/index.ts
@@ -26,6 +26,7 @@ import {ModalIdentifiers} from 'utils/constants';
 import {closeModal, openModal} from 'actions/views/modals';
 import {completeStripeAddPaymentMethod, subscribeCloudSubscription} from 'actions/cloud';
 import {ModalData} from 'types/actions';
+import withGetCloudSubscription from 'components/common/hocs/cloud/with_get_cloud_subscription';
 
 const PurchaseModal = makeAsyncComponent('PurchaseModal', React.lazy(() => import('./purchase_modal')));
 
@@ -79,4 +80,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PurchaseModal);
+export default connect(mapStateToProps, mapDispatchToProps)(withGetCloudSubscription(PurchaseModal));

--- a/components/purchase_modal/index.ts
+++ b/components/purchase_modal/index.ts
@@ -80,4 +80,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withGetCloudSubscription(PurchaseModal));
+export default withGetCloudSubscription(connect(mapStateToProps, mapDispatchToProps)(PurchaseModal));


### PR DESCRIPTION
#### Summary
When opening the purchase modal there is a potential for a race - [if the subscription hasn't yet loaded, the purchase modal will return the first product as the selected product](https://github.com/mattermost/mattermost-webapp/blob/master/components/purchase_modal/purchase_modal.tsx#L148)

In all environments, this product is Cloud Enterprise. 

This PR wraps the Purchase Modal component with the `withGetCloudSubscription` HOC. I also refactored the `withGetCloudSubscription` HOC to leverage the `useGetSubscription` hook, since that's more up to date. 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48317

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
