### PR TITLE
Fixes duplicated threads in thread list

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/threads/threads.test.js
+++ b/packages/mattermost-redux/src/reducers/entities/threads/threads.test.js
@@ -457,6 +457,14 @@ describe('threads', () => {
                 b: ['t4', 't5', 't6'],
             },
             threads: {
+                t0: {
+                    id: 't0',
+                    unread_replies: 0,
+                    unread_mentions: 0,
+                    post: {
+                        channel_id: 'ch1',
+                    },
+                },
                 t1: {
                     id: 't1',
                     unread_replies: 1,
@@ -508,7 +516,7 @@ describe('threads', () => {
             },
             counts: {
                 a: {
-                    total: 3,
+                    total: 4,
                     total_unread_threads: 3,
                     total_unread_mentions: 2,
                 },
@@ -520,7 +528,7 @@ describe('threads', () => {
             },
             countsIncludingDirect: {
                 a: {
-                    total: 3,
+                    total: 4,
                     total_unread_threads: 3,
                     total_unread_mentions: 2,
                 },

--- a/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
+++ b/packages/mattermost-redux/src/reducers/entities/threads/threadsInTeam.ts
@@ -166,8 +166,10 @@ function handleLeaveChannel(state: State, action: GenericAction, extra: ExtraDat
     for (const thread of extra.threadsToDelete) {
         if (nextState[teamId]) {
             const index = nextState[teamId].indexOf(thread.id);
-            nextState[teamId] = [...nextState[teamId].slice(0, index), ...nextState[teamId].slice(index + 1)];
-            threadDeleted = true;
+            if (index !== -1) {
+                nextState[teamId] = [...nextState[teamId].slice(0, index), ...nextState[teamId].slice(index + 1)];
+                threadDeleted = true;
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary

Upon leaving a channel we collect all threads that belong to that channel and then we remove them from the `threadsInTeam` lists. BUT if a thread is in `threads`, but not in `threadsInTeam` then it will duplicate the list.
This is happening because we didn't check thread's index against -1. So the slice would be 
```js
// list1 == [1,2,3,4]
list2 = [...list.slice(0, -1), ...list.slice(1 - 1)]
// list2 == [1,2,3,1,2,3,4]
// after sorting [1,1,2,2,3,3,4]
```

This commit fixes that issue by checking each thread's index in `threadsInTeam` list, and if it doesn't exist it does nothing.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48348

#### Release Note

```release-note
Fixed a bug where threads would appear duplicated in the threads list after leaving channels.
```
