### PR TITLE
Remove the play/check icon in onboarding task list

### DIFF
--- a/components/onboarding_tasklist/onboarding_tasklist_task.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist_task.tsx
@@ -3,7 +3,6 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import Icon from '@mattermost/compass-components/foundations/icon/Icon';
 
 import {CompletedAnimation} from './onboarding_tasklist_animations';
 

--- a/components/onboarding_tasklist/onboarding_tasklist_task.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist_task.tsx
@@ -69,11 +69,6 @@ export const Task = (props: TaskProps): JSX.Element => {
             onClick={handleOnClick}
         >
             {completedStatus && <CompletedAnimation completed={completedStatus}/>}
-            <Icon
-                className={completedStatus ? 'play completed' : 'play'}
-                glyph={completedStatus ? 'check' : 'play'}
-                size={16}
-            />
             <span>{label}</span>
         </StyledTask>
     );


### PR DESCRIPTION
#### Summary

With the intro of emojis in the tasklist, we want to remove the play/check icon so it's not so cluttered at the start. This is a request from UX. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48361

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
|  <img width="381" alt="Screen Shot 2022-11-11 at 12 10 50 PM" src="https://user-images.githubusercontent.com/936315/201397278-22ccf82d-55ec-4eae-8da0-0194ccc648eb.png"> | <img width="362" alt="Screen Shot 2022-11-11 at 12 35 32 PM" src="https://user-images.githubusercontent.com/936315/201397302-ce2be287-f9be-428a-a89f-8a80cb6baca3.png">|


-->

|  before  |  after  |
|----|----|
|  <img width="381" alt="Screen Shot 2022-11-11 at 12 10 50 PM" src="https://user-images.githubusercontent.com/936315/201397278-22ccf82d-55ec-4eae-8da0-0194ccc648eb.png"> | <img width="362" alt="Screen Shot 2022-11-11 at 12 35 32 PM" src="https://user-images.githubusercontent.com/936315/201397302-ce2be287-f9be-428a-a89f-8a80cb6baca3.png">|

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
