### PR TITLE
[MM-47606]: Blank message in threads if send leave/join message preference is off

### DIFF
--- a/components/threading/global_threads/thread_pane/thread_pane.test.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.test.tsx
@@ -4,16 +4,13 @@
 import React, {ComponentProps} from 'react';
 
 import {shallow} from 'enzyme';
-
 import {setThreadFollow} from 'mattermost-redux/actions/threads';
+import TestHelper from 'packages/mattermost-redux/test/test_helper';
 jest.mock('mattermost-redux/actions/threads');
-
 import Header from 'components/widgets/header';
-
 import FollowButton from 'components/threading/common/follow_button';
 import Button from 'components/threading/common/button';
 
-import TestHelper from '../../../../packages/mattermost-redux/test/test_helper';
 import {UserProfile} from '@mattermost/types/users';
 
 import ThreadPane from './thread_pane';

--- a/components/threading/global_threads/thread_pane/thread_pane.test.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.test.tsx
@@ -13,6 +13,9 @@ import Header from 'components/widgets/header';
 import FollowButton from 'components/threading/common/follow_button';
 import Button from 'components/threading/common/button';
 
+import TestHelper from '../../../../packages/mattermost-redux/test/test_helper';
+import {UserProfile} from '@mattermost/types/users';
+
 import ThreadPane from './thread_pane';
 
 const mockRouting = {
@@ -56,6 +59,10 @@ describe('components/threading/global_threads/thread_pane', () => {
             thread: mockThread,
         };
 
+        const user1 = TestHelper.fakeUserWithId('uid');
+        const profiles: Record<string, UserProfile> = {};
+        profiles[user1.id] = user1;
+
         mockState = {
             entities: {
                 general: {
@@ -85,6 +92,7 @@ describe('components/threading/global_threads/thread_pane', () => {
                     },
                 },
                 users: {
+                    profiles,
                     currentUserId: 'uid',
                 },
             },

--- a/components/threading/global_threads/thread_pane/thread_pane.test.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.test.tsx
@@ -4,6 +4,7 @@
 import React, {ComponentProps} from 'react';
 
 import {shallow} from 'enzyme';
+
 import {setThreadFollow} from 'mattermost-redux/actions/threads';
 import TestHelper from 'packages/mattermost-redux/test/test_helper';
 jest.mock('mattermost-redux/actions/threads');

--- a/packages/mattermost-redux/src/selectors/entities/posts.test.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.test.ts
@@ -2492,6 +2492,9 @@ describe('makeGetProfilesForThread', () => {
                     },
                     currentUserId: 'user1',
                 },
+                preferences: {
+                    myPreferences: {},
+                },
             },
         } as unknown as GlobalState;
 
@@ -2517,6 +2520,9 @@ describe('makeGetProfilesForThread', () => {
                         user2,
                     },
                     currentUserId: 'user2',
+                },
+                preferences: {
+                    myPreferences: {},
                 },
             },
         } as unknown as GlobalState;

--- a/packages/mattermost-redux/src/selectors/entities/posts.test.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.test.ts
@@ -2,18 +2,21 @@
 // See LICENSE.txt for license information.
 
 import {PostWithFormatData} from 'mattermost-redux/selectors/entities/posts';
-import {Post} from '@mattermost/types/posts';
-import {Reaction} from '@mattermost/types/reactions';
-import {GlobalState} from '@mattermost/types/store';
 
 import {Posts, Preferences} from 'mattermost-redux/constants';
 
 import * as Selectors from 'mattermost-redux/selectors/entities/posts';
+
 import {makeGetProfilesForReactions} from 'mattermost-redux/selectors/entities/users';
+
+import deepFreezeAndThrowOnMutation from 'mattermost-redux/utils/deep_freeze';
+
+import {Post} from '@mattermost/types/posts';
+import {Reaction} from '@mattermost/types/reactions';
+import {GlobalState} from '@mattermost/types/store';
 
 import TestHelper from '../../../test/test_helper';
 
-import deepFreezeAndThrowOnMutation from 'mattermost-redux/utils/deep_freeze';
 import {UserProfile} from '@mattermost/types/users';
 
 const p = (override: Partial<PostWithFormatData>) => Object.assign(TestHelper.getPostMock(override), override);
@@ -790,11 +793,22 @@ describe('Selectors.Posts', () => {
     });
 
     describe('getPostIdsForThread', () => {
+        const user1 = TestHelper.fakeUserWithId();
+        const profiles: Record<string, UserProfile> = {};
+        profiles[user1.id] = user1;
+
         it('single post', () => {
             const getPostIdsForThread = Selectors.makeGetPostIdsForThread();
 
             const state = {
                 entities: {
+                    users: {
+                        currentUserId: user1.id,
+                        profiles,
+                    },
+                    preferences: {
+                        myPreferences: {},
+                    },
                     posts: {
                         posts: {
                             1001: {id: '1001', create_at: 1001},
@@ -819,6 +833,13 @@ describe('Selectors.Posts', () => {
 
             const state = {
                 entities: {
+                    users: {
+                        currentUserId: user1.id,
+                        profiles,
+                    },
+                    preferences: {
+                        myPreferences: {},
+                    },
                     posts: {
                         posts: {
                             1001: {id: '1001', create_at: 1001},
@@ -843,6 +864,13 @@ describe('Selectors.Posts', () => {
 
             let state = {
                 entities: {
+                    users: {
+                        currentUserId: user1.id,
+                        profiles,
+                    },
+                    preferences: {
+                        myPreferences: {},
+                    },
                     posts: {
                         posts: {
                             1001: {id: '1001', create_at: 1001},
@@ -955,6 +983,13 @@ describe('Selectors.Posts', () => {
 
             const state = {
                 entities: {
+                    users: {
+                        currentUserId: user1.id,
+                        profiles,
+                    },
+                    preferences: {
+                        myPreferences: {},
+                    },
                     posts: {
                         posts: {
                             1001: {id: '1001', create_at: 1001},

--- a/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -358,9 +358,8 @@ export function makeGetPostsForThread(): (state: GlobalState, rootId: string) =>
         getCurrentUser,
         (state: GlobalState, rootId: string) => state.entities.posts.postsInThread[rootId],
         (state: GlobalState, rootId: string) => state.entities.posts.posts[rootId],
-        getMyPreferences,
         shouldShowJoinLeaveMessages,
-        (posts, currentUser, postsForThread, rootPost, myPreferences, showJoinLeave) => {
+        (posts, currentUser, postsForThread, rootPost, showJoinLeave) => {
             const thread: Post[] = [];
 
             if (rootPost) {

--- a/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -10,6 +10,19 @@ import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences'
 import {getUsers, getCurrentUserId, getUserStatuses} from 'mattermost-redux/selectors/entities/users';
 import {getConfig, getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
 
+import {createIdsSelector} from 'mattermost-redux/utils/helpers';
+
+import {
+    isPostEphemeral,
+    isSystemMessage,
+    shouldFilterJoinLeavePost,
+    comparePosts,
+    isPostPendingOrFailed,
+    isPostCommentMention,
+} from 'mattermost-redux/utils/post_utils';
+
+import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
+
 import {Channel} from '@mattermost/types/channels';
 import {
     MessageHistory,
@@ -25,17 +38,6 @@ import {
     RelationOneToOne,
     RelationOneToMany,
 } from '@mattermost/types/utilities';
-
-import {createIdsSelector} from 'mattermost-redux/utils/helpers';
-import {
-    isPostEphemeral,
-    isSystemMessage,
-    shouldFilterJoinLeavePost,
-    comparePosts,
-    isPostPendingOrFailed,
-    isPostCommentMention,
-} from 'mattermost-redux/utils/post_utils';
-import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
 export function getAllPosts(state: GlobalState) {
     return state.entities.posts.posts;
@@ -351,19 +353,26 @@ export function makeGetPostsForThread(): (state: GlobalState, rootId: string) =>
     return createIdsSelector(
         'makeGetPostsForThread',
         getAllPosts,
+        getCurrentUser,
         (state: GlobalState, rootId: string) => state.entities.posts.postsInThread[rootId],
         (state: GlobalState, rootId: string) => state.entities.posts.posts[rootId],
-        (posts, postsForThread, rootPost) => {
+        getMyPreferences,
+        (posts, currentUser, postsForThread, rootPost, myPreferences) => {
             const thread: Post[] = [];
 
             if (rootPost) {
                 thread.push(rootPost);
             }
 
+            const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE)];
+            const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
+
             postsForThread?.forEach((id) => {
                 const post = posts[id];
 
-                if (post) {
+                const skip = shouldFilterJoinLeavePost(post, showJoinLeave, currentUser ? currentUser.username : '');
+
+                if (post && !skip) {
                     thread.push(post);
                 }
             });

--- a/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -23,6 +23,8 @@ import {
 
 import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
 
+import {shouldShowJoinLeaveMessages} from 'mattermost-redux/utils/post_list';
+
 import {Channel} from '@mattermost/types/channels';
 import {
     MessageHistory,
@@ -357,15 +359,13 @@ export function makeGetPostsForThread(): (state: GlobalState, rootId: string) =>
         (state: GlobalState, rootId: string) => state.entities.posts.postsInThread[rootId],
         (state: GlobalState, rootId: string) => state.entities.posts.posts[rootId],
         getMyPreferences,
-        (posts, currentUser, postsForThread, rootPost, myPreferences) => {
+        shouldShowJoinLeaveMessages,
+        (posts, currentUser, postsForThread, rootPost, myPreferences, showJoinLeave) => {
             const thread: Post[] = [];
 
             if (rootPost) {
                 thread.push(rootPost);
             }
-
-            const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE)];
-            const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
             postsForThread?.forEach((id) => {
                 const post = posts[id];

--- a/packages/mattermost-redux/src/utils/post_list.ts
+++ b/packages/mattermost-redux/src/utils/post_list.ts
@@ -25,7 +25,7 @@ export const DATE_LINE = 'date-';
 export const START_OF_NEW_MESSAGES = 'start-of-new-messages';
 export const MAX_COMBINED_SYSTEM_POSTS = 100;
 
-function shouldShowJoinLeaveMessages(state: GlobalState) {
+export function shouldShowJoinLeaveMessages(state: GlobalState) {
     // This setting is true or not set if join/leave messages are to be displayed
     return getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true);
 }


### PR DESCRIPTION
#### Summary
Blank message in threads if send leave/join message preference is off.

#### Ticket Link
Fixes https://mattermost.atlassian.net/jira/software/c/projects/MM/boards/91?modal=detail&selectedIssue=MM-47606

#### Related Pull Requests
NA

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="477" alt="image-20221014-195045" src="https://user-images.githubusercontent.com/16203333/201605637-3f663fac-f6c9-4e99-9a79-03f2d8bc3c50.png"> | <img width="501" alt="Screenshot 2022-11-14 at 1 27 44 PM" src="https://user-images.githubusercontent.com/16203333/201605693-0fb544d6-6a4a-429f-a5aa-f19a4deb34bc.png">

#### Release Note
```release-note
* Blank message in threads if send leave/join message preference is off
```
