### PR TITLE
Fix docs link to advanced permissions

### DIFF
--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
@@ -622,7 +622,7 @@ export default class PermissionTeamSchemeSettings extends React.PureComponent<Pr
                                             ),
                                             linkSystemScheme: (msg: React.ReactNode) => (
                                                 <a
-                                                    href='https://docs.mattermost.com/onboard/advanced-permissions.htm'
+                                                    href='https://docs.mattermost.com/onboard/advanced-permissions.html'
                                                     target='_blank'
                                                     rel='noreferrer'
                                                 >

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.tsx
@@ -622,7 +622,7 @@ export default class PermissionTeamSchemeSettings extends React.PureComponent<Pr
                                             ),
                                             linkSystemScheme: (msg: React.ReactNode) => (
                                                 <a
-                                                    href='https://docs.mattermost.com/onboard/advanced-permissions.html'
+                                                    href='https://mattermost.com/pl/advanced-permissions/'
                                                     target='_blank'
                                                     rel='noreferrer'
                                                 >


### PR DESCRIPTION
#### Summary
The link to `System Scheme` in the team scheme system console page was broken:
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/1023171/201744093-ab97a062-2e1e-478b-96e4-c2be9674b6bd.png">

It was linking to `https://docs.mattermost.com/onboard/advanced-permissions.htm` instead of `https://docs.mattermost.com/onboard/advanced-permissions.html`. This fixes it, but perhaps we also want to find a way to permalink the "broken link" for existing systems? 0/5

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
