### PR TITLE
[MM-42357] Change mention search to use new mention parameter

### DIFF
--- a/actions/views/rhs.test.ts
+++ b/actions/views/rhs.test.ts
@@ -226,14 +226,13 @@ describe('rhs view actions', () => {
             const timeZoneOffset = getBrowserUtcOffset() * 60;
 
             const compareStore = mockStore(initialState);
-            compareStore.dispatch(SearchActions.searchPostsWithParams(currentTeamId, {include_deleted_channels: false, terms, is_or_search: false, time_zone_offset: timeZoneOffset, page: 0, per_page: 20}));
-            compareStore.dispatch(SearchActions.searchFilesWithParams(currentTeamId, {include_deleted_channels: false, terms, is_or_search: false, time_zone_offset: timeZoneOffset, page: 0, per_page: 20}));
+            compareStore.dispatch(SearchActions.searchPostsWithParams(currentTeamId, {include_deleted_channels: false, terms, is_or_search: false, time_zone_offset: timeZoneOffset, page: 0, per_page: 20, has_user_mention: false}));
+            compareStore.dispatch(SearchActions.searchFilesWithParams(currentTeamId, {include_deleted_channels: false, terms, is_or_search: false, time_zone_offset: timeZoneOffset, page: 0, per_page: 20, has_user_mention: false}));
 
             expect(store.getActions()).toEqual(compareStore.getActions());
 
             store.dispatch(performSearch(terms, true));
-            compareStore.dispatch(SearchActions.searchPostsWithParams('', {include_deleted_channels: false, terms, is_or_search: true, time_zone_offset: timeZoneOffset, page: 0, per_page: 20}));
-            compareStore.dispatch(SearchActions.searchFilesWithParams(currentTeamId, {include_deleted_channels: false, terms, is_or_search: true, time_zone_offset: timeZoneOffset, page: 0, per_page: 20}));
+            compareStore.dispatch(SearchActions.searchPostsWithParams(currentTeamId, {include_deleted_channels: false, terms, is_or_search: true, time_zone_offset: timeZoneOffset, page: 0, per_page: 20, has_user_mention: true}));
 
             expect(store.getActions()).toEqual(compareStore.getActions());
         });
@@ -426,11 +425,11 @@ describe('rhs view actions', () => {
 
             const compareStore = mockStore(initialState);
 
-            compareStore.dispatch(performSearch('@mattermost ', true));
+            compareStore.dispatch(performSearch('', true));
             compareStore.dispatch(batchActions([
                 {
                     type: ActionTypes.UPDATE_RHS_SEARCH_TERMS,
-                    terms: '@mattermost ',
+                    terms: '',
                 },
                 {
                     type: ActionTypes.UPDATE_RHS_STATE,
@@ -702,11 +701,11 @@ describe('rhs view actions', () => {
             store.dispatch(openAtPrevious({isMentionSearch: true}));
             const compareStore = mockStore(initialState);
 
-            compareStore.dispatch(performSearch('@mattermost ', true));
+            compareStore.dispatch(performSearch('', true));
             compareStore.dispatch(batchActions([
                 {
                     type: ActionTypes.UPDATE_RHS_SEARCH_TERMS,
-                    terms: '@mattermost ',
+                    terms: '',
                 },
                 {
                     type: ActionTypes.UPDATE_RHS_STATE,

--- a/components/search_results/search_results.tsx
+++ b/components/search_results/search_results.tsx
@@ -107,7 +107,9 @@ const SearchResults: React.FC<Props> = (props: Props): JSX.Element => {
         if (props.searchPage === 0 && !props.isChannelFiles && !props.isSearchingTerm) {
             setTimeout(() => {
                 props.getMorePostsForSearch();
-                props.getMoreFilesForSearch();
+                if (!props.isMentionSearch) {
+                    props.getMoreFilesForSearch();
+                }
             }, 100);
         }
     }, [props.searchPage, props.searchTerms, props.isSearchingTerm]);

--- a/components/sidebar_right/index.ts
+++ b/components/sidebar_right/index.ts
@@ -51,6 +51,7 @@ function mapStateToProps(state: GlobalState, props: RouteComponentProps) {
         isChannelInfo: rhsState === RHSStates.CHANNEL_INFO,
         isChannelMembers: rhsState === RHSStates.CHANNEL_MEMBERS,
         isPluginView: rhsState === RHSStates.PLUGIN,
+        isMentionSearch: rhsState === RHSStates.MENTION,
         rhsChannel: getSelectedChannel(state),
         selectedPostId,
         selectedPostCardId,

--- a/components/sidebar_right/sidebar_right.tsx
+++ b/components/sidebar_right/sidebar_right.tsx
@@ -37,6 +37,7 @@ type Props = {
     isChannelInfo: boolean;
     isChannelMembers: boolean;
     isPluginView: boolean;
+    isMentionSearch: boolean;
     previousRhsState: RhsState;
     rhsChannel: Channel;
     selectedPostId: string;
@@ -82,6 +83,7 @@ export default class SidebarRight extends React.PureComponent<Props, State> {
             isChannelFiles: this.props.isChannelFiles,
             isChannelInfo: this.props.isChannelInfo,
             isChannelMembers: this.props.isChannelMembers,
+            isMentionSearch: this.props.isMentionSearch,
             selectedPostId: this.props.selectedPostId,
             selectedPostCardId: this.props.selectedPostCardId,
             previousRhsState: this.props.previousRhsState,

--- a/packages/mattermost-redux/src/actions/search.ts
+++ b/packages/mattermost-redux/src/actions/search.ts
@@ -80,7 +80,7 @@ export function searchPostsWithParams(teamId: string, params: SearchParameter): 
         let posts;
 
         try {
-            posts = await Client4.searchPostsWithParams(teamId, params);
+            posts = await Client4.searchPostsWithParams(params.has_user_mention ? '' : teamId, params);
 
             const profilesAndStatuses = getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
             const missingChannels = dispatch(getMissingChannelsFromPosts(posts.posts));
@@ -117,7 +117,7 @@ export function searchPostsWithParams(teamId: string, params: SearchParameter): 
 }
 
 export function searchPosts(teamId: string, terms: string, isOrSearch: boolean, includeDeletedChannels: boolean) {
-    return searchPostsWithParams(teamId, {terms, is_or_search: isOrSearch, include_deleted_channels: includeDeletedChannels, page: 0, per_page: WEBAPP_SEARCH_PER_PAGE});
+    return searchPostsWithParams(teamId, {terms, is_or_search: isOrSearch, include_deleted_channels: includeDeletedChannels, page: 0, per_page: WEBAPP_SEARCH_PER_PAGE, has_user_mention: false});
 }
 
 export function getMorePostsForSearch(): ActionFunc {
@@ -186,7 +186,7 @@ export function searchFilesWithParams(teamId: string, params: SearchParameter): 
 }
 
 export function searchFiles(teamId: string, terms: string, isOrSearch: boolean, includeDeletedChannels: boolean) {
-    return searchFilesWithParams(teamId, {terms, is_or_search: isOrSearch, include_deleted_channels: includeDeletedChannels, page: 0, per_page: WEBAPP_SEARCH_PER_PAGE});
+    return searchFilesWithParams(teamId, {terms, is_or_search: isOrSearch, include_deleted_channels: includeDeletedChannels, page: 0, per_page: WEBAPP_SEARCH_PER_PAGE, has_user_mention: false});
 }
 
 export function getMoreFilesForSearch(): ActionFunc {

--- a/packages/types/src/search.ts
+++ b/packages/types/src/search.ts
@@ -30,4 +30,5 @@ export type SearchParameter = {
     page: number;
     per_page: number;
     include_deleted_channels: boolean;
+    has_user_mention: boolean;
 }


### PR DESCRIPTION
#### Summary

Changes the mention search to use the new `has_user_mention` parameter. This allows group mentions to appear in the recent mentions panel. It currently won't work until the corresponding server PR is merged. 



#### Ticket Link

[Jira ticket](https://mattermost.atlassian.net/browse/MM-42357)

#### Related Pull Requests

- Has server changes: https://github.com/mattermost/mattermost-server/pull/21659


#### Release Note

```release-note
Added group mentions to the recent mentions.
```
