### PR TITLE
MM-47561 : fix icons alignment in global threads

### DIFF
--- a/components/threading/common/button/button.scss
+++ b/components/threading/common/button/button.scss
@@ -100,12 +100,10 @@
     .Button_label {
         display: inline-block;
         max-width: 100%;
-    }
 
-    .Button_label_margin_extra {
-        display: inline-block;
-        max-width: 100%;
-        margin-top: 4px;
+        &.margin_extra {
+            margin-top: 4px;
+        }
     }
 
     .Button_prepended {

--- a/components/threading/common/button/button.scss
+++ b/components/threading/common/button/button.scss
@@ -102,6 +102,12 @@
         max-width: 100%;
     }
 
+    .Button_label_margin_extra {
+        display: inline-block;
+        max-width: 100%;
+        margin-top: 4px;
+    }
+
     .Button_prepended {
         margin-right: 0.5em;
     }

--- a/components/threading/common/button/button.scss
+++ b/components/threading/common/button/button.scss
@@ -101,7 +101,7 @@
         display: inline-block;
         max-width: 100%;
 
-        &.margin_extra {
+        &.margin_top {
             margin-top: 4px;
         }
     }

--- a/components/threading/common/button/button.tsx
+++ b/components/threading/common/button/button.tsx
@@ -37,7 +37,7 @@ function Button({
                     {prepend}
                 </span>
             )}
-            <span className={marginExtra ? 'Button_label_margin_extra' : 'Button_label'}>
+            <span className={classNames('Button_label', {margin_extra: marginExtra})}>
                 {children}
                 {hasDot && <span className='dot'/>}
             </span>

--- a/components/threading/common/button/button.tsx
+++ b/components/threading/common/button/button.tsx
@@ -12,6 +12,7 @@ type Props = {
     isActive?: boolean;
     hasDot?: boolean;
     allowTextOverflow?: boolean;
+    marginExtra?: boolean;
 }
 
 type Attrs = Exclude<ButtonHTMLAttributes<HTMLButtonElement>, Props>
@@ -22,6 +23,7 @@ function Button({
     children,
     isActive,
     hasDot,
+    marginExtra,
     allowTextOverflow = false,
     ...attrs
 }: Props & Attrs) {
@@ -35,7 +37,7 @@ function Button({
                     {prepend}
                 </span>
             )}
-            <span className='Button_label'>
+            <span className={marginExtra ? 'Button_label_margin_extra' : 'Button_label'}>
                 {children}
                 {hasDot && <span className='dot'/>}
             </span>

--- a/components/threading/common/button/button.tsx
+++ b/components/threading/common/button/button.tsx
@@ -12,7 +12,7 @@ type Props = {
     isActive?: boolean;
     hasDot?: boolean;
     allowTextOverflow?: boolean;
-    marginExtra?: boolean;
+    marginTop?: boolean;
 }
 
 type Attrs = Exclude<ButtonHTMLAttributes<HTMLButtonElement>, Props>
@@ -23,7 +23,7 @@ function Button({
     children,
     isActive,
     hasDot,
-    marginExtra,
+    marginTop,
     allowTextOverflow = false,
     ...attrs
 }: Props & Attrs) {
@@ -37,7 +37,7 @@ function Button({
                     {prepend}
                 </span>
             )}
-            <span className={classNames('Button_label', {margin_extra: marginExtra})}>
+            <span className={classNames('Button_label', {margin_top: marginTop})}>
                 {children}
                 {hasDot && <span className='dot'/>}
             </span>

--- a/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
+++ b/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
@@ -52,9 +52,10 @@ exports[`components/threading/global_threads/thread_item should report total num
       >
         <Memo(Button)
           className="Button___icon"
+          marginExtra={true}
         >
-          <i
-            className="icon icon-dots-vertical"
+          <DotsVerticalIcon
+            size={18}
           />
         </Memo(Button)>
       </SimpleTooltip>
@@ -171,9 +172,10 @@ exports[`components/threading/global_threads/thread_item should report unread me
       >
         <Memo(Button)
           className="Button___icon"
+          marginExtra={true}
         >
-          <i
-            className="icon icon-dots-vertical"
+          <DotsVerticalIcon
+            size={18}
           />
         </Memo(Button)>
       </SimpleTooltip>
@@ -288,9 +290,10 @@ exports[`components/threading/global_threads/thread_item should report unread me
       >
         <Memo(Button)
           className="Button___icon"
+          marginExtra={true}
         >
-          <i
-            className="icon icon-dots-vertical"
+          <DotsVerticalIcon
+            size={18}
           />
         </Memo(Button)>
       </SimpleTooltip>

--- a/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
+++ b/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`components/threading/global_threads/thread_item should report total num
           className="Button___icon"
         >
           <i
-            className="Icon icon-dots-vertical"
+            className="icon icon-dots-vertical"
           />
         </Memo(Button)>
       </SimpleTooltip>
@@ -173,7 +173,7 @@ exports[`components/threading/global_threads/thread_item should report unread me
           className="Button___icon"
         >
           <i
-            className="Icon icon-dots-vertical"
+            className="icon icon-dots-vertical"
           />
         </Memo(Button)>
       </SimpleTooltip>
@@ -290,7 +290,7 @@ exports[`components/threading/global_threads/thread_item should report unread me
           className="Button___icon"
         >
           <i
-            className="Icon icon-dots-vertical"
+            className="icon icon-dots-vertical"
           />
         </Memo(Button)>
       </SimpleTooltip>

--- a/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
+++ b/components/threading/global_threads/thread_item/__snapshots__/thread_item.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`components/threading/global_threads/thread_item should report total num
       >
         <Memo(Button)
           className="Button___icon"
-          marginExtra={true}
+          marginTop={true}
         >
           <DotsVerticalIcon
             size={18}
@@ -172,7 +172,7 @@ exports[`components/threading/global_threads/thread_item should report unread me
       >
         <Memo(Button)
           className="Button___icon"
-          marginExtra={true}
+          marginTop={true}
         >
           <DotsVerticalIcon
             size={18}
@@ -290,7 +290,7 @@ exports[`components/threading/global_threads/thread_item should report unread me
       >
         <Memo(Button)
           className="Button___icon"
-          marginExtra={true}
+          marginTop={true}
         >
           <DotsVerticalIcon
             size={18}

--- a/components/threading/global_threads/thread_item/thread_item.tsx
+++ b/components/threading/global_threads/thread_item/thread_item.tsx
@@ -6,6 +6,8 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import classNames from 'classnames';
 import {useDispatch, useSelector} from 'react-redux';
 
+import {DotsVerticalIcon} from '@mattermost/compass-icons/components';
+
 import {getChannel as fetchChannel} from 'mattermost-redux/actions/channels';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
@@ -219,8 +221,11 @@ function ThreadItem({
                             />
                         )}
                     >
-                        <Button className='Button___icon'>
-                            <i className='icon icon-dots-vertical'/>
+                        <Button
+                            marginExtra={true}
+                            className='Button___icon'
+                        >
+                            <DotsVerticalIcon size={18}/>
                         </Button>
                     </SimpleTooltip>
                 </ThreadMenu>

--- a/components/threading/global_threads/thread_item/thread_item.tsx
+++ b/components/threading/global_threads/thread_item/thread_item.tsx
@@ -220,7 +220,7 @@ function ThreadItem({
                         )}
                     >
                         <Button className='Button___icon'>
-                            <i className='Icon icon-dots-vertical'/>
+                            <i className='icon icon-dots-vertical'/>
                         </Button>
                     </SimpleTooltip>
                 </ThreadMenu>

--- a/components/threading/global_threads/thread_item/thread_item.tsx
+++ b/components/threading/global_threads/thread_item/thread_item.tsx
@@ -222,7 +222,7 @@ function ThreadItem({
                         )}
                     >
                         <Button
-                            marginExtra={true}
+                            marginTop={true}
                             className='Button___icon'
                         >
                             <DotsVerticalIcon size={18}/>

--- a/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
+++ b/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
@@ -54,13 +54,14 @@ exports[`components/threading/global_threads/thread_list should match snapshot 1
             className="Button___large Button___icon"
             disabled={false}
             id="threads-list__mark-all-as-read"
+            marginExtra={true}
             onClick={[Function]}
           >
             <span
               className="icon"
             >
-              <i
-                className="icon-playlist-check"
+              <PlaylistCheckIcon
+                size={18}
               />
             </span>
           </Memo(Button)>

--- a/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
+++ b/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`components/threading/global_threads/thread_list should match snapshot 1
             onClick={[Function]}
           >
             <span
-              className="Icon"
+              className="icon"
             >
               <i
                 className="icon-playlist-check"

--- a/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
+++ b/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`components/threading/global_threads/thread_list should match snapshot 1
             className="Button___large Button___icon"
             disabled={false}
             id="threads-list__mark-all-as-read"
-            marginExtra={true}
+            marginTop={true}
             onClick={[Function]}
           >
             <span

--- a/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/components/threading/global_threads/thread_list/thread_list.tsx
@@ -6,6 +6,8 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import {isEmpty} from 'lodash';
 
+import {PlaylistCheckIcon} from '@mattermost/compass-icons/components';
+
 import * as Utils from 'utils/utils';
 import {getThreadCountsInCurrentTeam} from 'mattermost-redux/selectors/entities/threads';
 import {getThreads, markAllThreadsInTeamRead} from 'mattermost-redux/actions/threads';
@@ -227,9 +229,10 @@ const ThreadList = ({
                                 disabled={!someUnread}
                                 className={'Button___large Button___icon'}
                                 onClick={handleOpenMarkAllAsReadModal}
+                                marginExtra={true}
                             >
                                 <span className='icon'>
-                                    <i className='icon-playlist-check'/>
+                                    <PlaylistCheckIcon size={18}/>
                                 </span>
                             </Button>
                         </SimpleTooltip>

--- a/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/components/threading/global_threads/thread_list/thread_list.tsx
@@ -228,7 +228,7 @@ const ThreadList = ({
                                 className={'Button___large Button___icon'}
                                 onClick={handleOpenMarkAllAsReadModal}
                             >
-                                <span className='Icon'>
+                                <span className='icon'>
                                     <i className='icon-playlist-check'/>
                                 </span>
                             </Button>

--- a/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/components/threading/global_threads/thread_list/thread_list.tsx
@@ -229,7 +229,7 @@ const ThreadList = ({
                                 disabled={!someUnread}
                                 className={'Button___large Button___icon'}
                                 onClick={handleOpenMarkAllAsReadModal}
-                                marginExtra={true}
+                                marginTop={true}
                             >
                                 <span className='icon'>
                                     <PlaylistCheckIcon size={18}/>

--- a/components/threading/global_threads/thread_pane/__snapshots__/thread_pane.test.tsx.snap
+++ b/components/threading/global_threads/thread_pane/__snapshots__/thread_pane.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`components/threading/global_threads/thread_pane should match snapshot 1
               className="Button___icon Button___large"
             >
               <i
-                className="Icon icon-dots-vertical"
+                className="icon icon-dots-vertical"
               />
             </Memo(Button)>
           </SimpleTooltip>

--- a/components/threading/global_threads/thread_pane/__snapshots__/thread_pane.test.tsx.snap
+++ b/components/threading/global_threads/thread_pane/__snapshots__/thread_pane.test.tsx.snap
@@ -53,8 +53,8 @@ exports[`components/threading/global_threads/thread_pane should match snapshot 1
             <Memo(Button)
               className="Button___icon Button___large"
             >
-              <i
-                className="icon icon-dots-vertical"
+              <DotsVerticalIcon
+                size={18}
               />
             </Memo(Button)>
           </SimpleTooltip>

--- a/components/threading/global_threads/thread_pane/thread_pane.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.tsx
@@ -5,6 +5,8 @@ import React, {memo, useCallback, ReactNode} from 'react';
 import {useIntl} from 'react-intl';
 import {useSelector, useDispatch} from 'react-redux';
 
+import {DotsVerticalIcon} from '@mattermost/compass-icons/components';
+
 import {UserThread} from '@mattermost/types/threads';
 import {setThreadFollow} from 'mattermost-redux/actions/threads';
 
@@ -124,7 +126,7 @@ const ThreadPane = ({
                                 })}
                             >
                                 <Button className='Button___icon Button___large'>
-                                    <i className='icon icon-dots-vertical'/>
+                                    <DotsVerticalIcon size={18}/>
                                 </Button>
                             </SimpleTooltip>
                         </ThreadMenu>

--- a/components/threading/global_threads/thread_pane/thread_pane.tsx
+++ b/components/threading/global_threads/thread_pane/thread_pane.tsx
@@ -124,7 +124,7 @@ const ThreadPane = ({
                                 })}
                             >
                                 <Button className='Button___icon Button___large'>
-                                    <i className='Icon icon-dots-vertical'/>
+                                    <i className='icon icon-dots-vertical'/>
                                 </Button>
                             </SimpleTooltip>
                         </ThreadMenu>


### PR DESCRIPTION
#### Summary
fix icons alignment in global threads

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/21402
JIRA: https://mattermost.atlassian.net/browse/MM-47561

#### Related Pull Requests
None

#### Screenshots
![1](https://user-images.githubusercontent.com/89139362/202083908-c5289703-ccd2-4848-90da-f5bfd3dc42df.png)
![2](https://user-images.githubusercontent.com/89139362/202083911-291025d2-4709-446c-a82b-c1921269568b.png)
![3](https://user-images.githubusercontent.com/89139362/202083916-0df27422-7bc4-4a77-8569-a11380ea731c.png)


#### Release Note
None

```release-note
NONE
```
