### PR TITLE
MM-48423 : Landing on "Team not found" page on clean slate browser

### DIFF
--- a/e2e/cypress/tests/integration/team/archive_team_spec.ts
+++ b/e2e/cypress/tests/integration/team/archive_team_spec.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('archive team', () => {
+    let adminUser: Cypress.UserProfile;
+
+    before(() => {
+        cy.apiCreateCustomAdmin({loginAfter: true}).then(({sysadmin}) => {
+            adminUser = sysadmin;
+        });
+    });
+
+    it('MM-XXXX should not go to deleted team on login', () => {
+        // # Create a new user
+        cy.apiCreateUser({prefix: 'testuser'}).then(({user: testUser}) => {
+            // # Create a new team 1
+            cy.apiCreateTeam('team1', 'team1').then(({team: team1}) => {
+                // # Create a new team 2
+                cy.apiCreateTeam('team2', 'team2').then(({team: team2}) => {
+                    // # Add user to both teams
+                    cy.apiAddUserToTeam(team1.id, testUser.id);
+                    cy.apiAddUserToTeam(team2.id, testUser.id);
+
+                    cy.apiLogin(testUser);
+
+                    // # Visit team 1 so the previous team is set to team 1 in local storage
+                    cy.visit(`/${team1.name}/channels/town-square`);
+
+                    // * Verify user is part of both teams
+                    cy.get(`#${team1.name}TeamButton`, {timeout: TIMEOUTS.TEN_SEC}).should('be.visible');
+                    cy.get(`#${team2.name}TeamButton`, {timeout: TIMEOUTS.TEN_SEC}).should('be.visible');
+
+                    // # Logout the user
+                    cy.apiLogout();
+                    cy.clearLocalStorage();
+                    cy.reload();
+
+                    // # Login as admin
+                    cy.apiLogin(adminUser);
+
+                    // # Archive team 1
+                    cy.apiDeleteTeam(team1.id);
+
+                    // # Logout the admin
+                    cy.apiLogout();
+
+                    // # Login as user
+                    cy.apiLogin(testUser);
+                    cy.visit('/');
+
+                    // * Verify we landed on team 2 url
+                    cy.url().should('include', `/${team2.name}/channels/town-square`);
+
+                    // # Try to visit team 1 from the url
+                    cy.visit(`/${team1.name}/channels/town-square`);
+
+                    // * Verify we are redirected to team not found
+                    cy.url().should('include', '/error?type=team_not_found');
+                });
+            });
+        });
+    });
+});

--- a/e2e/cypress/tests/integration/team_settings/archive_team_spec.ts
+++ b/e2e/cypress/tests/integration/team_settings/archive_team_spec.ts
@@ -1,29 +1,38 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @team_settings
+
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-describe('archive team', () => {
-    let adminUser: Cypress.UserProfile;
+describe('Teams Settings', () => {
+    let sysadmin: Cypress.UserProfile;
 
     before(() => {
-        cy.apiCreateCustomAdmin({loginAfter: true}).then(({sysadmin}) => {
-            adminUser = sysadmin;
+        cy.apiCreateCustomAdmin({loginAfter: true}).then(({sysadmin: admin}) => {
+            sysadmin = admin;
         });
     });
 
-    it('MM-XXXX should not go to deleted team on login', () => {
+    it('MM-T5299 User tries to go to archived team', () => {
         // # Create a new user
-        cy.apiCreateUser({prefix: 'testuser'}).then(({user: testUser}) => {
+        cy.apiCreateUser().then(({user}) => {
             // # Create a new team 1
             cy.apiCreateTeam('team1', 'team1').then(({team: team1}) => {
                 // # Create a new team 2
                 cy.apiCreateTeam('team2', 'team2').then(({team: team2}) => {
                     // # Add user to both teams
-                    cy.apiAddUserToTeam(team1.id, testUser.id);
-                    cy.apiAddUserToTeam(team2.id, testUser.id);
+                    cy.apiAddUserToTeam(team1.id, user.id);
+                    cy.apiAddUserToTeam(team2.id, user.id);
 
-                    cy.apiLogin(testUser);
+                    cy.apiLogin(user);
 
                     // # Visit team 1 so the previous team is set to team 1 in local storage
                     cy.visit(`/${team1.name}/channels/town-square`);
@@ -38,7 +47,7 @@ describe('archive team', () => {
                     cy.reload();
 
                     // # Login as admin
-                    cy.apiLogin(adminUser);
+                    cy.apiLogin(sysadmin);
 
                     // # Archive team 1
                     cy.apiDeleteTeam(team1.id);
@@ -47,7 +56,7 @@ describe('archive team', () => {
                     cy.apiLogout();
 
                     // # Login as user
-                    cy.apiLogin(testUser);
+                    cy.apiLogin(user);
                     cy.visit('/');
 
                     // * Verify we landed on team 2 url

--- a/packages/mattermost-redux/src/actions/users_queries.ts
+++ b/packages/mattermost-redux/src/actions/users_queries.ts
@@ -54,7 +54,9 @@ query gqlWebCurrentUserInfo {
         id
         display_name: displayName
         name
+        create_at: createAt
         update_at: updateAt
+        delete_at: deleteAt
         description
         email
         type
@@ -64,6 +66,8 @@ query gqlWebCurrentUserInfo {
         last_team_icon_update: lastTeamIconUpdate
         group_constrained: groupConstrained
         allow_open_invite: allowOpenInvite
+        scheme_id: schemeId
+        policy_id: policyId
       }
       roles {
         id
@@ -128,7 +132,7 @@ export function transformToRecievedMeReducerPayload(user: GraphQLUser): UserProf
 }
 
 export function transformToRecievedTeamsListReducerPayload(teamsMembers: GraphQLTeamMember[]): Team[] {
-    return teamsMembers.map((teamMember) => ({...teamMember?.team, delete_at: 0}));
+    return teamsMembers.map((teamMember) => ({...teamMember.team}));
 }
 
 export function transformToRecievedMyTeamMembersReducerPayload(
@@ -144,6 +148,7 @@ export function transformToRecievedMyTeamMembersReducerPayload(
         scheme_guest: teamMember?.scheme_guest ?? false,
         scheme_user: teamMember?.scheme_user ?? false,
 
+        // Remove these fields once webapp deprecates getting unread counts from teams
         // below fields arent included in the response but were inside of TeamMembership api types
         mention_count: 0,
         mention_count_root: 0,


### PR DESCRIPTION
#### Summary
Back when delete_at was not part of gQL query, we hardcoded it with `delete_at = 0`, after the support was added, we never changed that. This pr adds that and other fields to team object. Also adds an e2e test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48423

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed bug in webapp in graphQL environment where it became possible to for user to visit archived team.
```
