### PR TITLE
[MM-46415] Code block copy bugfix

### DIFF
--- a/components/code_block/code_block.tsx
+++ b/components/code_block/code_block.tsx
@@ -75,7 +75,20 @@ const CodeBlock: React.FC<Props> = ({id, code, language, searchedContent}: Props
         htmlContent = `${searchedContent} ${content}`;
     }
 
+    const [codeBlockSelection, setCodeBlockSelection] = useState('');
+
+    const setSelection = () => {
+        const selectedText = document.getSelection();
+        if (selectedText) {
+            setCodeBlockSelection(selectedText.toString());
+        }
+    };
+
     const copyText = () => {
+        if (codeBlockSelection) {
+            copyToClipboard(codeBlockSelection);
+            return;
+        }
         copyToClipboard(code);
     };
 
@@ -89,6 +102,7 @@ const CodeBlock: React.FC<Props> = ({id, code, language, searchedContent}: Props
             <ContextMenu
                 className='post-code__context-menu'
                 id={`copy-code-block-context-menu-${id}`}
+                onShow={setSelection}
             >
                 <MenuItem onClick={copyText}>
                     <FormattedMessage


### PR DESCRIPTION
#### Summary
Fixes a bug where pressing "copy" in the context (right-click) menu of a code block always copies the entire block.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46415

#### Release Note

```release-note
Fixed a bug where selections within a code block were not properly copied to clipboard.
```
