### PR TITLE
changed-DM-category-tooltip

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
   tabIndex={0}
-  tooltipText="Channel options"
+  tooltipText="Category  options"
 >
   <MenuGroup>
     <MenuItemAction
@@ -422,7 +422,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
   tabIndex={0}
-  tooltipText="Channel options"
+  tooltipText="Category  options"
 >
   <MenuGroup>
     <MenuItemAction
@@ -509,7 +509,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
   tabIndex={0}
-  tooltipText="Channel options"
+  tooltipText="Category  options"
 >
   <MenuGroup>
     <MenuItemAction
@@ -605,7 +605,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
   tabIndex={0}
-  tooltipText="Channel options"
+  tooltipText="Category  options"
 >
   <MenuGroup>
     <MenuItemAction
@@ -715,7 +715,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
   tabIndex={0}
-  tooltipText="Channel options"
+  tooltipText="Category  options"
 >
   <MenuGroup>
     <MenuItemAction
@@ -825,7 +825,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
   tabIndex={0}
-  tooltipText="Channel options"
+  tooltipText="Category  options"
 >
   <MenuGroup>
     <MenuItemAction
@@ -935,7 +935,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
   tabIndex={0}
-  tooltipText="Channel options"
+  tooltipText="Category  options"
 >
   <MenuGroup>
     <MenuItemAction
@@ -1045,7 +1045,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
   onOpenDirectionChange={[Function]}
   onToggleMenu={[Function]}
   tabIndex={0}
-  tooltipText="Channel options"
+  tooltipText="Category  options"
 >
   <MenuGroup>
     <MenuItemAction

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -292,7 +292,7 @@ export class SidebarChannelMenu extends React.PureComponent<Props, State> {
                 isMenuOpen={isMenuOpen}
                 onOpenDirectionChange={this.handleOpenDirectionChange}
                 onToggleMenu={this.onToggleMenu}
-                tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'})}
+                tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Category  options'})}
                 tabIndex={isCollapsed ? -1 : 0}
             >
                 {isMenuOpen && this.renderDropdownItems()}

--- a/e2e/cypress/tests/integration/channel_sidebar/dm_category_spec.ts
+++ b/e2e/cypress/tests/integration/channel_sidebar/dm_category_spec.ts
@@ -62,7 +62,7 @@ describe('MM-T3156 DM category', () => {
     });
 
     it('MM-T3156_3 should order DMs alphabetically ', () => {
-        // # Hover over DIRECT MESSAGES and click channel options
+        // # Hover over DIRECT MESSAGES and click category  options
         cy.get('.SidebarChannelGroupHeader:contains(DIRECT MESSAGES) .SidebarMenu').invoke('show').
             get('.SidebarChannelGroupHeader:contains(DIRECT MESSAGES) .SidebarMenu_menuButton').should('be.visible').click();
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4656,7 +4656,7 @@
   "sidebar_left.sidebar_channel_menu.channels": "Channels",
   "sidebar_left.sidebar_channel_menu.copyLink": "Copy Link",
   "sidebar_left.sidebar_channel_menu.dropdownAriaLabel": "Edit channel menu",
-  "sidebar_left.sidebar_channel_menu.editChannel": "Channel options",
+  "sidebar_left.sidebar_channel_menu.editChannel": "Category  options",
   "sidebar_left.sidebar_channel_menu.favoriteChannel": "Favorite",
   "sidebar_left.sidebar_channel_menu.favorites": "Favorites",
   "sidebar_left.sidebar_channel_menu.leaveChannel": "Leave Channel",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -4673,7 +4673,7 @@
   "sidebar_left.sidebar_channel_menu.channels": "Channels",
   "sidebar_left.sidebar_channel_menu.copyLink": "Copy Link",
   "sidebar_left.sidebar_channel_menu.dropdownAriaLabel": "Edit channel menu",
-  "sidebar_left.sidebar_channel_menu.editChannel": "Channel options",
+  "sidebar_left.sidebar_channel_menu.editChannel": "Category  options",
   "sidebar_left.sidebar_channel_menu.favoriteChannel": "Favourite",
   "sidebar_left.sidebar_channel_menu.favorites": "Favourites",
   "sidebar_left.sidebar_channel_menu.leaveChannel": "Leave Channel",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
On the Direct Messages category, the tooltip on the ••• menu is "Channel options". It should say "Category options" like the rest of the categories. The code changes are done based on the given requirements

#### Ticket Link
GitHub issue link - https://github.com/mattermost/mattermost-server/issues/19357
Jira ticket link - https://mattermost.atlassian.net/browse/MM-38332

#### Screenshots
Before 
![Screenshot (25)](https://user-images.githubusercontent.com/99125230/202456308-84952c51-034a-465c-a21e-7926dbe8559c.png)


After
![Screenshot (24)](https://user-images.githubusercontent.com/99125230/202455844-6e7ebb56-3540-4a81-8fb1-1360f3408483.png)


#### Release Note
NONE
