### PR TITLE
[MM-47634] Changed slash command description text

### DIFF
--- a/components/integrations/__snapshots__/abstract_command.test.jsx.snap
+++ b/components/integrations/__snapshots__/abstract_command.test.jsx.snap
@@ -85,7 +85,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
             className="form__help"
           >
             <MemoizedFormattedMessage
-              defaultMessage="Describe your incoming webhook."
+              defaultMessage="Describe your slash command."
               id="add_command.description.help"
             />
           </div>
@@ -555,7 +555,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
             className="form__help"
           >
             <MemoizedFormattedMessage
-              defaultMessage="Describe your incoming webhook."
+              defaultMessage="Describe your slash command."
               id="add_command.description.help"
             />
           </div>

--- a/components/integrations/abstract_command.jsx
+++ b/components/integrations/abstract_command.jsx
@@ -392,7 +392,7 @@ export default class AbstractCommand extends React.PureComponent {
                                 <div className='form__help'>
                                     <FormattedMessage
                                         id='add_command.description.help'
-                                        defaultMessage='Describe your incoming webhook.'
+                                        defaultMessage='Describe your slash command.'
                                     />
                                 </div>
                             </div>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -84,7 +84,7 @@
   "add_command.autocompleteHint.placeholder": "Example: [Patient Name]",
   "add_command.cancel": "Cancel",
   "add_command.description": "Description",
-  "add_command.description.help": "Describe your incoming webhook.",
+  "add_command.description.help": "Describe your slash command.",
   "add_command.displayName": "Title",
   "add_command.displayName.help": "Specify a title, of up to 64 characters, for the slash command settings page.",
   "add_command.doneHelp": "Your slash command is set up. The following token will be sent in the outgoing payload. Please use it to verify the request came from your Mattermost team (details at <link>Slash Commands</link>).",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -84,7 +84,7 @@
   "add_command.autocompleteHint.placeholder": "Example: [Patient Name]",
   "add_command.cancel": "Cancel",
   "add_command.description": "Description",
-  "add_command.description.help": "Describe your incoming webhook.",
+  "add_command.description.help": "Describe your slash command.",
   "add_command.displayName": "Title",
   "add_command.displayName.help": "Specify a title, of up to 64 characters, for the slash command settings page.",
   "add_command.doneHelp": "Your slash command is set up. The following token will be sent in the outgoing payload. Please use it to verify the request came from your Mattermost team (details at <link>Slash Commands</link>).",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -84,7 +84,7 @@
   "add_command.autocompleteHint.placeholder": "Example: [Patient Name]",
   "add_command.cancel": "Cancel",
   "add_command.description": "Description",
-  "add_command.description.help": "Describe your slash command.",
+  "add_command.description.help": "Describe your incoming webhook.",
   "add_command.displayName": "Title",
   "add_command.displayName.help": "Specify a title, of up to 64 characters, for the slash command settings page.",
   "add_command.doneHelp": "Your slash command is set up. The following token will be sent in the outgoing payload. Please use it to verify the request came from your Mattermost team (details at <link>Slash Commands</link>).",


### PR DESCRIPTION
#### Summary
Changed slash command description help text

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47634

#### Screenshots
![image](https://user-images.githubusercontent.com/26048106/202741661-ee25cac4-e5f8-4564-8acd-a45d5260904f.png)
The description text has been changed from "Describe your incoming webhook." to "Describe your slash command."

#### Release Note
```release-note
Fixed the slash command description help text
```