### PR TITLE
[MM-48111] Downgrade error modal z-index incorrect with single team

### DIFF
--- a/components/cloud_subscribe_result_modal/error.tsx
+++ b/components/cloud_subscribe_result_modal/error.tsx
@@ -37,11 +37,15 @@ function ErrorModal(props: Props) {
         isModalOpen(state, ModalIdentifiers.ERROR_MODAL),
     );
 
-    const onHide = () => {
-        dispatch(closeModal(ModalIdentifiers.ERROR_MODAL));
-        if (typeof props.backButtonAction === 'function') {
+    const onBackButtonPress = () => {
+        if (props.backButtonAction) {
             props.backButtonAction();
         }
+        dispatch(closeModal(ModalIdentifiers.ERROR_MODAL));
+    };
+
+    const onHide = () => {
+        dispatch(closeModal(ModalIdentifiers.ERROR_MODAL));
         if (typeof props.onHide === 'function') {
             props.onHide();
         }
@@ -94,7 +98,7 @@ function ErrorModal(props: Props) {
                         />
                     }
                     tertiaryButtonHandler={openContactUs}
-                    buttonHandler={onHide}
+                    buttonHandler={onBackButtonPress}
                     className={'success'}
                 />
             </div>

--- a/components/cloud_subscribe_result_modal/error.tsx
+++ b/components/cloud_subscribe_result_modal/error.tsx
@@ -25,6 +25,7 @@ import './style.scss';
 
 type Props = {
     onHide?: () => void;
+    backButtonAction?: () => void;
 };
 
 function ErrorModal(props: Props) {
@@ -38,6 +39,9 @@ function ErrorModal(props: Props) {
 
     const onHide = () => {
         dispatch(closeModal(ModalIdentifiers.ERROR_MODAL));
+        if (typeof props.backButtonAction === 'function') {
+            props.backButtonAction();
+        }
         if (typeof props.onHide === 'function') {
             props.onHide();
         }

--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -34,6 +34,8 @@ import YearlyMonthlyToggle from 'components/yearly_monthly_toggle';
 
 import {isAnnualSubscriptionEnabled} from 'mattermost-redux/selectors/entities/preferences';
 
+import useOpenPricingModal from 'components/common/hooks/useOpenPricingModal';
+
 import DowngradeTeamRemovalModal from './downgrade_team_removal_modal';
 import ContactSalesCTA from './contact_sales_cta';
 import StarterDisclaimerCTA from './starter_disclaimer_cta';
@@ -55,6 +57,7 @@ function Content(props: ContentProps) {
     const dispatch = useDispatch();
     const usage = useGetUsage();
     const [limits] = useGetLimits();
+    const openPricingModalBackAction = useOpenPricingModal();
 
     const isAdmin = useSelector(isCurrentUserSystemAdmin);
     const contactSalesLink = useSelector(getCloudContactUsLink)(InquiryType.Sales);
@@ -117,10 +120,15 @@ function Content(props: ContentProps) {
                 }),
             );
         } else {
+            dispatch(closeModal(ModalIdentifiers.CLOUD_DOWNGRADE_CHOOSE_TEAM));
+            dispatch(closeModal(ModalIdentifiers.PRICING_MODAL));
             dispatch(
                 openModal({
                     modalId: ModalIdentifiers.ERROR_MODAL,
                     dialogType: ErrorModal,
+                    dialogProps: {
+                        backButtonAction: openPricingModalBackAction,
+                    },
                 }),
             );
             return;


### PR DESCRIPTION
#### Summary
The full screen modal's z index is less than that of the non-full-screen modal, so it would appear behind. 

This change makes it so the pricing modal closes. The error modal now accepts a back action prop that, and it's passing the openPricingModal hook, so it re opens when you go back. Finally, clicking the X button in the top right will now completely abort you out of the process (ie, does not reopen the pricing modal)




#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48111

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
https://www.loom.com/share/ab62fd34d65d4fe09a6cc381976b3d54

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
