### PR TITLE
[MM-47760] Bugfix: filter out threads with deleted replies

### DIFF
--- a/packages/mattermost-redux/src/selectors/entities/threads.ts
+++ b/packages/mattermost-redux/src/selectors/entities/threads.ts
@@ -168,7 +168,7 @@ export const getUnreadThreadOrderInCurrentTeam: (
 );
 
 function sortByLastReply(ids: Array<UserThread['id']>, threads: ReturnType<typeof getThreads>) {
-    return ids.sort((a, b) => threads[b].last_reply_at - threads[a].last_reply_at).filter((id) => threads[id].last_reply_at !== 0);
+    return ids.filter((id) => threads[id].last_reply_at !== 0).sort((a, b) => threads[b].last_reply_at - threads[a].last_reply_at);
 }
 
 export const getThreadsInChannel: (

--- a/packages/mattermost-redux/src/selectors/entities/threads.ts
+++ b/packages/mattermost-redux/src/selectors/entities/threads.ts
@@ -168,7 +168,7 @@ export const getUnreadThreadOrderInCurrentTeam: (
 );
 
 function sortByLastReply(ids: Array<UserThread['id']>, threads: ReturnType<typeof getThreads>) {
-    return ids.sort((a, b) => threads[b].last_reply_at - threads[a].last_reply_at).filter((id) => threads[id].last_reply_at != 0);
+    return ids.sort((a, b) => threads[b].last_reply_at - threads[a].last_reply_at).filter((id) => threads[id].last_reply_at !== 0);
 }
 
 export const getThreadsInChannel: (

--- a/packages/mattermost-redux/src/selectors/entities/threads.ts
+++ b/packages/mattermost-redux/src/selectors/entities/threads.ts
@@ -168,7 +168,7 @@ export const getUnreadThreadOrderInCurrentTeam: (
 );
 
 function sortByLastReply(ids: Array<UserThread['id']>, threads: ReturnType<typeof getThreads>) {
-    return ids.sort((a, b) => threads[b].last_reply_at - threads[a].last_reply_at);
+    return ids.sort((a, b) => threads[b].last_reply_at - threads[a].last_reply_at).filter((id) => threads[id].last_reply_at != 0);
 }
 
 export const getThreadsInChannel: (


### PR DESCRIPTION
#### Summary
Filters out threads with last_reply_at being 0, which is set on threads where all replies have been deleted. This stops them from showing up in all threads (with an awkward date of 1970).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47760

#### Related Pull Requests
A related server change is incoming to address this behaviour when fetching threads as well. This ticket is for cached grabbed threads.

- Has server changes

https://github.com/mattermost/mattermost-server/pull/21702


#### Release Note

```release-note
Fixed a bug where threads with 0 replies would show in all threads
```
