### PR TITLE
[MM-42008] Fix getting data when checking if team exists

### DIFF
--- a/components/create_team/components/team_url/index.ts
+++ b/components/create_team/components/team_url/index.ts
@@ -13,7 +13,7 @@ import {ServerError} from '@mattermost/types/errors';
 import TeamUrl from './team_url';
 
 type Actions = {
-    checkIfTeamExists: (teamName: string) => Promise<{exists: boolean}>;
+    checkIfTeamExists: (teamName: string) => Promise<{data: boolean}>;
     createTeam: (team: Team) => Promise<{data: Team; error: ServerError}>;
 };
 

--- a/components/create_team/components/team_url/team_url.test.tsx
+++ b/components/create_team/components/team_url/team_url.test.tsx
@@ -21,7 +21,7 @@ describe('/components/create_team/components/display_name', () => {
             wizard: 'display_name',
         },
         actions: {
-            checkIfTeamExists: jest.fn().mockResolvedValue({exists: true}),
+            checkIfTeamExists: jest.fn().mockResolvedValue({data: true}),
             createTeam: jest.fn().mockResolvedValue({data: {name: 'test-team'}}),
             trackEvent: jest.fn(),
         },
@@ -57,8 +57,8 @@ describe('/components/create_team/components/display_name', () => {
 
     test('should successfully submit', async () => {
         const checkIfTeamExists = jest.fn().
-            mockResolvedValueOnce({exists: true}).
-            mockResolvedValue({exists: false});
+            mockResolvedValueOnce({data: true}).
+            mockResolvedValue({data: false});
 
         const actions = {...defaultProps.actions, checkIfTeamExists};
         const props = {...defaultProps, actions};

--- a/components/create_team/components/team_url/team_url.tsx
+++ b/components/create_team/components/team_url/team_url.tsx
@@ -46,7 +46,7 @@ type Props = {
         /*
          * Action creator to check if a team already exists
          */
-        checkIfTeamExists: (teamName: string) => Promise<{exists: boolean}>;
+        checkIfTeamExists: (teamName: string) => Promise<{data: boolean}>;
 
         /*
      * Action creator to create a new team
@@ -152,8 +152,8 @@ export default class TeamUrl extends React.PureComponent<Props, State> {
         teamSignup.team.type = 'O';
         teamSignup.team.name = name;
 
-        const checkIfTeamExistsData: { exists: boolean } = await checkIfTeamExists(name);
-        const exists = checkIfTeamExistsData.exists;
+        const checkIfTeamExistsData: { data: boolean } = await checkIfTeamExists(name);
+        const exists = checkIfTeamExistsData.data;
 
         if (exists) {
             this.setState({nameError: (


### PR DESCRIPTION
#### Summary

Check the right data when checking if team exists to avoid trying to create a team with the same URL.

#### Ticket Link

[Jira ticket](https://mattermost.atlassian.net/browse/MM-42008)

#### Screenshots

This error message already existed, with translations, so I didn't change it. 

<img width="437" alt="Screen Shot 2022-11-21 at 1 24 05 PM" src="https://user-images.githubusercontent.com/112951043/203131439-4c6e12fc-5c82-4cc1-9829-719a442390cf.png">


```release-note
NONE
```
