### PR TITLE
MM-48531 Skip building Docker images in CircleCI for master/release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,10 +194,10 @@ jobs:
             curl -f -o server.tar.gz https://pr-builds.mattermost.com/mattermost-server/$(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/mattermost-enterprise-linux-amd64.tar.gz || true
 
             if [[ -f server.tar.gz ]]; then
-                echo "Downloaded server bundle from ${CIRCLE_BRANCH} branch"
+                echo "Downloaded server bundle for ${CIRCLE_BRANCH} branch from pr-builds.mattermost.com"
             else
                 curl -f -o server.tar.gz https://s3.amazonaws.com/releases.mattermost.com/gitlab/bundle/master/mattermost-enterprise-linux-amd64.tar.gz
-                echo "Downloaded server bundle from master branch"
+                echo "Downloaded server bundle for master from releases.mattermost.com"
             fi
 
             tar xf server.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ workflows:
               ignore:
                 - master
                 - /^release-.*/
-                - /^count-.*/
+                - /^cloud-.*/
       - build-docker:
           context: matterbuild-docker
           requires:
@@ -292,7 +292,7 @@ workflows:
               ignore:
                 - master
                 - /^release-.*/
-                - /^count-.*/
+                - /^cloud-.*/
       - test:
           requires:
             - type-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,10 +277,22 @@ workflows:
           context: mattermost-ci-pr-builds-s3
           requires:
             - upload-s3
+          filters:
+            branches:
+              ignore:
+                - master
+                - /^release-.*/
+                - /^count-.*/
       - build-docker:
           context: matterbuild-docker
           requires:
             - prepare-docker-build
+          filters:
+            branches:
+              ignore:
+                - master
+                - /^release-.*/
+                - /^count-.*/
       - test:
           requires:
             - type-check


### PR DESCRIPTION
Currently, master CircleCI builds are failing because they're pulling an outdated version of the server bundle which doesn't include products when trying to generate a Docker image containing the latest version of the web app. While I still don't know why that happens (there's some more info available in the Jira ticket though), I don't think we even actually need that Docker image because, as far as I know, those images are only needed for generating Spinwick servers which isn't possible outside of a PR.

Because the Docker image is seemingly never used, I decided to just not even build it when CircleCI is running a build for a non-PR branch.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48531

#### Release Note
```release-note
NONE
```
