### PR TITLE
MM-47759 - fix telemetry id for self-hosted trial started from feature discovery pages

### DIFF
--- a/components/admin_console/feature_discovery/__snapshots__/feature_discovery.test.tsx.snap
+++ b/components/admin_console/feature_discovery/__snapshots__/feature_discovery.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`components/feature_discovery FeatureDiscovery should match snapshot 1`]
       btnClass="btn btn-primary"
       message="Start trial"
       renderAsButton={true}
-      telemetryId="start_cloud_trial_feature_discovery"
+      telemetryId="start_self_hosted_trial_from_test"
       trackingPage="test"
     />
     <a

--- a/components/admin_console/feature_discovery/feature_discovery.tsx
+++ b/components/admin_console/feature_discovery/feature_discovery.tsx
@@ -173,7 +173,7 @@ export default class FeatureDiscovery extends React.PureComponent<Props, State> 
                     'admin.ldap_feature_discovery.call_to_action.primary',
                     'Start trial',
                 )}
-                telemetryId={'start_cloud_trial_feature_discovery'}
+                telemetryId={`start_self_hosted_trial_from_${this.props.featureName}`}
                 btnClass='btn btn-primary'
                 renderAsButton={true}
                 trackingPage={this.props.featureName}


### PR DESCRIPTION
#### Summary
fix telemetry id for self-hosted trial started from feature discovery pages

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47759

#### Related Pull Requests
n/a

#### Screenshots
<img width="1450" alt="Captura de Pantalla 2022-11-23 a las 13 37 38" src="https://user-images.githubusercontent.com/10082627/203548994-c3923549-90a8-4ffd-be8f-876a231be9bb.png">


#### Release Note
```release-note
NONE
```
