### PR TITLE
[MM-48618, MM-48639] Fix thread replies not clearing text box and not syncing across sessions

### DIFF
--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -317,6 +317,10 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         if (this.props.createPostErrorId === 'api.post.create_post.root_id.app_error' && this.props.createPostErrorId !== prevProps.createPostErrorId) {
             this.showPostDeletedModal();
         }
+
+        if (prevProps.draft.message !== this.props.draft.message || prevProps.draft.fileInfos !== this.props.draft.fileInfos) {
+            this.setState({draft: {...this.props.draft}});
+        }
     }
 
     getChannelMemberCountsByGroup = () => {

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -212,6 +212,8 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
     private saveDraftFrame?: number | null;
 
+    private isDraftSubmitting = false;
+
     private readonly textboxRef: React.RefObject<TextboxClass>;
     private readonly fileUploadRef: React.RefObject<FileUploadClass>;
 
@@ -532,6 +534,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
     handleSubmit = async (e: React.FormEvent | React.MouseEvent) => {
         e.preventDefault();
         this.setShowPreview(false);
+        this.isDraftSubmitting = true;
 
         const {
             channelMembersCount,
@@ -619,6 +622,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
         if (memberNotifyCount > 0) {
             this.showNotifyAllModal(mentions, channelTimezoneCount, memberNotifyCount);
+            this.isDraftSubmitting = false;
             return;
         }
 
@@ -634,10 +638,12 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         const enableAddButton = this.shouldEnableAddButton();
 
         if (!enableAddButton) {
+            this.isDraftSubmitting = false;
             return;
         }
 
         if (draft.uploadsInProgress.length > 0) {
+            this.isDraftSubmitting = false;
             return;
         }
 
@@ -646,11 +652,13 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
             setTimeout(() => {
                 this.setState({errorClass: null});
             }, Constants.ANIMATION_TIMEOUT);
+            this.isDraftSubmitting = false;
             return;
         }
 
         if (this.props.rootDeleted) {
             this.showPostDeletedModal();
+            this.isDraftSubmitting = false;
             return;
         }
 
@@ -680,12 +688,15 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
             }
             err.submittedMessage = draft.message;
             this.setState({serverError: err});
+            this.isDraftSubmitting = false;
             return;
         }
 
         if (this.saveDraftFrame) {
             clearTimeout(this.saveDraftFrame);
         }
+
+        this.isDraftSubmitting = false;
         this.setState({draft: {...this.props.draft, uploadsInProgress: []}});
         this.draftsForPost[this.props.rootId] = null;
     }
@@ -706,6 +717,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         if (allowSending) {
             e.persist?.();
 
+            this.isDraftSubmitting = true;
             this.textboxRef.current?.blur();
             this.handleSubmit(e);
 
@@ -1131,7 +1143,9 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
     }
 
     handleBlur = () => {
-        this.saveDraftWithShow();
+        if (!this.isDraftSubmitting) {
+            this.saveDraftWithShow();
+        }
         this.lastBlurAt = Date.now();
     }
 

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -231,7 +231,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
         const rootChanged = props.rootId !== state.rootId;
         const messageInHistoryChanged = props.messageInHistory !== state.messageInHistory;
-        if (rootChanged || messageInHistoryChanged) {
+        if (rootChanged || messageInHistoryChanged || props.draft.remote) {
             updatedState = {...updatedState, draft: {...props.draft, uploadsInProgress: rootChanged ? [] : props.draft.uploadsInProgress}};
         }
 
@@ -316,10 +316,6 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
         if (this.props.createPostErrorId === 'api.post.create_post.root_id.app_error' && this.props.createPostErrorId !== prevProps.createPostErrorId) {
             this.showPostDeletedModal();
-        }
-
-        if (prevProps.draft.message !== this.props.draft.message || prevProps.draft.fileInfos !== this.props.draft.fileInfos) {
-            this.setState({draft: {...this.props.draft}});
         }
     }
 

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -317,10 +317,6 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         if (this.props.createPostErrorId === 'api.post.create_post.root_id.app_error' && this.props.createPostErrorId !== prevProps.createPostErrorId) {
             this.showPostDeletedModal();
         }
-
-        if (prevProps.draft.message !== this.props.draft.message || prevProps.draft.fileInfos !== this.props.draft.fileInfos) {
-            this.setState({draft: {...this.props.draft}});
-        }
     }
 
     getChannelMemberCountsByGroup = () => {

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -212,8 +212,6 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
     private saveDraftFrame?: number | null;
 
-    private isDraftSubmitting = false;
-
     private readonly textboxRef: React.RefObject<TextboxClass>;
     private readonly fileUploadRef: React.RefObject<FileUploadClass>;
 
@@ -534,7 +532,6 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
     handleSubmit = async (e: React.FormEvent | React.MouseEvent) => {
         e.preventDefault();
         this.setShowPreview(false);
-        this.isDraftSubmitting = true;
 
         const {
             channelMembersCount,
@@ -622,7 +619,6 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
         if (memberNotifyCount > 0) {
             this.showNotifyAllModal(mentions, channelTimezoneCount, memberNotifyCount);
-            this.isDraftSubmitting = false;
             return;
         }
 
@@ -638,12 +634,10 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         const enableAddButton = this.shouldEnableAddButton();
 
         if (!enableAddButton) {
-            this.isDraftSubmitting = false;
             return;
         }
 
         if (draft.uploadsInProgress.length > 0) {
-            this.isDraftSubmitting = false;
             return;
         }
 
@@ -652,13 +646,11 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
             setTimeout(() => {
                 this.setState({errorClass: null});
             }, Constants.ANIMATION_TIMEOUT);
-            this.isDraftSubmitting = false;
             return;
         }
 
         if (this.props.rootDeleted) {
             this.showPostDeletedModal();
-            this.isDraftSubmitting = false;
             return;
         }
 
@@ -688,15 +680,12 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
             }
             err.submittedMessage = draft.message;
             this.setState({serverError: err});
-            this.isDraftSubmitting = false;
             return;
         }
 
         if (this.saveDraftFrame) {
             clearTimeout(this.saveDraftFrame);
         }
-
-        this.isDraftSubmitting = false;
         this.setState({draft: {...this.props.draft, uploadsInProgress: []}});
         this.draftsForPost[this.props.rootId] = null;
     }
@@ -717,7 +706,6 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         if (allowSending) {
             e.persist?.();
 
-            this.isDraftSubmitting = true;
             this.textboxRef.current?.blur();
             this.handleSubmit(e);
 
@@ -1143,9 +1131,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
     }
 
     handleBlur = () => {
-        if (!this.isDraftSubmitting) {
-            this.saveDraftWithShow();
-        }
+        this.saveDraftWithShow();
         this.lastBlurAt = Date.now();
     }
 

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -231,7 +231,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
         const rootChanged = props.rootId !== state.rootId;
         const messageInHistoryChanged = props.messageInHistory !== state.messageInHistory;
-        if (rootChanged || messageInHistoryChanged || props.draft.remote) {
+        if (rootChanged || messageInHistoryChanged) {
             updatedState = {...updatedState, draft: {...props.draft, uploadsInProgress: rootChanged ? [] : props.draft.uploadsInProgress}};
         }
 
@@ -316,6 +316,10 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
 
         if (this.props.createPostErrorId === 'api.post.create_post.root_id.app_error' && this.props.createPostErrorId !== prevProps.createPostErrorId) {
             this.showPostDeletedModal();
+        }
+
+        if (prevProps.draft.message !== this.props.draft.message || prevProps.draft.fileInfos !== this.props.draft.fileInfos) {
+            this.setState({draft: {...this.props.draft}});
         }
     }
 

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -266,6 +266,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     private draftsForChannel: {[channelID: string]: PostDraft | null} = {};
     private lastOrientation?: string;
     private saveDraftFrame?: number | null;
+    private isDraftSubmitting = false;
 
     private topDiv: React.RefObject<HTMLFormElement>;
     private textboxRef: React.RefObject<TextboxClass>;
@@ -572,6 +573,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             clearTimeout(this.saveDraftFrame);
         }
 
+        this.isDraftSubmitting = false;
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, null);
         this.draftsForChannel[channelId] = null;
     }
@@ -619,6 +621,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         } = this.props;
 
         this.setShowPreview(false);
+        this.isDraftSubmitting = true;
 
         const notificationsToChannel = this.props.enableConfirmNotificationsToChannel && this.props.useChannelMentions;
         let memberNotifyCount = 0;
@@ -668,6 +671,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
 
         if (memberNotifyCount > 0) {
             this.showNotifyAllModal(mentions, channelTimezoneCount, memberNotifyCount);
+            this.isDraftSubmitting = false;
             return;
         }
 
@@ -682,6 +686,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             this.props.actions.openModal(resetStatusModalData);
 
             this.setState({message: ''});
+            this.isDraftSubmitting = false;
             return;
         }
 
@@ -695,6 +700,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             this.props.actions.openModal(editChannelHeaderModalData);
 
             this.setState({message: ''});
+            this.isDraftSubmitting = false;
             return;
         }
 
@@ -710,6 +716,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             this.props.actions.openModal(editChannelPurposeModalData);
 
             this.setState({message: ''});
+            this.isDraftSubmitting = false;
             return;
         }
 
@@ -760,6 +767,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
                 submitting: false,
             });
 
+            this.isDraftSubmitting = false;
             return hookResult;
         }
 
@@ -768,9 +776,8 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         actions.onSubmitPost(post, draft.fileInfos);
         actions.scrollPostListToBottom();
 
-        this.setState({
-            submitting: false,
-        });
+        this.setState({submitting: false});
+        this.isDraftSubmitting = false;
 
         return {data: true};
     }
@@ -831,6 +838,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
                 e.persist();
             }
             if (this.textboxRef.current) {
+                this.isDraftSubmitting = true;
                 this.textboxRef.current.blur();
             }
 
@@ -1362,7 +1370,10 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     }
 
     handleBlur = () => {
-        this.saveDraftWithShow();
+        if (!this.isDraftSubmitting) {
+            this.saveDraftWithShow();
+        }
+
         this.lastBlurAt = Date.now();
     }
 

--- a/components/advanced_create_post/advanced_create_post.tsx
+++ b/components/advanced_create_post/advanced_create_post.tsx
@@ -266,7 +266,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     private draftsForChannel: {[channelID: string]: PostDraft | null} = {};
     private lastOrientation?: string;
     private saveDraftFrame?: number | null;
-    private isDraftSubmitting = false;
 
     private topDiv: React.RefObject<HTMLFormElement>;
     private textboxRef: React.RefObject<TextboxClass>;
@@ -573,7 +572,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             clearTimeout(this.saveDraftFrame);
         }
 
-        this.isDraftSubmitting = false;
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, null);
         this.draftsForChannel[channelId] = null;
     }
@@ -621,7 +619,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         } = this.props;
 
         this.setShowPreview(false);
-        this.isDraftSubmitting = true;
 
         const notificationsToChannel = this.props.enableConfirmNotificationsToChannel && this.props.useChannelMentions;
         let memberNotifyCount = 0;
@@ -671,7 +668,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
 
         if (memberNotifyCount > 0) {
             this.showNotifyAllModal(mentions, channelTimezoneCount, memberNotifyCount);
-            this.isDraftSubmitting = false;
             return;
         }
 
@@ -686,7 +682,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             this.props.actions.openModal(resetStatusModalData);
 
             this.setState({message: ''});
-            this.isDraftSubmitting = false;
             return;
         }
 
@@ -700,7 +695,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             this.props.actions.openModal(editChannelHeaderModalData);
 
             this.setState({message: ''});
-            this.isDraftSubmitting = false;
             return;
         }
 
@@ -716,7 +710,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
             this.props.actions.openModal(editChannelPurposeModalData);
 
             this.setState({message: ''});
-            this.isDraftSubmitting = false;
             return;
         }
 
@@ -767,7 +760,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
                 submitting: false,
             });
 
-            this.isDraftSubmitting = false;
             return hookResult;
         }
 
@@ -776,8 +768,9 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
         actions.onSubmitPost(post, draft.fileInfos);
         actions.scrollPostListToBottom();
 
-        this.setState({submitting: false});
-        this.isDraftSubmitting = false;
+        this.setState({
+            submitting: false,
+        });
 
         return {data: true};
     }
@@ -838,7 +831,6 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
                 e.persist();
             }
             if (this.textboxRef.current) {
-                this.isDraftSubmitting = true;
                 this.textboxRef.current.blur();
             }
 
@@ -1370,10 +1362,7 @@ class AdvancedCreatePost extends React.PureComponent<Props, State> {
     }
 
     handleBlur = () => {
-        if (!this.isDraftSubmitting) {
-            this.saveDraftWithShow();
-        }
-
+        this.saveDraftWithShow();
         this.lastBlurAt = Date.now();
     }
 

--- a/components/drafts/drafts.tsx
+++ b/components/drafts/drafts.tsx
@@ -59,7 +59,7 @@ function Drafts({
                 })}
                 subtitle={formatMessage({
                     id: 'drafts.subtitle',
-                    defaultMessage: 'All messages you\'ve started will show here',
+                    defaultMessage: 'Any messages you\'ve started will show here',
                 })}
             />
             <div className='Drafts__main'>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3204,7 +3204,7 @@
   "drafts.heading": "Drafts",
   "drafts.info.sync": "Updated from another device",
   "drafts.sidebarLink": "Drafts",
-  "drafts.subtitle": "All messages you've started will show here",
+  "drafts.subtitle": "Any messages you've started will show here",
   "drafts.title": "{prefix}Drafts - {displayName} {siteName}",
   "edit_category_modal.helpText": "Drag channels into this category to organize your sidebar.",
   "edit_category_modal.placeholder": "Name your category",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

- Fixes an issue where sending a message in a comment reply by pressing `Enter` would result in the text box failing to clear. When a message is sent the text box unfocused which automatically triggered a draft save, and so this "new" draft would appear in the text box. This PR adds a flag to only save drafts when not in a submitting state.

- Also fixes an issue where drafts would not update for a thread until you closed and reopened the RHS.

- Changes text on drafts page to use "Any" instead of "All".

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

- https://mattermost.atlassian.net/browse/MM-48618
- https://mattermost.atlassian.net/browse/MM-48639


<!--
#### Related Pull Requests
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.

- Has server changes (please link here)
- Has mobile changes (please link here)
-->



<!--
#### Screenshots
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```
NONE
```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
