### PR TITLE
Automated cherry pick of #11644

### DIFF
--- a/e2e/playwright/support/server/default_config.ts
+++ b/e2e/playwright/support/server/default_config.ts
@@ -664,7 +664,6 @@ const defaultServerConfig: AdminConfig = {
         CallsMobile: false,
         CallsEnabled: true,
         BoardsFeatureFlags: '',
-        CustomGroups: true,
         BoardsDataRetention: false,
         NormalizeLdapDNs: false,
         EnableInactivityCheckJob: true,

--- a/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -245,7 +245,7 @@ export function isGroupChannelManuallyVisible(state: GlobalState, channelId: str
 }
 
 export function isCustomGroupsEnabled(state: GlobalState): boolean {
-    return getFeatureFlagValue(state, 'CustomGroups') === 'true' && getConfig(state).EnableCustomGroups === 'true';
+    return getConfig(state).EnableCustomGroups === 'true';
 }
 
 export function getUseCaseOnboarding(state: GlobalState): boolean {


### PR DESCRIPTION
Cherry pick of #11644 on cloud.

/cc  @mkraft

```release-note
NONE
```