### PR TITLE
[MM-46463] Use last_picture_update in insights

### DIFF
--- a/components/activity_and_insights/insights/top_dms_and_new_members/new_members_item/new_members_item.tsx
+++ b/components/activity_and_insights/insights/top_dms_and_new_members/new_members_item/new_members_item.tsx
@@ -42,7 +42,7 @@ const NewMembersItem = ({newMember, team}: Props) => {
             to={`/${team.name}/messages/@${newMember.username}`}
         >
             <Avatar
-                url={imageURLForUser(newMember.id)}
+                url={imageURLForUser(newMember.id, newMember.last_picture_update || 0)}
                 size={'xl'}
             />
             <div className='dm-info'>


### PR DESCRIPTION
#### Summary
Use last_picture_update to get the latest user's picture in insights.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46463

#### Related Pull Requests
Server: https://github.com/mattermost/mattermost-server/pull/21758

#### Screenshots
N/A

#### Release Note
```release-note
Fixes fetching the latest user's picture in insights.
```
