### PR TITLE
[MM-45907] Fixes: Clicking on a reply post time stamp in global threads inbox opens two RHS

### DIFF
--- a/components/permalink_view/permalink_view.tsx
+++ b/components/permalink_view/permalink_view.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useEffect, useCallback, memo} from 'react';
+import React, {useState, useEffect, useCallback, memo, useRef} from 'react';
 import {match} from 'react-router-dom';
 
 type Props = {
@@ -20,22 +20,31 @@ type Props = {
 }
 
 const PermalinkView = (props: Props) => {
-    const [mounted, setMounted] = useState(false);
+    const mounted = useRef(false);
+    const [valid, setValid] = useState(false);
+
+    useEffect(() => {
+        mounted.current = true;
+        return () => {
+            mounted.current = false;
+        };
+    }, []);
 
     const doPermalinkAction = useCallback(async () => {
         const postId = props.match.params.postid;
         await props.actions.focusPost(postId, props.returnTo, props.currentUserId);
-    }, [props]);
+        if (mounted.current) {
+            setValid(true);
+        }
+    }, [props.match.params.postid, props.returnTo, props.currentUserId, props.actions]);
 
     useEffect(() => {
         document.body.classList.add('app__body');
-        doPermalinkAction().then(() => setMounted(true));
-    }, [props, doPermalinkAction]);
-
-    const isStateValid = mounted && props.channelId && props.teamName;
+        doPermalinkAction();
+    }, [doPermalinkAction]);
 
     // it is returning null because main idea of this component is to fire focusPost redux action
-    if (isStateValid) {
+    if (valid && props.channelId && props.teamName) {
         return null;
     }
 


### PR DESCRIPTION
#### Summary
Fixes: Clicking on a reply post time stamp in the global threads inbox opens two RHS

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-45907
  Fixes https://mattermost.atlassian.net/browse/MM-48226
  
#### Related Pull Requests
NA

#### Screenshots

https://user-images.githubusercontent.com/16203333/204783581-2e000149-d94f-4654-b11d-91b3cfb8c688.mov

https://user-images.githubusercontent.com/16203333/204783603-e4f2650f-f844-4c0e-a7b6-3cd013cf2bf0.mov


https://user-images.githubusercontent.com/16203333/204783663-16aa2df9-bd2b-4d9e-839b-b8caa934baed.mov





#### Release Note
```release-note
* Fixes: Clicking on a reply post time stamp in the global threads inbox opens two RHS
```
