### PR TITLE
[MM-44347] Use new display name parameter to fetch users in group

### DIFF
--- a/components/user_group_popover/group_member_list/group_member_list.tsx
+++ b/components/user_group_popover/group_member_list/group_member_list.tsx
@@ -73,7 +73,7 @@ export type Props = {
     searchTerm: string;
 
     actions: {
-        getUsersInGroup: (groupId: string, page: number, perPage: number) => Promise<{ data: UserProfile[] }>;
+        getUsersInGroup: (groupId: string, page: number, perPage: number, sort: string) => Promise<{ data: UserProfile[] }>;
         openDirectChannelToUserId: (userId?: string) => Promise<{ error: ServerError }>;
         closeRightHandSide: () => void;
     };
@@ -117,7 +117,7 @@ const GroupMemberList = (props: Props) => {
 
     const loadNextPage = async () => {
         setNextPageLoadState(Load.LOADING);
-        const res = await actions.getUsersInGroup(group.id, nextPage, USERS_PER_PAGE);
+        const res = await actions.getUsersInGroup(group.id, nextPage, USERS_PER_PAGE, 'display_name');
         if (res.data) {
             setNextPage(nextPage + 1);
             setNextPageLoadState(Load.DONE);

--- a/components/user_group_popover/group_member_list/index.ts
+++ b/components/user_group_popover/group_member_list/index.ts
@@ -11,7 +11,7 @@ import {Group} from '@mattermost/types/groups';
 
 import {GlobalState} from 'types/store';
 
-import {getProfilesInGroup, searchProfilesInGroup} from 'mattermost-redux/selectors/entities/users';
+import {getProfilesInGroupWithoutSorting, searchProfilesInGroupWithoutSorting} from 'mattermost-redux/selectors/entities/users';
 import {getProfilesInGroup as getUsersInGroup} from 'mattermost-redux/actions/users';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
@@ -54,14 +54,14 @@ const sortProfileList = (
 
 const getProfilesSortedByDisplayName = createSelector(
     'getProfilesSortedByDisplayName',
-    getProfilesInGroup,
+    getProfilesInGroupWithoutSorting,
     getTeammateNameDisplaySetting,
     sortProfileList,
 );
 
 const searchProfilesSortedByDisplayName = createSelector(
     'searchProfilesSortedByDisplayName',
-    searchProfilesInGroup,
+    searchProfilesInGroupWithoutSorting,
     getTeammateNameDisplaySetting,
     sortProfileList,
 );

--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -859,9 +859,9 @@ export default class Client4 {
         );
     };
 
-    getProfilesInGroup = (groupId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getProfilesInGroup = (groupId: string, page = 0, perPage = PER_PAGE_DEFAULT, sort = '') => {
         return this.doFetch<UserProfile[]>(
-            `${this.getUsersRoute()}${buildQueryString({in_group: groupId, page, per_page: perPage})}`,
+            `${this.getUsersRoute()}${buildQueryString({in_group: groupId, page, per_page: perPage, sort})}`,
             {method: 'get'},
         );
     };

--- a/packages/mattermost-redux/src/actions/users.ts
+++ b/packages/mattermost-redux/src/actions/users.ts
@@ -576,13 +576,13 @@ export function updateMyTermsOfServiceStatus(termsOfServiceId: string, accepted:
     };
 }
 
-export function getProfilesInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE): ActionFunc {
+export function getProfilesInGroup(groupId: string, page = 0, perPage: number = General.PROFILE_CHUNK_SIZE, sort = ''): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const {currentUserId} = getState().entities.users;
         let profiles;
 
         try {
-            profiles = await Client4.getProfilesInGroup(groupId, page, perPage);
+            profiles = await Client4.getProfilesInGroup(groupId, page, perPage, sort);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));

--- a/packages/mattermost-redux/src/selectors/entities/users.ts
+++ b/packages/mattermost-redux/src/selectors/entities/users.ts
@@ -712,6 +712,17 @@ export const getProfilesInGroup: (state: GlobalState, groupId: Group['id'], filt
     },
 );
 
+export const getProfilesInGroupWithoutSorting: (state: GlobalState, groupId: Group['id'], filters?: Filters) => UserProfile[] = createSelector(
+    'getProfilesInGroup',
+    getUsers,
+    getUserIdsInGroups,
+    (state: GlobalState, groupId: string) => groupId,
+    (state: GlobalState, groupId: string, filters: Filters) => filters,
+    (profiles, usersInGroups, groupId, filters) => {
+        return injectProfiles(filterProfiles(profiles, filters), usersInGroups[groupId] || new Set());
+    },
+);
+
 export const getProfilesNotInCurrentGroup: (state: GlobalState, groupId: Group['id'], filters?: Filters) => UserProfile[] = createSelector(
     'getProfilesNotInGroup',
     getUsers,
@@ -725,6 +736,15 @@ export const getProfilesNotInCurrentGroup: (state: GlobalState, groupId: Group['
 
 export function searchProfilesInGroup(state: GlobalState, groupId: Group['id'], term: string, skipCurrent = false, filters?: Filters): UserProfile[] {
     const profiles = filterProfilesStartingWithTerm(getProfilesInGroup(state, groupId, filters), term);
+    if (skipCurrent) {
+        removeCurrentUserFromList(profiles, getCurrentUserId(state));
+    }
+
+    return profiles;
+}
+
+export function searchProfilesInGroupWithoutSorting(state: GlobalState, groupId: Group['id'], term: string, skipCurrent = false, filters?: Filters): UserProfile[] {
+    const profiles = filterProfilesStartingWithTerm(getProfilesInGroupWithoutSorting(state, groupId, filters), term);
     if (skipCurrent) {
         removeCurrentUserFromList(profiles, getCurrentUserId(state));
     }


### PR DESCRIPTION
#### Summary

Use new display name parameter to fetch users in group, so that they are loaded in order of display name.

#### Ticket Link

Intended to be used for this feature: [Jira ticket](https://mattermost.atlassian.net/browse/MM-44347)

#### Related Pull Requests

Requires https://github.com/mattermost/mattermost-server/pull/21775

#### Release Note

```release-note
NONE
```
