### PR TITLE
MM-48609 : channels/DM/GMs  moveTo sub menu options revise

### DIFF
--- a/components/category_menu_items/index.ts
+++ b/components/category_menu_items/index.ts
@@ -1,4 +1,0 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-
-export {default} from './category_menu_items';

--- a/components/channel_header_dropdown/__snapshots__/channel_header_dropdown.test.tsx.snap
+++ b/components/channel_header_dropdown/__snapshots__/channel_header_dropdown.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`components/ChannelHeaderDropdown should match snapshot with no plugin i
     }
     show={true}
   />
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -44,7 +44,7 @@ exports[`components/ChannelHeaderDropdown should match snapshot with no plugin i
         "update_at": 0,
       }
     }
-    location="channel"
+    inHeaderDropdown={true}
     openUp={false}
   />
   <MenuGroup>
@@ -813,7 +813,7 @@ exports[`components/ChannelHeaderDropdown should match snapshot with plugins 1`]
     }
     show={true}
   />
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -833,7 +833,7 @@ exports[`components/ChannelHeaderDropdown should match snapshot with plugins 1`]
         "update_at": 0,
       }
     }
-    location="channel"
+    inHeaderDropdown={true}
     openUp={false}
   />
   <MenuGroup>

--- a/components/channel_header_dropdown/channel_header_dropdown_items.tsx
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.tsx
@@ -11,7 +11,7 @@ import {isGuest} from 'mattermost-redux/utils/user_utils';
 
 import MobileChannelHeaderPlug from 'plugins/mobile_channel_header_plug';
 
-import CategoryMenuItems from 'components/category_menu_items';
+import ChannelMoveToSubMenu from 'components/channel_move_to_sub_menu';
 import ChannelNotificationsModal from 'components/channel_notifications_modal';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import EditChannelHeaderModal from 'components/edit_channel_header_modal';
@@ -108,7 +108,7 @@ export default class ChannelHeaderDropdown extends React.PureComponent<Props> {
                     show={channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL}
                     channel={channel}
                 />
-                <CategoryMenuItems
+                <ChannelMoveToSubMenu
                     channel={channel}
                     openUp={false}
                     inHeaderDropdown={true}

--- a/components/channel_header_dropdown/channel_header_dropdown_items.tsx
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.tsx
@@ -111,7 +111,7 @@ export default class ChannelHeaderDropdown extends React.PureComponent<Props> {
                 <CategoryMenuItems
                     channel={channel}
                     openUp={false}
-                    location={'channel'}
+                    inHeaderDropdown={true}
                 />
                 <Menu.Group divider={divider}>
                     <MenuItemToggleFavoriteChannel

--- a/components/channel_move_to_sub_menu/index.tsx
+++ b/components/channel_move_to_sub_menu/index.tsx
@@ -151,21 +151,19 @@ const ChannelMoveToSubMenu = (props: Props) => {
     }
 
     return (
-        <React.Fragment>
-            <Menu.Group>
-                <Menu.ItemSubMenu
-                    id={`moveTo-${props.channel.id}`}
-                    subMenu={getMoveToCategorySubmenuItems(categories)}
-                    text={formatMessage({id: 'sidebar_left.sidebar_channel_menu.moveTo', defaultMessage: 'Move to...'})}
-                    direction={'right'}
-                    icon={props.inHeaderDropdown ? null : <FolderMoveOutlineIcon size={16}/>}
-                    openUp={props.openUp}
-                    styleSelectableItem={true}
-                    selectedValueText={currentCategory?.display_name}
-                    renderSelected={false}
-                />
-            </Menu.Group>
-        </React.Fragment>
+        <Menu.Group>
+            <Menu.ItemSubMenu
+                id={`moveTo-${props.channel.id}`}
+                subMenu={getMoveToCategorySubmenuItems(categories)}
+                text={formatMessage({id: 'sidebar_left.sidebar_channel_menu.moveTo', defaultMessage: 'Move to...'})}
+                direction={'right'}
+                icon={props.inHeaderDropdown ? null : <FolderMoveOutlineIcon size={16}/>}
+                openUp={props.openUp}
+                styleSelectableItem={true}
+                selectedValueText={currentCategory?.display_name}
+                renderSelected={false}
+            />
+        </Menu.Group>
     );
 };
 

--- a/components/channel_move_to_sub_menu/index.tsx
+++ b/components/channel_move_to_sub_menu/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {memo} from 'react';
 import {useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -40,7 +40,7 @@ type Props = {
     inHeaderDropdown?: boolean;
 };
 
-const CategoryMenuItems = (props: Props) => {
+const ChannelMoveToSubMenu = (props: Props) => {
     const {formatMessage} = useIntl();
 
     const dispatch = useDispatch<DispatchFunc>();
@@ -119,11 +119,7 @@ const CategoryMenuItems = (props: Props) => {
         return categories.filter((category) => category.type !== CategoryTypes.DIRECT_MESSAGES);
     }
 
-    function getMoveToCategorySubmenuItems() {
-        if (!categories) {
-            return [];
-        }
-
+    function getMoveToCategorySubmenuItems(categories: ChannelCategory[]) {
         const isSubmenuOneOfSelectedChannels = multiSelectedChannelIds.includes(props.channel.id);
 
         // If sub menu is in channel header dropdown OR If multiple channels are selected but the menu is open outside of those selected channels
@@ -159,7 +155,7 @@ const CategoryMenuItems = (props: Props) => {
             <Menu.Group>
                 <Menu.ItemSubMenu
                     id={`moveTo-${props.channel.id}`}
-                    subMenu={getMoveToCategorySubmenuItems()}
+                    subMenu={getMoveToCategorySubmenuItems(categories)}
                     text={formatMessage({id: 'sidebar_left.sidebar_channel_menu.moveTo', defaultMessage: 'Move to...'})}
                     direction={'right'}
                     icon={props.inHeaderDropdown ? null : <FolderMoveOutlineIcon size={16}/>}
@@ -173,4 +169,4 @@ const CategoryMenuItems = (props: Props) => {
     );
 };
 
-export default CategoryMenuItems;
+export default memo(ChannelMoveToSubMenu);

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
       text="Mute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -66,7 +66,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>
@@ -156,7 +155,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
       text="Mute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -176,7 +175,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>
@@ -266,7 +264,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
       text="Mute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -286,7 +284,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>
@@ -376,7 +373,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       text="Mute Conversation"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -396,7 +393,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup />
@@ -463,7 +459,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       text="Mute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -483,7 +479,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>
@@ -559,7 +554,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       text="Mute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -579,7 +574,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>
@@ -669,7 +663,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       text="Unmute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -689,7 +683,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>
@@ -779,7 +772,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       text="Mute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -799,7 +792,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>
@@ -889,7 +881,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       text="Mute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -909,7 +901,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>
@@ -999,7 +990,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
       text="Mute Channel"
     />
   </MenuGroup>
-  <CategoryMenuItems
+  <Memo(ChannelMoveToSubMenu)
     channel={
       Object {
         "create_at": 0,
@@ -1019,7 +1010,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should show cor
         "update_at": 0,
       }
     }
-    location="sidebar"
     openUp={false}
   />
   <MenuGroup>

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -17,7 +17,7 @@ import {
 
 import {trackEvent} from 'actions/telemetry_actions';
 
-import CategoryMenuItems from 'components/category_menu_items';
+import ChannelMoveToSubMenu from 'components/channel_move_to_sub_menu';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import SidebarMenu from 'components/sidebar/sidebar_menu';
 import Menu from 'components/widgets/menu/menu';
@@ -244,7 +244,7 @@ const SidebarChannelMenu = (props: Props) => {
                         {favoriteMenuItem}
                         {muteChannelMenuItem}
                     </Menu.Group>
-                    <CategoryMenuItems
+                    <ChannelMoveToSubMenu
                         channel={props.channel}
                         openUp={openUp}
                     />

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -247,7 +247,6 @@ const SidebarChannelMenu = (props: Props) => {
                     <CategoryMenuItems
                         channel={props.channel}
                         openUp={openUp}
-                        location={'sidebar'}
                     />
                     <Menu.Group>
                         {copyLinkMenuItem}


### PR DESCRIPTION
#### Summary
Sub menu items of channel move to of channel menu improved for following cases
- when a sub menu is under channel header dropdown, its shows correct categories i.e For DM/GM category "Channel" is not shown and vice versa
- when multiple same dms/gms are selected, Other categories along with "Direct Messages" is shown and not "Channel" category
- when multiple channels non dm/gm are selected, other categories along with "Channel" is shown and "Direct Messages" is not shown.
- when multiple any types of channels which included mix of DM/GM and other are selected, we show other categories but not show either of "Direct messages" nor "Channels"

Reviewing the PR
- [actual code change commit](https://github.com/mattermost/mattermost-webapp/pull/11694/commits/971dd6ea17f52971f064d4f409b4da1d693c04df)
- Rest is file name change for better knowing what that component is : `category_menu_items` => `channel_move_to_sub_menu`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48609

#### Related Pull Requests
n/a

#### Screenshots
tba

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
