### PR TITLE
Stop exposing components package as a shared module for now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@mattermost/client": "*",
         "@mattermost/compass-components": "^0.2.12",
         "@mattermost/compass-icons": "0.1.30",
-        "@mattermost/components": "*",
         "@mattermost/types": "*",
         "@stripe/react-stripe-js": "1.13.0",
         "@stripe/stripe-js": "1.41.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@mattermost/client": "*",
     "@mattermost/compass-components": "^0.2.12",
     "@mattermost/compass-icons": "0.1.30",
-    "@mattermost/components": "*",
     "@mattermost/types": "*",
     "@stripe/react-stripe-js": "1.13.0",
     "@stripe/stripe-js": "1.41.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -418,7 +418,6 @@ async function initializeModuleFederation() {
             // Other containers will use these shared modules if their required versions match. If they don't match, the
             // version packaged with the container will be used.
             '@mattermost/client',
-            '@mattermost/components',
             '@mattermost/types',
             'prop-types',
 


### PR DESCRIPTION
I added the components package to the package.json to silence the warnings printed by Webpack when we tried to share it via module federation, but because it doesn't exist as a package on NPM, this caused `npm install` to error out for anyone using `mattermost-webapp` as a git dependency.

Since we currently use the web app as a git dependency and we don't use the components package in any products, this seems like the easiest way to fix everyone's issues until we're ready to support the package properly.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
```release-note
NONE
```
