### PR TITLE
MM-48688 Add separate benchmark flow for master/release branches

### DIFF
--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -47,9 +47,25 @@ jobs:
       - name: Download the thing
         working-directory: e2e/cypress
         run: |
-          curl https://pr-builds.mattermost.com/mattermost-webapp/commit/${{ github.event.pull_request.head.sha || github.sha }}/mattermost-enterprise-linux-amd64.tar.gz > mattermost.tar.gz
-          tar -xvf mattermost.tar.gz
+          if [[ "${{ github.event.pull_request.head.sha }}" != "" ]]; then
+            echo "Using server build from pr-builds.mattermost.com"
+            curl https://pr-builds.mattermost.com/mattermost-webapp/commit/${{ github.event.pull_request.head.sha }}/mattermost-enterprise-linux-amd64.tar.gz > mattermost.tar.gz
 
+            tar xf mattermost.tar.gz
+          else
+            echo "Using server build from releases.mattermost.com with web app build from pr-builds.mattermost.com"
+
+            # Note that the server commit might not be the latest if we merge server and web app branches at the same time
+            curl https://s3.amazonaws.com/releases.mattermost.com/gitlab/bundle/master/mattermost-enterprise-linux-amd64.tar.gz > mattermost-server.tar.gz
+            curl https://pr-builds.mattermost.com/mattermost-webapp/commit/${{ github.sha }}/mattermost-webapp.tar.gz > mattermost-webapp.tar.gz
+
+            # Unzip the server, replace the web app, and re-add product files
+            tar xf mattermost-server.tar.gz
+            mv mattermost/client client-original
+            tar xf mattermost-webapp.tar.gz
+            mv client mattermost
+            mv client-original/products mattermost/client/products
+          fi
       - name: Run the E2E tests
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -56,7 +56,7 @@ jobs:
             echo "Using server build from releases.mattermost.com with web app build from pr-builds.mattermost.com"
 
             # Note that the server commit might not be the latest if we merge server and web app branches at the same time
-            curl https://s3.amazonaws.com/releases.mattermost.com/gitlab/bundle/master/mattermost-enterprise-linux-amd64.tar.gz > mattermost-server.tar.gz
+            curl https://s3.amazonaws.com/releases.mattermost.com/gitlab/bundle/${{ github.ref_name }}/mattermost-enterprise-linux-amd64.tar.gz > mattermost-server.tar.gz
             curl https://pr-builds.mattermost.com/mattermost-webapp/commit/${{ github.sha }}/mattermost-webapp.tar.gz > mattermost-webapp.tar.gz
 
             # Unzip the server, replace the web app, and re-add product files


### PR DESCRIPTION
When the previous version of this downloaded the web app and server for running benchmarks, it tried downloading a server+webapp bundle from pr-builds.mattermost.com, but that's only available for PR builds and not for the master/release branches. pr-builds does still have the web app code for those branches though (uploaded by the upload-s3 step of the CircleCI flow), so we can use that plus a server build from releases.mattermost.com combined together to run these benchmarks on.

This PR obviously uses the PR flow so it won't exercise the master/release flow, but an earlier version of this pretended to be on master, and you can see that run [here](https://github.com/mattermost/mattermost-webapp/actions/runs/3603560912/jobs/6071906015) where the download step runs through the master/release flow.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48688

#### Release Note
```release-note
NONE
```