### PR TITLE
MM-48778: Render strikethrough on at-mentions in posts.

### DIFF
--- a/sass/components/_mentions.scss
+++ b/sass/components/_mentions.scss
@@ -1,5 +1,13 @@
 @charset 'UTF-8';
 
+del .mention-link {
+    text-decoration: line-through;
+}
+
+del .mention-link:hover {
+    text-decoration: line-through underline;
+}
+
 .mention {
     position: relative;
     z-index: 10;


### PR DESCRIPTION
#### Summary

Fix to render the strikethrough on at-mentions in posts.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48778

#### Screenshots

Before fix:

<img width="583" alt="Screenshot 2022-12-02 at 2 04 58 PM" src="https://user-images.githubusercontent.com/1149597/205368022-343814a7-f7e0-4836-9b53-227f5b1c8cce.png">

After fix (non-hover and hover):

<img width="558" alt="Screenshot 2022-12-02 at 2 05 32 PM" src="https://user-images.githubusercontent.com/1149597/205368023-5b0cfa99-4329-4d86-b105-f244fb83dc9b.png">

<img width="643" alt="Screenshot 2022-12-02 at 2 05 45 PM" src="https://user-images.githubusercontent.com/1149597/205368024-5bbfbcc7-df3d-43eb-9d38-43518b2f8cf7.png">

#### Release Note

```release-note
Fixed the strikethrough display on at-mentions in posts.
```
