### PR TITLE
[MM-48818]: Fix bugs related to yearly subscriptions

### DIFF
--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -156,17 +156,19 @@ function Content(props: ContentProps) {
     ];
 
     // Default professional price
-    const defaultProfessionalPrice = monthlyProfessionalProduct ? monthlyProfessionalProduct.price_per_seat : 0;
+    const monthlyProfessionalPrice = monthlyProfessionalProduct ? monthlyProfessionalProduct.price_per_seat : 0;
+    const yearlyProfessionalPrice = yearlyProfessionalProduct ? yearlyProfessionalProduct.price_per_seat / 12 : 0;
+    const defaultProfessionalPrice = currentSubscriptionIsMonthly ? monthlyProfessionalPrice : yearlyProfessionalPrice;
     const [professionalPrice, setProfessionalPrice] = useState(defaultProfessionalPrice);
     const [isMonthlyPlan, setIsMonthlyPlan] = useState(true);
 
     // Set professional price
     const updateProfessionalPrice = (newIsMonthly: boolean) => {
-        if (newIsMonthly && monthlyProfessionalProduct) {
-            setProfessionalPrice(monthlyProfessionalProduct.price_per_seat);
+        if (newIsMonthly) {
+            setProfessionalPrice(monthlyProfessionalPrice);
             setIsMonthlyPlan(true);
         } else if (!newIsMonthly && yearlyProfessionalProduct) {
-            setProfessionalPrice(yearlyProfessionalProduct.price_per_seat / 12);
+            setProfessionalPrice(yearlyProfessionalPrice);
             setIsMonthlyPlan(false);
         }
     };
@@ -190,7 +192,7 @@ function Content(props: ContentProps) {
             </Modal.Header>
             <Modal.Body>
                 <div className='pricing-options-container'>
-                    {annualSubscriptionEnabled &&
+                    {(annualSubscriptionEnabled && currentSubscriptionIsMonthly) &&
                         <>
                             <div className='save-text'>
                                 {formatMessage({id: 'pricing_modal.saveWithYearly', defaultMessage: 'Save 20% with Yearly!'})}
@@ -258,7 +260,7 @@ function Content(props: ContentProps) {
                                 }
                             },
                             text: formatMessage({id: 'pricing_modal.btn.downgrade', defaultMessage: 'Downgrade'}),
-                            disabled: isStarter || isEnterprise || !isAdmin,
+                            disabled: isStarter || isEnterprise || !isAdmin || !currentSubscriptionIsMonthly,
                             customClass: ButtonCustomiserClasses.secondary,
                         }}
                         briefing={{

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -489,20 +489,18 @@ function Card(props: CardProps) {
     const monthlyYearlyPlan = (
         <div className='PlanCard'>
             <div className='bottom bottom-monthly-yearly'>
+                <div className='save_text'>
+                    <FormattedMessage
+                        defaultMessage={'Save 20% with Yearly.'}
+                        id={'pricing_modal.saveWithYearly'}
+                    />
+                </div>
                 {!props.isCurrentPlanMonthlyProfessional && (
-                    <>
-                        <div className='save_text'>
-                            <FormattedMessage
-                                defaultMessage={'Save 20% with Yearly.'}
-                                id={'pricing_modal.saveWithYearly'}
-                            />
-                        </div>
-                        <YearlyMonthlyToggle
-                            updatePrice={updateDisplayPage}
-                            isPurchases={true}
-                            isInitialPlanMonthly={props.isInitialPlanMonthly}
-                        />
-                    </>
+                    <YearlyMonthlyToggle
+                        updatePrice={updateDisplayPage}
+                        isPurchases={true}
+                        isInitialPlanMonthly={props.isInitialPlanMonthly}
+                    />
                 )}
                 {/* the style below will eventually be added to the plan_price_rate_section once the annualSubscription feature flag is removed*/}
                 <div

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -94,6 +94,7 @@ type CardProps = {
     updateIsMonthly: (isMonthly: boolean) => void;
     updateInputUserCount: (userCount: number) => void;
     setUserCountError: (hasError: boolean) => void;
+    isCurrentPlanMonthlyProfessional: boolean;
 }
 
 type Props = {
@@ -488,17 +489,21 @@ function Card(props: CardProps) {
     const monthlyYearlyPlan = (
         <div className='PlanCard'>
             <div className='bottom bottom-monthly-yearly'>
-                <div className='save_text'>
-                    <FormattedMessage
-                        defaultMessage={'Save 20% with Yearly.'}
-                        id={'pricing_modal.saveWithYearly'}
-                    />
-                </div>
-                <YearlyMonthlyToggle
-                    updatePrice={updateDisplayPage}
-                    isPurchases={true}
-                    isInitialPlanMonthly={props.isInitialPlanMonthly}
-                />
+                {!props.isCurrentPlanMonthlyProfessional && (
+                    <>
+                        <div className='save_text'>
+                            <FormattedMessage
+                                defaultMessage={'Save 20% with Yearly.'}
+                                id={'pricing_modal.saveWithYearly'}
+                            />
+                        </div>
+                        <YearlyMonthlyToggle
+                            updatePrice={updateDisplayPage}
+                            isPurchases={true}
+                            isInitialPlanMonthly={props.isInitialPlanMonthly}
+                        />
+                    </>
+                )}
                 {/* the style below will eventually be added to the plan_price_rate_section once the annualSubscription feature flag is removed*/}
                 <div
                     className='plan_price_rate_section'
@@ -904,6 +909,10 @@ class PurchaseModal extends React.PureComponent<Props, State> {
             return crossSellsToProduct ? crossSellsToProduct.price_per_seat / 12 : this.state.selectedProduct.price_per_seat;
         };
 
+        const checkIsMonthlyProfessionalProduct = (product: Product) => {
+            return product.recurring_interval === RecurringIntervals.MONTH && product.sku === CloudProducts.PROFESSIONAL;
+        };
+
         return (
             <>
                 <div
@@ -954,6 +963,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                     setUserCountError={(hasError: boolean) => this.setState({userCountError: hasError})}
                     updateIsMonthly={(newIsMonthly: boolean) => this.setState({isMonthly: newIsMonthly})}
                     updateInputUserCount={(newUsersCount: number) => this.setState({inputUserCount: newUsersCount})}
+                    isCurrentPlanMonthlyProfessional={this.state.currentProduct ? checkIsMonthlyProfessionalProduct(this.state.currentProduct) : false}
                 />
             </>
         );

--- a/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.js
@@ -445,6 +445,28 @@ describe('Pricing modal', () => {
         cy.get('#pricingModal').get('#enterprise').get('#start_cloud_trial_btn').should('be.disabled');
     });
 
+    it('should not allow downgrades from yearly plans', () => {
+        const subscription = {
+            id: 'sub_test1',
+            product_id: 'prod_4',
+            is_free_trial: 'false',
+        };
+        simulateSubscription(subscription);
+        cy.apiLogout();
+        cy.apiAdminLogin();
+        cy.visit(urlL);
+
+        // # Open the pricing modal
+        cy.visit('/admin_console/billing/subscription?action=show_pricing_modal');
+
+        // * Pricing modal should be open
+        cy.get('#pricingModal').should('exist');
+        cy.get('#pricingModal').get('.PricingModal__header').contains('Select a plan');
+
+        // * Check that free card Downgrade button is disabled
+        cy.get('#pricingModal').get('#free').get('#free_action').should('be.disabled').contains('Downgrade');
+    });
+
     it('should not allow starting a trial from professional plans', () => {
         const subscription = {
             id: 'sub_test1',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -324,7 +324,7 @@
   "admin.billing.subscription.paymentBegins": "Payment begins: {beginDate}. ",
   "admin.billing.subscription.paymentFailed": "Payment failed. Please try again or contact support.",
   "admin.billing.subscription.paymentVerificationFailed": "Sorry, the payment verification failed",
-  "admin.billing.subscription.planDetails.currentPlan": "(Current Plan)",
+  "admin.billing.subscription.planDetails.currentPlan": "Current Plan",
   "admin.billing.subscription.planDetails.features.advanceTeamPermission": "Advanced team permissions",
   "admin.billing.subscription.planDetails.features.autoComplianceExports": "Automated compliance exports",
   "admin.billing.subscription.planDetails.features.customRetentionPolicies": "Custom data retention policies",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fix a few bugs related to the yearly subscriptions.
1. Disable the "Downgrade" button when the user is on a yearly plan. 

|  before  |  after  |
|----|----|
| <img width="1438" alt="image" src="https://user-images.githubusercontent.com/44761757/205382606-5c5a16e0-4471-455a-91c2-0bf3145aee73.png"> |<img width="1437" alt="image" src="https://user-images.githubusercontent.com/44761757/205383588-941dad67-3958-46df-9ad4-7c325d052c8b.png"> |
2. When a user is subscribed to the monthly professional plan and opens the purchase modal, hide the yearly/monthly toggle. This ensures that they can't try to subscribe to the monthly professional plan when they are already on that plan.

|  before  |  after  |
|----|----|
|<img width="2040" alt="image" src="https://user-images.githubusercontent.com/44761757/205385450-8b8595bb-3ccc-45fc-b628-bf01653c027f.png"> |<img width="1800" alt="image" src="https://user-images.githubusercontent.com/44761757/205386245-0b4b5291-cef9-4d12-a600-758b9aa5183b.png">|

3. When a user is subscribed to the yearly professional plan and opens the pricing modal, hide the yearly/monthly toggle so the text "current plan" is only shown on the yearly plan (with the corresponding price).  (see images above)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48818
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
