### PR TITLE
MM-48773: fixes position of ACK users popover

### DIFF
--- a/components/post_view/acknowledgements/post_acknowledgements.tsx
+++ b/components/post_view/acknowledgements/post_acknowledgements.tsx
@@ -6,17 +6,17 @@ import {FormattedMessage} from 'react-intl';
 import classNames from 'classnames';
 import {useDispatch} from 'react-redux';
 import {
-    useFloating,
-    autoUpdate,
-    offset,
-    flip,
-    shift,
-    useHover,
-    useRole,
-    useInteractions,
-    safePolygon,
     FloatingFocusManager,
+    autoUpdate,
+    flip,
+    offset,
+    safePolygon,
+    shift,
+    useFloating,
+    useHover,
     useId,
+    useInteractions,
+    useRole,
 } from '@floating-ui/react-dom-interactions';
 
 import {CheckCircleOutlineIcon} from '@mattermost/compass-icons/components';
@@ -66,8 +66,13 @@ function PostAcknowledgements({
         whileElementsMounted: autoUpdate,
         middleware: [
             offset(5),
-            flip({fallbackPlacements: ['bottom', 'right'], padding: 5}),
-            shift(),
+            flip({
+                fallbackPlacements: ['bottom-start', 'right'],
+                padding: 12,
+            }),
+            shift({
+                padding: 12,
+            }),
         ],
     });
 


### PR DESCRIPTION
#### Summary

The fallback position for the post acknowledgements users popover should be `bottom-start`, 
so if the popover doesn't fit at `top-start`, it would be placed at bottom`-start`, 
and if it doesn't fit there, or in `right`, it will use the `best-fit` position.

Fixes both RHS, and Center Channel.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48773

#### Screenshots

|  before  |  after  |
|----|----|
|![Screenshot 2022-12-03 at 3 20 34 PM](https://user-images.githubusercontent.com/3829551/205442868-1f12056d-086b-44bb-a817-b8cf37d4fa77.png)|![Screenshot 2022-12-03 at 3 20 06 PM](https://user-images.githubusercontent.com/3829551/205442856-48ba06e2-2ee9-46eb-9660-b239aed57289.png)|


#### Release Note

```release-note
NONE
```
