### PR TITLE
MM-48565: fixes delay in channel urgent mention

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -789,6 +789,7 @@ export function handlePostUnreadEvent(msg) {
                 msgCountRoot: msg.data.msg_count_root,
                 mentionCount: msg.data.mention_count,
                 mentionCountRoot: msg.data.mention_count_root,
+                urgentMentionCount: msg.data.urgent_mention_count,
             },
         },
     );


### PR DESCRIPTION
#### Summary

When we mark a channel as unread through a post which has mentions in urgent posts, we show briefly the normal badge, and then we show the "urgent" badge, instead of immediately.
It seems that we didn't pass the urgent mention counts upon the websocket event handling for post_unread_event.

This commit fixes that so it shows the urgent badge immediately.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48565

#### Release Note

```release-note
NONE
```
