### PR TITLE
MM-48831: fixes displaying of first acknowledgement

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -1220,18 +1220,12 @@ export function acknowledgements(state: RelationOneToOne<Post, Record<UserProfil
     switch (action.type) {
     case PostTypes.CREATE_ACK_POST_SUCCESS: {
         const ack = action.data as PostAcknowledgement;
-
-        if (!state[ack.post_id]) {
-            return {
-                ...state,
-                [ack.post_id]: ack.acknowledged_at,
-            };
-        }
+        const oldState = state[ack.post_id] || {};
 
         return {
             ...state,
             [ack.post_id]: {
-                ...state[ack.post_id],
+                ...oldState,
                 [ack.user_id]: ack.acknowledged_at,
             },
         };


### PR DESCRIPTION
#### Summary

Currently if a post exists which requested acknowledgements, but no-one has yet to acknowledge, when the first ACK happens it won't display to other users because of a bug.

This commit fixes that bug by returning the correct state shape upon the first ACK.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48831

#### Release Note

```release-note
NONE
```
