### PR TITLE
Fixes: a button cannot be a descendant of a button

### DIFF
--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -21,15 +21,15 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"
@@ -251,15 +251,15 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"
@@ -562,15 +562,15 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"
@@ -825,15 +825,15 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"
@@ -1088,15 +1088,15 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"
@@ -1356,15 +1356,15 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
       size="sm"
       url="http://localhost:8065/api/v4/users/jsx5jmdiyjyuzp9rzwfaf5pwjo/image?_=1590519110944"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"
@@ -1590,15 +1590,15 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"
@@ -1820,15 +1820,15 @@ exports[`components/StatusDropdown should not show clear status button when cust
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"
@@ -2083,15 +2083,15 @@ exports[`components/StatusDropdown should show clear status button when custom s
       showTooltip={true}
       tooltipDirection="bottom"
     />
-    <button
+    <div
       aria-label="user status is set to  you can change status by selecting your profile picture"
-      className="status style--none"
+      className="status"
     >
       <StatusIcon
         size="sm"
         status="offline"
       />
-    </button>
+    </div>
   </button>
   <Menu
     ariaLabel="Set a status"

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -428,7 +428,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
                     />
                     {this.renderProfilePicture('sm')}
                     <div
-                        className='status style--none'
+                        className='status'
                         aria-label={menuAriaLabeltext}
                     >
                         <StatusIcon

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -427,7 +427,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
                         onClick={this.handleCustomStatusEmojiClick as () => void}
                     />
                     {this.renderProfilePicture('sm')}
-                    <button
+                    <div
                         className='status style--none'
                         aria-label={menuAriaLabeltext}
                     >
@@ -435,7 +435,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
                             size={'sm'}
                             status={(this.props.status || 'offline') as TUserStatus}
                         />
-                    </button>
+                    </div>
                 </button>
                 <Menu
                     ariaLabel={localizeMessage('status_dropdown.menuAriaLabel', 'Set a status')}


### PR DESCRIPTION
#### Summary

Fixes a console error that shows upon development.
A button cannot be a descendant of a button.

-- EDIT --

I didn't realize that we had inserted that button due to accessibility, 
I'll refer to the original committer if my change is acceptable or not.

Still I think we must not nest buttons under other buttons, even if this change is
not acceptable we still have to serve valid DOM nesting.

#### Release Note

```release-note
NONE
```
