### PR TITLE
MM-48839 : Combine single module.rule for sass and css in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ var config = {
     module: {
         rules: [
             {
-                test: /\.(js|jsx|ts|tsx)?$/,
+                test: /\.(js|jsx|ts|tsx)$/,
                 exclude: STANDARD_EXCLUDE,
                 use: {
                     loader: 'babel-loader',
@@ -86,7 +86,7 @@ var config = {
                 ],
             },
             {
-                test: /\.scss$/,
+                test: /\.s?css$/,
                 use: [
                     DEV ? 'style-loader' : MiniCssExtractPlugin.loader,
                     {
@@ -99,15 +99,6 @@ var config = {
                                 includePaths: ['sass'],
                             },
                         },
-                    },
-                ],
-            },
-            {
-                test: /\.css$/,
-                use: [
-                    DEV ? 'style-loader' : MiniCssExtractPlugin.loader,
-                    {
-                        loader: 'css-loader',
                     },
                 ],
             },


### PR DESCRIPTION
#### Summary
Webpack is designed to handle large amounts of data through dependency resolution. It does that my creating module dependency graph. Having two seperate module rules for sass and css, leads to creating two different file tree of sass and css. And 3 loaders i.e miniCssExtract + cssLoader + sassLoaders have to be run for sass, and another run of miniCssExtract + cssLoader for css separately have to be run. Instead both can be done with single rule. There is not much difference in the build time however.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48839

#### Related Pull Requests
<!--
na

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="582" alt="image" src="https://user-images.githubusercontent.com/17708702/205510026-be019c27-2b27-48d1-9fdd-f17dd31f8abe.png"> | <img width="582" alt="image" src="https://user-images.githubusercontent.com/17708702/205510068-a4cb28e2-5584-41db-b57d-8e728a175a28.png"> |


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
