### PR TITLE
[MM-44348] Show number of group members in group autocomplete

### DIFF
--- a/components/suggestion/at_mention_provider/at_mention_suggestion.tsx
+++ b/components/suggestion/at_mention_provider/at_mention_suggestion.tsx
@@ -12,10 +12,12 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 import GuestBadge from 'components/widgets/badges/guest_badge';
 import SharedUserIndicator from 'components/shared_user_indicator';
 import Avatar from 'components/widgets/users/avatar';
+import Badge from 'components/widgets/badges/badge';
 
-import Suggestion from '../suggestion.jsx';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import StatusIcon from 'components/status_icon';
+
+import Suggestion from '../suggestion.jsx';
 
 import {UserProfile} from '../command_provider/app_command_parser/app_command_parser_dependencies.js';
 
@@ -24,6 +26,10 @@ interface Item extends UserProfile {
     name: string;
     isCurrentUser: boolean;
     type: string;
+}
+
+interface Group extends Item {
+    member_count: number;
 }
 
 class AtMentionSuggestion extends Suggestion {
@@ -92,7 +98,9 @@ class AtMentionSuggestion extends Suggestion {
             );
         } else if (item.type === Constants.MENTION_GROUPS) {
             itemname = item.name;
-            description = `- ${item.display_name}`;
+            description = (
+                <span className='ml-1'>{'- '}{item.display_name}</span>
+            );
             icon = (
                 <span className='suggestion-list__icon suggestion-list__icon--large'>
                     <i
@@ -173,6 +181,23 @@ class AtMentionSuggestion extends Suggestion {
             );
         }
 
+        let countBadge;
+        if (item.type === Constants.MENTION_GROUPS) {
+            countBadge = (
+                <span className='suggestion-list__group-count'>
+                    <Badge>
+                        {(item as Group).member_count}
+                        <span className='ml-1'>
+                            <FormattedMessage
+                                id='suggestion.group.members'
+                                defaultMessage='members'
+                            />
+                        </span>
+                    </Badge>
+                </span>
+            );
+        }
+
         return (
             <div
                 className={className}
@@ -199,6 +224,7 @@ class AtMentionSuggestion extends Suggestion {
                         className='badge-autocomplete'
                     />
                 </span>
+                {countBadge}
             </div>
         );
     }

--- a/components/suggestion/at_mention_provider/at_mention_suggestion.tsx
+++ b/components/suggestion/at_mention_provider/at_mention_suggestion.tsx
@@ -186,13 +186,13 @@ class AtMentionSuggestion extends Suggestion {
             countBadge = (
                 <span className='suggestion-list__group-count'>
                     <Badge>
-                        {(item as Group).member_count}
-                        <span className='ml-1'>
-                            <FormattedMessage
-                                id='suggestion.group.members'
-                                defaultMessage='members'
-                            />
-                        </span>
+                        <FormattedMessage
+                            id='suggestion.group.members'
+                            defaultMessage='{member_count} {member_count, plural, one {member} other {members}}'
+                            values={{
+                                member_count: (item as Group).member_count,
+                            }}
+                        />
                     </Badge>
                 </span>
             );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4840,6 +4840,7 @@
   "suggestion.archive": "Archived Channels",
   "suggestion.commands": "Commands",
   "suggestion.emoji": "Emoji",
+  "suggestion.group.members": "members",
   "suggestion.mention.all": "Notifies everyone in this channel",
   "suggestion.mention.channel": "Notifies everyone in this channel",
   "suggestion.mention.channels": "My Channels",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4840,7 +4840,7 @@
   "suggestion.archive": "Archived Channels",
   "suggestion.commands": "Commands",
   "suggestion.emoji": "Emoji",
-  "suggestion.group.members": "members",
+  "suggestion.group.members": "{member_count} {member_count, plural, one {member} other {members}}",
   "suggestion.mention.all": "Notifies everyone in this channel",
   "suggestion.mention.channel": "Notifies everyone in this channel",
   "suggestion.mention.channels": "My Channels",

--- a/sass/components/_suggestion-list.scss
+++ b/sass/components/_suggestion-list.scss
@@ -341,3 +341,15 @@
         white-space: nowrap;
     }
 }
+
+.suggestion-list__group-count {
+    display: flex;
+    flex-grow: 1;
+    justify-content: end;
+
+    @media screen and (max-width: 480px) {
+        .Badge__box span {
+            display: none;
+        }
+    }
+}


### PR DESCRIPTION
#### Summary
Added a badge with group members count. Also fixed the spacing between username and name.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44348

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="600" alt="image" src="https://user-images.githubusercontent.com/684680/205632121-13175b9a-956a-489c-862b-bf7db0baeae6.png"> | <img width="591" alt="image" src="https://user-images.githubusercontent.com/684680/205631721-f873396c-d6c6-4f4e-ab30-cb9ba2e11e87.png"> |

#### Release Note
```release-note
Added group members count in autocomplete
```
