### PR TITLE
MM-48456 - restrict analytics call to only admins

### DIFF
--- a/components/announcement_bar/announcement_bar_controller.tsx
+++ b/components/announcement_bar/announcement_bar_controller.tsx
@@ -87,6 +87,13 @@ class AnnouncementBarController extends React.PureComponent<Props> {
             );
         }
 
+        let autoStartTrialModal = null;
+        if (this.props.userIsAdmin) {
+            autoStartTrialModal = (
+                <AutoStartTrialModal/>
+            );
+        }
+
         return (
             <>
                 {adminConfiguredAnnouncementBar}
@@ -97,7 +104,7 @@ class AnnouncementBarController extends React.PureComponent<Props> {
                 {cloudDelinquencyAnnouncementBar}
                 {notifyAdminDowngradeDelinquencyBar}
                 {this.props.license?.Cloud !== 'true' && <OverageUsersBanner/>}
-                <AutoStartTrialModal/>
+                {autoStartTrialModal}
                 <ShowThreeDaysLeftTrialModal/>
                 <VersionBar/>
                 <ConfigurationAnnouncementBar

--- a/components/announcement_bar/show_start_trial_modal/show_start_trial_modal.tsx
+++ b/components/announcement_bar/show_start_trial_modal/show_start_trial_modal.tsx
@@ -59,7 +59,7 @@ const ShowStartTrialModal = () => {
         if (!stats?.TOTAL_USERS) {
             dispatch(getStandardAnalytics());
         }
-    }, [!stats?.TOTAL_USERS]);
+    }, []);
 
     const handleOnClose = () => {
         trackEvent(

--- a/components/announcement_bar/show_start_trial_modal/show_start_trial_modal.tsx
+++ b/components/announcement_bar/show_start_trial_modal/show_start_trial_modal.tsx
@@ -59,7 +59,7 @@ const ShowStartTrialModal = () => {
         if (!stats?.TOTAL_USERS) {
             dispatch(getStandardAnalytics());
         }
-    }, []);
+    }, [stats?.TOTAL_USERS]);
 
     const handleOnClose = () => {
         trackEvent(

--- a/components/announcement_bar/show_start_trial_modal/show_start_trial_modal.tsx
+++ b/components/announcement_bar/show_start_trial_modal/show_start_trial_modal.tsx
@@ -59,7 +59,7 @@ const ShowStartTrialModal = () => {
         if (!stats?.TOTAL_USERS) {
             dispatch(getStandardAnalytics());
         }
-    }, [stats?.TOTAL_USERS]);
+    }, []);
 
     const handleOnClose = () => {
         trackEvent(

--- a/components/system_notice/system_notice.tsx
+++ b/components/system_notice/system_notice.tsx
@@ -34,13 +34,13 @@ type Props = {
 }
 export default class SystemNotice extends React.PureComponent<Props> {
     componentDidMount() {
-        if (this.props.isSystemAdmin) {
+        if (this.props.isSystemAdmin && !this.props.analytics) {
             this.props.actions.getStandardAnalytics();
         }
     }
 
     componentDidUpdate(prevProps: Props) {
-        if (prevProps.isSystemAdmin !== this.props.isSystemAdmin && this.props.isSystemAdmin) {
+        if ((prevProps.isSystemAdmin !== this.props.isSystemAdmin && this.props.isSystemAdmin && !this.props.analytics)) {
             this.props.actions.getStandardAnalytics();
         }
     }

--- a/components/system_notice/system_notice.tsx
+++ b/components/system_notice/system_notice.tsx
@@ -34,13 +34,13 @@ type Props = {
 }
 export default class SystemNotice extends React.PureComponent<Props> {
     componentDidMount() {
-        if (this.props.isSystemAdmin && !this.props.analytics) {
+        if (this.props.isSystemAdmin) {
             this.props.actions.getStandardAnalytics();
         }
     }
 
     componentDidUpdate(prevProps: Props) {
-        if ((prevProps.isSystemAdmin !== this.props.isSystemAdmin && this.props.isSystemAdmin && !this.props.analytics)) {
+        if ((prevProps.isSystemAdmin !== this.props.isSystemAdmin && this.props.isSystemAdmin)) {
             this.props.actions.getStandardAnalytics();
         }
     }

--- a/components/system_notice/system_notice.tsx
+++ b/components/system_notice/system_notice.tsx
@@ -40,7 +40,7 @@ export default class SystemNotice extends React.PureComponent<Props> {
     }
 
     componentDidUpdate(prevProps: Props) {
-        if ((prevProps.isSystemAdmin !== this.props.isSystemAdmin && this.props.isSystemAdmin)) {
+        if (prevProps.isSystemAdmin !== this.props.isSystemAdmin && this.props.isSystemAdmin) {
             this.props.actions.getStandardAnalytics();
         }
     }


### PR DESCRIPTION
#### Summary
This PR makes sure that the show start trial modal only calls the analytics endpoint when the user is an admin user.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48456

#### Related Pull Requests

#### Screenshots


#### Release Note
```release-note
NONE
```
