### PR TITLE
MM-48824 - move onboarding tasklist to logged in component

### DIFF
--- a/components/logged_in/index.ts
+++ b/components/logged_in/index.ts
@@ -15,6 +15,7 @@ import {viewChannel} from 'mattermost-redux/actions/channels';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser, shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {getHistory} from 'utils/browser_history';
 import {checkIfMFARequired} from 'utils/route';
@@ -40,6 +41,7 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         mfaRequired: checkIfMFARequired(getCurrentUser(state), license, config, ownProps.match.url),
         enableTimezone: config.ExperimentalTimezone === 'true',
         showTermsOfService,
+        theme: getTheme(state),
     };
 }
 

--- a/components/logged_in/logged_in.test.tsx
+++ b/components/logged_in/logged_in.test.tsx
@@ -1,23 +1,23 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from "react";
-import { shallow } from "enzyme";
+import React from 'react';
+import {shallow} from 'enzyme';
 
-import LoggedIn, { Props } from "components/logged_in/logged_in";
-import BrowserStore from "stores/browser_store";
-import * as GlobalActions from "actions/global_actions";
-import { UserProfile } from "@mattermost/types/users";
-import { Theme } from "mattermost-redux/selectors/entities/preferences";
+import LoggedIn, {Props} from 'components/logged_in/logged_in';
+import BrowserStore from 'stores/browser_store';
+import * as GlobalActions from 'actions/global_actions';
+import {UserProfile} from '@mattermost/types/users';
+import {Theme} from 'mattermost-redux/selectors/entities/preferences';
 
-jest.mock("actions/websocket_actions.jsx", () => ({
+jest.mock('actions/websocket_actions.jsx', () => ({
     initialize: jest.fn(),
 }));
 
 BrowserStore.signalLogin = jest.fn();
 
-describe("components/logged_in/LoggedIn", () => {
-    const children = <span>{"Test"}</span>;
+describe('components/logged_in/LoggedIn', () => {
+    const children = <span>{'Test'}</span>;
     const baseProps: Props = {
         currentUser: {} as UserProfile,
         mfaRequired: false,
@@ -29,13 +29,13 @@ describe("components/logged_in/LoggedIn", () => {
         },
         showTermsOfService: false,
         location: {
-            pathname: "/",
-            search: "",
+            pathname: '/',
+            search: '',
         },
         theme: {} as Theme,
     };
 
-    it("should render loading state without user", () => {
+    it('should render loading state without user', () => {
         const props = {
             ...baseProps,
             currentUser: undefined,
@@ -43,10 +43,10 @@ describe("components/logged_in/LoggedIn", () => {
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
-        expect(wrapper).toMatchInlineSnapshot("<LoadingScreen />");
+        expect(wrapper).toMatchInlineSnapshot('<LoadingScreen />');
     });
 
-    it("should redirect to mfa when required and not on /mfa/setup", () => {
+    it('should redirect to mfa when required and not on /mfa/setup', () => {
         const props = {
             ...baseProps,
             mfaRequired: true,
@@ -61,13 +61,13 @@ describe("components/logged_in/LoggedIn", () => {
         `);
     });
 
-    it("should render children when mfa required and already on /mfa/setup", () => {
+    it('should render children when mfa required and already on /mfa/setup', () => {
         const props = {
             ...baseProps,
             mfaRequired: true,
             location: {
-                pathname: "/mfa/setup",
-                search: "",
+                pathname: '/mfa/setup',
+                search: '',
             },
         };
 
@@ -87,13 +87,13 @@ describe("components/logged_in/LoggedIn", () => {
         `);
     });
 
-    it("should render children when mfa is not required and on /mfa/confirm", () => {
+    it('should render children when mfa is not required and on /mfa/confirm', () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
             location: {
-                pathname: "/mfa/confirm",
-                search: "",
+                pathname: '/mfa/confirm',
+                search: '',
             },
         };
 
@@ -113,7 +113,7 @@ describe("components/logged_in/LoggedIn", () => {
         `);
     });
 
-    it("should redirect to terms of service when mfa not required and terms of service required but not on /terms_of_service", () => {
+    it('should redirect to terms of service when mfa not required and terms of service required but not on /terms_of_service', () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
@@ -129,14 +129,14 @@ describe("components/logged_in/LoggedIn", () => {
         `);
     });
 
-    it("should render children when mfa is not required and terms of service required and on /terms_of_service", () => {
+    it('should render children when mfa is not required and terms of service required and on /terms_of_service', () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
             showTermsOfService: true,
             location: {
-                pathname: "/terms_of_service",
-                search: "",
+                pathname: '/terms_of_service',
+                search: '',
             },
         };
 
@@ -156,7 +156,7 @@ describe("components/logged_in/LoggedIn", () => {
         `);
     });
 
-    it("should render children when neither mfa nor terms of service required", () => {
+    it('should render children when neither mfa nor terms of service required', () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
@@ -179,7 +179,7 @@ describe("components/logged_in/LoggedIn", () => {
         `);
     });
 
-    it("should signal to other tabs when login is successful", () => {
+    it('should signal to other tabs when login is successful', () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
@@ -191,7 +191,7 @@ describe("components/logged_in/LoggedIn", () => {
         expect(BrowserStore.signalLogin).toBeCalledTimes(1);
     });
 
-    it("should set state to unfocused if it starts in the background", () => {
+    it('should set state to unfocused if it starts in the background', () => {
         document.hasFocus = jest.fn(() => false);
 
         const obj = Object.assign(GlobalActions);

--- a/components/logged_in/logged_in.test.tsx
+++ b/components/logged_in/logged_in.test.tsx
@@ -1,22 +1,23 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
-import {shallow} from 'enzyme';
+import React from "react";
+import { shallow } from "enzyme";
 
-import LoggedIn, {Props} from 'components/logged_in/logged_in';
-import BrowserStore from 'stores/browser_store';
-import * as GlobalActions from 'actions/global_actions';
-import {UserProfile} from '@mattermost/types/users';
+import LoggedIn, { Props } from "components/logged_in/logged_in";
+import BrowserStore from "stores/browser_store";
+import * as GlobalActions from "actions/global_actions";
+import { UserProfile } from "@mattermost/types/users";
+import { Theme } from "mattermost-redux/selectors/entities/preferences";
 
-jest.mock('actions/websocket_actions.jsx', () => ({
+jest.mock("actions/websocket_actions.jsx", () => ({
     initialize: jest.fn(),
 }));
 
 BrowserStore.signalLogin = jest.fn();
 
-describe('components/logged_in/LoggedIn', () => {
-    const children = <span>{'Test'}</span>;
+describe("components/logged_in/LoggedIn", () => {
+    const children = <span>{"Test"}</span>;
     const baseProps: Props = {
         currentUser: {} as UserProfile,
         mfaRequired: false,
@@ -28,12 +29,13 @@ describe('components/logged_in/LoggedIn', () => {
         },
         showTermsOfService: false,
         location: {
-            pathname: '/',
-            search: '',
+            pathname: "/",
+            search: "",
         },
+        theme: {} as Theme,
     };
 
-    it('should render loading state without user', () => {
+    it("should render loading state without user", () => {
         const props = {
             ...baseProps,
             currentUser: undefined,
@@ -41,10 +43,10 @@ describe('components/logged_in/LoggedIn', () => {
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
-        expect(wrapper).toMatchInlineSnapshot('<LoadingScreen />');
+        expect(wrapper).toMatchInlineSnapshot("<LoadingScreen />");
     });
 
-    it('should redirect to mfa when required and not on /mfa/setup', () => {
+    it("should redirect to mfa when required and not on /mfa/setup", () => {
         const props = {
             ...baseProps,
             mfaRequired: true,
@@ -59,45 +61,59 @@ describe('components/logged_in/LoggedIn', () => {
         `);
     });
 
-    it('should render children when mfa required and already on /mfa/setup', () => {
+    it("should render children when mfa required and already on /mfa/setup", () => {
         const props = {
             ...baseProps,
             mfaRequired: true,
             location: {
-                pathname: '/mfa/setup',
-                search: '',
+                pathname: "/mfa/setup",
+                search: "",
             },
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
         expect(wrapper).toMatchInlineSnapshot(`
-            <span>
-              Test
-            </span>
+            <Fragment>
+              <CompassThemeProvider
+                theme={Object {}}
+              >
+                <OnBoardingTaskList />
+              </CompassThemeProvider>
+              <span>
+                Test
+              </span>
+            </Fragment>
         `);
     });
 
-    it('should render children when mfa is not required and on /mfa/confirm', () => {
+    it("should render children when mfa is not required and on /mfa/confirm", () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
             location: {
-                pathname: '/mfa/confirm',
-                search: '',
+                pathname: "/mfa/confirm",
+                search: "",
             },
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
         expect(wrapper).toMatchInlineSnapshot(`
-            <span>
-              Test
-            </span>
+            <Fragment>
+              <CompassThemeProvider
+                theme={Object {}}
+              >
+                <OnBoardingTaskList />
+              </CompassThemeProvider>
+              <span>
+                Test
+              </span>
+            </Fragment>
         `);
     });
 
-    it('should redirect to terms of service when mfa not required and terms of service required but not on /terms_of_service', () => {
+    it("should redirect to terms of service when mfa not required and terms of service required but not on /terms_of_service", () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
@@ -113,27 +129,34 @@ describe('components/logged_in/LoggedIn', () => {
         `);
     });
 
-    it('should render children when mfa is not required and terms of service required and on /terms_of_service', () => {
+    it("should render children when mfa is not required and terms of service required and on /terms_of_service", () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
             showTermsOfService: true,
             location: {
-                pathname: '/terms_of_service',
-                search: '',
+                pathname: "/terms_of_service",
+                search: "",
             },
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
         expect(wrapper).toMatchInlineSnapshot(`
-            <span>
-              Test
-            </span>
+            <Fragment>
+              <CompassThemeProvider
+                theme={Object {}}
+              >
+                <OnBoardingTaskList />
+              </CompassThemeProvider>
+              <span>
+                Test
+              </span>
+            </Fragment>
         `);
     });
 
-    it('should render children when neither mfa nor terms of service required', () => {
+    it("should render children when neither mfa nor terms of service required", () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
@@ -143,13 +166,20 @@ describe('components/logged_in/LoggedIn', () => {
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
         expect(wrapper).toMatchInlineSnapshot(`
-            <span>
-              Test
-            </span>
+            <Fragment>
+              <CompassThemeProvider
+                theme={Object {}}
+              >
+                <OnBoardingTaskList />
+              </CompassThemeProvider>
+              <span>
+                Test
+              </span>
+            </Fragment>
         `);
     });
 
-    it('should signal to other tabs when login is successful', () => {
+    it("should signal to other tabs when login is successful", () => {
         const props = {
             ...baseProps,
             mfaRequired: false,
@@ -161,7 +191,7 @@ describe('components/logged_in/LoggedIn', () => {
         expect(BrowserStore.signalLogin).toBeCalledTimes(1);
     });
 
-    it('should set state to unfocused if it starts in the background', () => {
+    it("should set state to unfocused if it starts in the background", () => {
         document.hasFocus = jest.fn(() => false);
 
         const obj = Object.assign(GlobalActions);

--- a/components/logged_in/logged_in.test.tsx
+++ b/components/logged_in/logged_in.test.tsx
@@ -75,11 +75,6 @@ describe('components/logged_in/LoggedIn', () => {
 
         expect(wrapper).toMatchInlineSnapshot(`
             <Fragment>
-              <CompassThemeProvider
-                theme={Object {}}
-              >
-                <OnBoardingTaskList />
-              </CompassThemeProvider>
               <span>
                 Test
               </span>
@@ -101,11 +96,6 @@ describe('components/logged_in/LoggedIn', () => {
 
         expect(wrapper).toMatchInlineSnapshot(`
             <Fragment>
-              <CompassThemeProvider
-                theme={Object {}}
-              >
-                <OnBoardingTaskList />
-              </CompassThemeProvider>
               <span>
                 Test
               </span>
@@ -144,11 +134,6 @@ describe('components/logged_in/LoggedIn', () => {
 
         expect(wrapper).toMatchInlineSnapshot(`
             <Fragment>
-              <CompassThemeProvider
-                theme={Object {}}
-              >
-                <OnBoardingTaskList />
-              </CompassThemeProvider>
               <span>
                 Test
               </span>
@@ -167,11 +152,6 @@ describe('components/logged_in/LoggedIn', () => {
 
         expect(wrapper).toMatchInlineSnapshot(`
             <Fragment>
-              <CompassThemeProvider
-                theme={Object {}}
-              >
-                <OnBoardingTaskList />
-              </CompassThemeProvider>
               <span>
                 Test
               </span>

--- a/components/logged_in/logged_in.tsx
+++ b/components/logged_in/logged_in.tsx
@@ -10,11 +10,14 @@ import * as GlobalActions from 'actions/global_actions';
 import * as WebSocketActions from 'actions/websocket_actions.jsx';
 import * as UserAgent from 'utils/user_agent';
 import LoadingScreen from 'components/loading_screen';
+import OnBoardingTaskList from 'components/onboarding_tasklist';
+import {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {getBrowserTimezone} from 'utils/timezone';
 import WebSocketClient from 'client/web_websocket_client.jsx';
 import BrowserStore from 'stores/browser_store';
 import {UserProfile} from '@mattermost/types/users';
 import {Channel} from '@mattermost/types/channels';
+import CompassThemeProvider from 'components/compass_theme_provider/compass_theme_provider';
 
 const BACKSPACE_CHAR = 8;
 
@@ -32,6 +35,7 @@ export type Props = {
     children?: React.ReactNode;
     mfaRequired: boolean;
     enableTimezone: boolean;
+    theme: Theme;
     actions: {
         autoUpdateTimezone: (deviceTimezone: string) => void;
         getChannelURLAction: (channel: Channel, teamId: string, url: string) => void;
@@ -152,7 +156,14 @@ export default class LoggedIn extends React.PureComponent<Props> {
             }
         }
 
-        return this.props.children;
+        return (
+            <>
+                <CompassThemeProvider theme={this.props.theme}>
+                    <OnBoardingTaskList/>
+                </CompassThemeProvider>
+                {this.props.children}
+            </>
+        );
     }
 
     private onFocusListener(): void {

--- a/components/logged_in/logged_in.tsx
+++ b/components/logged_in/logged_in.tsx
@@ -10,14 +10,12 @@ import * as GlobalActions from 'actions/global_actions';
 import * as WebSocketActions from 'actions/websocket_actions.jsx';
 import * as UserAgent from 'utils/user_agent';
 import LoadingScreen from 'components/loading_screen';
-import OnBoardingTaskList from 'components/onboarding_tasklist';
 import {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {getBrowserTimezone} from 'utils/timezone';
 import WebSocketClient from 'client/web_websocket_client.jsx';
 import BrowserStore from 'stores/browser_store';
 import {UserProfile} from '@mattermost/types/users';
 import {Channel} from '@mattermost/types/channels';
-import CompassThemeProvider from 'components/compass_theme_provider/compass_theme_provider';
 
 const BACKSPACE_CHAR = 8;
 
@@ -158,9 +156,6 @@ export default class LoggedIn extends React.PureComponent<Props> {
 
         return (
             <>
-                <CompassThemeProvider theme={this.props.theme}>
-                    <OnBoardingTaskList/>
-                </CompassThemeProvider>
                 {this.props.children}
             </>
         );

--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -35,7 +35,6 @@ import CloudEffects from 'components/cloud_effects';
 import ModalController from 'components/modal_controller';
 import {HFTRoute, LoggedInHFTRoute} from 'components/header_footer_template_route';
 import {HFRoute} from 'components/header_footer_route/header_footer_route';
-import OnBoardingTaskList from 'components/onboarding_tasklist';
 import LaunchingWorkspace, {LAUNCHING_WORKSPACE_FULLSCREEN_Z_INDEX} from 'components/preparing_workspace/launching_workspace';
 import {Animations} from 'components/preparing_workspace/steps';
 import OpenPricingModalPost from 'components/custom_open_pricing_modal_post_renderer';
@@ -593,9 +592,6 @@ export default class Root extends React.PureComponent<Props, State> {
                                 />
                                 <RootRedirect/>
                             </Switch>
-                            <CompassThemeProvider theme={this.props.theme}>
-                                <OnBoardingTaskList/>
-                            </CompassThemeProvider>
                         </>
                     </Route>
                     <LoggedInHFTRoute
@@ -641,7 +637,6 @@ export default class Root extends React.PureComponent<Props, State> {
                         <SystemNotice/>
                         <GlobalHeader/>
                         <CloudEffects/>
-                        <OnBoardingTaskList/>
                         <TeamSidebar/>
                         <DelinquencyModalController/>
                         <Switch>

--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -74,6 +74,7 @@ const LazyMfa = React.lazy(() => import('components/mfa/mfa_controller'));
 const LazyPreparingWorkspace = React.lazy(() => import('components/preparing_workspace'));
 const LazyTeamController = React.lazy(() => import('components/team_controller'));
 const LazyDelinquencyModalController = React.lazy(() => import('components/delinquency_modal'));
+const LazyOnBoardingTaskList = React.lazy(() => import('components/onboarding_tasklist'));
 
 import store from 'stores/redux_store.jsx';
 import {getSiteURL} from 'utils/url';
@@ -111,18 +112,23 @@ const Mfa = makeAsyncComponent('Mfa', LazyMfa);
 const PreparingWorkspace = makeAsyncComponent('PreparingWorkspace', LazyPreparingWorkspace);
 const TeamController = makeAsyncComponent('TeamController', LazyTeamController);
 const DelinquencyModalController = makeAsyncComponent('DelinquencyModalController', LazyDelinquencyModalController);
+const OnBoardingTaskList = makeAsyncComponent('OnboardingTaskList', LazyOnBoardingTaskList);
 
 type LoggedInRouteProps<T> = {
     component: React.ComponentType<T>;
     path: string;
+    theme: Theme;
 };
 function LoggedInRoute<T>(props: LoggedInRouteProps<T>) {
-    const {component: Component, ...rest} = props;
+    const {component: Component, theme, ...rest} = props;
     return (
         <Route
             {...rest}
             render={(routeProps: RouteComponentProps) => (
                 <LoggedIn {...routeProps}>
+                    <CompassThemeProvider theme={theme}>
+                        <OnBoardingTaskList/>
+                    </CompassThemeProvider>
                     <Component {...(routeProps as unknown as T)}/>
                 </LoggedIn>
             )}
@@ -574,6 +580,7 @@ export default class Root extends React.PureComponent<Props, State> {
                         component={HelpController}
                     />
                     <LoggedInRoute
+                        theme={this.props.theme}
                         path={'/terms_of_service'}
                         component={TermsOfService}
                     />
@@ -584,15 +591,14 @@ export default class Root extends React.PureComponent<Props, State> {
                     <Route
                         path={'/admin_console'}
                     >
-                        <>
-                            <Switch>
-                                <LoggedInRoute
-                                    path={'/admin_console'}
-                                    component={AdminConsole}
-                                />
-                                <RootRedirect/>
-                            </Switch>
-                        </>
+                        <Switch>
+                            <LoggedInRoute
+                                theme={this.props.theme}
+                                path={'/admin_console'}
+                                component={AdminConsole}
+                            />
+                            <RootRedirect/>
+                        </Switch>
                     </Route>
                     <LoggedInHFTRoute
                         path={'/select_team'}
@@ -607,10 +613,12 @@ export default class Root extends React.PureComponent<Props, State> {
                         component={CreateTeam}
                     />
                     <LoggedInRoute
+                        theme={this.props.theme}
                         path={'/mfa'}
                         component={Mfa}
                     />
                     <LoggedInRoute
+                        theme={this.props.theme}
                         path={'/preparing-workspace'}
                         component={PreparingWorkspace}
                     />
@@ -683,6 +691,7 @@ export default class Root extends React.PureComponent<Props, State> {
                                 />
                             ))}
                             <LoggedInRoute
+                                theme={this.props.theme}
                                 path={'/:team'}
                                 component={TeamController}
                             />


### PR DESCRIPTION
#### Summary
This PR moves the OnboardingTaskList component from the root component to the LoggedIn component to make sure that all the requests made from this component are only made once the user has logged in which is where actually makes sense.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48824

#### Related Pull Requests


#### Release Note
```release-note
NONE
```
