### PR TITLE
Automated cherry pick of #11672

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -6840,6 +6840,27 @@ const AdminDefinition = {
                         isHidden: it.licensedForFeature('Cloud'),
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
                     },
+                    {
+                        type: Constants.SettingsTypes.TYPE_BOOL,
+                        key: 'ExperimentalSettings.PatchPluginsReactDOM',
+                        label: t('admin.experimental.patchPluginsReactDOM.title'),
+                        label_default: 'Patch React DOM used by plugins:',
+                        help_text: t('admin.experimental.patchPluginsReactDOM.desc'),
+                        help_text_default: 'When true, client-side plugins will be patched to use the version of React DOM provided by the web app. This should only be enabled if plugins break after upgrading to Mattermost 7.6. The server must be restarted for this setting to take effect. See the <link>Important Upgrade Notes</link> for more information.',
+                        help_text_values: {
+                            link: (msg) => (
+                                <a
+                                    href='https://docs.mattermost.com/upgrade/important-upgrade-notes.html'
+                                    target='_blank'
+                                    rel='noreferrer'
+                                >
+                                    {msg}
+                                </a>
+                            ),
+                        },
+                        isHidden: it.licensedForFeature('Cloud'),
+                        isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
+                    },
                 ],
             },
         },

--- a/e2e/playwright/support/server/default_config.ts
+++ b/e2e/playwright/support/server/default_config.ts
@@ -529,6 +529,7 @@ const defaultServerConfig: AdminConfig = {
         EnableSharedChannels: false,
         EnableRemoteClusterService: false,
         EnableAppBar: false,
+        PatchPluginsReactDOM: false,
     },
     AnalyticsSettings: {
         MaxUsersForStatistics: 2500,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -896,6 +896,8 @@
   "admin.experimental.linkMetadataTimeoutMilliseconds.desc": "The number of milliseconds to wait for metadata from a third-party link. Used with Post Metadata.",
   "admin.experimental.linkMetadataTimeoutMilliseconds.example": "E.g.: \"5000\"",
   "admin.experimental.linkMetadataTimeoutMilliseconds.title": "Link Metadata Timeout:",
+  "admin.experimental.patchPluginsReactDOM.desc": "When true, client-side plugins will be patched to use the version of React DOM provided by the web app. This should only be enabled if plugins break after upgrading to Mattermost 7.6. The server must be restarted for this setting to take effect. See the <link>Important Upgrade Notes</link> for more information.",
+  "admin.experimental.patchPluginsReactDOM.title": "Patch React DOM used by plugins:",
   "admin.experimental.samlSettingsLoginButtonBorderColor.desc": "Specify the color of the SAML login button border for white labeling purposes. Use a hex code with a #-sign before the code. This setting only applies to the mobile apps.",
   "admin.experimental.samlSettingsLoginButtonBorderColor.title": "SAML login Button Border Color:",
   "admin.experimental.samlSettingsLoginButtonColor.desc": "Specify the color of the SAML login button for white labeling purposes. Use a hex code with a #-sign before the code. This setting only applies to the mobile apps.",

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -715,6 +715,7 @@ export type ExperimentalSettings = {
     EnableSharedChannels: boolean;
     EnableRemoteClusterService: boolean;
     EnableAppBar: boolean;
+    PatchPluginsReactDOM: boolean;
 };
 
 export type AnalyticsSettings = {


### PR DESCRIPTION
Cherry pick of #11672 on release-7.6.

/cc  @hmhealey

```release-note
NONE
```