### PR TITLE
MM-48819 Increase timeout for benchmark tests

### DIFF
--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -70,6 +70,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           browser: chrome
+          config: defaultCommandTimeout=60000
           install: false
           spec: ./tests/integration/performance/*
           start: npm run benchmarks:run-server


### PR DESCRIPTION
This is to prevent these tests accidentally timing out on CircleCI. Since we're checking the amount of time taken to run these tests as part of the test, it's okay for us to more or less disable the built-in timeout and instead check for it ourselves.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48819

#### Release Note
```release-note
NONE
```
