### PR TITLE
MM-48905 Add MM_DONT_INCLUDE_PRODUCTS to build web app for production without products included

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -363,43 +363,44 @@ async function initializeModuleFederation() {
             {name: 'boards', baseUrl: boardsDevServerUrl},
         ];
 
-        if (!DEV) {
+        const remotes = {};
+
+        if (DEV) {
+            // For development, identify which product dev servers are available
+
+            // Wait a second for product dev servers to start up if they were started at the same time as this one
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            const productsFound = await Promise.all(products.map((product) => isWebpackDevServerAvailable(product.baseUrl)));
+            for (let i = 0; i < products.length; i++) {
+                const product = products[i];
+                const found = productsFound[i];
+
+                if (found) {
+                    console.log(`Product ${product.name} found, adding as remote module`);
+
+                    remotes[product.name] = `${product.name}@${product.baseUrl}/remote_entry.js`;
+                } else {
+                    console.log(`Product ${product.name} not found`);
+                }
+            }
+        } else {
             // For production, hardcode the URLs of product containers to be based on the web app URL
-            const remotes = {};
             for (const product of products) {
                 remotes[product.name] = `${product.name}@[window.basename]/static/products/${product.name}/remote_entry.js`;
             }
-
-            return {
-                remotes,
-                aliases: {},
-            };
         }
 
-        // Wait a second for product dev servers to start up if they were started at the same time as this one
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-
-        // For development, identify which product dev servers are available
-        const productsFound = await Promise.all(products.map((product) => isWebpackDevServerAvailable(product.baseUrl)));
-
-        const remotes = {};
         const aliases = {};
 
-        for (let i = 0; i < products.length; i++) {
-            const product = products[i];
-            const found = productsFound[i];
-
-            if (found) {
-                console.log(`Product ${product.name} found, adding as remote module`);
-
-                remotes[product.name] = `${product.name}@${product.baseUrl}/remote_entry.js`;
-            } else {
-                console.log(`Product ${product.name} not found`);
-
-                // Add false aliases to prevent Webpack from trying to resolve the missing modules
-                aliases[product.name] = false;
-                aliases[`${product.name}/manifest`] = false;
+        for (const product of products) {
+            if (remotes[product.name]) {
+                continue;
             }
+
+            // Add false aliases to prevent Webpack from trying to resolve the missing modules
+            aliases[product.name] = false;
+            aliases[`${product.name}/manifest`] = false;
         }
 
         return {remotes, aliases};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -365,30 +365,34 @@ async function initializeModuleFederation() {
 
         const remotes = {};
 
-        if (DEV) {
-            // For development, identify which product dev servers are available
+        if (process.env.MM_DONT_INCLUDE_PRODUCTS) {
+            if (DEV) {
+                // For development, identify which product dev servers are available
 
-            // Wait a second for product dev servers to start up if they were started at the same time as this one
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+                // Wait a second for product dev servers to start up if they were started at the same time as this one
+                await new Promise((resolve) => setTimeout(resolve, 1000));
 
-            const productsFound = await Promise.all(products.map((product) => isWebpackDevServerAvailable(product.baseUrl)));
-            for (let i = 0; i < products.length; i++) {
-                const product = products[i];
-                const found = productsFound[i];
+                const productsFound = await Promise.all(products.map((product) => isWebpackDevServerAvailable(product.baseUrl)));
+                for (let i = 0; i < products.length; i++) {
+                    const product = products[i];
+                    const found = productsFound[i];
 
-                if (found) {
-                    console.log(`Product ${product.name} found, adding as remote module`);
+                    if (found) {
+                        console.log(`Product ${product.name} found, adding as remote module`);
 
-                    remotes[product.name] = `${product.name}@${product.baseUrl}/remote_entry.js`;
-                } else {
-                    console.log(`Product ${product.name} not found`);
+                        remotes[product.name] = `${product.name}@${product.baseUrl}/remote_entry.js`;
+                    } else {
+                        console.log(`Product ${product.name} not found`);
+                    }
+                }
+            } else {
+                // For production, hardcode the URLs of product containers to be based on the web app URL
+                for (const product of products) {
+                    remotes[product.name] = `${product.name}@[window.basename]/static/products/${product.name}/remote_entry.js`;
                 }
             }
         } else {
-            // For production, hardcode the URLs of product containers to be based on the web app URL
-            for (const product of products) {
-                remotes[product.name] = `${product.name}@[window.basename]/static/products/${product.name}/remote_entry.js`;
-            }
+            console.warn('Skipping initialization of products');
         }
 
         const aliases = {};


### PR DESCRIPTION
Currently, we assume all production builds of the web app have the available code for Boards included. This will make that optional for people who want to produce production builds without Boards for whatever reason.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48905

#### Related Pull Requests
This'll also have a server component at some point

#### Release Note
```release-note
NONE
```
