### PR TITLE
Automated cherry pick of #11750

### DIFF
--- a/components/drafts/drafts.tsx
+++ b/components/drafts/drafts.tsx
@@ -14,6 +14,8 @@ import {Draft} from 'selectors/drafts';
 import NoResultsIndicator from 'components/no_results_indicator';
 import Header from 'components/widgets/header';
 
+import {suppressRHS, unsuppressRHS} from 'actions/views/rhs';
+
 import DraftRow from './draft_row';
 import DraftsIllustration from './drafts_illustration';
 
@@ -39,6 +41,11 @@ function Drafts({
 
     useEffect(() => {
         dispatch(selectChannel(''));
+        dispatch(suppressRHS);
+
+        return () => {
+            dispatch(unsuppressRHS);
+        };
     }, []);
 
     if (!localDraftsAreEnabled) {


### PR DESCRIPTION
Cherry pick of #11750 on release-7.6.

/cc  @mylonsuren

```release-note
NONE
```