### PR TITLE
MM-48897: Reverts text change.

### DIFF
--- a/components/analytics/activated_users_card/index.tsx
+++ b/components/analytics/activated_users_card/index.tsx
@@ -35,7 +35,7 @@ export const ActivatedUserCard = ({activatedUsers, seatsPurchased, isCloud}: Act
             title={
                 <FormattedMessage
                     id='analytics.team.totalUsers'
-                    defaultMessage='Total Activated Users'
+                    defaultMessage='Total Active Users'
                 />
             }
             icon='fa-users'

--- a/e2e/cypress/tests/integration/enterprise/system_console/reporting/site_statistics_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/system_console/reporting/site_statistics_spec.js
@@ -37,7 +37,7 @@ describe('System Console > Site Statistics', () => {
         cy.get('.admin-console__content .row').should('have.length', 5);
 
         // * Check that the title content for the stats is as expected.
-        cy.get('.admin-console__content .row').eq(0).find('.title').eq(0).should('contain', 'Total Activated Users');
+        cy.get('.admin-console__content .row').eq(0).find('.title').eq(0).should('contain', 'Total Active Users');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(1).should('contain', 'Total Teams');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(2).should('contain', 'Total Channels');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(3).should('contain', 'Total Posts');

--- a/e2e/cypress/tests/integration/system_console/reporting/site_statistics_te_spec.js
+++ b/e2e/cypress/tests/integration/system_console/reporting/site_statistics_te_spec.js
@@ -28,7 +28,7 @@ describe('System Console > Site Statistics', () => {
         cy.get('.admin-console__content .row').should('have.length', 4);
 
         // * Check that the title content for the stats is as expected.
-        cy.get('.admin-console__content .row').eq(0).find('.title').eq(0).should('contain', 'Total Activated Users');
+        cy.get('.admin-console__content .row').eq(0).find('.title').eq(0).should('contain', 'Total Active Users');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(1).should('contain', 'Total Teams');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(2).should('contain', 'Total Channels');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(3).should('contain', 'Total Posts');

--- a/e2e/cypress/tests/integration/system_console/reporting/team_statistics_spec.js
+++ b/e2e/cypress/tests/integration/system_console/reporting/team_statistics_spec.js
@@ -38,7 +38,7 @@ describe('System Console > Team Statistics', () => {
         cy.get('.admin-console__content .row').should('have.length', 4);
 
         // * Check that the title content for the stats is as expected.
-        cy.get('.admin-console__content .row').eq(0).find('.title').eq(0).should('contain', 'Total Activated Users');
+        cy.get('.admin-console__content .row').eq(0).find('.title').eq(0).should('contain', 'Total Active Users');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(1).should('contain', 'Public Channels');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(2).should('contain', 'Private Channels');
         cy.get('.admin-console__content .row').eq(0).find('.title').eq(3).should('contain', 'Total Posts');

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2551,7 +2551,7 @@
   "analytics.team.recentUsers": "Recent Active Users",
   "analytics.team.title": "Team Statistics for {team}",
   "analytics.team.totalPosts": "Total Posts",
-  "analytics.team.totalUsers": "Total Activated Users",
+  "analytics.team.totalUsers": "Total Active Users",
   "announcement_bar.error.email_verification_required": "Check your email inbox to verify the address.",
   "announcement_bar.error.license_expired": "{licenseSku} license is expired and some features may be disabled.",
   "announcement_bar.error.license_expiring": "{licenseSku} license expires on {date, date, long}.",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -2547,7 +2547,7 @@
   "analytics.team.recentUsers": "Recent Active Users",
   "analytics.team.title": "Team Statistics for {team}",
   "analytics.team.totalPosts": "Total Posts",
-  "analytics.team.totalUsers": "Total Activated Users",
+  "analytics.team.totalUsers": "Total Active Users",
   "announcement_bar.error.email_verification_required": "Check your email inbox to verify the address.",
   "announcement_bar.error.license_expired": "Enterprise licence is expired and some features may be disabled.",
   "announcement_bar.error.license_expiring": "Enterprise licence expires on {date, date, long}.",


### PR DESCRIPTION
#### Summary

Reverting a text pending legal approval.

Original PR: https://github.com/mattermost/mattermost-webapp/pull/11490

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48897

#### Screenshots

Previous change:

<img width="246" alt="Screenshot 2022-12-08 at 1 26 59 PM" src="https://user-images.githubusercontent.com/1149597/206536436-899dd4a0-458d-49cb-89d2-be2f1b292f77.png">

This PR reverts back to:

<img width="240" alt="Screenshot 2022-12-08 at 1 28 35 PM" src="https://user-images.githubusercontent.com/1149597/206536888-d9e84083-8753-4f29-8369-251de8ad2000.png">

#### Release Note

```release-note
NONE
```
