### PR TITLE
Encourage downloading original instead of preview

### DIFF
--- a/components/file_preview_modal/__snapshots__/image_preview.test.jsx.snap
+++ b/components/file_preview_modal/__snapshots__/image_preview.test.jsx.snap
@@ -3,7 +3,10 @@
 exports[`components/view_image/ImagePreview should match snapshot, with preview 1`] = `
 <a
   className="image_preview"
-  href="#"
+  download={true}
+  href="/api/v4/files/file_id_1?download=1"
+  rel="noopener noreferrer"
+  target="_blank"
 >
   <img
     alt="preview url image"
@@ -11,6 +14,9 @@ exports[`components/view_image/ImagePreview should match snapshot, with preview 
     data-testid="imagePreview"
     loading="lazy"
     src="/api/v4/files/file_id_1/preview"
+  />
+  <span
+    className="image_preview__save_helper"
   />
 </a>
 `;
@@ -24,7 +30,10 @@ exports[`components/view_image/ImagePreview should match snapshot, with preview,
 exports[`components/view_image/ImagePreview should match snapshot, without preview 1`] = `
 <a
   className="image_preview"
-  href="#"
+  download={true}
+  href="/api/v4/files/file_id?download=1"
+  rel="noopener noreferrer"
+  target="_blank"
 >
   <img
     alt="preview url image"
@@ -32,6 +41,9 @@ exports[`components/view_image/ImagePreview should match snapshot, without previ
     data-testid="imagePreview"
     loading="lazy"
     src="/api/v4/files/file_id?download=1"
+  />
+  <span
+    className="image_preview__save_helper"
   />
 </a>
 `;

--- a/components/file_preview_modal/image_preview.scss
+++ b/components/file_preview_modal/image_preview.scss
@@ -1,4 +1,6 @@
 .image_preview {
+    position: relative;
+
     &__image {
         max-height: calc(100vh - 168px);
         border-radius: 8px;
@@ -7,5 +9,14 @@
         @media screen and (max-width: 768px) {
             border-radius: 0;
         }
+    }
+
+    &__save_helper {
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: block;
+        width: 100%;
+        height: 100%;
     }
 }

--- a/components/file_preview_modal/image_preview.test.jsx
+++ b/components/file_preview_modal/image_preview.test.jsx
@@ -68,6 +68,14 @@ describe('components/view_image/ImagePreview', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should download link for internal file', () => {
+        const wrapper = shallow(
+            <ImagePreview {...baseProps}/>,
+        );
+
+        expect(wrapper.find('a').prop('download')).toBe(true);
+    });
+
     test('should not download link for external file', () => {
         const props = {
             ...baseProps,
@@ -80,7 +88,8 @@ describe('components/view_image/ImagePreview', () => {
             <ImagePreview {...props}/>,
         );
 
-        expect(wrapper.find('a').prop('href')).toBe('#');
+        expect(wrapper.find('a').prop('download')).toBe(false);
+        expect(wrapper.find('a').prop('href')).toBe(props.fileInfo.link);
         expect(wrapper.find('img').prop('src')).toBe(props.fileInfo.link);
     });
 });

--- a/components/file_preview_modal/image_preview.tsx
+++ b/components/file_preview_modal/image_preview.tsx
@@ -34,7 +34,10 @@ export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
     return (
         <a
             className='image_preview'
-            href='#'
+            href={fileUrl}
+            target='_blank'
+            rel='noopener noreferrer'
+            download={!isExternalFile}
         >
             <img
                 className='image_preview__image'
@@ -43,6 +46,7 @@ export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
                 alt={'preview url image'}
                 src={previewUrl}
             />
+            <span className='image_preview__save_helper'/>
         </a>
     );
 }


### PR DESCRIPTION
#### Summary
Prevents accidental downloads of preview files rather than originals from the image preview modal.

Image previews are useful for bandwidth saving but the normal intent of sharing a file is for the recipient to get the original. It is natural for many users to save images via their context menu. The problem is that the context options are those of the low-res (and sometimes wrong type of) image.

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/21230 fixed the obvious cosmetic issue related to transparent images, but leaves opaque JPEGs, etc. unaffected. [This comment](https://mattermost.atlassian.net/browse/MM-36295?focusedCommentId=114695) and the line "Also, it displayed incorrectly after downloading it locally." from [the original issue for that PR](https://github.com/mattermost/mattermost-server/issues/19947) provides evidence that people are not expecting to get a modified file from that interface.

#### Screenshots
The appearance of the interface is unchanged, it is only the behaviour of clicking that differs.

#### Release Note
```release-note
Image in preview modal now links to original.
```
