### PR TITLE
[MM-48987] Removing team insights if no enterprise build available

### DIFF
--- a/components/activity_and_insights/insights/hooks.ts
+++ b/components/activity_and_insights/insights/hooks.ts
@@ -12,7 +12,7 @@ import {CloudProducts} from 'utils/constants';
 /**
  * Returns some checks for free trial users or starter licenses
  */
-export function useLicenseChecks(): [boolean, boolean] {
+export function useLicenseChecks(): [boolean, boolean, boolean] {
     const subscription = useSelector(getCloudSubscription);
     const license = useSelector(getLicense);
     const subscriptionProduct = useSelector(getSubscriptionProduct);
@@ -32,5 +32,6 @@ export function useLicenseChecks(): [boolean, boolean] {
     return [
         isStarterFree,
         isFreeTrial,
+        isEnterpriseReady,
     ];
 }

--- a/components/activity_and_insights/insights/hooks.ts
+++ b/components/activity_and_insights/insights/hooks.ts
@@ -12,7 +12,7 @@ import {CloudProducts} from 'utils/constants';
 /**
  * Returns some checks for free trial users or starter licenses
  */
-export function useLicenseChecks(): [boolean, boolean, boolean] {
+export function useLicenseChecks(): {isStarterFree: boolean; isFreeTrial: boolean; isEnterpriseReady: boolean} {
     const subscription = useSelector(getCloudSubscription);
     const license = useSelector(getLicense);
     const subscriptionProduct = useSelector(getSubscriptionProduct);
@@ -29,9 +29,9 @@ export function useLicenseChecks(): [boolean, boolean, boolean] {
     const isStarterFree = isCloudStarterFree || isSelfHostedStarter;
     const isFreeTrial = isCloudFreeTrial || isSelfHostedFreeTrial;
 
-    return [
+    return {
         isStarterFree,
         isFreeTrial,
         isEnterpriseReady,
-    ];
+    };
 }

--- a/components/activity_and_insights/insights/insights.tsx
+++ b/components/activity_and_insights/insights/insights.tsx
@@ -46,7 +46,7 @@ const Insights = () => {
 
     const [filterType, setFilterType] = useGlobalState(InsightsScopes.TEAM, 'insightsScope');
     const [timeFrame, setTimeFrame] = useGlobalState(TimeFrames.INSIGHTS_7_DAYS as string, 'insightsTimeFrame');
-    const [isStarterFree, _, isEnterpriseReady] = useLicenseChecks();
+    const {isStarterFree, isEnterpriseReady} = useLicenseChecks();
 
     const setFilterTypeTeam = useCallback(() => {
         trackEvent('insights', 'change_scope_to_team_insights');

--- a/components/activity_and_insights/insights/insights.tsx
+++ b/components/activity_and_insights/insights/insights.tsx
@@ -79,7 +79,7 @@ const Insights = () => {
         return () => {
             dispatch(unsuppressRHS);
         };
-    });
+    }, []);
 
     return (
         <>

--- a/components/activity_and_insights/insights/insights.tsx
+++ b/components/activity_and_insights/insights/insights.tsx
@@ -46,7 +46,7 @@ const Insights = () => {
 
     const [filterType, setFilterType] = useGlobalState(InsightsScopes.TEAM, 'insightsScope');
     const [timeFrame, setTimeFrame] = useGlobalState(TimeFrames.INSIGHTS_7_DAYS as string, 'insightsTimeFrame');
-    const [isStarterFree] = useLicenseChecks();
+    const [isStarterFree, _, isEnterpriseReady] = useLicenseChecks();
 
     const setFilterTypeTeam = useCallback(() => {
         trackEvent('insights', 'change_scope_to_team_insights');
@@ -72,7 +72,7 @@ const Insights = () => {
             LocalStorageStore.setPreviousViewedType(currentUserId, currentTeamId, PreviousViewedTypes.INSIGHTS);
         }
 
-        if (isStarterFree) {
+        if (isStarterFree || !isEnterpriseReady) {
             setFilterType(InsightsScopes.MY);
         }
 

--- a/components/activity_and_insights/insights/insights_header/insights_header.scss
+++ b/components/activity_and_insights/insights/insights_header/insights_header.scss
@@ -8,7 +8,7 @@
         background-color: var(--center-channel-bg);
         grid-area: header;
 
-        button.insights-title {
+        .insights-title {
             display: flex;
             align-items: center;
             padding: 2px 6px 2px 8px;
@@ -21,7 +21,9 @@
             font-size: 16px;
             font-weight: 600;
             line-height: 24px;
+        }
 
+        button.insights-title {
             i.icon {
                 width: 16px;
                 height: 16px;

--- a/components/activity_and_insights/insights/insights_title/insights_title.tsx
+++ b/components/activity_and_insights/insights/insights_title/insights_title.tsx
@@ -25,7 +25,7 @@ type Props = {
 const InsightsTitle = (props: Props) => {
     const {formatMessage} = useIntl();
 
-    const [isStarterFree, isFreeTrial] = useLicenseChecks();
+    const [isStarterFree, isFreeTrial, isEnterpriseReady] = useLicenseChecks();
 
     const title = useCallback(() => {
         if (props.filterType === InsightsScopes.TEAM) {
@@ -55,6 +55,14 @@ const InsightsTitle = (props: Props) => {
     const openContactSales = useCallback(() => {
         trackEvent('insights', 'open_contact_sales_from_insights');
     }, []);
+
+    if (!isEnterpriseReady) {
+        return (
+            <div className='insights-title'>
+                {title()}
+            </div>
+        );
+    }
 
     return (
         <MenuWrapper id='insightsFilterDropdown'>

--- a/components/activity_and_insights/insights/insights_title/insights_title.tsx
+++ b/components/activity_and_insights/insights/insights_title/insights_title.tsx
@@ -25,7 +25,7 @@ type Props = {
 const InsightsTitle = (props: Props) => {
     const {formatMessage} = useIntl();
 
-    const [isStarterFree, isFreeTrial, isEnterpriseReady] = useLicenseChecks();
+    const {isStarterFree, isFreeTrial, isEnterpriseReady} = useLicenseChecks();
 
     const title = useCallback(() => {
         if (props.filterType === InsightsScopes.TEAM) {


### PR DESCRIPTION
#### Summary
There are instances where no enterprise build is available (Team edition) so we want to hide the team insights dropdown and default to "my insights". To recreate this locally you will need to remove your enterprise repo

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48987

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixing a bug where the team insights dropdown was available in non-enterprise builds
```
