### PR TITLE
MM-48824 - remove unnecessary theme prop from LoggedIn Component

### DIFF
--- a/components/logged_in/index.ts
+++ b/components/logged_in/index.ts
@@ -15,7 +15,6 @@ import {viewChannel} from 'mattermost-redux/actions/channels';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser, shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
-import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {getHistory} from 'utils/browser_history';
 import {checkIfMFARequired} from 'utils/route';
@@ -41,7 +40,6 @@ function mapStateToProps(state: GlobalState, ownProps: Props) {
         mfaRequired: checkIfMFARequired(getCurrentUser(state), license, config, ownProps.match.url),
         enableTimezone: config.ExperimentalTimezone === 'true',
         showTermsOfService,
-        theme: getTheme(state),
     };
 }
 

--- a/components/logged_in/logged_in.test.tsx
+++ b/components/logged_in/logged_in.test.tsx
@@ -74,11 +74,9 @@ describe('components/logged_in/LoggedIn', () => {
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
         expect(wrapper).toMatchInlineSnapshot(`
-            <Fragment>
-              <span>
-                Test
-              </span>
-            </Fragment>
+            <span>
+              Test
+            </span>
         `);
     });
 
@@ -95,11 +93,9 @@ describe('components/logged_in/LoggedIn', () => {
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
         expect(wrapper).toMatchInlineSnapshot(`
-            <Fragment>
-              <span>
-                Test
-              </span>
-            </Fragment>
+            <span>
+              Test
+            </span>
         `);
     });
 
@@ -133,11 +129,9 @@ describe('components/logged_in/LoggedIn', () => {
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
         expect(wrapper).toMatchInlineSnapshot(`
-            <Fragment>
-              <span>
-                Test
-              </span>
-            </Fragment>
+            <span>
+              Test
+            </span>
         `);
     });
 
@@ -151,11 +145,9 @@ describe('components/logged_in/LoggedIn', () => {
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
 
         expect(wrapper).toMatchInlineSnapshot(`
-            <Fragment>
-              <span>
-                Test
-              </span>
-            </Fragment>
+            <span>
+              Test
+            </span>
         `);
     });
 

--- a/components/logged_in/logged_in.test.tsx
+++ b/components/logged_in/logged_in.test.tsx
@@ -8,7 +8,6 @@ import LoggedIn, {Props} from 'components/logged_in/logged_in';
 import BrowserStore from 'stores/browser_store';
 import * as GlobalActions from 'actions/global_actions';
 import {UserProfile} from '@mattermost/types/users';
-import {Theme} from 'mattermost-redux/selectors/entities/preferences';
 
 jest.mock('actions/websocket_actions.jsx', () => ({
     initialize: jest.fn(),
@@ -32,7 +31,6 @@ describe('components/logged_in/LoggedIn', () => {
             pathname: '/',
             search: '',
         },
-        theme: {} as Theme,
     };
 
     it('should render loading state without user', () => {

--- a/components/logged_in/logged_in.tsx
+++ b/components/logged_in/logged_in.tsx
@@ -10,7 +10,6 @@ import * as GlobalActions from 'actions/global_actions';
 import * as WebSocketActions from 'actions/websocket_actions.jsx';
 import * as UserAgent from 'utils/user_agent';
 import LoadingScreen from 'components/loading_screen';
-import {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {getBrowserTimezone} from 'utils/timezone';
 import WebSocketClient from 'client/web_websocket_client.jsx';
 import BrowserStore from 'stores/browser_store';
@@ -33,7 +32,6 @@ export type Props = {
     children?: React.ReactNode;
     mfaRequired: boolean;
     enableTimezone: boolean;
-    theme: Theme;
     actions: {
         autoUpdateTimezone: (deviceTimezone: string) => void;
         getChannelURLAction: (channel: Channel, teamId: string, url: string) => void;
@@ -154,11 +152,7 @@ export default class LoggedIn extends React.PureComponent<Props> {
             }
         }
 
-        return (
-            <>
-                {this.props.children}
-            </>
-        );
+        return this.props.children;
     }
 
     private onFocusListener(): void {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR removes an unnecessary theme prop from the LoggedIn component that was a leftover from initial changes made on this PR https://github.com/mattermost/mattermost-webapp/pull/11737

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48824
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
https://github.com/mattermost/mattermost-webapp/pull/11737

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
n/a
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
