### PR TITLE
Move benchmark-specific Cypress config into its own file

### DIFF
--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -70,7 +70,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           browser: chrome
-          configFile: ./benchmark.config.ts
+          config-file: ./benchmark.config.ts
           install: false
           spec: ./tests/integration/performance/*
           start: npm run benchmarks:run-server

--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -70,7 +70,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           browser: chrome
-          config: defaultCommandTimeout=60000
+          configFile: ./benchmark.config.ts
           install: false
           spec: ./tests/integration/performance/*
           start: npm run benchmarks:run-server

--- a/e2e/cypress/benchmark.config.ts
+++ b/e2e/cypress/benchmark.config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {defineConfig} from 'cypress';
+
+import defaultConfig from './cypress.config';
+
+export default defineConfig({
+    ...defaultConfig,
+    defaultCommandTimeout: 60000,
+});


### PR DESCRIPTION
I'm not entirely sure why the benchmark tests seemed to pass on my previous PR and then failed on future PRs, but I think the reason why it was failing is because the single config setting I passed from the yml file caused Cypress to not receive any of the other config settings that were in `cypress.config.ts`. By moving the benchmark-specific config to a file that explicitly extends the base Cypress config, hopefully that fixes everything.

#### Release Note
```release-note
NONE
```
