### PR TITLE
[MM-41722] Add the upgrade enterprise sales reason

### DIFF
--- a/components/admin_console/billing/billing_subscriptions/cloud_trial_banner.tsx
+++ b/components/admin_console/billing/billing_subscriptions/cloud_trial_banner.tsx
@@ -24,6 +24,7 @@ import AlertBanner from 'components/alert_banner';
 import UpgradeLink from 'components/widgets/links/upgrade_link';
 
 import './cloud_trial_banner.scss';
+import {SalesInquiryIssue} from 'selectors/cloud';
 
 export interface Props {
     trialEndDate: number;
@@ -33,7 +34,7 @@ const CloudTrialBanner = ({trialEndDate}: Props): JSX.Element | null => {
     const endDate = new Date(trialEndDate);
     const DISMISSED_DAYS = 10;
     const {formatMessage} = useIntl();
-    const openSalesLink = useOpenSalesLink();
+    const openSalesLink = useOpenSalesLink(SalesInquiryIssue.UpgradeEnterprise);
     const dispatch = useDispatch();
     const user = useSelector(getCurrentUser);
     const storedDismissedEndDate = useSelector((state: GlobalState) => getPreference(state, Preferences.CLOUD_TRIAL_BANNER, CloudBanners.UPGRADE_FROM_TRIAL));

--- a/components/pricing_modal/contact_sales_cta.tsx
+++ b/components/pricing_modal/contact_sales_cta.tsx
@@ -12,6 +12,7 @@ import {trackEvent} from 'actions/telemetry_actions';
 import useOpenSalesLink from 'components/common/hooks/useOpenSalesLink';
 
 import {LicenseLinks, TELEMETRY_CATEGORIES} from 'utils/constants';
+import {SalesInquiryIssue} from 'selectors/cloud';
 
 const StyledA = styled.a`
 color: var(--denim-button-bg);
@@ -26,7 +27,7 @@ text-align: center;
 
 function ContactSalesCTA() {
     const {formatMessage} = useIntl();
-    const openSalesLink = useOpenSalesLink();
+    const openSalesLink = useOpenSalesLink(SalesInquiryIssue.UpgradeEnterprise);
 
     const openSelfHostedLink = () => {
         window.open(LicenseLinks.CONTACT_SALES, '_blank');

--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -10,7 +10,7 @@ import {CloudLinks, CloudProducts, LicenseSkus, ModalIdentifiers, PaidFeatures, 
 import {fallbackStarterLimits, fallbackProfessionalLimits, asGBString, hasSomeLimits} from 'utils/limits';
 import {findProductBySkuAndInterval} from 'utils/products';
 
-import {getCloudContactUsLink, InquiryType} from 'selectors/cloud';
+import {getCloudContactUsLink, InquiryType, SalesInquiryIssue} from 'selectors/cloud';
 
 import {trackEvent} from 'actions/telemetry_actions';
 import {closeModal, openModal} from 'actions/views/modals';
@@ -62,7 +62,7 @@ function Content(props: ContentProps) {
     const openPricingModalBackAction = useOpenPricingModal();
 
     const isAdmin = useSelector(isCurrentUserSystemAdmin);
-    const contactSalesLink = useSelector(getCloudContactUsLink)(InquiryType.Sales);
+    const contactSalesLink = useSelector(getCloudContactUsLink)(InquiryType.Sales, SalesInquiryIssue.UpgradeEnterprise);
 
     const subscription = useSelector(selectCloudSubscription);
     const product = useSelector(selectSubscriptionProduct);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Pre-fill the contact us form when the admin click `Contact Sales` on upgrade enterprise.

#### Ticket Link
https://mattermost.atlassian.net/jira/software/c/projects/MM/boards/106?modal=detail&selectedIssue=MM-41722&assignee=62ed333d48e310e672967cc8

#### Screenshots
Pre-trial pricing modal clicking contact sales
![pre-trial](https://user-images.githubusercontent.com/713534/207376159-12386267-431c-4028-ac9c-13d4b7d7b6c9.gif)

Post-trial pricing modal clicking contact sales
![post-trial](https://user-images.githubusercontent.com/713534/207376213-f5964c4c-8487-4eff-818e-9985b739a373.gif)


#### Release Note
```release-note
Bug fix where clicking contact sales hasn't prefilled the reason of contact to sales.
```
