### PR TITLE
Automated cherry pick of #11641

### DIFF
--- a/components/sidebar/channel_filter/__snapshots__/channel_filter.test.tsx.snap
+++ b/components/sidebar/channel_filter/__snapshots__/channel_filter.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`components/sidebar/channel_filter should match snapshot 1`] = `
     }
   >
     <a
-      aria-label="Filter by unread"
+      aria-label="unreads filter"
       className="SidebarFilters_filterButton"
       href="#"
       onClick={[Function]}
@@ -93,7 +93,7 @@ exports[`components/sidebar/channel_filter should match snapshot if the unread f
     }
   >
     <a
-      aria-label="Show all channels"
+      aria-label="unreads filter"
       className="SidebarFilters_filterButton active"
       href="#"
       onClick={[Function]}

--- a/components/sidebar/channel_filter/channel_filter.tsx
+++ b/components/sidebar/channel_filter/channel_filter.tsx
@@ -66,6 +66,8 @@ export class ChannelFilter extends React.PureComponent<Props> {
             tooltipMessage = intl.formatMessage({id: 'sidebar_left.channel_filter.showAllChannels', defaultMessage: 'Show all channels'});
         }
 
+        const unreadsAriaLabel = intl.formatMessage({id: 'sidebar_left.channel_filter.filterUnreadAria', defaultMessage: 'unreads filter'});
+
         const tooltip = (
             <Tooltip
                 id='new-group-tooltip'
@@ -93,7 +95,7 @@ export class ChannelFilter extends React.PureComponent<Props> {
                             active: unreadFilterEnabled,
                         })}
                         onClick={this.toggleUnreadFilter}
-                        aria-label={tooltipMessage}
+                        aria-label={unreadsAriaLabel}
                     >
                         <i className='icon icon-filter-variant'/>
                     </a>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4696,6 +4696,7 @@
   "sidebar_left.add_channel_dropdown.invitePeople": "Invite People",
   "sidebar_left.add_channel_dropdown.invitePeopleExtraText": "Add people to the team",
   "sidebar_left.channel_filter.filterByUnread": "Filter by unread",
+  "sidebar_left.channel_filter.filterUnreadAria": "unreads filter",
   "sidebar_left.channel_filter.showAllChannels": "Show all channels",
   "sidebar_left.channel_navigator.channelSwitcherLabel": "Find Channels",
   "sidebar_left.channel_navigator.goBackLabel": "Back",


### PR DESCRIPTION
Cherry pick of #11641 on release-7.6.

/cc  @babinderrathi

```release-note
NONE
```