### PR TITLE
MM-48895 : Remove tab index on collapsed channel link in sidebar

### DIFF
--- a/components/sidebar/sidebar_channel/__snapshots__/sidebar_channel.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/__snapshots__/sidebar_channel.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`components/sidebar/sidebar_channel should match snapshot 1`] = `
       }
     }
     currentTeamName="team_name"
-    isCollapsed={false}
   />
 </li>
 `;
@@ -65,7 +64,6 @@ exports[`components/sidebar/sidebar_channel should match snapshot when DM channe
       }
     }
     currentTeamName="team_name"
-    isCollapsed={false}
   />
 </li>
 `;
@@ -100,7 +98,6 @@ exports[`components/sidebar/sidebar_channel should match snapshot when GM channe
       }
     }
     currentTeamName="team_name"
-    isCollapsed={false}
   />
 </li>
 `;
@@ -135,7 +132,6 @@ exports[`components/sidebar/sidebar_channel should match snapshot when active 1`
       }
     }
     currentTeamName="team_name"
-    isCollapsed={false}
   />
 </li>
 `;
@@ -170,7 +166,6 @@ exports[`components/sidebar/sidebar_channel should match snapshot when collapsed
       }
     }
     currentTeamName="team_name"
-    isCollapsed={true}
   />
 </li>
 `;
@@ -205,7 +200,6 @@ exports[`components/sidebar/sidebar_channel should match snapshot when unread 1`
       }
     }
     currentTeamName="team_name"
-    isCollapsed={false}
   />
 </li>
 `;

--- a/components/sidebar/sidebar_channel/sidebar_base_channel/__snapshots__/sidebar_base_channel.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_base_channel/__snapshots__/sidebar_base_channel.test.tsx.snap
@@ -28,7 +28,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_base_channel should match sn
       className="icon icon-globe"
     />
   }
-  isCollapsed={false}
   label="channel_display_name"
   link="/team_name/channels/"
 />
@@ -62,7 +61,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_base_channel should match sn
       className="icon icon-lock-outline"
     />
   }
-  isCollapsed={false}
   label="channel_display_name"
   link="/team_name/channels/"
 />
@@ -99,7 +97,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_base_channel should match sn
       withTooltip={true}
     />
   }
-  isCollapsed={false}
   label="channel_display_name"
   link="/team_name/channels/"
 />
@@ -136,7 +133,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_base_channel should match sn
       withTooltip={true}
     />
   }
-  isCollapsed={false}
   label="channel_display_name"
   link="/team_name/channels/"
 />

--- a/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
@@ -28,7 +28,6 @@ describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
             group_constrained: false,
         },
         currentTeamName: 'team_name',
-        isCollapsed: false,
         actions: {
             leaveChannel: jest.fn(),
             openModal: jest.fn(),

--- a/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -18,7 +18,6 @@ import type {PropsFromRedux} from './index';
 interface Props extends PropsFromRedux {
     channel: Channel;
     currentTeamName: string;
-    isCollapsed: boolean;
 }
 
 export default class SidebarBaseChannel extends React.PureComponent<Props> {
@@ -88,7 +87,6 @@ export default class SidebarBaseChannel extends React.PureComponent<Props> {
                 ariaLabelPrefix={ariaLabelPrefix}
                 closeHandler={this.getCloseHandler()!}
                 icon={this.getIcon()!}
-                isCollapsed={this.props.isCollapsed}
             />
         );
     }

--- a/components/sidebar/sidebar_channel/sidebar_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {AnimationEvent} from 'react';
+import React, {AnimationEvent, ReactNode} from 'react';
 import {Draggable} from 'react-beautiful-dnd';
 import classNames from 'classnames';
 
@@ -105,7 +105,7 @@ export default class SidebarChannel extends React.PureComponent<Props, State> {
         return this.props.getChannelRef(this.props.channel.id);
     }
 
-    setRef = (refMethod?: (element: HTMLLIElement) => any) => {
+    setRef = (refMethod?: (element: HTMLLIElement) => void) => {
         return (ref: HTMLLIElement) => {
             this.props.setChannelRef(this.props.channel.id, ref);
             refMethod?.(ref);
@@ -139,20 +139,31 @@ export default class SidebarChannel extends React.PureComponent<Props, State> {
             autoSortedCategoryIds,
         } = this.props;
 
-        let ChannelComponent: React.ComponentType<{channel: Channel; currentTeamName: string; isCollapsed: boolean}> = SidebarBaseChannel;
-        if (channel.type === Constants.DM_CHANNEL) {
-            ChannelComponent = SidebarDirectChannel;
+        let component: ReactNode;
+        if (!this.state.show) {
+            component = null;
+        } else if (channel.type === Constants.DM_CHANNEL) {
+            component = (
+                <SidebarDirectChannel
+                    channel={channel}
+                    currentTeamName={currentTeamName}
+                />
+            );
         } else if (channel.type === Constants.GM_CHANNEL) {
-            ChannelComponent = SidebarGroupChannel;
+            component = (
+                <SidebarGroupChannel
+                    channel={channel}
+                    currentTeamName={currentTeamName}
+                />
+            );
+        } else {
+            component = (
+                <SidebarBaseChannel
+                    channel={channel}
+                    currentTeamName={currentTeamName}
+                />
+            );
         }
-
-        const component = this.state.show ? (
-            <ChannelComponent
-                isCollapsed={this.isCollapsed(this.props)}
-                channel={channel}
-                currentTeamName={currentTeamName}
-            />
-        ) : null;
 
         let wrappedComponent: React.ReactNode;
 

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
@@ -72,7 +72,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
       }
     }
     channelLink="http://a.fake.link"
-    isCollapsed={false}
     isMenuOpen={false}
     isUnread={false}
     onToggleMenu={[Function]}
@@ -152,7 +151,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
       }
     }
     channelLink="http://a.fake.link"
-    isCollapsed={false}
     isMenuOpen={false}
     isUnread={false}
     onToggleMenu={[Function]}
@@ -256,7 +254,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
       }
     }
     channelLink="http://a.fake.link"
-    isCollapsed={false}
     isMenuOpen={false}
     isUnread={false}
     onToggleMenu={[Function]}
@@ -336,7 +333,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
       }
     }
     channelLink="http://a.fake.link"
-    isCollapsed={false}
     isMenuOpen={false}
     isUnread={true}
     onToggleMenu={[Function]}

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.test.tsx
@@ -33,7 +33,6 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_link', () => {
         unreadMentions: 0,
         isUnread: false,
         isMuted: false,
-        isCollapsed: false,
         isChannelSelected: false,
         hasUrgent: false,
         showChannelsTutorialStep: false,

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -50,11 +50,6 @@ type Props = {
      */
     isMuted: boolean;
 
-    /**
-     * Checks if channel is collapsed
-     */
-    isCollapsed: boolean;
-
     isChannelSelected: boolean;
 
     teammateId?: string;
@@ -257,7 +252,6 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                     channel={channel}
                     channelLink={link}
                     isMenuOpen={this.state.isMenuOpen}
-                    isCollapsed={this.props.isCollapsed}
                     isUnread={isUnread}
                     closeHandler={this.props.closeHandler}
                     onToggleMenu={this.handleMenuToggle}
@@ -282,7 +276,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                 aria-label={this.getAriaLabel()}
                 to={link}
                 onClick={this.handleChannelClick}
-                tabIndex={this.props.isCollapsed ? -1 : 0}
+                tabIndex={0}
             >
                 {content}
                 {channelsTutorialTip}

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/index.ts
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/index.ts
@@ -29,7 +29,6 @@ import SidebarChannelMenu from './sidebar_channel_menu';
 export type OwnProps = {
     channel: Channel;
     channelLink: string;
-    isCollapsed: boolean;
     isUnread: boolean;
     isMenuOpen: boolean;
     onToggleMenu: (isMenuOpen: boolean) => void;

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -38,7 +38,6 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
         managePublicChannelMembers: true,
         managePrivateChannelMembers: true,
         closeHandler: jest.fn(),
-        isCollapsed: false,
         isMenuOpen: true,
         onToggleMenu: jest.fn(),
         multiSelectedChannelIds: [],

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -234,7 +234,7 @@ const SidebarChannelMenu = (props: Props) => {
             onOpenDirectionChange={handleOpenDirectionChange}
             onToggleMenu={onToggleMenu}
             tooltipText={formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'})}
-            tabIndex={props.isCollapsed ? -1 : 0}
+            tabIndex={0}
         >
             {props.isMenuOpen && (
                 <>

--- a/components/sidebar/sidebar_channel/sidebar_direct_channel/__snapshots__/sidebar_direct_channel.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_direct_channel/__snapshots__/sidebar_direct_channel.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_direct_channel should match 
       wrapperClass="DirectChannel__profile-picture"
     />
   }
-  isCollapsed={false}
   label="channel_display_name"
   link="/team_name/messages/@some-user"
   teammateId="user_id"
@@ -78,7 +77,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_direct_channel should match 
       wrapperClass="DirectChannel__profile-picture"
     />
   }
-  isCollapsed={false}
   label="channel_display_name"
   link="/team_name/messages/@some-user"
   teammateId="user_id"
@@ -120,7 +118,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_direct_channel should match 
       wrapperClass="DirectChannel__profile-picture"
     />
   }
-  isCollapsed={false}
   label="channel_display_name (you)"
   link="/team_name/messages/@some-user"
   teammateId="user_id"
@@ -154,7 +151,6 @@ exports[`components/sidebar/sidebar_channel/sidebar_direct_channel should match 
       className="icon icon-archive-outline"
     />
   }
-  isCollapsed={false}
   label="channel_display_name"
   link="/team_name/messages/@some-user"
   teammateId="user_id"

--- a/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.test.tsx
@@ -34,7 +34,6 @@ describe('components/sidebar/sidebar_channel/sidebar_direct_channel', () => {
         currentUserId: 'current_user_id',
         redirectChannel: 'redirect-channel',
         active: false,
-        isCollapsed: false,
         isMobile: false,
         actions: {
             savePreferences: jest.fn(),

--- a/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
@@ -25,7 +25,6 @@ type Props = {
     currentUserId: string;
     redirectChannel: string;
     active: boolean;
-    isCollapsed: boolean;
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<{data: boolean}>;
         leaveDirectChannel: (channelId: string) => Promise<{data: boolean}>;
@@ -107,7 +106,6 @@ class SidebarDirectChannel extends React.PureComponent<Props> {
                 label={displayName}
                 closeHandler={this.handleLeaveChannel}
                 icon={this.getIcon()}
-                isCollapsed={this.props.isCollapsed}
             />
         );
     }

--- a/components/sidebar/sidebar_channel/sidebar_group_channel/sidebar_group_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_group_channel/sidebar_group_channel.tsx
@@ -19,7 +19,6 @@ type Props = {
     redirectChannel: string;
     active: boolean;
     membersCount: number;
-    isCollapsed: boolean;
     actions: {
         savePreferences: (userId: string, preferences: PreferenceType[]) => Promise<{data: boolean}>;
     };
@@ -58,7 +57,6 @@ export default class SidebarGroupChannel extends React.PureComponent<Props, Stat
                 label={channel.display_name}
                 closeHandler={this.handleLeaveChannel}
                 icon={this.getIcon()}
-                isCollapsed={this.props.isCollapsed}
             />
         );
     }


### PR DESCRIPTION
#### Summary
`isCollapsed` prop was passed down in sidebarChannelLink for the sole reason of checking tabIndex on the collapsed channel link. But with https://github.com/mattermost/mattermost-webapp/pull/9732 pr we dont render the collapsed channels anymore, making this check redundant.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48895

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
