### PR TITLE
Updated Cloud admin docs links in-product

### DIFF
--- a/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.tsx
+++ b/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.tsx
@@ -96,7 +96,7 @@ class AdminNavbarDropdown extends React.PureComponent<Props> {
 
         let adminGuideLink = 'https://docs.mattermost.com/guides/administration.html';
         if (isCloud) {
-            adminGuideLink = 'https://docs.mattermost.com/guides/cloud-admin-guide.html';
+            adminGuideLink = 'https://docs.mattermost.com/guides/administration.html#cloud-workspace-management';
         }
 
         return (

--- a/e2e/cypress/tests/integration/system_console/main_menu_spec.js
+++ b/e2e/cypress/tests/integration/system_console/main_menu_spec.js
@@ -34,7 +34,7 @@ describe('Main menu', () => {
     it('MM-T910 Can open Administrators Guide', () => {
         cy.apiGetClientLicense().then(({isCloudLicensed}) => {
             const guideLink = isCloudLicensed ?
-                'https://docs.mattermost.com/guides/cloud-admin-guide.html' :
+                'https://docs.mattermost.com/guides/administration.html#cloud-workspace-management' :
                 'https://docs.mattermost.com/guides/administration.html';
 
             // * Verify administrator's guide link


### PR DESCRIPTION
#### Summary
Corrected in-product System Console legacy link to point to the current Cloud Administrator's Guide.


#### Release Note

```release-note
Corrected in-product System Console legacy link to the Cloud Administrator's Guide.
```
