### PR TITLE
MM-48567 Fix Client4 and ability to create a board with a channel in MPA

### DIFF
--- a/components/keyboard_shortcuts/keyboard_shortcuts_modal/keyboard_shortcuts_modal.test.tsx
+++ b/components/keyboard_shortcuts/keyboard_shortcuts_modal/keyboard_shortcuts_modal.test.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import * as redux from 'react-redux';
 
-import {suitePluginIds} from 'packages/client/src/client4';
 import mockStore from 'tests/test_store';
+import {suitePluginIds} from 'utils/constants';
 
 import KeyboardShortcutsModal from 'components/keyboard_shortcuts/keyboard_shortcuts_modal/keyboard_shortcuts_modal';
 

--- a/components/keyboard_shortcuts/keyboard_shortcuts_modal/keyboard_shortcuts_modal.tsx
+++ b/components/keyboard_shortcuts/keyboard_shortcuts_modal/keyboard_shortcuts_modal.tsx
@@ -8,7 +8,7 @@ import {useSelector} from 'react-redux';
 
 import {GlobalState} from 'types/store';
 
-import {suitePluginIds} from 'packages/client/src/client4';
+import {suitePluginIds} from 'utils/constants';
 
 import {t} from 'utils/i18n';
 import * as Utils from 'utils/utils';

--- a/components/new_channel_modal/new_channel_modal.tsx
+++ b/components/new_channel_modal/new_channel_modal.tsx
@@ -38,13 +38,15 @@ import {sendGenericPostMessage} from 'actions/global_actions';
 
 import {GlobalState} from 'types/store';
 
-import Constants, {ItemStatus, ModalIdentifiers, suitePluginIds} from 'utils/constants';
+import Constants, {ItemStatus, ModalIdentifiers} from 'utils/constants';
 import {cleanUpUrlable, validateChannelUrl, getSiteURL} from 'utils/url';
 import {localizeMessage} from 'utils/utils';
 
 import {Board, BoardPatch, BoardTemplate} from '@mattermost/types/boards';
 import {ChannelType, Channel} from '@mattermost/types/channels';
 import {ServerError} from '@mattermost/types/errors';
+
+import {canCreateBoards} from './selectors';
 
 import './new_channel_modal.scss';
 
@@ -107,13 +109,11 @@ const NewChannelModal = () => {
     const [selectedBoardTemplate, setSelectedBoardTemplate] = useState<BoardTemplate | null>(null);
 
     // create a board along with the channel
-    const BOARDS_API_ENABLED_VERSION = '7.2.1'; // 7.2.1 is the minimum required; it exposes the boards templates api
     const [addBoard, setAddBoard] = useState(false);
     const [boardTemplates, setBoardTemplates] = useState<BoardTemplate[]>([]);
     const newChannelWithBoardPulsatingDotState = useSelector((state: GlobalState) => getPreference(state, Preferences.APP_BAR, Preferences.NEW_CHANNEL_WITH_BOARD_TOUR_SHOWED, ''));
     const EMPTY_BOARD = 'empty-board';
-    const focalboardPlugin = useSelector((state: GlobalState) => state.plugins.plugins?.focalboard);
-    const focalboardEnabled = focalboardPlugin?.id === suitePluginIds.focalboard && focalboardPlugin.version >= BOARDS_API_ENABLED_VERSION;
+    const focalboardEnabled = useSelector(canCreateBoards);
 
     const handleOnModalConfirm = async () => {
         if (!canCreate) {

--- a/components/new_channel_modal/selectors.ts
+++ b/components/new_channel_modal/selectors.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {isMinimumServerVersion} from 'mattermost-redux/utils/helpers';
+
+import {GlobalState} from 'types/store';
+
+import {suitePluginIds} from 'utils/constants';
+
+export function canCreateBoards(state: GlobalState) {
+    const config = getConfig(state);
+    if (config.FeatureFlagBoardsProduct === 'true') {
+        return true;
+    }
+
+    // 7.2.1 is the minimum required; it exposes the boards templates api
+    const focalboardManifest = state.plugins.plugins.focalboard;
+    return focalboardManifest &&
+        focalboardManifest.id === suitePluginIds.focalboard &&
+        isMinimumServerVersion(focalboardManifest.version, 7, 2, 1);
+}

--- a/e2e/cypress/tests/integration/channel/new_channel_with_board_spec.js
+++ b/e2e/cypress/tests/integration/channel/new_channel_with_board_spec.js
@@ -28,11 +28,6 @@ describe('Channel routing', () => {
                 EnableMarketplace: true,
                 EnableRemoteMarketplace: true,
                 MarketplaceURL: 'https://api.integrations.mattermost.com',
-                PluginStates: {
-                    focalboard: {
-                        Enable: true,
-                    },
-                },
             },
         });
     });

--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -154,17 +154,6 @@ export const DEFAULT_LIMIT_AFTER = 30;
 
 const GRAPHQL_ENDPOINT = '/api/v5/graphql';
 
-// placed here because currently not supported
-// to import from outside the package from main bundle
-export const suitePluginIds = {
-    playbooks: 'playbooks',
-    focalboard: 'focalboard',
-    apps: 'com.mattermost.apps',
-    calls: 'com.mattermost.calls',
-    nps: 'com.mattermost.nps',
-    channelExport: 'com.mattermost.plugin-channel-export',
-};
-
 export default class Client4 {
     logToConsole = false;
     serverVersion = '';
@@ -186,6 +175,8 @@ export default class Client4 {
     };
     userRoles = '';
     telemetryHandler?: TelemetryHandler;
+
+    useBoardsProduct = false;
 
     getUrl() {
         return this.url;
@@ -248,6 +239,10 @@ export default class Client4 {
 
     setTelemetryHandler(telemetryHandler?: TelemetryHandler) {
         this.telemetryHandler = telemetryHandler;
+    }
+
+    setUseBoardsProduct(useBoardsProduct: boolean) {
+        this.useBoardsProduct = useBoardsProduct;
     }
 
     getServerVersion() {
@@ -479,6 +474,10 @@ export default class Client4 {
 
     getDraftsRoute() {
         return `${this.getBaseRoute()}/drafts`;
+    }
+
+    getBoardsRoute() {
+        return this.useBoardsProduct ? '/plugins/boards/api/v2' : '/plugins/focalboard/api/v2';
     }
 
     getCSRFFromCookie() {
@@ -3498,35 +3497,35 @@ export default class Client4 {
 
     getBoardsUsage = () => {
         return this.doFetch<BoardsUsageResponse>(
-            `/plugins/${suitePluginIds.focalboard}/api/v2/limits`,
+            `${this.getBoardsRoute()}/limits`,
             {method: 'get'},
         );
     }
 
     getBoardsTemplates = (teamId = '0') => {
         return this.doFetch<BoardTemplate[]>(
-            `/plugins/${suitePluginIds.focalboard}/api/v2/teams/${teamId}/templates`,
+            `${this.getBoardsRoute()}/teams/${teamId}/templates`,
             {method: 'get'},
         );
     }
 
     createBoard = (board: Board) => {
         return this.doFetch<CreateBoardResponse>(
-            `/plugins/${suitePluginIds.focalboard}/api/v2/boards`,
+            `${this.getBoardsRoute()}/boards`,
             {method: 'POST', body: JSON.stringify({...board})},
         );
     }
 
     createBoardFromTemplate = (boardTemplateId: string, teamId: string) => {
         return this.doFetch<CreateBoardResponse>(
-            `/plugins/${suitePluginIds.focalboard}/api/v2/boards/${boardTemplateId}/duplicate?asTemplate=false&toTeam=${teamId}`,
+            `${this.getBoardsRoute()}/boards/${boardTemplateId}/duplicate?asTemplate=false&toTeam=${teamId}`,
             {method: 'POST'},
         );
     }
 
     patchBoard = (newBoardId: string, boardPatch: BoardPatch) => {
         return this.doFetch<Board>(
-            `/plugins/${suitePluginIds.focalboard}/api/v2/boards/${newBoardId}`,
+            `${this.getBoardsRoute()}/boards/${newBoardId}`,
             {method: 'PATCH', body: JSON.stringify({...boardPatch})},
         );
     }

--- a/plugins/products.test.ts
+++ b/plugins/products.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Client4} from 'mattermost-redux/client';
+
+import testConfigureStore from 'tests/test_store';
+
+import {initializeProducts} from './products';
+
+(window as any).REMOTE_CONTAINERS = {};
+
+describe('initializeProducts', () => {
+    test('should set Client4 to use the correct Boards URL for product mode', async () => {
+        const store = testConfigureStore({
+            entities: {
+                general: {
+                    config: {
+                        FeatureFlagBoardsProduct: 'true',
+                    },
+                },
+            },
+        });
+
+        await store.dispatch(initializeProducts());
+
+        expect(Client4.getBoardsRoute().startsWith('/plugins/boards')).toBe(true);
+    });
+
+    test('should set Client4 to use the correct Boards URL for plugin mode', async () => {
+        const store = testConfigureStore({
+            entities: {
+                general: {
+                    config: {
+                        FeatureFlagBoardsProduct: 'false',
+                    },
+                },
+            },
+        });
+
+        await store.dispatch(initializeProducts());
+
+        expect(Client4.getBoardsRoute().startsWith('/plugins/focalboard')).toBe(true);
+    });
+});

--- a/plugins/products.ts
+++ b/plugins/products.ts
@@ -3,6 +3,7 @@
 
 import {Store} from 'redux';
 
+import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 
@@ -16,6 +17,25 @@ export abstract class ProductPlugin {
 }
 
 export function initializeProducts() {
+    return (dispatch: DispatchFunc) => {
+        return Promise.all([
+            dispatch(loadRemoteModules()),
+            dispatch(configureClient()),
+        ]);
+    };
+}
+
+function configureClient() {
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const config = getConfig(getState());
+
+        Client4.setUseBoardsProduct(config.FeatureFlagBoardsProduct === 'true');
+
+        return Promise.resolve({data: true});
+    };
+}
+
+function loadRemoteModules() {
     /* eslint-disable no-console */
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const config = getConfig(getState());


### PR DESCRIPTION
The feature to make a board for a new channel is currently broken in MPA because:
1. The code that checks if Boards is enabled and is the correct version doesn't work with the Boards product
2. That code calls the Boards API directly, and that didn't support the fact that Boards routes are different in MPA

This fixes those, and it also fixes the accompanying E2E test (MM-T5141)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48567
https://mattermost.atlassian.net/browse/MM-47938

#### Release Note
```release-note
Fixed ability to create a board when Boards is running without a plugin
```
