### PR TITLE
MM-48567 Fix Boards button in app bar appearing below divider

### DIFF
--- a/components/app_bar/app_bar.tsx
+++ b/components/app_bar/app_bar.tsx
@@ -32,7 +32,7 @@ export default function AppBar() {
         return null;
     }
 
-    const coreProductsPluginIds = [suitePluginIds.focalboard, suitePluginIds.playbooks];
+    const coreProductsPluginIds = [suitePluginIds.boards, suitePluginIds.focalboard, suitePluginIds.playbooks];
 
     const [coreProductComponents, pluginComponents] = partition(appBarPluginComponents, ({pluginId}) => {
         return coreProductsPluginIds.includes(pluginId);

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -182,7 +182,19 @@ export const TrialPeriodDays = {
 
 export const suitePluginIds = {
     playbooks: 'playbooks',
+
+    /**
+     * @warning This only applies to the Boards product and will not work with the Boards plugin. Both cases need to
+     * be supported until we enable the Boards product permanently.
+     */
+    boards: 'boards',
+
+    /**
+     * @deprecated This only applies to the Boards plugin and will not work with the Boards product. Both cases need
+     * to be supported until we enable the Boards product permanently.
+     */
     focalboard: 'focalboard',
+
     apps: 'com.mattermost.apps',
     calls: 'com.mattermost.calls',
     nps: 'com.mattermost.nps',


### PR DESCRIPTION
This is another issue with the Boards product. The product ID for Boards changed when it became a product, and because we were looking for the old ID when determining if something should come above or below the divider, it ended up below it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48567

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/11800

#### Release Note
```release-note
Fixed position of Boards icon in app bar when Boards is running without a plugin
```
