### PR TITLE
[MM-49061] Fix Thread Drafts not Updating on Team Switch

### DIFF
--- a/components/advanced_create_comment/advanced_create_comment.test.jsx
+++ b/components/advanced_create_comment/advanced_create_comment.test.jsx
@@ -561,7 +561,6 @@ describe('components/AdvancedCreateComment', () => {
             message: 'some valid text',
             uploadsInProgress: [],
             fileInfos: [{}, {}, {}],
-            show: true,
         }, {ignoreSlash: false});
     });
 

--- a/components/advanced_create_comment/advanced_create_comment.test.jsx
+++ b/components/advanced_create_comment/advanced_create_comment.test.jsx
@@ -561,6 +561,7 @@ describe('components/AdvancedCreateComment', () => {
             message: 'some valid text',
             uploadsInProgress: [],
             fileInfos: [{}, {}, {}],
+            show: true,
         }, {ignoreSlash: false});
     });
 

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -213,6 +213,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
     private saveDraftFrame?: number | null;
 
     private isDraftSubmitting = false;
+    private isDraftEdited = false;
 
     private readonly textboxRef: React.RefObject<TextboxClass>;
     private readonly fileUploadRef: React.RefObject<FileUploadClass>;
@@ -284,7 +285,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         document.removeEventListener('paste', this.pasteHandler);
         document.removeEventListener('keydown', this.focusTextboxIfNecessary);
         window.removeEventListener('beforeunload', this.saveDraftWithShow);
-        this.saveDraftWithShow();
+        this.saveDraftOnUnmount();
     }
 
     componentDidUpdate(prevProps: Props, prevState: State) {
@@ -331,6 +332,20 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
                 getChannelMemberCountsByGroup(channelId, isTimezoneEnabled);
             }
         }
+    }
+
+    saveDraftOnUnmount = () => {
+        if (!this.isDraftEdited || !this.state.draft) {
+            return;
+        }
+
+        const updatedDraft = {
+            ...this.state.draft,
+            show: !isDraftEmpty(this.state.draft),
+            remote: false,
+        } as PostDraft;
+
+        this.props.onUpdateCommentDraft(updatedDraft, true);
     }
 
     saveDraftWithShow = () => {
@@ -754,8 +769,8 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         }
 
         const draft = this.state.draft!;
-        const show = isDraftEmpty(draft) ? false : draft.show;
-        const updatedDraft = {...draft, message, show};
+        const updatedDraft = {...draft, message};
+        updatedDraft.show = !isDraftEmpty(updatedDraft);
 
         this.handleDraftChange(updatedDraft);
 
@@ -768,6 +783,8 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
     }
 
     handleDraftChange = (draft: PostDraft, rootId?: string, save = false) => {
+        this.isDraftEdited = true;
+
         if (this.saveDraftFrame) {
             clearTimeout(this.saveDraftFrame);
         }
@@ -973,6 +990,7 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
     }
 
     handleFileUploadChange = () => {
+        this.isDraftEdited = true;
         this.focusTextbox();
     }
 

--- a/components/advanced_create_comment/advanced_create_comment.tsx
+++ b/components/advanced_create_comment/advanced_create_comment.tsx
@@ -769,8 +769,8 @@ class AdvancedCreateComment extends React.PureComponent<Props, State> {
         }
 
         const draft = this.state.draft!;
-        const updatedDraft = {...draft, message};
-        updatedDraft.show = !isDraftEmpty(updatedDraft);
+        const show = isDraftEmpty(draft) ? false : draft.show;
+        const updatedDraft = {...draft, message, show};
 
         this.handleDraftChange(updatedDraft);
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fixed thread drafts not syncing to server when RHS is unmounted

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-49061

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
- Has server changes (please link here)
- Has mobile changes (please link here)
-->

- This should be merged after https://github.com/mattermost/mattermost-webapp/pull/11733.

<!--
#### Screenshots

If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
