### PR TITLE
[MM-48799] - Adjusted windows text notification length

### DIFF
--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -18,12 +18,15 @@ import {isThreadOpen} from 'selectors/views/threads';
 import {getHistory} from 'utils/browser_history';
 import Constants, {NotificationLevels, UserStatuses} from 'utils/constants';
 import {showNotification} from 'utils/notifications';
-import {isDesktopApp, isMobileApp} from 'utils/user_agent';
+import {isDesktopApp, isMobileApp, isWindowsApp} from 'utils/user_agent';
 import * as Utils from 'utils/utils';
 import {t} from 'utils/i18n';
 import {stripMarkdown} from 'utils/markdown';
 
 const NOTIFY_TEXT_MAX_LENGTH = 50;
+
+// windows notification length is based windows chrome which supports 128 characters and is the lowest length of windows browsers
+const WINDOWS_NOTIFY_TEXT_MAX_LENGTH = 120;
 
 export function sendDesktopNotification(post, msgProps) {
     return async (dispatch, getState) => {
@@ -134,8 +137,10 @@ export function sendDesktopNotification(post, msgProps) {
         });
 
         let strippedMarkdownNotifyText = stripMarkdown(notifyText);
-        if (strippedMarkdownNotifyText.length > NOTIFY_TEXT_MAX_LENGTH) {
-            strippedMarkdownNotifyText = strippedMarkdownNotifyText.substring(0, NOTIFY_TEXT_MAX_LENGTH - 1) + '...';
+
+        const notifyTextMaxLength = isWindowsApp() ? WINDOWS_NOTIFY_TEXT_MAX_LENGTH : NOTIFY_TEXT_MAX_LENGTH;
+        if (strippedMarkdownNotifyText.length > notifyTextMaxLength) {
+            strippedMarkdownNotifyText = strippedMarkdownNotifyText.substring(0, notifyTextMaxLength - 1) + '...';
         }
 
         let body = `@${username}`;


### PR DESCRIPTION
#### Summary
Increased the max text notification length on Windows to 120. This value was chosen because Chrome on Windows supports 128 max length, and other browsers support higher. I opted to keep it a bit under the lowest value to accommodate all potential browsers with lower complexity.

#### Ticket Link
fixes https://mattermost.atlassian.net/browse/MM-48799

#### Screenshots

#### Before Changes
![Screenshot 2022-12-14 at 11 56 38 AM](https://user-images.githubusercontent.com/46071821/207658752-cd18f146-9e7d-4acc-9a13-114bfd2889dc.jpg)


#### After Changes
![Screenshot 2022-12-14 at 11 14 14 AM](https://user-images.githubusercontent.com/46071821/207658689-efa1f9d6-dc0a-4c3f-b264-e5b0b61f032f.jpg)
![Screenshot 2022-12-14 at 11 13 45 AM](https://user-images.githubusercontent.com/46071821/207658693-582107d2-79d7-4bc7-8cd4-43839f7e6436.jpg)

#### Release Note

```release-note
Increased notification length on Windows to 120 from 50.
```