### PR TITLE
do not show two screens at once

### DIFF
--- a/components/self_hosted_purchase_modal/index.test.tsx
+++ b/components/self_hosted_purchase_modal/index.test.tsx
@@ -94,6 +94,9 @@ jest.mock('mattermost-redux/client', () => {
                 progress: mockCreatedLicense,
                 license: {Users: existingUsers * 2},
             }),
+            getClientLicenseOld: () => Promise.resolve({
+                data: {Sku: 'Enterprise'},
+            }),
         },
     };
 });
@@ -137,7 +140,9 @@ const initialState: DeepPartial<GlobalState> = {
             config: {
                 EnableDeveloper: 'false',
             },
-            license: {},
+            license: {
+                Sku: 'Enterprise',
+            },
         },
         cloud: {
             subscription: {},

--- a/components/self_hosted_purchase_modal/index.tsx
+++ b/components/self_hosted_purchase_modal/index.tsx
@@ -700,7 +700,7 @@ export default function SelfHostedPurchaseModal(props: Props) {
                                 />
                             </div>
                         </div>}
-                        {(state.succeeded || progress === SelfHostedSignupProgress.CREATED_LICENSE) && (
+                        {(state.succeeded || progress === SelfHostedSignupProgress.CREATED_LICENSE) && !state.error && !state.submitting && (
                             <SuccessPage
                                 onClose={controlModal.close}
                                 planName={desiredPlanName}

--- a/components/self_hosted_purchase_modal/index.tsx
+++ b/components/self_hosted_purchase_modal/index.tsx
@@ -15,7 +15,7 @@ import {
 import {UserProfile} from '@mattermost/types/users';
 import {ValueOf} from '@mattermost/types/utilities';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getAdminAnalytics} from 'mattermost-redux/selectors/entities/admin';
 import {getSelfHostedProducts, getSelfHostedSignupProgress} from 'mattermost-redux/selectors/entities/hosted_customer';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
@@ -298,6 +298,7 @@ export default function SelfHostedPurchaseModal(props: Props) {
     const desiredPlanName = getPlanNameFromProductName(desiredProductName);
     const currentUsers = analytics[StatTypes.TOTAL_USERS] as number;
     const isDevMode = useSelector(getConfig).EnableDeveloper === 'true';
+    const hasLicense = Object.keys(useSelector(getLicense) || {}).length > 0;
 
     const intl = useIntl();
     const fakeProgressRef = useRef<FakeProgress>({
@@ -700,7 +701,7 @@ export default function SelfHostedPurchaseModal(props: Props) {
                                 />
                             </div>
                         </div>}
-                        {(state.succeeded || progress === SelfHostedSignupProgress.CREATED_LICENSE) && !state.error && !state.submitting && (
+                        {((state.succeeded || progress === SelfHostedSignupProgress.CREATED_LICENSE) && hasLicense) && !state.error && !state.submitting && (
                             <SuccessPage
                                 onClose={controlModal.close}
                                 planName={desiredPlanName}


### PR DESCRIPTION
#### Summary
While tweaking the self-hosted purchase flow, I discovered that if CWS sends license successfully but mattermost-server fails to apply it (I originally was creating a license with no seats on accident), we would show both the success screen and the failure screen at the same time because of how. We are unlikely to see this happen in production, but should cover the case nonetheless.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47423

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note

```release-note
NONE
```
