### PR TITLE
Clarified string impact for the user

### DIFF
--- a/components/notify_confirm_modal.tsx
+++ b/components/notify_confirm_modal.tsx
@@ -46,7 +46,7 @@ export default class NotifyConfirmModal extends React.PureComponent<Props> {
                     />
                 );
             } else {
-                const atHereMsg = 'By using **@here** you are about to send notifications to up to **{totalMembers} people**. Are you sure you want to do this?';
+                const atHereMsg = 'By using **@here** you are about to send notifications to up to **{totalMembers} other people**. Are you sure you want to do this?';
                 const atAllChannelMsg = 'By using **@all** or **@channel** you are about to send notifications to **{totalMembers} people**. Are you sure you want to do this?';
                 const msg = mentions.length === 1 && mentions[0] === '@here' ? atHereMsg : atAllChannelMsg;
                 const msgID = mentions.length === 1 && mentions[0] === '@here' ? t('notify_here.question') : t('notify_all.question');

--- a/components/notify_confirm_modal.tsx
+++ b/components/notify_confirm_modal.tsx
@@ -31,7 +31,7 @@ export default class NotifyConfirmModal extends React.PureComponent<Props> {
                 />
             );
             if (channelTimezoneCount > 0) {
-                const atHereMsg = 'By using **@here** you are about to send notifications to up to **{totalMembers} people** in **{timezones, number} {timezones, plural, one {timezone} other {timezones}}**. Are you sure you want to do this?';
+                const atHereMsg = 'By using **@here** you are about to send notifications to up to **{totalMembers} other people** in **{timezones, number} {timezones, plural, one {timezone} other {timezones}}**. Are you sure you want to do this?';
                 const atAllChannelMsg = 'By using **@all** or **@channel** you are about to send notifications to **{totalMembers} people** in **{timezones, number} {timezones, plural, one {timezone} other {timezones}}**. Are you sure you want to do this?';
                 const msg = mentions.length === 1 && mentions[0] === '@here' ? atHereMsg : atAllChannelMsg;
                 const msgID = mentions.length === 1 && mentions[0] === '@here' ? t('notify_here.question_timezone') : t('notify_all.question_timezone');

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4196,7 +4196,7 @@
   "notify_all.question_timezone_one_group": "By using **{mention}** you are about to send notifications to **{totalMembers} people** in **{timezones, number} {timezones, plural, one {timezone} other {timezones}}**. Are you sure you want to do this?",
   "notify_all.title.confirm": "Confirm Sending Notifications to Entire Channel",
   "notify_all.title.confirm_groups": "Confirm sending notifications to groups",
-  "notify_here.question": "By using **@here** you are about to send notifications to up to **{totalMembers} people**. Are you sure you want to do this?",
+  "notify_here.question": "By using **@here** you are about to send notifications to up to **{totalMembers} other people**. Are you sure you want to do this?",
   "notify_here.question_timezone": "By using **@here** you are about to send notifications to up to **{totalMembers} other people** in **{timezones, number} {timezones, plural, one {timezone} other {timezones}}**. Are you sure you want to do this?",
   "numMembers": "{num, number} {num, plural, one {member} other {members}}",
   "onboarding_wizard.launching_workspace.description": "It’ll be ready in a moment",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4197,7 +4197,7 @@
   "notify_all.title.confirm": "Confirm Sending Notifications to Entire Channel",
   "notify_all.title.confirm_groups": "Confirm sending notifications to groups",
   "notify_here.question": "By using **@here** you are about to send notifications to up to **{totalMembers} people**. Are you sure you want to do this?",
-  "notify_here.question_timezone": "By using **@here** you are about to send notifications to up to **{totalMembers} people** in **{timezones, number} {timezones, plural, one {timezone} other {timezones}}**. Are you sure you want to do this?",
+  "notify_here.question_timezone": "By using **@here** you are about to send notifications to up to **{totalMembers} other people** in **{timezones, number} {timezones, plural, one {timezone} other {timezones}}**. Are you sure you want to do this?",
   "numMembers": "{num, number} {num, plural, one {member} other {members}}",
   "onboarding_wizard.launching_workspace.description": "It’ll be ready in a moment",
   "onboarding_wizard.launching_workspace.title": "Launching your workspace now",


### PR DESCRIPTION
#### Summary
Updated in-product confirmation modal for `@here` mentions to clarify that people & timezone counts don't include the current user.  

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-48777


#### Release Note

```release-note
Updated in-product confirmation modal for `@here` mentions to clarify that people & timezone counts don't include the current user.  
```

@fmartingr @mkraft - There's a second product string (id: `notify_here.question`) that's identical to this string (id: `notify_here.question_timezone`) that's missing the timezone count. Is this second string calculated the same way such that it would also benefit from the addition of the word "other"?
