### PR TITLE
Fix Apps form loading background color

### DIFF
--- a/components/apps_form/apps_form_component.scss
+++ b/components/apps_form/apps_form_component.scss
@@ -9,7 +9,7 @@
     align-items: center;
     justify-content: center;
     backdrop-filter: blur(0);
-    background: rgba(255, 255, 255, 0.8);
+    background: var(--center-channel-bg);
 }
 
 .apps-form-modal-body-loaded {


### PR DESCRIPTION
#### Summary

This PR fixes an issue with the background color of the loading spinner when an Apps form is refreshing. The color was hardcoded to white, which didn't look right on dark mode. Light mode themes are essentially unchanged. More context here https://mattermost.atlassian.net/browse/MM-49184

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-49184

#### Screenshots

Before

<img width="400" alt="image" src="https://user-images.githubusercontent.com/6913320/208602229-1ea7fe93-64e8-4394-befd-137a75ba2f94.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/6913320/208602336-51564a0f-afa6-41c9-9fa0-fe336b583a8b.png">

After

<img width="400" alt="image" src="https://user-images.githubusercontent.com/6913320/208602632-fd9e876a-c579-4a9f-a504-9a075c15b4e6.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/6913320/208602587-2c5f6519-bfd2-4b89-a023-99a2f9009741.png">


#### Release Note

```release-note
NONE
```
