### PR TITLE
[MM-49232]: Prevent the "view Plans" tooltip from showing on the Purchases modal

### DIFF
--- a/components/global_header/right_controls/plan_upgrade_button/index.tsx
+++ b/components/global_header/right_controls/plan_upgrade_button/index.tsx
@@ -89,7 +89,7 @@ const PlanUpgradeButton = (): JSX.Element | null => {
 
     return (
         <OverlayTrigger
-            trigger={['hover', 'focus']}
+            trigger={['hover']}
             delayShow={Constants.OVERLAY_TIME_DELAY}
             placement='bottom'
             overlay={tooltip}

--- a/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.js
@@ -245,6 +245,9 @@ describe('Pricing modal', () => {
         cy.get('#professional').find('#professional_action').should('be.enabled').should('have.text', 'Upgrade').click();
         cy.get('.PurchaseModal').should('exist');
 
+        // * Check that the upgrade button tooltip does not exist on the purchase modal
+        cy.get('#upgrade_button_tooltip').should('not.exist');
+
         // * Close PurchaseModal
         cy.get('#closeIcon').click();
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Previously, when a user clicks on the "View Plans" button in the header followed by the "Upgrade" button in the Pricing modal, the tooltip from the "View Plans" button shows up on the Purchases modal. 

The new change stops this behaviour. The tooltip will only show up when a user hovers over the "View Plans" button in the header and it will not show up in the Purchases modal. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-49232
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.



-->
|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/44761757/208747656-72b7362e-5e8d-4de4-a54e-85dc05f6d1f1.png)| <img alt="image" src="https://user-images.githubusercontent.com/44761757/208747739-760d6d95-e00e-4b0b-a938-f99bde3c843a.png">|
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
