### PR TITLE
close pricing modal when purchase modal is ready to open

### DIFF
--- a/components/common/hooks/useControlSelfHostedPurchaseModal.ts
+++ b/components/common/hooks/useControlSelfHostedPurchaseModal.ts
@@ -5,7 +5,7 @@ import {useMemo} from 'react';
 import {useDispatch} from 'react-redux';
 
 import {trackEvent} from 'actions/telemetry_actions';
-import {openModal} from 'actions/views/modals';
+import {closeModal} from 'actions/views/modals';
 import {ModalIdentifiers, TELEMETRY_CATEGORIES} from 'utils/constants';
 import SelfHostedPurchaseModal from 'components/self_hosted_purchase_modal';
 import {Client4} from 'mattermost-redux/client';
@@ -44,13 +44,8 @@ export default function useControlSelfHostedPurchaseModal(options: HookOptions):
                         type: HostedCustomerTypes.RECEIVED_SELF_HOSTED_SIGNUP_PROGRESS,
                         data: result.progress,
                     });
-                    dispatch(openModal({
-                        modalId: ModalIdentifiers.SELF_HOSTED_PURCHASE,
-                        dialogType: SelfHostedPurchaseModal,
-                        dialogProps: {
-                            productId: options.productId,
-                        },
-                    }));
+                    dispatch(closeModal(ModalIdentifiers.PRICING_MODAL));
+                    controlModal.open();
                 } catch (e) {
                     // eslint-disable-next-line no-console
                     console.error('error bootstrapping self hosted purchase modal', e);

--- a/components/pricing_modal/self_hosted_content.tsx
+++ b/components/pricing_modal/self_hosted_content.tsx
@@ -232,7 +232,13 @@ function SelfHostedContent(props: ContentProps) {
 
                                 const professionalProduct = findSelfHostedProductBySku(products, SelfHostedProducts.PROFESSIONAL);
                                 if (productsLoaded && professionalProduct) {
-                                    closePricingModal();
+                                    // let the control modal close this modal
+                                    // we need to wait for its timing,
+                                    // it doesn't return a signal,
+                                    // and we can not do this in a useEffect hook
+                                    // at the top of this file easily because
+                                    // sometimes we want both modals to be open if user is in purchase
+                                    // modal and wants to compare plans
                                     controlSelfHostedPurchaseModal.open();
                                 }
                             },


### PR DESCRIPTION
#### Summary
We should wait to close the pricing modal until the purchase modal is ready to open. When using a local license generator, getting the bootstrap license was very quick. Using a real license generator, its a little longer, on the order of 1.5 seconds, which is too long to close the modal and wait to open the other one. This should be cherry-picked to release-7.7 so that admins trying to purchase in-app have a less distracting experience.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49258

#### Release Note

```release-note
NONE
```
