### PR TITLE
[MM-48862] Unify style and position of arrows for month selection on date picker

### DIFF
--- a/components/common/day_picker_navbar/index.tsx
+++ b/components/common/day_picker_navbar/index.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import { NavbarElementProps } from 'react-day-picker';
+
+interface CustomNavbarProps extends NavbarElementProps {
+    ifSearchDateSuggestion: boolean;
+}
+
+const Navbar: React.FC<Partial<CustomNavbarProps>> = (navbarProps: Partial<CustomNavbarProps>) => {
+    const {
+        onPreviousClick,
+        onNextClick,
+        className,
+        ifSearchDateSuggestion,
+    } = navbarProps;
+    const styleLeft: React.CSSProperties = {
+        float: 'left',
+        fontSize: 18,
+    };
+    const styleRight: React.CSSProperties = {
+        float: 'right',
+        fontSize: 18,
+    };
+
+    return (
+        <div className={className}>
+            <button
+                className='style--none'
+                style={styleLeft}
+                onClick={(e) => {
+                    e.preventDefault();
+                    if (onPreviousClick) {
+                        onPreviousClick();
+                    }
+                }}
+            >
+                <i
+                    className='fa fa-angle-left'
+                    aria-hidden='true'
+                    style={ifSearchDateSuggestion ? {marginLeft:48} : {}}
+                />
+            </button>
+            <button
+                className='style--none'
+                style={styleRight}
+                onClick={(e) => {
+                    e.preventDefault();
+                    if (onNextClick) {
+                        onNextClick();
+                    }
+                }}
+            >
+                <i
+                    className='fa fa-angle-right'
+                    aria-hidden='true'
+                    style={ifSearchDateSuggestion ? {marginRight:48}: {}}
+                />
+            </button>
+        </div>
+    );
+};
+
+export default Navbar;

--- a/components/custom_status/date_time_input.tsx
+++ b/components/custom_status/date_time_input.tsx
@@ -15,59 +15,9 @@ import Menu from 'components/widgets/menu/menu';
 import Timestamp from 'components/timestamp';
 import {getCurrentLocale} from 'selectors/i18n';
 import {getCurrentMomentForTimezone} from 'utils/timezone';
+import Navbar from 'components/common/day_picker_navbar';
 
 const CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES = 30;
-
-const Navbar: React.FC<Partial<NavbarElementProps>> = (navbarProps: Partial<NavbarElementProps>) => {
-    const {
-        onPreviousClick,
-        onNextClick,
-        className,
-    } = navbarProps;
-    const styleLeft: React.CSSProperties = {
-        float: 'left',
-        fontSize: 18,
-    };
-    const styleRight: React.CSSProperties = {
-        float: 'right',
-        fontSize: 18,
-    };
-
-    return (
-        <div className={className}>
-            <button
-                className='style--none'
-                style={styleLeft}
-                onClick={(e) => {
-                    e.preventDefault();
-                    if (onPreviousClick) {
-                        onPreviousClick();
-                    }
-                }}
-            >
-                <i
-                    className='fa fa-angle-left'
-                    aria-hidden='true'
-                />
-            </button>
-            <button
-                className='style--none'
-                style={styleRight}
-                onClick={(e) => {
-                    e.preventDefault();
-                    if (onNextClick) {
-                        onNextClick();
-                    }
-                }}
-            >
-                <i
-                    className='fa fa-angle-right'
-                    aria-hidden='true'
-                />
-            </button>
-        </div>
-    );
-};
 
 export function getRoundedTime(value: Moment) {
     const roundedTo = CUSTOM_STATUS_TIME_PICKER_INTERVALS_IN_MINUTES;

--- a/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
+++ b/components/dnd_custom_time_picker_modal/dnd_custom_time_picker_modal.tsx
@@ -17,6 +17,7 @@ import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 import './dnd_custom_time_picker_modal.scss';
 import {toUTCUnix} from 'utils/datetime';
 import {localizeMessage} from 'utils/utils';
+import Navbar from 'components/common/day_picker_navbar';
 
 type Props = {
     onExited: () => void;
@@ -186,6 +187,7 @@ export default class DndCustomTimePicker extends React.PureComponent<Props, Stat
                                 value={this.formatDate(selectedDate)}
                                 onDayChange={this.handleDaySelection}
                                 dayPickerProps={{
+                                    navbarElement: <Navbar />,
                                     selectedDays: selectedDate,
                                     disabledDays: {
                                         before: dayPickerStartDate,

--- a/components/suggestion/search_date_suggestion/search_date_suggestion.tsx
+++ b/components/suggestion/search_date_suggestion/search_date_suggestion.tsx
@@ -12,6 +12,7 @@ import Suggestion from '../suggestion.jsx';
 import 'react-day-picker/lib/style.css';
 
 import 'moment';
+import Navbar from 'components/common/day_picker_navbar';
 
 const loadedLocales: Record<string, moment.Locale> = {};
 
@@ -64,6 +65,7 @@ export default class SearchDateSuggestion extends Suggestion {
                 modifiers={modifiers}
                 localeUtils={MomentLocaleUtils}
                 locale={locale}
+                navbarElement={<Navbar ifSearchDateSuggestion={true}/>}
             />
         );
     }

--- a/sass/components/_day-picker.scss
+++ b/sass/components/_day-picker.scss
@@ -13,6 +13,9 @@
             border-bottom: 1px solid transparent;
             margin: 0 0.5rem 0.7rem;
             text-align: center;
+            color: var(--center-channel-color);
+            font-size: 14px;
+            font-weight: 600;
 
             > div {
                 font-size: inherit;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Environment: master, raised during PR testing https://github.com/mattermost/mattermost-webapp/pull/11615%7Csmart-link

There are few differences in the style and position of arrows for month selection on the date picker.
See https://github.com/mattermost/mattermost-webapp/pull/11615#issuecomment-1327646502 for more info.

Expected: We should use the arrow style/position that is being used in the custom status date picker for all other date selectors.
Date selector locations:

Custom status
Search on: , after: before: modifiers
Custom Do Not Disturb modal
The Custom status is currently using the most correct style

However, we should adjust the month title style with the following updates:
```

font-weight: 600;
color: var(--center-channel-color);
```

![](image-20221209-155740.png|width=318,height=362)

The search filter date picker is not consistent with the above and needs to be adjusted:

  * arrow style
  * arrow positioning
  * month title font styles as noted above

![](image-20221209-155933.png|width=478,height=333)

The do not disturb until picker is also inconsistent

  * arrow style
  * arrow positioning
  * month title font styles as noted above

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/21876
Fixes https://mattermost.atlassian.net/browse/MM-48862

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
