### PR TITLE
Make file attachments pluggable

### DIFF
--- a/components/file_attachment/file_attachment.tsx
+++ b/components/file_attachment/file_attachment.tsx
@@ -35,7 +35,7 @@ import FileThumbnail from './file_thumbnail';
 
 import type {PropsFromRedux} from './index';
 
-interface Props extends PropsFromRedux {
+export interface FileAttachmentProps extends PropsFromRedux {
 
     /*
     * File detailed information
@@ -59,7 +59,7 @@ interface Props extends PropsFromRedux {
     handleFileDropdownOpened?: (open: boolean) => void;
 }
 
-export default function FileAttachment(props: Props) {
+export default function FileAttachment(props: FileAttachmentProps) {
     const mounted = useRef(true);
     const intl = useIntl();
     const [loaded, setLoaded] = useState(getFileType(props.fileInfo.extension) !== FileTypes.IMAGE);

--- a/components/file_attachment/index.ts
+++ b/components/file_attachment/index.ts
@@ -36,8 +36,8 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     };
 }
 
-const connector = connect(mapStateToProps, mapDispatchToProps);
+export const fileAttachmentConnector = connect(mapStateToProps, mapDispatchToProps);
 
-export type PropsFromRedux = ConnectedProps<typeof connector>;
+export type PropsFromRedux = ConnectedProps<typeof fileAttachmentConnector>;
 
-export default connector(FileAttachment);
+export default fileAttachmentConnector(FileAttachment);

--- a/components/file_attachment_list/file_attachment_list.test.tsx
+++ b/components/file_attachment_list/file_attachment_list.test.tsx
@@ -33,6 +33,7 @@ describe('FileAttachmentList', () => {
         actions: {
             openModal: jest.fn(),
         },
+        pluginFileAttachmentComponents: [],
     };
 
     test('should render a FileAttachment for a single file', () => {
@@ -112,6 +113,43 @@ describe('FileAttachmentList', () => {
         );
 
         expect(wrapper.find(SingleImageView).exists()).toBe(false);
+        expect(wrapper.find(FileAttachment).exists()).toBe(true);
+    });
+
+    test('should render plugin previews if some are registered', () => {
+        const AudioCmp = ((props) => <p>{props.fileInfo.name}</p>) as typeof FileAttachment;
+        const VideoCmp = ((props) => <p>{props.fileInfo.extension}</p>) as typeof FileAttachment;
+        const props = {
+            ...baseProps,
+            fileCount: 2,
+            fileInfos: [
+                TestHelper.getFileInfoMock({id: 'file_id_1', name: 'audio.mp3', extension: 'mp3'}),
+                TestHelper.getFileInfoMock({id: 'file_id_2', name: 'video.mp4', extension: 'mp4'}),
+                TestHelper.getFileInfoMock({id: 'file_id_3', name: 'image.png', extension: 'png'}),
+            ],
+        };
+
+        const wrapper = shallow(
+            <FileAttachmentList
+                {...props}
+                pluginFileAttachmentComponents={[
+                    {
+                        id: '1',
+                        pluginId: '1',
+                        component: AudioCmp,
+                        match: (fileInfo) => fileInfo.extension === 'mp3',
+                    },
+                    {
+                        id: '2',
+                        pluginId: '2',
+                        component: VideoCmp,
+                        match: (fileInfo) => fileInfo.extension === 'mp4',
+                    },
+                ]}
+            />,
+        );
+        expect(wrapper.find(AudioCmp).exists()).toBe(true);
+        expect(wrapper.find(VideoCmp).exists()).toBe(true);
         expect(wrapper.find(FileAttachment).exists()).toBe(true);
     });
 });

--- a/components/file_attachment_list/file_attachment_list.tsx
+++ b/components/file_attachment_list/file_attachment_list.tsx
@@ -63,15 +63,17 @@ export default function FileAttachmentList(props: Props) {
     if (sortedFileInfos && sortedFileInfos.length > 0) {
         for (let i = 0; i < sortedFileInfos.length; i++) {
             const fileInfo = sortedFileInfos[i];
+            const fileAttachmentProps = {
+                key: fileInfo.id,
+                fileInfo,
+                index: i,
+                handleImageClick,
+                compactDisplay,
+                handleFileDropdownOpened: props.handleFileDropdownOpened,
+            };
+            const Component = props.pluginFileAttachmentComponents.find((p) => p.match(fileInfo))?.component ?? FileAttachment;
             postFiles.push(
-                <FileAttachment
-                    key={fileInfo.id}
-                    fileInfo={sortedFileInfos[i]}
-                    index={i}
-                    handleImageClick={handleImageClick}
-                    compactDisplay={compactDisplay}
-                    handleFileDropdownOpened={props.handleFileDropdownOpened}
-                />,
+                <Component {...fileAttachmentProps}/>,
             );
         }
     } else if (fileCount > 0) {

--- a/components/file_attachment_list/index.ts
+++ b/components/file_attachment_list/index.ts
@@ -6,7 +6,7 @@ import {bindActionCreators, Dispatch} from 'redux';
 
 import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-
+import {Post} from '@mattermost/types/posts';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {GlobalState} from 'types/store';
@@ -16,8 +16,7 @@ import {isEmbedVisible} from 'selectors/posts';
 
 import {openModal} from 'actions/views/modals';
 
-import {Post} from '@mattermost/types/posts';
-import {FileAttachmentPluginComponent} from '../../types/store/plugins';
+import {FileAttachmentPluginComponent} from 'types/store/plugins';
 
 import FileAttachmentList from './file_attachment_list';
 

--- a/components/file_attachment_list/index.ts
+++ b/components/file_attachment_list/index.ts
@@ -6,7 +6,7 @@ import {bindActionCreators, Dispatch} from 'redux';
 
 import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {Post} from '@mattermost/types/posts';
+
 import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {GlobalState} from 'types/store';
@@ -15,6 +15,9 @@ import {getCurrentLocale} from 'selectors/i18n';
 import {isEmbedVisible} from 'selectors/posts';
 
 import {openModal} from 'actions/views/modals';
+
+import {Post} from '@mattermost/types/posts';
+import {FileAttachmentPluginComponent} from '../../types/store/plugins';
 
 import FileAttachmentList from './file_attachment_list';
 
@@ -46,6 +49,7 @@ function makeMapStateToProps() {
             fileInfos,
             fileCount,
             isEmbedVisible: isEmbedVisible(state, ownProps.post.id),
+            pluginFileAttachmentComponents: state.plugins.components.FileAttachmentPluginComponent as unknown as FileAttachmentPluginComponent[],
             locale: getCurrentLocale(state),
         };
     };

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {ComponentType} from 'react';
 import {isValidElementType} from 'react-is';
 import {Reducer} from 'redux';
 
@@ -37,6 +37,8 @@ import {GlobalState} from 'types/store';
 import {FileInfo} from '@mattermost/types/files';
 import {Channel, ChannelMembership} from '@mattermost/types/channels';
 import {reArg} from 'utils/func';
+import {fileAttachmentConnector} from '../components/file_attachment';
+import {FileAttachmentProps} from '../components/file_attachment/file_attachment';
 
 const defaultShouldRender = () => true;
 
@@ -336,6 +338,29 @@ export default class PluginRegistry {
                 component,
                 match,
                 toggleable,
+            },
+        });
+
+        return id;
+    });
+
+    // Register a component to render a custom file attachments in posts.
+    // Accepts the following:
+    // - match - A function that receives fileInfo and returns a
+    //   boolean indicating if the plugin is able to process it.
+    // - component - The component that renders the attachment preview
+    // Returns a unique identifier.
+    registerFileAttachmentPluginComponent = reArg(['component', 'match'], ({match, component}) => {
+        const id = generateId();
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
+            name: 'FileAttachmentPluginComponent',
+            data: {
+                id,
+                pluginId: this.id,
+                component: fileAttachmentConnector(component as ComponentType<FileAttachmentProps>),
+                match,
             },
         });
 

--- a/types/store/plugins.ts
+++ b/types/store/plugins.ts
@@ -5,6 +5,8 @@ import React from 'react';
 
 import {TIconGlyph} from '@mattermost/compass-components/foundations/icon';
 
+import {GlobalState} from 'types/store';
+
 import {ProductScope} from '@mattermost/types/products';
 
 import {ClientPluginManifest} from '@mattermost/types/plugins';
@@ -16,7 +18,7 @@ import {TopBoardResponse} from '@mattermost/types/insights';
 
 import {WebSocketClient} from '@mattermost/client';
 
-import {GlobalState} from 'types/store';
+import type FileAttachment from '../../components/file_attachment';
 
 export type PluginSiteStatsHandler = () => Promise<Record<string, PluginAnalyticsRow>>;
 
@@ -146,6 +148,13 @@ export type PostWillRenderEmbedPluginComponent = {
     component: React.ComponentType<{ embed: PostEmbed; webSocketClient?: WebSocketClient }>;
     match: (arg: PostEmbed) => boolean;
     toggleable: boolean;
+}
+
+export type FileAttachmentPluginComponent = {
+    id: string;
+    pluginId: string;
+    component: typeof FileAttachment;
+    match: (arg: FileInfo) => boolean;
 }
 
 export type ProductComponent = {

--- a/types/store/plugins.ts
+++ b/types/store/plugins.ts
@@ -6,6 +6,7 @@ import React from 'react';
 import {TIconGlyph} from '@mattermost/compass-components/foundations/icon';
 
 import {GlobalState} from 'types/store';
+import type FileAttachment from 'components/file_attachment';
 
 import {ProductScope} from '@mattermost/types/products';
 
@@ -17,8 +18,6 @@ import {IDMappedObjects} from '@mattermost/types/utilities';
 import {TopBoardResponse} from '@mattermost/types/insights';
 
 import {WebSocketClient} from '@mattermost/client';
-
-import type FileAttachment from '../../components/file_attachment';
 
 export type PluginSiteStatsHandler = () => Promise<Record<string, PluginAnalyticsRow>>;
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Hello! I was thinking that it would be nice if file attachment previews for special file types can be made by any plugin maker. Especially audio and video players, may be some other applications can be found.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-49453

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Webapp plugins can now register a custom component for specific file attachments listed under a post.
```