### PR TITLE
[MM-47187] Certificate auth for Elasticsearch

### DIFF
--- a/components/admin_console/__snapshots__/elasticsearch_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/elasticsearch_settings.test.jsx.snap
@@ -98,6 +98,66 @@ exports[`components/ElasticSearchSettings should match snapshot, disabled 1`] = 
         setByEnv={false}
         value="test"
       />
+      <AdminTextSetting
+        disabled={true}
+        helpText={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="(Optional) Custom Certificate Authority certificates for the Elasticsearch server. Leave this empty to use the default CAs from the operating system."
+            id="admin.elasticsearch.caDescription"
+          />
+        }
+        id="ca"
+        label={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="CA path:"
+            id="admin.elasticsearch.caTitle"
+          />
+        }
+        onChange={[Function]}
+        placeholder="E.g.: \\"./elasticsearch/ca.pem\\""
+        setByEnv={false}
+        value="test.ca"
+      />
+      <AdminTextSetting
+        disabled={true}
+        helpText={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="(Optional) The client certificate for the connection to the Elasticsearch server."
+            id="admin.elasticsearch.clientCertDescription"
+          />
+        }
+        id="clientCert"
+        label={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Client Certificate path:"
+            id="admin.elasticsearch.clientCertTitle"
+          />
+        }
+        onChange={[Function]}
+        placeholder="E.g.: \\"./elasticsearch/client.crt\\""
+        setByEnv={false}
+        value="test.crt"
+      />
+      <AdminTextSetting
+        disabled={true}
+        helpText={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="(Optional) The key for the client certificate."
+            id="admin.elasticsearch.clientKeyDescription"
+          />
+        }
+        id="clientKey"
+        label={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Client Certificate Key path:"
+            id="admin.elasticsearch.clientKeyTitle"
+          />
+        }
+        onChange={[Function]}
+        placeholder="E.g.: \\"./elasticsearch/client.key\\""
+        setByEnv={false}
+        value="test.key"
+      />
       <BooleanSetting
         disabled={true}
         falseText={
@@ -510,6 +570,66 @@ exports[`components/ElasticSearchSettings should match snapshot, enabled 1`] = `
         placeholder="E.g.: \\"https://elasticsearch.example.org:9200\\""
         setByEnv={false}
         value="test"
+      />
+      <AdminTextSetting
+        disabled={false}
+        helpText={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="(Optional) Custom Certificate Authority certificates for the Elasticsearch server. Leave this empty to use the default CAs from the operating system."
+            id="admin.elasticsearch.caDescription"
+          />
+        }
+        id="ca"
+        label={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="CA path:"
+            id="admin.elasticsearch.caTitle"
+          />
+        }
+        onChange={[Function]}
+        placeholder="E.g.: \\"./elasticsearch/ca.pem\\""
+        setByEnv={false}
+        value="test.ca"
+      />
+      <AdminTextSetting
+        disabled={false}
+        helpText={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="(Optional) The client certificate for the connection to the Elasticsearch server."
+            id="admin.elasticsearch.clientCertDescription"
+          />
+        }
+        id="clientCert"
+        label={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Client Certificate path:"
+            id="admin.elasticsearch.clientCertTitle"
+          />
+        }
+        onChange={[Function]}
+        placeholder="E.g.: \\"./elasticsearch/client.crt\\""
+        setByEnv={false}
+        value="test.crt"
+      />
+      <AdminTextSetting
+        disabled={false}
+        helpText={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="(Optional) The key for the client certificate."
+            id="admin.elasticsearch.clientKeyDescription"
+          />
+        }
+        id="clientKey"
+        label={
+          <Memo(MemoizedFormattedMessage)
+            defaultMessage="Client Certificate Key path:"
+            id="admin.elasticsearch.clientKeyTitle"
+          />
+        }
+        onChange={[Function]}
+        placeholder="E.g.: \\"./elasticsearch/client.key\\""
+        setByEnv={false}
+        value="test.key"
       />
       <BooleanSetting
         disabled={false}

--- a/components/admin_console/elasticsearch_settings.jsx
+++ b/components/admin_console/elasticsearch_settings.jsx
@@ -20,6 +20,9 @@ export default class ElasticsearchSettings extends AdminSettings {
     getConfigFromState = (config) => {
         config.ElasticsearchSettings.ConnectionURL = this.state.connectionUrl;
         config.ElasticsearchSettings.SkipTLSVerification = this.state.skipTLSVerification;
+        config.ElasticsearchSettings.CA = this.state.ca;
+        config.ElasticsearchSettings.ClientCert = this.state.clientCert;
+        config.ElasticsearchSettings.ClientKey = this.state.clientKey;
         config.ElasticsearchSettings.Username = this.state.username;
         config.ElasticsearchSettings.Password = this.state.password;
         config.ElasticsearchSettings.Sniff = this.state.sniff;
@@ -34,6 +37,9 @@ export default class ElasticsearchSettings extends AdminSettings {
         return {
             connectionUrl: config.ElasticsearchSettings.ConnectionURL,
             skipTLSVerification: config.ElasticsearchSettings.SkipTLSVerification,
+            ca: config.ElasticsearchSettings.CA,
+            clientCert: config.ElasticsearchSettings.ClientCert,
+            clientKey: config.ElasticsearchSettings.ClientKey,
             username: config.ElasticsearchSettings.Username,
             password: config.ElasticsearchSettings.Password,
             sniff: config.ElasticsearchSettings.Sniff,
@@ -61,7 +67,7 @@ export default class ElasticsearchSettings extends AdminSettings {
             }
         }
 
-        if (id === 'connectionUrl' || id === 'skipTLSVerification' || id === 'username' || id === 'password' || id === 'sniff') {
+        if (id === 'connectionUrl' || id === 'skipTLSVerification' || id === 'username' || id === 'password' || id === 'sniff' || id === 'ca' || id === 'clientCert' || id === 'clientKey') {
             this.setState({
                 configTested: false,
                 canSave: false,
@@ -202,6 +208,66 @@ export default class ElasticsearchSettings extends AdminSettings {
                     disabled={this.props.isDisabled || !this.state.enableIndexing}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.ConnectionURL')}
+                />
+                <TextSetting
+                    id='ca'
+                    label={
+                        <FormattedMessage
+                            id='admin.elasticsearch.caTitle'
+                            defaultMessage='CA path:'
+                        />
+                    }
+                    placeholder={Utils.localizeMessage('admin.elasticsearch.caExample', 'E.g.: "./elasticsearch/ca.pem"')}
+                    helpText={
+                        <FormattedMessage
+                            id='admin.elasticsearch.caDescription'
+                            defaultMessage='(Optional) Custom Certificate Authority certificates for the Elasticsearch server. Leave this empty to use the default CAs from the operating system.'
+                        />
+                    }
+                    value={this.state.ca}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing}
+                    onChange={this.handleSettingChanged}
+                    setByEnv={this.isSetByEnv('ElasticsearchSettings.CA')}
+                />
+                <TextSetting
+                    id='clientCert'
+                    label={
+                        <FormattedMessage
+                            id='admin.elasticsearch.clientCertTitle'
+                            defaultMessage='Client Certificate path:'
+                        />
+                    }
+                    placeholder={Utils.localizeMessage('admin.elasticsearch.clientCertExample', 'E.g.: "./elasticsearch/client.crt"')}
+                    helpText={
+                        <FormattedMessage
+                            id='admin.elasticsearch.clientCertDescription'
+                            defaultMessage='(Optional) The client certificate for the connection to the Elasticsearch server.'
+                        />
+                    }
+                    value={this.state.clientCert}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing}
+                    onChange={this.handleSettingChanged}
+                    setByEnv={this.isSetByEnv('ElasticsearchSettings.ClientCert')}
+                />
+                <TextSetting
+                    id='clientKey'
+                    label={
+                        <FormattedMessage
+                            id='admin.elasticsearch.clientKeyTitle'
+                            defaultMessage='Client Certificate Key path:'
+                        />
+                    }
+                    placeholder={Utils.localizeMessage('admin.elasticsearch.clientKeyExample', 'E.g.: "./elasticsearch/client.key"')}
+                    helpText={
+                        <FormattedMessage
+                            id='admin.elasticsearch.clientKeyDescription'
+                            defaultMessage='(Optional) The key for the client certificate.'
+                        />
+                    }
+                    value={this.state.clientKey}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing}
+                    onChange={this.handleSettingChanged}
+                    setByEnv={this.isSetByEnv('ElasticsearchSettings.ClientKey')}
                 />
                 <BooleanSetting
                     id='skipTLSVerification'

--- a/components/admin_console/elasticsearch_settings.test.jsx
+++ b/components/admin_console/elasticsearch_settings.test.jsx
@@ -20,6 +20,9 @@ describe('components/ElasticSearchSettings', () => {
             ElasticsearchSettings: {
                 ConnectionURL: 'test',
                 SkipTLSVerification: false,
+                CA: 'test.ca',
+                ClientCert: 'test.crt',
+                ClientKey: 'test.key',
                 Username: 'test',
                 Password: 'test',
                 Sniff: false,
@@ -41,6 +44,9 @@ describe('components/ElasticSearchSettings', () => {
             ElasticsearchSettings: {
                 ConnectionURL: 'test',
                 SkipTLSVerification: false,
+                CA: 'test.ca',
+                ClientCert: 'test.crt',
+                ClientKey: 'test.key',
                 Username: 'test',
                 Password: 'test',
                 Sniff: false,


### PR DESCRIPTION
#### Summary
This PR adds the Elasticsearch settings for CA and client certificates. They may be used in conjunction with basic auth credentials or replace them (PKI).

#### Ticket Link
[MM-47187](https://mattermost.atlassian.net/browse/MM-47187)

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/21958)

#### Screenshots
_coming soon, stay tuned_

#### Release Note
```release-note
NONE
```
