### PR TITLE
[MM-48290] Fix white screen when guest is removed from last channel while on Threads

### DIFF
--- a/components/threading/global_threads/thread_item/index.ts
+++ b/components/threading/global_threads/thread_item/index.ts
@@ -25,6 +25,10 @@ function makeMapStateToProps() {
 
         const post = getPost(state, threadId);
 
+        if (!post) {
+            return {};
+        }
+
         return {
             post,
             channel: getChannel(state, {id: post.channel_id}),


### PR DESCRIPTION
#### Summary
When the user is a guest and removed, while being on that page there weren't any post information until the redirect so it would throw an error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48290

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```


[MM-48290]: https://mattermost.atlassian.net/browse/MM-48290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ