### PR TITLE
more license checks. Prettify downloaded content. Expect object from back end

### DIFF
--- a/packages/mattermost-redux/src/reducers/entities/hosted_customer.ts
+++ b/packages/mattermost-redux/src/reducers/entities/hosted_customer.ts
@@ -127,7 +127,7 @@ function trueUpReviewProfile(state: TrueUpReviewProfileReducer | null = null, ac
         return {
             ...state,
             getRequestState: 'OK',
-            ...action.data,
+            content: action.data,
         };
     }
     case HostedCustomerTypes.TRUE_UP_REVIEW_PROFILE_REQUEST: {

--- a/packages/mattermost-redux/src/store/initial_state.ts
+++ b/packages/mattermost-redux/src/store/initial_state.ts
@@ -226,7 +226,7 @@ const state: GlobalState = {
                 invoicesLoaded: false,
             },
             trueUpReviewProfile: {
-                content: '',
+                content: {},
                 getRequestState: 'IDLE',
             },
             trueUpReviewStatus: {

--- a/packages/types/src/hosted_customer.ts
+++ b/packages/types/src/hosted_customer.ts
@@ -53,7 +53,7 @@ export type HostedCustomerState = {
 }
 
 export type TrueUpReviewProfile = {
-    content: string;
+    content: Record<string, any>;
 }
 
 export type TrueUpReviewStatus = {


### PR DESCRIPTION
#### Summary
Tested out manually, and found a few tweaks we'll want:
* Expect an object from the backend, and store it and download it accordingly as (prettified) json.
* Non licensed does not see this UI
* Starter license does not see this UI

```release-note
NONE
```
