### PR TITLE
MM-49414 : Fix failing e2e due to recent a11y changes

### DIFF
--- a/e2e/cypress/tests/integration/accessibility/accessibility_account_settings_spec.js
+++ b/e2e/cypress/tests/integration/accessibility/accessibility_account_settings_spec.js
@@ -96,17 +96,19 @@ describe('Verify Accessibility Support in different sections in Settings and Pro
     it('MM-T1465_1 Verify Label & Tab behavior in section links', () => {
         // * Verify aria-label and tab support in section of Account settings modal
         cy.uiOpenProfileModal();
-        cy.findByRole('button', {name: 'profile settings'}).should('be.visible').focus().should('be.focused');
+        cy.findByRole('tab', {name: 'profile settings'}).should('be.visible').focus().should('be.focused');
         ['profile settings', 'security'].forEach((text) => {
-            cy.focused().should('have.attr', 'aria-label', text).tab();
+            // * Verify aria-label on each tab and it supports navigating to the next tab with arrow keys
+            cy.focused().should('have.attr', 'aria-label', text).type('{downarrow}');
         });
         cy.uiClose();
 
         // * Verify aria-label and tab support in section of Settings modal
         cy.uiOpenSettingsModal();
-        cy.findByRole('button', {name: 'notifications'}).should('be.visible').focus().should('be.focused');
+        cy.findByRole('tab', {name: 'notifications'}).should('be.visible').focus().should('be.focused');
         ['notifications', 'display', 'sidebar', 'advanced'].forEach((text) => {
-            cy.focused().should('have.attr', 'aria-label', text).tab();
+            // * Verify aria-label on each tab and it supports navigating to the next tab with arrow keys
+            cy.focused().should('have.attr', 'aria-label', text).type('{downarrow}');
         });
     });
 
@@ -115,14 +117,11 @@ describe('Verify Accessibility Support in different sections in Settings and Pro
         cy.uiOpenProfileModal();
 
         // * Verify if the focus goes to the individual fields in Profile section
-        cy.findByRole('button', {name: 'profile settings'}).click();
-        cy.findByRole('button', {name: 'security'}).focus();
-        cy.focused().should('have.attr', 'aria-label', 'security').tab();
+        cy.findByRole('tab', {name: 'profile settings'}).click().tab();
         verifySettings(accountSettings.profile);
 
         // * Verify if the focus goes to the individual fields in Security section
-        cy.findByRole('button', {name: 'security'}).click().focus();
-        cy.focused().should('have.attr', 'aria-label', 'security').tab();
+        cy.findByRole('tab', {name: 'security'}).click().tab();
         verifySettings(accountSettings.security);
         cy.uiClose();
 
@@ -130,26 +129,19 @@ describe('Verify Accessibility Support in different sections in Settings and Pro
         cy.uiOpenSettingsModal();
 
         // * Verify if the focus goes to the individual fields in Notifications section
-        cy.findByRole('button', {name: 'notifications'}).click();
-        cy.findByRole('button', {name: 'advanced'}).focus();
-        cy.focused().should('have.attr', 'aria-label', 'advanced').tab();
+        cy.findByRole('tab', {name: 'notifications'}).click().tab();
         verifySettings(settings.notifications);
 
         // // * Verify if the focus goes to the individual fields in Display section
-        cy.findByRole('button', {name: 'display'}).click();
-        cy.findByRole('button', {name: 'advanced'}).focus();
-        cy.focused().should('have.attr', 'aria-label', 'advanced').tab();
+        cy.findByRole('tab', {name: 'display'}).click().tab();
         verifySettings(settings.display);
 
         // // * Verify if the focus goes to the individual fields in Sidebar section
-        cy.findByRole('button', {name: 'sidebar'}).click();
-        cy.findByRole('button', {name: 'advanced'}).focus();
-        cy.focused().should('have.attr', 'aria-label', 'advanced').tab();
+        cy.findByRole('tab', {name: 'sidebar'}).click().tab();
         verifySettings(settings.sidebar);
 
         // // * Verify if the focus goes to the individual fields in Advanced section
-        cy.findByRole('button', {name: 'advanced'}).click().focus();
-        cy.focused().should('have.attr', 'aria-label', 'advanced').tab();
+        cy.findByRole('tab', {name: 'advanced'}).click().tab();
         verifySettings(settings.advanced);
     });
 

--- a/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_input_fields_spec.js
+++ b/e2e/cypress/tests/integration/enterprise/accessibility/accessibility_input_fields_spec.js
@@ -39,8 +39,10 @@ describe('Verify Accessibility Support in different input fields', () => {
         // # Click invite members if needed
         cy.get('.InviteAs').findByTestId('inviteMembersLink').click();
 
-        // * Verify Accessibility support in Share this link input field
-        cy.findByTestId('InviteView__copyInviteLink').should('have.attr', 'aria-label', 'team invite link');
+        cy.findByTestId('InviteView__copyInviteLink').then((el) => {
+            const copyInviteLinkAriaLabel = el.attr('aria-label');
+            expect(copyInviteLinkAriaLabel).to.match(/^team invite link/i);
+        });
 
         // * Verify Accessibility Support in Add or Invite People input field
         cy.get('.users-emails-input__control').should('be.visible').within(() => {

--- a/e2e/cypress/tests/integration/notifications/channel_links_show_as_links_spec.js
+++ b/e2e/cypress/tests/integration/notifications/channel_links_show_as_links_spec.js
@@ -59,7 +59,7 @@ describe('Notifications', () => {
                     });
 
                     // # As receiver, set status to offline and logout
-                    cy.findByLabelText('set status').should('be.visible').click();
+                    cy.uiGetSetStatusButton().click();
                     cy.findByText('Offline').should('be.visible').click();
                     cy.apiLogout();
 

--- a/e2e/cypress/tests/support/ui/account_settings_modal.js
+++ b/e2e/cypress/tests/support/ui/account_settings_modal.js
@@ -12,7 +12,7 @@ Cypress.Commands.add('uiOpenProfileModal', (section = '') => {
     }
 
     // # Click on a particular section
-    cy.findByRoleExtended('button', {name: section}).should('be.visible').click();
+    cy.findByRoleExtended('tab', {name: section}).should('be.visible').click();
 
     return profileSettingsModal();
 });

--- a/e2e/cypress/tests/support/ui/global_header.js
+++ b/e2e/cypress/tests/support/ui/global_header.js
@@ -72,7 +72,7 @@ Cypress.Commands.add('uiOpenHelpMenu', (item = '') => {
 });
 
 Cypress.Commands.add('uiGetHelpButton', () => {
-    return cy.findByRole('button', {name: 'Select to toggle the help menu.'}).should('be.visible');
+    return cy.findByRole('button', {name: 'Help'}).should('be.visible');
 });
 
 Cypress.Commands.add('uiGetHelpMenu', (options = {visible: true}) => {

--- a/e2e/cypress/tests/support/ui/global_header.js
+++ b/e2e/cypress/tests/support/ui/global_header.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 Cypress.Commands.add('uiGetProductMenuButton', () => {
-    return cy.findByRole('button', {name: 'Select to open product switch menu.'}).should('be.visible');
+    return cy.findByRole('button', {name: 'Product switch menu'}).should('be.visible');
 });
 
 Cypress.Commands.add('uiGetProductMenu', () => {
@@ -27,7 +27,7 @@ Cypress.Commands.add('uiOpenProductMenu', (item = '') => {
 });
 
 Cypress.Commands.add('uiGetSetStatusButton', () => {
-    return cy.findByRole('button', {name: 'set status'}).should('be.visible');
+    return cy.findByRole('button', {name: /Select to open profile and status menu\./i}).should('be.visible');
 });
 
 Cypress.Commands.add('uiGetProfileHeader', () => {
@@ -111,15 +111,15 @@ Cypress.Commands.add('uiGetSearchBox', () => {
 });
 
 Cypress.Commands.add('uiGetRecentMentionButton', () => {
-    return cy.findByRole('button', {name: 'Select to toggle a list of recent mentions.'}).should('be.visible');
+    return cy.findByRole('button', {name: 'Recent mentions'}).should('be.visible');
 });
 
 Cypress.Commands.add('uiGetSavedPostButton', () => {
-    return cy.findByRole('button', {name: 'Select to toggle a list of saved posts.'}).should('be.visible');
+    return cy.findByRole('button', {name: 'Saved posts'}).should('be.visible');
 });
 
 Cypress.Commands.add('uiGetSettingsButton', () => {
-    return cy.findByRole('button', {name: 'Select to open the settings modal.'}).should('be.visible');
+    return cy.findByRole('button', {name: 'Settings'}).should('be.visible');
 });
 
 Cypress.Commands.add('uiGetChannelInfoButton', () => {
@@ -140,7 +140,7 @@ Cypress.Commands.add('uiOpenSettingsModal', (section = '') => {
     }
 
     // # Click on a particular section
-    cy.findByRoleExtended('button', {name: section}).should('be.visible').click();
+    cy.findByRoleExtended('tab', {name: section}).should('be.visible').click();
 
     return cy.uiGetSettingsModal();
 });


### PR DESCRIPTION
#### Summary
Conversation here https://community.mattermost.com/core/pl/9s4rk93kkbfb7dr54u3utsxp8h

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49414

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
