### PR TITLE
[MM-49483] Failing preferences request causes infinite loop in onboarding tasklist

### DIFF
--- a/components/onboarding_tasklist/onboarding_tasklist.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist.tsx
@@ -218,7 +218,7 @@ const OnBoardingTaskList = (): JSX.Element | null => {
         if (firstTimeOnboarding) {
             initOnboardingPrefs();
         }
-    }, [firstTimeOnboarding]);
+    }, []);
 
     useEffect(() => {
         if (firstTimeOnboarding && showTaskList && isEnableOnboardingFlow) {


### PR DESCRIPTION
#### Summary
When you try to setup Multi Factor Authentication for a user the page gets stuck in an infinite loop of network requests to the `savePreferences` endpoint. Since technically you aren't fully logged in until MFA is setup, that endpoint repeatedly returns a 403. 
The problem is that when `savePreferences` fails, it calls a reducer (PreferenceTypes.DELETED_PREFERENCES) that updates state  and that cascades back down to the onboarding tasklist component causing the `firstTimeOnboarding` selector to recalculate which in turn causes the `savePreferences` endpoint to be called again, and again, and again...

Removing `firstTimeOnboarding` as a dependency in the useEffect fixes the issue. I'm under the opinion that network call should only run on page load?

I've done some testing and I don't see any changes to the feature behaviour but @pvev would know best.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49483

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```


[MM-49483]: https://mattermost.atlassian.net/browse/MM-49483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ