### PR TITLE
MM-49487: fixes post priority picker in safari

### DIFF
--- a/components/post_priority/post_priority_picker_item.tsx
+++ b/components/post_priority/post_priority_picker_item.tsx
@@ -69,15 +69,17 @@ const StyledCheckIcon = styled(CheckIcon)`
 `;
 
 const Menu = styled.ul`
-    display: block;
-    position: relative;
-    box-shadow: none;
-    border-radius: 0;
-    border: 0;
-    padding: 0 0 8px;
-    margin: 0;
-    color: var(--center-channel-color-rgb);
-    list-style: none;
+    &&& {
+        display: block;
+        position: relative;
+        box-shadow: none;
+        border-radius: 0;
+        border: 0;
+        padding: 0 0 8px;
+        margin: 0;
+        color: var(--center-channel-color-rgb);
+        list-style: none;
+    }
 `;
 
 function Item({


### PR DESCRIPTION
#### Summary
For some reason when Boards Product is enabled, and the .Menu CSS class is overwritten by it, the ordering of classes in Safari is reversed than in Firefox which makes the post priority picker not to be visible.

This commit fixes that by bumping the styled components rule's specificity.

See https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49487

#### Release Note

```release-note
NONE
```
