### PR TITLE
MM-47680 : correct measurements for thread footer button

### DIFF
--- a/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
+++ b/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`components/threading/channel_threads/thread_footer should match snapsho
         onClick={[Function]}
       >
         <button
-          className="Button Button___transparent is-active separated FollowButton"
+          className="mm-button mm-button__transparent is-active separated FollowButton"
           disabled={false}
           onClick={[Function]}
         >
@@ -860,7 +860,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
       }
     >
       <button
-        className="Button Button___transparent ReplyButton separated"
+        className="mm-button mm-button__transparent ReplyButton separated"
         onClick={[Function]}
       >
         <span
@@ -905,7 +905,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
         onClick={[Function]}
       >
         <button
-          className="Button Button___transparent is-active separated FollowButton"
+          className="mm-button mm-button__transparent is-active separated FollowButton"
           disabled={false}
           onClick={[Function]}
         >
@@ -1988,7 +1988,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
       }
     >
       <button
-        className="Button Button___transparent ReplyButton separated"
+        className="mm-button mm-button__transparent ReplyButton separated"
         onClick={[Function]}
       >
         <span
@@ -2033,7 +2033,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
         onClick={[Function]}
       >
         <button
-          className="Button Button___transparent is-active separated FollowButton"
+          className="mm-button mm-button__transparent is-active separated FollowButton"
           disabled={false}
           onClick={[Function]}
         >

--- a/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
+++ b/components/threading/channel_threads/thread_footer/__snapshots__/thread_footer.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`components/threading/channel_threads/thread_footer should match snapsho
         onClick={[Function]}
       >
         <button
-          className="mm-button mm-button__transparent is-active separated FollowButton"
+          className="ThreadingButton ThreadingButton__transparent is-active separated FollowButton"
           disabled={false}
           onClick={[Function]}
         >
@@ -860,7 +860,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
       }
     >
       <button
-        className="mm-button mm-button__transparent ReplyButton separated"
+        className="ThreadingButton ThreadingButton__transparent ReplyButton separated"
         onClick={[Function]}
       >
         <span
@@ -905,7 +905,7 @@ exports[`components/threading/channel_threads/thread_footer should report total 
         onClick={[Function]}
       >
         <button
-          className="mm-button mm-button__transparent is-active separated FollowButton"
+          className="ThreadingButton ThreadingButton__transparent is-active separated FollowButton"
           disabled={false}
           onClick={[Function]}
         >
@@ -1988,7 +1988,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
       }
     >
       <button
-        className="mm-button mm-button__transparent ReplyButton separated"
+        className="ThreadingButton ThreadingButton__transparent ReplyButton separated"
         onClick={[Function]}
       >
         <span
@@ -2033,7 +2033,7 @@ exports[`components/threading/channel_threads/thread_footer should show unread i
         onClick={[Function]}
       >
         <button
-          className="mm-button mm-button__transparent is-active separated FollowButton"
+          className="ThreadingButton ThreadingButton__transparent is-active separated FollowButton"
           disabled={false}
           onClick={[Function]}
         >

--- a/components/threading/common/button/__snapshots__/button.test.tsx.snap
+++ b/components/threading/common/button/__snapshots__/button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`components/threading/common/button should support appended content 1`] = `
 <button
-  className="mm-button mm-button__transparent"
+  className="ThreadingButton ThreadingButton__transparent"
 >
   <span
     className="Button_label"
@@ -19,7 +19,7 @@ exports[`components/threading/common/button should support appended content 1`] 
 
 exports[`components/threading/common/button should support children 1`] = `
 <button
-  className="mm-button mm-button__transparent"
+  className="ThreadingButton ThreadingButton__transparent"
 >
   <span
     className="Button_label"
@@ -31,7 +31,7 @@ exports[`components/threading/common/button should support children 1`] = `
 
 exports[`components/threading/common/button should support className 1`] = `
 <button
-  className="mm-button mm-button__transparent test-class other-test-class"
+  className="ThreadingButton ThreadingButton__transparent test-class other-test-class"
 >
   <span
     className="Button_label"
@@ -41,7 +41,7 @@ exports[`components/threading/common/button should support className 1`] = `
 
 exports[`components/threading/common/button should support onClick 1`] = `
 <button
-  className="mm-button mm-button__transparent"
+  className="ThreadingButton ThreadingButton__transparent"
   onClick={[MockFunction]}
 >
   <span
@@ -52,7 +52,7 @@ exports[`components/threading/common/button should support onClick 1`] = `
 
 exports[`components/threading/common/button should support prepended content 1`] = `
 <button
-  className="mm-button mm-button__transparent"
+  className="ThreadingButton ThreadingButton__transparent"
 >
   <span
     className="Button_prepended"

--- a/components/threading/common/button/__snapshots__/button.test.tsx.snap
+++ b/components/threading/common/button/__snapshots__/button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`components/threading/common/button should support appended content 1`] = `
 <button
-  className="Button Button___transparent"
+  className="mm-button mm-button__transparent"
 >
   <span
     className="Button_label"
@@ -19,7 +19,7 @@ exports[`components/threading/common/button should support appended content 1`] 
 
 exports[`components/threading/common/button should support children 1`] = `
 <button
-  className="Button Button___transparent"
+  className="mm-button mm-button__transparent"
 >
   <span
     className="Button_label"
@@ -31,7 +31,7 @@ exports[`components/threading/common/button should support children 1`] = `
 
 exports[`components/threading/common/button should support className 1`] = `
 <button
-  className="Button Button___transparent test-class other-test-class"
+  className="mm-button mm-button__transparent test-class other-test-class"
 >
   <span
     className="Button_label"
@@ -41,7 +41,7 @@ exports[`components/threading/common/button should support className 1`] = `
 
 exports[`components/threading/common/button should support onClick 1`] = `
 <button
-  className="Button Button___transparent"
+  className="mm-button mm-button__transparent"
   onClick={[MockFunction]}
 >
   <span
@@ -52,7 +52,7 @@ exports[`components/threading/common/button should support onClick 1`] = `
 
 exports[`components/threading/common/button should support prepended content 1`] = `
 <button
-  className="Button Button___transparent"
+  className="mm-button mm-button__transparent"
 >
   <span
     className="Button_prepended"

--- a/components/threading/common/button/button.scss
+++ b/components/threading/common/button/button.scss
@@ -44,7 +44,7 @@
     }
 }
 
-.mm-button{
+.mm-button {
     position: relative;
     padding: 4px 10px;
     border-radius: 4px;

--- a/components/threading/common/button/button.scss
+++ b/components/threading/common/button/button.scss
@@ -44,7 +44,7 @@
     }
 }
 
-.Button__prior {
+.mm-button{
     position: relative;
     padding: 4px 10px;
     border-radius: 4px;
@@ -71,7 +71,7 @@
         opacity: 32%;
     }
 
-    &.Button___transparent {
+    &.mm-button__transparent {
         border: none;
         background: transparent;
 
@@ -130,9 +130,9 @@
     margin-left: var(--button-separator-gap, 0);
 }
 
-.separated:not(.Button__prior),
+.separated:not(.mm-button),
 .separated:not(:hover):not(.is-active) {
-    + .separated:not(.Button__prior),
+    + .separated:not(.mm-button),
     + .separated:not(:hover):not(.is-active) {
         position: relative;
 

--- a/components/threading/common/button/button.scss
+++ b/components/threading/common/button/button.scss
@@ -44,7 +44,7 @@
     }
 }
 
-.Button {
+.Button__prior {
     position: relative;
     padding: 4px 10px;
     border-radius: 4px;
@@ -130,9 +130,9 @@
     margin-left: var(--button-separator-gap, 0);
 }
 
-.separated:not(.Button),
+.separated:not(.Button__prior),
 .separated:not(:hover):not(.is-active) {
-    + .separated:not(.Button),
+    + .separated:not(.Button__prior),
     + .separated:not(:hover):not(.is-active) {
         position: relative;
 

--- a/components/threading/common/button/button.scss
+++ b/components/threading/common/button/button.scss
@@ -44,7 +44,7 @@
     }
 }
 
-.mm-button {
+.ThreadingButton {
     position: relative;
     padding: 4px 10px;
     border-radius: 4px;
@@ -71,7 +71,7 @@
         opacity: 32%;
     }
 
-    &.mm-button__transparent {
+    &.ThreadingButton__transparent {
         border: none;
         background: transparent;
 
@@ -130,9 +130,9 @@
     margin-left: var(--button-separator-gap, 0);
 }
 
-.separated:not(.mm-button),
+.separated:not(.ThreadingButton),
 .separated:not(:hover):not(.is-active) {
-    + .separated:not(.mm-button),
+    + .separated:not(.ThreadingButton),
     + .separated:not(:hover):not(.is-active) {
         position: relative;
 

--- a/components/threading/common/button/button.tsx
+++ b/components/threading/common/button/button.tsx
@@ -30,7 +30,7 @@ function Button({
     return (
         <button
             {...attrs}
-            className={classNames('Button Button___transparent', {'is-active': isActive, allowTextOverflow}, attrs.className)}
+            className={classNames('Button__prior Button___transparent', {'is-active': isActive, allowTextOverflow}, attrs.className)}
         >
             {prepend && (
                 <span className='Button_prepended'>

--- a/components/threading/common/button/button.tsx
+++ b/components/threading/common/button/button.tsx
@@ -30,7 +30,7 @@ function Button({
     return (
         <button
             {...attrs}
-            className={classNames('mm-button mm-button__transparent', {'is-active': isActive, allowTextOverflow}, attrs.className)}
+            className={classNames('ThreadingButton ThreadingButton__transparent', {'is-active': isActive, allowTextOverflow}, attrs.className)}
         >
             {prepend && (
                 <span className='Button_prepended'>

--- a/components/threading/common/button/button.tsx
+++ b/components/threading/common/button/button.tsx
@@ -30,7 +30,7 @@ function Button({
     return (
         <button
             {...attrs}
-            className={classNames('Button__prior Button___transparent', {'is-active': isActive, allowTextOverflow}, attrs.className)}
+            className={classNames('mm-button mm-button__transparent', {'is-active': isActive, allowTextOverflow}, attrs.className)}
         >
             {prepend && (
                 <span className='Button_prepended'>

--- a/components/threading/common/follow_button/__snapshots__/follow_button.test.tsx.snap
+++ b/components/threading/common/follow_button/__snapshots__/follow_button.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`components/threading/common/follow_button should say follow 1`] = `
     onClick={[MockFunction]}
   >
     <button
-      className="mm-button mm-button__transparent FollowButton"
+      className="ThreadingButton ThreadingButton__transparent FollowButton"
       disabled={false}
       onClick={[MockFunction]}
     >
@@ -36,7 +36,7 @@ exports[`components/threading/common/follow_button should say following 1`] = `
     isActive={true}
   >
     <button
-      className="mm-button mm-button__transparent is-active FollowButton"
+      className="ThreadingButton ThreadingButton__transparent is-active FollowButton"
       disabled={false}
     >
       <span

--- a/components/threading/common/follow_button/__snapshots__/follow_button.test.tsx.snap
+++ b/components/threading/common/follow_button/__snapshots__/follow_button.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`components/threading/common/follow_button should say follow 1`] = `
     onClick={[MockFunction]}
   >
     <button
-      className="Button Button___transparent FollowButton"
+      className="mm-button mm-button__transparent FollowButton"
       disabled={false}
       onClick={[MockFunction]}
     >
@@ -36,7 +36,7 @@ exports[`components/threading/common/follow_button should say following 1`] = `
     isActive={true}
   >
     <button
-      className="Button Button___transparent is-active FollowButton"
+      className="mm-button mm-button__transparent is-active FollowButton"
       disabled={false}
     >
       <span


### PR DESCRIPTION
#### Summary
correct measurements for thread footer button

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-47680

#### Related Pull Requests
None

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| 
![Screenshot from 2023-01-10 12-13-03](https://user-images.githubusercontent.com/89139362/211480068-e34a2813-db31-4c83-9ce3-dd0902a15551.png)
 | 
![Screenshot from 2023-01-10 12-11-49](https://user-images.githubusercontent.com/89139362/211480204-01702e6f-6a7f-4a91-aab5-b84d5ed7fafe.png)
 |

-->

#### Release Note
NONE
```release-note
correct measurements for thread footer button
```
