### PR TITLE
MM-49563 Append query parameter to remote_entry.js files to fix bad caching on community

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,11 @@ if (DEV) {
     }
 }
 
+// Track the build time so that we can bust any caches that may have incorrectly cached remote_entry.js from before we
+// started setting Cache-Control: no-cache for that file on the server. This can be removed in 2024 after those cached
+// entries are guaranteed to have expired.
+const buildTimestamp = Date.now();
+
 var config = {
     entry: ['./root.tsx', 'root.html'],
     output: {
@@ -380,7 +385,7 @@ async function initializeModuleFederation() {
         } else {
             // For production, hardcode the URLs of product containers to be based on the web app URL
             for (const product of products) {
-                remotes[product.name] = `${product.name}@[window.basename]/static/products/${product.name}/remote_entry.js`;
+                remotes[product.name] = `${product.name}@[window.basename]/static/products/${product.name}/remote_entry.js?bt=${buildTimestamp}`;
             }
         }
 
@@ -440,7 +445,7 @@ async function initializeModuleFederation() {
         './styles': './sass/styles.scss',
         './registry': 'module_registry',
     };
-    moduleFederationPluginOptions.filename = 'remote_entry.js';
+    moduleFederationPluginOptions.filename = `remote_entry.js?bt=${buildTimestamp}`;
 
     config.plugins.push(new ModuleFederationPlugin(moduleFederationPluginOptions));
 


### PR DESCRIPTION
Since we accidentally cached these files previously, a few people on community have incorrectly cached versions of those files still in their browser cache which causes them to see outdated parts of the web app or get errors because their browser tried to load the now-missing versions of those files. Adding a query parameter to give each version of those files a unique URL should be enough to fix that without requiring us to give them unique file names like other JS files because that would make it difficult for the web app to know where to find Boards's remote entrypoint

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47938

#### Release Note
```release-note
Ensured that remote_entry.js files aren't cached
```
