### PR TITLE
[MM-49590] Moving header buttons for insights

### DIFF
--- a/components/activity_and_insights/insights/insights_header/insights_header.scss
+++ b/components/activity_and_insights/insights/insights_header/insights_header.scss
@@ -1,12 +1,28 @@
 .Insights___header {
     &.Header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
         padding: 15px 12px;
         border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
         background-color: var(--center-channel-bg);
         grid-area: header;
+
+        .header-container {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin: auto;
+            width: calc(100% - 40px);
+            // Account for the scrollbar that shifts the insights-body content
+            padding-right: 6px;
+
+            @media screen and (min-width: 1680px) {
+                width: 1268px;
+                align-self: center;
+            }
+
+            @media screen and (max-width: 768px) {
+                width: calc(100% - 10px);
+            }
+        }
 
         .insights-title {
             display: flex;

--- a/components/activity_and_insights/insights/insights_header/insights_header.tsx
+++ b/components/activity_and_insights/insights/insights_header/insights_header.tsx
@@ -28,18 +28,20 @@ const InsightsHeader = (props: Props) => {
         <header
             className={classNames('Header Insights___header')}
         >
-            <div className='left'>
-                <InsightsTitle
-                    filterType={props.filterType}
-                    setFilterTypeTeam={props.setFilterTypeTeam}
-                    setFilterTypeMy={props.setFilterTypeMy}
-                />
-            </div>
-            <div className='right'>
-                <TimeFrameDropdown
-                    timeFrame={props.timeFrame}
-                    setTimeFrame={props.setTimeFrame}
-                />
+            <div className='header-container'>
+                <div className='left'>
+                    <InsightsTitle
+                        filterType={props.filterType}
+                        setFilterTypeTeam={props.setFilterTypeTeam}
+                        setFilterTypeMy={props.setFilterTypeMy}
+                    />
+                </div>
+                <div className='right'>
+                    <TimeFrameDropdown
+                        timeFrame={props.timeFrame}
+                        setTimeFrame={props.setTimeFrame}
+                    />
+                </div>
             </div>
         </header>
     );


### PR DESCRIPTION
#### Summary
Moved the header buttons to align with the content. According to our telemetry people were having trouble finding them

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49590

#### Screenshots
Before:
![Screen Shot 2023-01-10 at 12 28 17 PM](https://user-images.githubusercontent.com/14115924/211621161-9af6d423-79ca-4bbc-bcdf-06c49f3a8bd5.png)

After:
![Screen Shot 2023-01-10 at 12 22 55 PM](https://user-images.githubusercontent.com/14115924/211621191-872afe52-730a-4b26-ac1e-0576ee1603b3.png)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
