### PR TITLE
MM-47938 Ensure feature flag is set before running E2E test

### DIFF
--- a/e2e/cypress/tests/integration/channel/new_channel_with_board_spec.js
+++ b/e2e/cypress/tests/integration/channel/new_channel_with_board_spec.js
@@ -9,7 +9,7 @@
 
 // Group: @channel
 
-describe('Channel routing', () => {
+describe('New Channel modal with Boards enabled', () => {
     let testTeam;
 
     before(() => {
@@ -22,14 +22,7 @@ describe('Channel routing', () => {
             cy.visit(`/${testTeam.name}/channels/town-square`);
         });
 
-        cy.apiUpdateConfig({
-            PluginSettings: {
-                Enable: true,
-                EnableMarketplace: true,
-                EnableRemoteMarketplace: true,
-                MarketplaceURL: 'https://api.integrations.mattermost.com',
-            },
-        });
+        cy.shouldHaveFeatureFlag('BoardsProduct', true);
     });
 
     it('MM-T5141 New Channel is created with an associated Board', () => {

--- a/e2e/cypress/tests/integration/channel/new_channel_with_board_spec.js
+++ b/e2e/cypress/tests/integration/channel/new_channel_with_board_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel
 
 describe('New Channel modal with Boards enabled', () => {

--- a/e2e/playwright/support/server/default_config.ts
+++ b/e2e/playwright/support/server/default_config.ts
@@ -673,7 +673,7 @@ const defaultServerConfig: AdminConfig = {
         GraphQL: false,
         InsightsEnabled: true,
         CommandPalette: false,
-        BoardsProduct: false,
+        BoardsProduct: true,
         SendWelcomePost: true,
         PostPriority: false,
         PeopleProduct: false,


### PR DESCRIPTION
This test is still failing on nightly builds, and I think it might be because the feature flag is missing for this. Since the feature flag is now on-by-default on master, that should be fixed for us, but I wanted to be extra sure so I changed the test to fail if it's not enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47938

#### Release Note
```release-note
NONE
```
