### PR TITLE
Add additional debugging information to benchmark tests

### DIFF
--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -82,11 +82,27 @@ jobs:
           working-directory: e2e/cypress
         env:
           MM_LOGSETTINGS_ENABLECONSOLE: false
+          MM_LOGSETTINGS_FILELEVEL: debug
           MM_SQLSETTINGS_DATASOURCE: postgres://mmuser:mostest@localhost/postgres?sslmode=disable&connect_timeout=10&binary_parameters=yes
           MM_TEAMSETTINGS_ENABLEOPENSERVER: true
-      - name: Upload artifacts
+      - name: Upload Cypress logs
+        if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: Test logs
+          name: Cypress logs
           path: e2e/cypress/tests/integration/performance/logs/
+          retention-days: 3
+      - name: Upload Mattermost logs
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Mattermost logs
+          path: e2e/cypress/mattermost/logs/mattermost.log
+          retention-days: 3
+      - name: Upload screenshots
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test screenshots
+          path: e2e/cypress/tests/screenshots
           retention-days: 3

--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           browser: chrome
-          config: defaultCommandTimeout=60000
+          config: defaultCommandTimeout=60000,video=true,videosFolder=tests/videos
           install: false
           spec: ./tests/integration/performance/*
           start: npm run benchmarks:run-server
@@ -86,23 +86,29 @@ jobs:
           MM_SQLSETTINGS_DATASOURCE: postgres://mmuser:mostest@localhost/postgres?sslmode=disable&connect_timeout=10&binary_parameters=yes
           MM_TEAMSETTINGS_ENABLEOPENSERVER: true
       - name: Upload Cypress logs
-        if: ${{ success() || failure() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: Cypress logs
           path: e2e/cypress/tests/integration/performance/logs/
           retention-days: 3
       - name: Upload Mattermost logs
-        if: ${{ success() || failure() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: Mattermost logs
           path: e2e/cypress/mattermost/logs/mattermost.log
           retention-days: 3
       - name: Upload screenshots
-        if: ${{ success() || failure() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: Test screenshots
           path: e2e/cypress/tests/screenshots
           retention-days: 3
+      - name: Upload videos
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Videos
+          path: e2e/cypress/tests/videos


### PR DESCRIPTION
I've made it so that we're also uploading the MM server logs, screenshots from Cypress of failures, and videos of all Cypress runs to the build artifacts to help debugging performance issues that cause the CircleCI job to fail

#### Release Note
```release-note
NONE
```
