### PR TITLE
MM-49596: Fix team switching in Playbooks and Boards

### DIFF
--- a/components/team_sidebar/components/team_button.tsx
+++ b/components/team_sidebar/components/team_button.tsx
@@ -43,8 +43,9 @@ interface Props {
 
 // eslint-disable-next-line react/require-optimization
 class TeamButton extends React.PureComponent<Props> {
-    handleSwitch = () => {
+    handleSwitch = (e: React.MouseEvent) => {
         mark('TeamLink#click');
+        e.preventDefault();
         this.props.switchTeam(this.props.url);
 
         setTimeout(() => {


### PR DESCRIPTION
#### Summary
Re-adds `preventDefault` to click handler of `team_button` to prevent the url-navigation from jumping back to Channels when switching teams in Playbooks/Boards.

Ref: https://github.com/mattermost/mattermost-webapp/pull/11871/files/9e8cc16467cec3a6ec08f3f4de99b5aa8a12a419#diff-ae42b3ea72596c99207b70a9441cbef02e2409bdbf90f14419d6e8a62105e10bL48

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-49596

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
