### PR TITLE
[MM-48394] Wrangler UI/UX tweaks 

### DIFF
--- a/components/forward_post_modal/forward_post_modal.scss
+++ b/components/forward_post_modal/forward_post_modal.scss
@@ -1,4 +1,9 @@
 .forward-post {
+    &.move-thread {
+        .modal-body {
+            overflow: visible;
+        }
+    }
     &.modal-dialog {
         margin-top: 64px;
     }

--- a/components/forward_post_modal/forward_post_modal.scss
+++ b/components/forward_post_modal/forward_post_modal.scss
@@ -4,6 +4,7 @@
             overflow: visible;
         }
     }
+
     &.modal-dialog {
         margin-top: 64px;
     }

--- a/components/move_thread_modal/move_thread_modal.tsx
+++ b/components/move_thread_modal/move_thread_modal.tsx
@@ -192,7 +192,7 @@ const MoveThreadModal = ({onExited, post, actions}: Props) => {
 
     return (
         <GenericModal
-            className='a11y__modal forward-post'
+            className='a11y__modal forward-post move-thread'
             id='forward-post-modal'
             show={true}
             enforceFocus={false}


### PR DESCRIPTION
#### Summary
Fixes the move thread modal-body scroll bar appearing when opening the picklist. All options of picklist are now visible

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48394

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
|
![image](https://user-images.githubusercontent.com/12176405/212176401-01266832-f32a-4de2-afc2-f12ee3c117fe.png)
| ![image](https://user-images.githubusercontent.com/12176405/212176346-b99a85a5-f2b7-4d59-995e-902751ea7330.png) |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
