### PR TITLE
Have Cypress use custom site URL if set

### DIFF
--- a/e2e/cypress/cypress.config.ts
+++ b/e2e/cypress/cypress.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
         setupNodeEvents(on, config) {
             return require('./tests/plugins/index.js')(on, config); // eslint-disable-line global-require
         },
-        baseUrl: 'http://localhost:8065',
+        baseUrl: process.env.MM_SERVICESETTINGS_SITEURL || 'http://localhost:8065',
         excludeSpecPattern: '**/node_modules/**/*',
         specPattern: 'tests/integration/**/*_spec.{js,ts}',
         supportFile: 'tests/support/index.js',


### PR DESCRIPTION
This environment variable is normally for setting the Site URL on the server, but we also use it in a few places like the web app's webpack.config.js when setting up some subpath stuff

#### Release Note
```release-note
NONE
```
