### PR TITLE
MM-49615 - Fix Downgrade Success/Failure Text Alignment

### DIFF
--- a/components/purchase_modal/icon_message.scss
+++ b/components/purchase_modal/icon_message.scss
@@ -40,7 +40,6 @@
                 color: #db3214;
             }
 
-            max-width: 800px;
             margin-top: 16px;
             color: var(--center-channel-color);
             font-size: 14px;


### PR DESCRIPTION
#### Summary
Some text on the downgrade success and failure screens was not aligned properly.

I mentioned I have this fixed in another PR, but this change alone will get in faster and the ticket will be closed out sooner if the change is in it's own PR.

A really basi change, this just removes the `max-width` style on the `IconMessage-sub` styling. This screen is the only place it's used.

#### Ticket Link

[MM-49615](https://mattermost.atlassian.net/browse/MM-49615)

#### Screenshots

|  before  |  after  |
|----|----|
| ![Screen Shot 2023-01-17 at 2 15 35 PM](https://user-images.githubusercontent.com/116016004/212992318-9ebdb39f-094b-4b07-88e8-26aba085ee71.png) | ![Screen Shot 2023-01-17 at 2 15 47 PM](https://user-images.githubusercontent.com/116016004/212992527-6dfa1d71-f290-4676-b4a3-1f600fe1f476.png) |
| ![Screen Shot 2023-01-17 at 2 13 55 PM](https://user-images.githubusercontent.com/116016004/212992417-bf94341c-e4ea-4041-807b-558da18ec332.png) | ![Screen Shot 2023-01-17 at 2 14 36 PM](https://user-images.githubusercontent.com/116016004/212992507-6d388c2e-677c-4589-8956-f15bac946285.png) |

#### Release Note

```release-note
NONE
```


[MM-49615]: https://mattermost.atlassian.net/browse/MM-49615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ