### PR TITLE
MM-49617 - Add Contact Support CTA for Downgrade to Starter if the Current Subscription is Yearly

### DIFF
--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -70,7 +70,7 @@ function Content(props: ContentProps) {
 
     const annualSubscriptionEnabled = useSelector(isAnnualSubscriptionEnabled);
 
-    const contactSupportLink = useSelector(getCloudContactUsLink)(InquiryType.Sales);
+    const contactSupportLink = useSelector(getCloudContactUsLink)(InquiryType.Technical);
 
     const currentSubscriptionIsMonthly = product?.recurring_interval === RecurringIntervals.MONTH;
     const isEnterprise = product?.sku === CloudProducts.ENTERPRISE;

--- a/components/pricing_modal/content.tsx
+++ b/components/pricing_modal/content.tsx
@@ -70,6 +70,8 @@ function Content(props: ContentProps) {
 
     const annualSubscriptionEnabled = useSelector(isAnnualSubscriptionEnabled);
 
+    const contactSupportLink = useSelector(getCloudContactUsLink)(InquiryType.Sales);
+
     const currentSubscriptionIsMonthly = product?.recurring_interval === RecurringIntervals.MONTH;
     const isEnterprise = product?.sku === CloudProducts.ENTERPRISE;
     const isEnterpriseTrial = subscription?.is_free_trial === 'true';
@@ -89,6 +91,8 @@ function Content(props: ContentProps) {
     if ((subscription && subscription.trial_end_at > 0) && !isEnterpriseTrial && (isStarter || isEnterprise)) {
         isPostTrial = true;
     }
+
+    const freeTierText = !isStarter && !currentSubscriptionIsMonthly ? formatMessage({id: 'pricing_modal.btn.contactSupport', defaultMessage: 'Contact Support'}) : formatMessage({id: 'pricing_modal.btn.downgrade', defaultMessage: 'Downgrade'});
 
     const openCloudPurchaseModal = useOpenCloudPurchaseModal({});
     const openCloudDelinquencyModal = useOpenCloudPurchaseModal({
@@ -252,6 +256,11 @@ function Content(props: ContentProps) {
                         planExtraInformation={<StarterDisclaimerCTA/>}
                         buttonDetails={{
                             action: () => {
+                                if (!isStarter && !currentSubscriptionIsMonthly) {
+                                    window.open(contactSupportLink, '_blank');
+                                    return;
+                                }
+
                                 if (!starterProduct) {
                                     return;
                                 }
@@ -270,8 +279,8 @@ function Content(props: ContentProps) {
                                     downgrade('click_pricing_modal_free_card_downgrade_button');
                                 }
                             },
-                            text: formatMessage({id: 'pricing_modal.btn.downgrade', defaultMessage: 'Downgrade'}),
-                            disabled: isStarter || isEnterprise || !isAdmin || !currentSubscriptionIsMonthly,
+                            text: freeTierText,
+                            disabled: isStarter || isEnterprise || !isAdmin,
                             customClass: ButtonCustomiserClasses.secondary,
                         }}
                         briefing={{

--- a/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.ts
@@ -612,8 +612,7 @@ describe('Pricing modal', () => {
         cy.get('#pricingModal').should('exist');
 
         // * Click the free action (downgrade).
-        cy.get('#free').should('exist');
-        cy.get('#free').contains('Contact Support');
+        cy.get('#free').should('exist').contains('Contact Support');
         cy.get('#free_action').should('be.enabled').click();
     });
 });

--- a/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.ts
@@ -596,4 +596,25 @@ describe('Pricing modal', () => {
         // * Check that the downgrade modal has appeard.
         cy.get('div.DowngradeTeamRemovalModal__body').should('exist');
     });
+
+    it('Should display a "Contact Support" CTA for downgrading when the current subscription is yearly and not on starter', () => {
+        const subscription = {
+            id: 'sub_test1',
+            product_id: 'prod_4',
+            is_free_trial: 'false',
+        };
+        simulateSubscription(subscription);
+        cy.apiLogout();
+        cy.apiAdminLogin();
+        cy.visit('/admin_console/billing/subscription?action=show_pricing_modal');
+
+
+        // * Pricing modal should be open
+        cy.get('#pricingModal').should('exist');
+
+        // * Click the free action (downgrade).
+        cy.get('#free').should('exist');
+        cy.get('#free').contains('Contact Support');
+        cy.get('#free_action').should('be.enabled').click();
+    })
 });

--- a/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.ts
@@ -608,7 +608,6 @@ describe('Pricing modal', () => {
         cy.apiAdminLogin();
         cy.visit('/admin_console/billing/subscription?action=show_pricing_modal');
 
-
         // * Pricing modal should be open
         cy.get('#pricingModal').should('exist');
 
@@ -616,5 +615,5 @@ describe('Pricing modal', () => {
         cy.get('#free').should('exist');
         cy.get('#free').contains('Contact Support');
         cy.get('#free_action').should('be.enabled').click();
-    })
+    });
 });

--- a/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/cloud/billing/cloud_pricing_modal_spec.ts
@@ -615,4 +615,23 @@ describe('Pricing modal', () => {
         cy.get('#free').should('exist').contains('Contact Support');
         cy.get('#free_action').should('be.enabled').click();
     });
+
+    it('Should not display a "Contact Support" CTA for downgrading when the current subscription is monthly and not on starter', () => {
+        const subscription = {
+            id: 'sub_test1',
+            product_id: 'prod_2',
+            is_free_trial: 'false',
+        };
+        simulateSubscription(subscription);
+        cy.apiLogout();
+        cy.apiAdminLogin();
+        cy.visit('/admin_console/billing/subscription?action=show_pricing_modal');
+
+        // * Pricing modal should be open
+        cy.get('#pricingModal').should('exist');
+
+        // # The free action button should be disabled and contain the text "Downgrade".
+        cy.get('#free').should('exist').contains('Downgrade');
+        cy.get('#free_action').should('be.disabled');
+    });
 });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4442,6 +4442,7 @@
   "pricing_modal.briefing.unlimitedWorkspaceTeams": "Unlimited workspace teams",
   "pricing_modal.btn.contactSales": "Contact Sales",
   "pricing_modal.btn.contactSalesForQuote": "Contact Sales",
+  "pricing_modal.btn.contactSupport": "Contact Support",
   "pricing_modal.btn.downgrade": "Downgrade",
   "pricing_modal.btn.tooltip": "Only visible to system admins",
   "pricing_modal.btn.tryDays": "Try free for {days} days",


### PR DESCRIPTION
#### Summary

Currently, the downgrade button is grayed out for Cloud Annual Subscriptions as this is not available yet for self-serve. 
We need to update this CTA to Contact Support and open to support form in the portal. 

For monthly subscriptions, it should still have the downgrade option as it does

Issue created from a [message in Mattermost](https://community.mattermost.com/private-core/pl/wgochxkd7jnetxzy9sskz8swnw).

#### Ticket Link

[MM-49617](https://mattermost.atlassian.net/browse/MM-49617)

#### Screenshots

|  before  |  after  |
|----|----|
| ![Screen Shot 2023-01-17 at 3 30 41 PM](https://user-images.githubusercontent.com/116016004/213006857-008c37fc-f109-44b6-aa16-fd0e6a73ef7d.png) | ![Screen Shot 2023-01-17 at 3 29 10 PM](https://user-images.githubusercontent.com/116016004/213006896-24fbbd7d-a2b6-463c-a99f-ba9bc5db08c8.png) |
| N/A | ![Screen Shot 2023-01-17 at 3 30 07 PM](https://user-images.githubusercontent.com/116016004/213006981-c6873337-70d8-419e-a9ee-31ace6d86467.png) |

#### Test Plan

1. Ensure that you have the feature flag `AnnualSubscription` set to `true`
2. Log in to the web app as an admin user
3. Navigate to the `Subscription` sub-section under the `Billing & Account` section of the system console.
4. Click `View Plans`
5. Upgrade to **YEARLY** professional
6. Once the upgrade succeeds, click `View Plans` again, and notice the free tier's button is no longer disabled and no longer says `Downgrade`. Instead, now it says `Contact Support` and is enabled.
7. Click the button, and notice it takes you to the contact support page in the portal.

#### Release Note

```release-note
NONE
```


[MM-49617]: https://mattermost.atlassian.net/browse/MM-49617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ