### PR TITLE
MM-49714 Start Boards product as long as Focalboard is found

### DIFF
--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -6,16 +6,29 @@
 const chalk = require('chalk');
 const concurrently = require('concurrently');
 
-const {getWorkspaceCommands} = require('./utils.js');
+const {getProductStartCommands, getWorkspaceCommands} = require('./utils.js');
 
 async function watchAllWithDevServer() {
-    console.log(chalk.inverse.bold('Watching web app and all subpackages...') + '\n');
+    console.log(chalk.inverse.bold('Watching web app and all subpackages...'));
+
+    const commands = [
+        {command: 'npm:dev-server:webapp', name: 'webapp', prefixColor: 'cyan'},
+    ];
+
+    const productCommands = getProductStartCommands();
+    if (productCommands.length > 0) {
+        console.log(chalk.green('Found products: ' + productCommands.map((command) => command.name).join(', ')));
+    } else {
+        console.log(chalk.yellow('No products found'));
+    }
+    commands.push(...productCommands);
+
+    commands.push(...getWorkspaceCommands('run'));
+
+    console.log('\n');
 
     const {result} = concurrently(
-        [
-            {command: 'npm:dev-server:webapp', name: 'webapp', prefixColor: 'cyan'},
-            ...getWorkspaceCommands('run'),
-        ],
+        commands,
         {
             killOthers: 'failure',
         },

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -3,39 +3,40 @@
 
 /* eslint-disable no-console, no-process-env */
 
-const fs = require('fs');
-
 const chalk = require('chalk');
 const concurrently = require('concurrently');
 
 const {makeRunner} = require('./runner.js');
-const {getWorkspaceCommands} = require('./utils.js');
+const {getProductStartCommands, getWorkspaceCommands} = require('./utils.js');
 
 async function watchAll(useRunner) {
-    const commands = [];
-
-    commands.unshift(...getWorkspaceCommands('run'));
-
-    if (fs.existsSync('../focalboard')) {
-        console.log(chalk.inverse.bold('Focalboard found. Starting Boards product.') + '\n');
-
-        if (!useRunner) {
-            commands.unshift({command: 'make watch-product', cwd: '../focalboard', name: 'boards', prefixColor: 'red'});
-        }
-    } else if (!useRunner) {
-        console.log(chalk.inverse.bold('Focalboard not found. Not starting Boards product.') + '\n');
+    if (!useRunner) {
+        console.log(chalk.inverse.bold('Watching web app and all subpackages...'));
     }
 
-    commands.unshift({command: 'npm:run:webapp', name: 'webapp', prefixColor: 'cyan'});
+    const commands = [
+        {command: 'npm:run:webapp', name: 'webapp', prefixColor: 'cyan'},
+    ];
+
+    const productCommands = getProductStartCommands();
+    commands.push(...productCommands);
+
+    if (!useRunner) {
+        if (productCommands.length > 0) {
+            console.log(chalk.green('Found products: ' + productCommands.map((command) => command.name).join(', ')));
+        } else {
+            console.log(chalk.yellow('No products found'));
+        }
+    }
+
+    commands.push(...getWorkspaceCommands('run'));
 
     let runner;
     if (useRunner) {
         runner = makeRunner(commands);
     }
 
-    if (!useRunner) {
-        console.log(chalk.inverse.bold('Watching web app and all subpackages...') + '\n');
-    }
+    console.log('\n');
 
     const {result, commands: runningCommands} = concurrently(
         commands,

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -3,6 +3,8 @@
 
 /* eslint-disable no-console, no-process-env */
 
+const fs = require('fs');
+
 const chalk = require('chalk');
 const concurrently = require('concurrently');
 
@@ -14,8 +16,14 @@ async function watchAll(useRunner) {
 
     commands.unshift(...getWorkspaceCommands('run'));
 
-    if (process.env.MM_FEATUREFLAGS_BoardsProduct) {
-        commands.unshift({command: 'make watch-product', cwd: '../focalboard', name: 'boards', prefixColor: 'red'});
+    if (fs.existsSync('../focalboard')) {
+        console.log(chalk.inverse.bold('Focalboard found. Starting Boards product.') + '\n');
+
+        if (!useRunner) {
+            commands.unshift({command: 'make watch-product', cwd: '../focalboard', name: 'boards', prefixColor: 'red'});
+        }
+    } else if (!useRunner) {
+        console.log(chalk.inverse.bold('Focalboard not found. Not starting Boards product.') + '\n');
     }
 
     commands.unshift({command: 'npm:run:webapp', name: 'webapp', prefixColor: 'cyan'});

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,11 +1,22 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+const fs = require('fs');
 const path = require('path');
 
 const chalk = require('chalk');
 
 const packageJson = require('../package.json');
+
+function getProductStartCommands() {
+    const commands = [];
+
+    if (fs.existsSync('../focalboard')) {
+        commands.push({command: 'make watch-product', cwd: '../focalboard', name: 'boards', prefixColor: 'red'});
+    }
+
+    return commands;
+}
 
 function getWorkspaces() {
     return packageJson.workspaces;
@@ -39,6 +50,7 @@ function getColorForWorkspace(workspace) {
 }
 
 module.exports = {
+    getProductStartCommands,
     getWorkspaces,
     getWorkspaceCommands,
 };


### PR DESCRIPTION
With the feature flag for this being on-by-default now, it doesn't make sense to require the feature flag be set while developing on the frontend, so now we just start the Focalboard product as long as its found.

I also realized when doing this that Focalboard wasn't run by `make dev` so that's also the case now as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49714

#### Release Note
```release-note
NONE
```
