### PR TITLE
Self-hosted purchase not available case (for v7.8)

### DIFF
--- a/components/pricing_modal/self_hosted_content.tsx
+++ b/components/pricing_modal/self_hosted_content.tsx
@@ -224,8 +224,14 @@ function SelfHostedContent(props: ContentProps) {
                                 }
 
                                 if (!canUseSelfHostedSignup) {
-                                    closePricingModal();
-                                    controlAirgappedModal.open();
+                                    // closePricingModal();
+                                    // controlAirgappedModal.open();
+                                    // NOTE: This behavior of directly opening the link is to
+                                    // work around in v7.8 (an Extended Support Release),
+                                    // an issue where self-hosted purchase is not actually ready
+                                    // for use. Work in https://mattermost.atlassian.net/browse/MM-49772
+                                    // should revert this behavior and instead open the airgapped modal
+                                    window.open(CloudLinks.SELF_HOSTED_SIGNUP, '_blank');
                                     return;
                                 }
 

--- a/components/pricing_modal/self_hosted_content.tsx
+++ b/components/pricing_modal/self_hosted_content.tsx
@@ -27,7 +27,8 @@ import StartTrialBtn from 'components/learn_more_trial_modal/start_trial_btn';
 
 import useCanSelfHostedSignup from 'components/common/hooks/useCanSelfHostedSignup';
 
-import {useControlAirGappedSelfHostedPurchaseModal} from 'components/common/hooks/useControlModal';
+// Revert in MM-49772
+// import {useControlAirGappedSelfHostedPurchaseModal} from 'components/common/hooks/useControlModal';
 
 import ContactSalesCTA from './contact_sales_cta';
 import StartTrialCaution from './start_trial_caution';
@@ -85,7 +86,8 @@ function SelfHostedContent(props: ContentProps) {
     const isEnterprise = license.SkuShortName === LicenseSkus.Enterprise;
     const isPostSelfHostedEnterpriseTrial = prevSelfHostedTrialLicense.IsLicensed === 'true';
 
-    const controlAirgappedModal = useControlAirGappedSelfHostedPurchaseModal();
+    // Revert in MM-49772
+    // const controlAirgappedModal = useControlAirGappedSelfHostedPurchaseModal();
 
     const closePricingModal = () => {
         dispatch(closeModal(ModalIdentifiers.PRICING_MODAL));


### PR DESCRIPTION
#### Summary
Self-hosted purchase (for v7.8) when purchase not available, direcly open the customer portal purchase experience. QA deferred to post-merge because we don't yet have a good way to to test this from spinwicks.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49771

#### Screenshots
This is now the experience if CWS reports signup is not available;

https://user-images.githubusercontent.com/13738432/213553508-50608a99-0450-4218-845e-c96d21d28e4e.mp4

#### Release Note
```release-note
If self-hosted purchase is not available, go to cws purchase portal experience directly instead of showing air-gapped modal.
```
