### PR TITLE
MM-49632 Correctly count GraphQL requests during performance events

### DIFF
--- a/actions/telemetry_actions.jsx
+++ b/actions/telemetry_actions.jsx
@@ -240,9 +240,17 @@ function initRequestCountingIfNecessary() {
         for (const entry of entries.getEntries()) {
             const url = entry.name;
 
-            if (url.includes('/api/v4/') && (entry.initiatorType === 'fetch' || entry.initiatorType === 'xmlhttprequest')) {
-                requestCount += 1;
+            if (!url.includes('/api/v4/') && !url.includes('/api/v5/')) {
+                // Don't count requests made outside of the MM server's API
+                continue;
             }
+
+            if (entry.initiatorType !== 'fetch' && entry.initiatorType !== 'xmlhttprequest') {
+                // Only look for API requests made by code and ignore things like attachments thumbnails
+                continue;
+            }
+
+            requestCount += 1;
         }
     });
     requestObserver.observe({type: 'resource', buffered: true});


### PR DESCRIPTION
The request count for `team_switch` and `channel_switch` events isn't the most accurate, but it currently ignores GraphQL API requests since those are under `/api/v5`, so there's no chance of us seeing any effects of those in Looker

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49632

#### Release Note
```release-note
Correctly count GraphQL APIs when measuring performance telemetry
```
