### PR TITLE
[MM-49748] Adding telemetry for mfa

### DIFF
--- a/components/mfa/confirm.tsx
+++ b/components/mfa/confirm.tsx
@@ -43,7 +43,7 @@ export default class Confirm extends React.PureComponent<Props> {
 
     submit = (e: KeyboardEvent | React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault();
-        trackEvent('mfa_setup', 'mfa_confirmed', {isMobile: isMobile()});
+        trackEvent('mfa_setup', 'submit_mfa_confirm', {isMobile: isMobile()});
         redirectUserToDefaultTeam();
     }
 

--- a/components/mfa/confirm.tsx
+++ b/components/mfa/confirm.tsx
@@ -43,7 +43,7 @@ export default class Confirm extends React.PureComponent<Props> {
 
     submit = (e: KeyboardEvent | React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault();
-        trackEvent('mfa_setup', 'mfa_confirmed', {isMobile: isMobile()})
+        trackEvent('mfa_setup', 'mfa_confirmed', {isMobile: isMobile()});
         redirectUserToDefaultTeam();
     }
 

--- a/components/mfa/confirm.tsx
+++ b/components/mfa/confirm.tsx
@@ -6,8 +6,10 @@ import {FormattedMessage} from 'react-intl';
 
 import Constants from 'utils/constants';
 import {isKeyPressed} from 'utils/utils';
+import {isMobile} from 'utils/user_agent';
 
 import {redirectUserToDefaultTeam} from 'actions/global_actions';
+import {trackEvent} from 'actions/telemetry_actions';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
@@ -41,6 +43,7 @@ export default class Confirm extends React.PureComponent<Props> {
 
     submit = (e: KeyboardEvent | React.FormEvent<HTMLFormElement>): void => {
         e.preventDefault();
+        trackEvent('mfa_setup', 'mfa_confirmed', {isMobile: isMobile()})
         redirectUserToDefaultTeam();
     }
 

--- a/components/mfa/setup/setup.tsx
+++ b/components/mfa/setup/setup.tsx
@@ -6,8 +6,11 @@ import {FormattedMessage} from 'react-intl';
 
 import {UserProfile} from '@mattermost/types/users';
 
+import {trackEvent} from 'actions/telemetry_actions';
+
 import * as Utils from 'utils/utils';
 import {t} from 'utils/i18n';
+import {isMobile} from 'utils/user_agent';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import LocalizedInput from 'components/localized_input/localized_input';
@@ -77,6 +80,7 @@ export default class Setup extends React.PureComponent<Props, State> {
             this.props.history.push('/');
             return;
         }
+        trackEvent('mfa_setup', 'mfa_setup_page_loaded', {isMobile: isMobile()});
 
         this.props.actions.generateMfaSecret().then(({data, error}) => {
             if (error) {
@@ -117,7 +121,7 @@ export default class Setup extends React.PureComponent<Props, State> {
 
                 return;
             }
-
+            trackEvent('mfa_setup', 'mfa_setup_saved', {isMobile: isMobile()});
             this.props.history.push('/mfa/confirm');
         });
     }

--- a/components/mfa/setup/setup.tsx
+++ b/components/mfa/setup/setup.tsx
@@ -80,15 +80,16 @@ export default class Setup extends React.PureComponent<Props, State> {
             this.props.history.push('/');
             return;
         }
-        trackEvent('mfa_setup', 'mfa_setup_page_loaded', {isMobile: isMobile()});
 
         this.props.actions.generateMfaSecret().then(({data, error}) => {
             if (error) {
                 this.setState({
                     serverError: error.message,
                 });
+                trackEvent('mfa_setup', 'mfa_setup_page_error_on_load', {isMobile: isMobile()});
                 return;
             }
+            trackEvent('mfa_setup', 'mfa_setup_page_loaded', {isMobile: isMobile()});
 
             this.setState({
                 secret: data.secret,
@@ -109,6 +110,7 @@ export default class Setup extends React.PureComponent<Props, State> {
 
         this.props.actions.activateMfa(code).then(({error}) => {
             if (error) {
+                trackEvent('mfa_setup', 'mfa_setup_error_on_save', {isMobile: isMobile(), errorId: error.server_error_id});
                 if (error.server_error_id === 'ent.mfa.activate.authenticate.app_error') {
                     this.setState({
                         error: Utils.localizeMessage('mfa.setup.badCode', 'Invalid code. If this issue persists, contact your System Administrator.'),

--- a/components/setting_item_min/setting_item_min.test.tsx
+++ b/components/setting_item_min/setting_item_min.test.tsx
@@ -43,7 +43,7 @@ describe('components/SettingItemMin', () => {
             <SettingItemMin {...props}/>,
         );
 
-        wrapper.instance().handleUpdateSection({preventDefault: jest.fn()} as any);
+        wrapper.instance().handleUpdateSection({preventDefault: jest.fn(), stopPropagation: jest.fn()} as any);
         expect(updateSection).toHaveBeenCalled();
         expect(updateSection).toHaveBeenCalledWith('section');
     });
@@ -55,7 +55,7 @@ describe('components/SettingItemMin', () => {
             <SettingItemMin {...props}/>,
         );
 
-        wrapper.instance().handleUpdateSection({preventDefault: jest.fn()} as any);
+        wrapper.instance().handleUpdateSection({preventDefault: jest.fn(), stopPropagation: jest.fn()} as any);
         expect(updateSection).toHaveBeenCalled();
         expect(updateSection).toHaveBeenCalledWith('');
     });

--- a/components/setting_item_min/setting_item_min.tsx
+++ b/components/setting_item_min/setting_item_min.tsx
@@ -51,6 +51,7 @@ export default class SettingItemMin extends React.PureComponent<Props> {
 
     handleUpdateSection = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
+        e.stopPropagation();
         this.props.updateSection(this.props.section);
     }
 

--- a/components/user_settings/security/mfa_section/mfa_section.tsx
+++ b/components/user_settings/security/mfa_section/mfa_section.tsx
@@ -9,6 +9,9 @@ import SettingItemMin from 'components/setting_item_min';
 import SettingItemMinComponent from 'components/setting_item_min/setting_item_min';
 
 import {getHistory} from 'utils/browser_history';
+import {isMobile} from 'utils/user_agent';
+
+import {trackEvent} from 'actions/telemetry_actions';
 
 const SECTION_MFA = 'mfa';
 
@@ -58,6 +61,7 @@ export default class MfaSection extends React.PureComponent<Props, State> {
     public setupMfa = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
 
+        trackEvent('security_settings', 'click_setup_mfa', {isMobile: isMobile()});
         getHistory().push('/mfa/setup');
     };
 

--- a/components/user_settings/security/user_settings_security.tsx
+++ b/components/user_settings/security/user_settings_security.tsx
@@ -9,11 +9,14 @@ import {Link} from 'react-router-dom';
 
 import SettingItemMax from 'components/setting_item_max';
 
+import {trackEvent} from 'actions/telemetry_actions';
+
 import {ActionResult} from 'mattermost-redux/types/actions';
 
 import Constants from 'utils/constants';
 import {t} from 'utils/i18n';
 import * as Utils from 'utils/utils';
+import {isMobile} from 'utils/user_agent';
 import icon50 from 'images/icon50x50.png';
 import AccessHistoryModal from 'components/access_history_modal';
 import ActivityLogModal from 'components/activity_log_modal';
@@ -210,6 +213,9 @@ export default class SecurityTab extends React.PureComponent<Props, State> {
 
     handleUpdateSection = (section: string) => {
         if (section) {
+            if (section === SECTION_MFA) {
+                trackEvent('security_settings', 'expand_mfa_section', {isMobile: isMobile()});
+            }
             this.props.updateSection(section);
         } else {
             switch (this.props.activeSection) {


### PR DESCRIPTION
#### Summary
Adding telemetry for MFA

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49748

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Telemetry for mfa
```
