### PR TITLE
MM-49644 - Add Legal Link in Purchase Process.

### DIFF
--- a/components/purchase_modal/purchase.scss
+++ b/components/purchase_modal/purchase.scss
@@ -208,7 +208,7 @@
 
                 .bottom {
                     &:not(.delinquency, .bottom-monthly-yearly) {
-                        height: 363px;
+                        height: 410px;
                     }
 
                     padding-right: 24px;

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -26,6 +26,7 @@ import {
     ModalIdentifiers,
     ItemStatus,
     RecurringIntervals,
+    LicenseLinks,
 } from 'utils/constants';
 import {findProductByID} from 'utils/products';
 import {areBillingDetailsValid, BillingDetails} from '../../types/cloud/sku';
@@ -267,6 +268,32 @@ export function Card(props: CardProps) {
         }
     };
 
+    const licenseAgreement = (
+        <>
+            <br/>
+            <br/>
+            <FormattedMessage
+                defaultMessage={
+                    'By clicking {buttonContent}, you agree to the <linkAgreement>{legalText}</linkAgreement>'
+                }
+                id={'admin.billing.subscription.byClickingYouAgree'}
+                values={{
+                    buttonContent: props.buttonDetails.text.toLowerCase(),
+                    legalText: LicenseLinks.SOFTWARE_SERVICES_LICENSE_AGREEMENT_TEXT,
+                    linkAgreement: (legalText: React.ReactNode) => (
+                        <a
+                            href={LicenseLinks.SOFTWARE_SERVICES_LICENSE_AGREEMENT}
+                            target='_blank'
+                            rel='noreferrer'
+                        >
+                            {legalText}
+                        </a>
+                    ),
+                }}
+            />
+        </>
+    )
+
     const userCountTooltip = (
         <Tooltip
             id='userCount__tooltip'
@@ -318,6 +345,7 @@ export function Card(props: CardProps) {
                         id={'admin.billing.subscription.howItWorks'}
                     />
                 </a>
+                {licenseAgreement}
             </div>
         </>
     );
@@ -447,6 +475,7 @@ export function Card(props: CardProps) {
                         id={'admin.billing.subscription.howItWorks'}
                     />
                 </a>
+                {licenseAgreement}
             </div>
         </>
     );
@@ -488,6 +517,7 @@ export function Card(props: CardProps) {
                             id={'admin.billing.subscription.howItWorks'}
                         />
                     </a>
+                    {licenseAgreement}
                 </div>}
                 {props.afterButtonContent}
             </div>

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1081,6 +1081,7 @@ export const LicenseLinks = {
     TRIAL_INFO_LINK: 'https://mattermost.com/trial',
     EMBARGOED_COUNTRIES: 'https://mattermost.com/pl/limitations-for-embargoed-countries',
     SOFTWARE_SERVICES_LICENSE_AGREEMENT: 'https://mattermost.com/pl/software-and-services-license-agreement',
+    SOFTWARE_SERVICES_LICENSE_AGREEMENT_TEXT: 'Software Services and License Agreement',
 };
 
 export const BillingSchemes = {


### PR DESCRIPTION
#### Summary

We need to: 
- Update our user experience to reflect updated legal terms specifically around activating a trial and upgrading to a paid plan
- Notify existing Cloud Free workspaces and Professional (monthly) of new terms, as well as document this

This change adds a link to the [new Software and Services License Agreement](https://mattermost.com/software-services-license-agreement/) to the purchase modal.

#### Ticket Link

[MM-49644](https://mattermost.atlassian.net/browse/MM-49644)

#### Screenshots

|  before  |  after  |
|----|----|
| ![original](https://user-images.githubusercontent.com/116016004/213733097-55ed4552-58c5-49a7-9176-f451da3b641b.png) | ![original](https://user-images.githubusercontent.com/116016004/213733188-bb1cb4ef-4172-4b66-8e09-c8d10e7cea9c.png) |
| ![monthly](https://user-images.githubusercontent.com/116016004/213733126-4f163d8d-307a-43e9-bda8-bd4b5302c611.png) | ![monthly](https://user-images.githubusercontent.com/116016004/213733218-3702e9a9-f3e4-4bcd-b044-26ab7093a907.png) |
| ![yearly](https://user-images.githubusercontent.com/116016004/213733148-8da3a59a-afa7-4d6a-bf4d-9b6decb2124c.png) | ![yearly](https://user-images.githubusercontent.com/116016004/213733239-98d7a037-a743-4e64-a058-dc9d6f3192f6.png) |

#### Release Note

```release-note
NONE
```
