### PR TITLE
[MM-49810] Fix UTM params not sent to rudder

### DIFF
--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -277,7 +277,7 @@ export default class Root extends React.PureComponent<Props, State> {
                 anonymousId: '00000000000000000000000000',
             });
 
-            const utmParams = this.captureUTMCampaign();
+            const utmParams = this.captureUTMParams();
             rudderAnalytics.ready(() => {
                 Client4.setTelemetryHandler(new RudderTelemetryHandler());
                 if (utmParams) {
@@ -389,7 +389,7 @@ export default class Root extends React.PureComponent<Props, State> {
         GlobalActions.redirectUserToDefaultTeam();
     }
 
-    captureUTMCampaign() {
+    captureUTMParams() {
         const qs = new URLSearchParams(window.location.search);
 
         // list of key that we want to track

--- a/components/root/root.tsx
+++ b/components/root/root.tsx
@@ -277,13 +277,14 @@ export default class Root extends React.PureComponent<Props, State> {
                 anonymousId: '00000000000000000000000000',
             });
 
+            const utmParams = this.captureUTMCampaign();
             rudderAnalytics.ready(() => {
                 Client4.setTelemetryHandler(new RudderTelemetryHandler());
+                if (utmParams) {
+                    trackEvent('utm_params', 'utm_params', utmParams);
+                }
             });
         }
-
-        // This needs to be called as early as possible to ensure that a redirect won't remove the query string
-        this.trackUTMCampaign();
 
         if (this.props.location.pathname === '/' && this.props.noAccounts) {
             this.props.history.push('/signup_user_complete');
@@ -388,7 +389,7 @@ export default class Root extends React.PureComponent<Props, State> {
         GlobalActions.redirectUserToDefaultTeam();
     }
 
-    trackUTMCampaign() {
+    captureUTMCampaign() {
         const qs = new URLSearchParams(window.location.search);
 
         // list of key that we want to track
@@ -406,9 +407,10 @@ export default class Root extends React.PureComponent<Props, State> {
         }, {} as Record<string, string>);
 
         if (Object.keys(campaign).length > 0) {
-            trackEvent('utm_params', 'utm_params', campaign);
             this.props.history.replace({search: qs.toString()});
+            return campaign;
         }
+        return null;
     }
 
     initiateMeRequests = async () => {


### PR DESCRIPTION
#### Summary
This PR fixes an issue causing UTM params to not being sent to rudder.

@stevemudie we might have to defer QA, I don't know how to set rudder in spinwicks (locally I have to  change the code directly)
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49810

#### Related Pull Requests
N/A

#### Screenshots
Visiting http://localhost:8065/login/?utm_source=nurture&utm_medium=email&utm_campaign=cloud-starter-v2

![image](https://user-images.githubusercontent.com/785518/213762581-12cbcf27-ec5e-417a-8285-a13e6cc1383d.png)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
