### PR TITLE
[MM-49773] Updating telemetry for the invite modal

### DIFF
--- a/components/invitation_modal/invitation_modal.tsx
+++ b/components/invitation_modal/invitation_modal.tsx
@@ -162,13 +162,11 @@ export class InvitationModal extends React.PureComponent<Props, State> {
         const roleForTrackFlow = getRoleForTrackFlow();
         const inviteAs = this.state.invite.inviteType;
         const eventProps = {
-            num_invitations: this.state.invite.usersEmails.length, 
-            ...roleForTrackFlow
+            num_invitations: this.state.invite.usersEmails.length,
+            ...roleForTrackFlow,
+            invite_type: inviteAs,
         };
-        if (inviteAs === InviteType.MEMBER && this.props.isCloud) {
-            trackEvent('cloud_invite_users', 'click_send_invitations', eventProps);
-        }
-        trackEvent('invite_users', 'click_invite', {...eventProps, invite_type: inviteAs});
+        trackEvent('invite_users', 'click_invite', eventProps);
 
         const users: UserProfile[] = [];
         const emails: string[] = [];

--- a/components/invitation_modal/invitation_modal.tsx
+++ b/components/invitation_modal/invitation_modal.tsx
@@ -161,10 +161,14 @@ export class InvitationModal extends React.PureComponent<Props, State> {
     invite = async () => {
         const roleForTrackFlow = getRoleForTrackFlow();
         const inviteAs = this.state.invite.inviteType;
+        const eventProps = {
+            num_invitations: this.state.invite.usersEmails.length, 
+            ...roleForTrackFlow
+        };
         if (inviteAs === InviteType.MEMBER && this.props.isCloud) {
-            trackEvent('cloud_invite_users', 'click_send_invitations', {num_invitations: this.state.invite.usersEmails.length, ...roleForTrackFlow});
+            trackEvent('cloud_invite_users', 'click_send_invitations', eventProps);
         }
-        trackEvent('invite_users', 'click_invite', roleForTrackFlow);
+        trackEvent('invite_users', 'click_invite', {...eventProps, invite_type: inviteAs});
 
         const users: UserProfile[] = [];
         const emails: string[] = [];


### PR DESCRIPTION
#### Summary
We need to ensure that the Invite button has tracking.

Track:
- ~~Number of invitations sent for on prem.~~ 
- ~~The invite type: guest vs user.~~ 
- Method of input (paste vs type). Covered here: https://github.com/mattermost/mattermost-webapp/pull/12052#issuecomment-1410268505

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49773

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Telemetry for the invite modal
```
