### PR TITLE
MM-38465 Add Discard Modal for Company Information Edit

### DIFF
--- a/components/admin_console/billing/company_info_edit.tsx
+++ b/components/admin_console/billing/company_info_edit.tsx
@@ -82,7 +82,7 @@ const CompanyInfoEdit: React.FC<Props> = () => {
         if (contentChanged) {
             dispatch(setNavigationBlocked(true));
         }
-    }, [contentChanged])
+    }, [contentChanged]);
 
     if (!companyInfo) {
         return null;

--- a/components/admin_console/billing/company_info_edit.tsx
+++ b/components/admin_console/billing/company_info_edit.tsx
@@ -64,10 +64,10 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     const updateNumEmployees = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.target.value) {
             setNumEmployees(parseInt(event.target.value, 10));
-            setContentChanged(true);
         } else {
             setNumEmployees(undefined);
         }
+        setContentChanged(true);
     };
 
     useEffect(() => {

--- a/components/admin_console/billing/company_info_edit.tsx
+++ b/components/admin_console/billing/company_info_edit.tsx
@@ -18,6 +18,8 @@ import {GlobalState} from 'types/store';
 import {COUNTRIES} from 'utils/countries';
 import * as Utils from 'utils/utils';
 
+import {setNavigationBlocked} from 'actions/admin_actions.jsx';
+
 import './company_info_edit.scss';
 
 type Props = Record<string, never>;
@@ -37,6 +39,7 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     const [postalCode, setPostalCode] = useState(companyInfo?.company_address?.postal_code);
     const [country, setCountry] = useState(companyInfo?.company_address?.country || getName('US'));
     const [state, setState] = useState(companyInfo?.company_address?.state);
+    const [contentChanged, setContentChanged] = useState(false);
 
     const [sameAsBillingAddress, setSameAsBillingAddress] = useState(Boolean(!companyInfo?.company_address?.line1 && companyInfo?.billing_address?.line1));
     const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
@@ -54,6 +57,7 @@ const CompanyInfoEdit: React.FC<Props> = () => {
         return (event: React.ChangeEvent<HTMLInputElement>) => {
             setStateFunc(event.target.value);
             setValidation();
+            setContentChanged(true);
         };
     };
 
@@ -72,6 +76,12 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     useEffect(() => {
         setValidation();
     }, [setValidation]);
+
+    useEffect(() => {
+        if (contentChanged) {
+            dispatch(setNavigationBlocked(true));
+        }
+    }, [contentChanged])
 
     if (!companyInfo) {
         return null;
@@ -125,7 +135,7 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     const companyAddressInput = (
         <>
             <DropdownInput
-                onChange={(option) => setCountry(option.value)}
+                onChange={(option) => {setCountry(option.value); setContentChanged(true);}}
                 value={country ? {value: country, label: country} : undefined}
                 options={COUNTRIES.map((c) => ({value: c.name, label: c.name}))}
                 legend={Utils.localizeMessage('admin.billing.company_info.country', 'Country')}

--- a/components/admin_console/billing/company_info_edit.tsx
+++ b/components/admin_console/billing/company_info_edit.tsx
@@ -64,6 +64,7 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     const updateNumEmployees = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.target.value) {
             setNumEmployees(parseInt(event.target.value, 10));
+            setContentChanged(true);
         } else {
             setNumEmployees(undefined);
         }
@@ -135,7 +136,10 @@ const CompanyInfoEdit: React.FC<Props> = () => {
     const companyAddressInput = (
         <>
             <DropdownInput
-                onChange={(option) => {setCountry(option.value); setContentChanged(true);}}
+                onChange={(option) => {
+                    setCountry(option.value);
+                    setContentChanged(true);
+                }}
                 value={country ? {value: country, label: country} : undefined}
                 options={COUNTRIES.map((c) => ({value: c.name, label: c.name}))}
                 legend={Utils.localizeMessage('admin.billing.company_info.country', 'Country')}
@@ -176,7 +180,10 @@ const CompanyInfoEdit: React.FC<Props> = () => {
                     <StateSelector
                         country={country!}
                         state={state!}
-                        onChange={(stateValue) => setState(stateValue)}
+                        onChange={(stateValue) => {
+                            setState(stateValue);
+                            setContentChanged(true);
+                        }}
                     />
                 </div>
                 <div className='form-row-third-2'>
@@ -248,7 +255,10 @@ const CompanyInfoEdit: React.FC<Props> = () => {
                                         <input
                                             type='checkbox'
                                             checked={sameAsBillingAddress}
-                                            onChange={(event) => setSameAsBillingAddress(event.target.checked)}
+                                            onChange={(event) => {
+                                                setSameAsBillingAddress(event.target.checked);
+                                                setContentChanged(true);
+                                            }}
                                         />
                                         <FormattedMessage
                                             id='admin.billing.company_info_edit.sameAsBillingAddress'


### PR DESCRIPTION
#### Summary

When editing company information, the standard discard modal is not presented when navigating to another page.
This change ensures the modal appears when any field is modified.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38465

#### Screenshots

![Screen Shot 2023-01-24 at 10 53 02 AM](https://user-images.githubusercontent.com/116016004/214341867-4915fb95-6d68-42f4-bcd5-8f2be8933811.png)

#### Test Plan

1. Go to System Console ➜ Billing & Account ➜ Company Information
2. Add a new address without clicking the Save Info button
3. Click the back arrow to exit
**Expected**: The standard System Console Discard Changes modal prevents me from leaving (see screenshot) 

#### Release Note

```release-note
NONE
```
