### PR TITLE
[MM-49929] Work templates: allow simple users to list marketplace plugins

### DIFF
--- a/actions/marketplace.ts
+++ b/actions/marketplace.ts
@@ -26,9 +26,8 @@ export function fetchRemoteListing(): ActionFunc {
         const state = getState() as GlobalState;
         const filter = getFilter(state);
 
-        let plugins: MarketplacePlugin[];
         try {
-            plugins = await Client4.getRemoteMarketplacePlugins(filter);
+            const plugins = await Client4.getRemoteMarketplacePlugins(filter);
             dispatch({
                 type: ActionTypes.RECEIVED_MARKETPLACE_PLUGINS,
                 plugins,

--- a/actions/marketplace.ts
+++ b/actions/marketplace.ts
@@ -21,6 +21,25 @@ import {isError} from 'types/actions';
 
 import {executeCommand} from './command';
 
+export function fetchRemoteListing(): ActionFunc {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState() as GlobalState;
+        const filter = getFilter(state);
+
+        let plugins: MarketplacePlugin[];
+        try {
+            plugins = await Client4.getRemoteMarketplacePlugins(filter);
+            dispatch({
+                type: ActionTypes.RECEIVED_MARKETPLACE_PLUGINS,
+                plugins,
+            });
+            return {data: plugins};
+        } catch (error: any) {
+            return {error};
+        }
+    };
+}
+
 // fetchPlugins fetches the latest marketplace plugins and apps, subject to any existing search filter.
 export function fetchListing(localOnly = false): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {

--- a/components/work_templates/index.tsx
+++ b/components/work_templates/index.tsx
@@ -21,7 +21,7 @@ import {
 import {Category, ExecuteWorkTemplateRequest, ExecuteWorkTemplateResponse, Visibility, WorkTemplate} from '@mattermost/types/work_templates';
 import {GlobalState} from '@mattermost/types/store';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {fetchListing} from 'actions/marketplace';
+import {fetchRemoteListing} from 'actions/marketplace';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {ActionResult} from 'mattermost-redux/types/actions';
 import {switchToChannelById} from 'actions/views/channel';
@@ -100,7 +100,7 @@ const WorkTemplateModal = () => {
 
     useEffect(() => {
         if (pluginsEnabled) {
-            dispatch(fetchListing());
+            dispatch(fetchRemoteListing());
         }
     }, [dispatch, pluginsEnabled]);
 

--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -3468,6 +3468,13 @@ export default class Client4 {
         );
     };
 
+    getRemoteMarketplacePlugins = (filter: string) => {
+        return this.doFetch<MarketplacePlugin[]>(
+            `${this.getPluginsMarketplaceRoute()}${buildQueryString({filter: filter || '', remote_only: true})}`,
+            {method: 'get'},
+        );
+    }
+
     getMarketplacePlugins = (filter: string, localOnly = false) => {
         return this.doFetch<MarketplacePlugin[]>(
             `${this.getPluginsMarketplaceRoute()}${buildQueryString({filter: filter || '', local_only: localOnly})}`,


### PR DESCRIPTION
#### Summary
This PR uses the marketplace listing new flag `?remote_only=true` to allow users to get public plugin info. Without this being on, non admins would not be able to see public plugins info at all.

QA @ server side PR

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49929

#### Related Pull Requests
- Has server changes https://github.com/mattermost/mattermost-server/pull/22151

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
