### PR TITLE
[MM-49480] Delinquency modal updates for cloud annual subscriptions

### DIFF
--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -79,6 +79,9 @@ type DelinquencyCardProps = {
     price: string;
     buttonDetails: ButtonDetails;
     onViewBreakdownClick: () => void;
+    isCloudDelinquencyGreaterThan90Days: boolean;
+    users: number;
+    cost: number;
 };
 
 type CardProps = {
@@ -181,20 +184,19 @@ function findProductInDictionary(products: Record<string, Product> | undefined, 
 
 function getSelectedProduct(
     products: Record<string, Product> | undefined,
+    yearlyProducts: Record<string, Product>,
     currentProductId?: string | null,
     isDelinquencyModal?: boolean,
     isCloudDelinquencyGreaterThan90Days?: boolean) {
-    const currentProduct = findProductInDictionary(products, currentProductId); // if current product id is for monthly, currentProduct will not be found and nextSku by default is professional annual
     if (isDelinquencyModal && !isCloudDelinquencyGreaterThan90Days) {
+        const currentProduct = findProductInDictionary(products, currentProductId, undefined, RecurringIntervals.MONTH);
+
+        // if the account hasn't been delinquent for more than 90 days, then we will allow them to settle up and stay on their current product
         return currentProduct;
     }
-    let nextSku = CloudProducts.PROFESSIONAL;
 
-    // Don't switch the product to enterprise if the recurring interval of the selected product is yearly. This means that it can only be the yearly professional product.
-    if (currentProduct?.sku === CloudProducts.PROFESSIONAL) {
-        nextSku = CloudProducts.ENTERPRISE;
-    }
-    return findProductInDictionary(products, null, nextSku, RecurringIntervals.YEAR);
+    // Otherwise, we will default to upgrading them to the yearly professional plan
+    return findProductInDictionary(yearlyProducts, null, CloudProducts.PROFESSIONAL, RecurringIntervals.YEAR);
 }
 
 export function Card(props: CardProps) {
@@ -271,7 +273,6 @@ function DelinquencyCard(props: DelinquencyCardProps) {
                         </div>
                     </div>
                 </div>
-
                 <div>
                     <button
                         className={
@@ -284,18 +285,54 @@ function DelinquencyCard(props: DelinquencyCardProps) {
                     </button>
                 </div>
                 <div className='plan_billing_cycle delinquency'>
-                    <FormattedMessage
-                        defaultMessage={
-                            'Upon reactivation you will be charged the total owed.  Your bill is calculated at the end of the billing cycle based on the number of enabled users.'
-                        }
-                        id={'cloud_delinquency.cc_modal.disclaimer'}
-                    />
-                    <a onClick={seeHowBillingWorks}>
+                    {Boolean(!props.isCloudDelinquencyGreaterThan90Days) && (
                         <FormattedMessage
-                            defaultMessage={'See how billing works.'}
-                            id={'admin.billing.subscription.howItWorks'}
+                            defaultMessage={
+                                'Upon reactivation you will be charged the total owed.  Your bill is calculated at the end of the billing cycle based on the number of enabled users. {seeHowBillingWorks}'
+                            }
+                            id={'cloud_delinquency.cc_modal.disclaimer'}
+                            values={{
+                                seeHowBillingWorks: (
+                                    <a onClick={seeHowBillingWorks}>
+                                        <FormattedMessage
+                                            defaultMessage={
+                                                'See how billing works.'
+                                            }
+                                            id={
+                                                'admin.billing.subscription.howItWorks'
+                                            }
+                                        />
+                                    </a>
+                                ),
+                            }}
                         />
-                    </a>
+                    )}
+                    {Boolean(props.isCloudDelinquencyGreaterThan90Days) && (
+                        <FormattedMessage
+                            defaultMessage={
+                                'Upon reactivation you will be charged the total owed.  You will be further charged {cost} immediately for the cost of a 1 year subscription according to your currently active user count of {users} users. {seeHowBillingWorks}'
+                            }
+                            id={
+                                'cloud_delinquency.cc_modal.disclaimer_with_upgrade_info'
+                            }
+                            values={{
+                                cost: `$${props.cost}`,
+                                users: props.users,
+                                seeHowBillingWorks: (
+                                    <a onClick={seeHowBillingWorks}>
+                                        <FormattedMessage
+                                            defaultMessage={
+                                                'See how billing works.'
+                                            }
+                                            id={
+                                                'admin.billing.subscription.howItWorks'
+                                            }
+                                        />
+                                    </a>
+                                ),
+                            }}
+                        />
+                    )}
                 </div>
             </div>
         </div>
@@ -321,6 +358,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                 props.productId,
             ),
             selectedProduct: getSelectedProduct(
+                props.products,
                 props.yearlyProducts,
                 props.productId,
                 props.isDelinquencyModal,
@@ -328,7 +366,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
             ),
             isUpgradeFromTrial: props.isFreeTrial,
             buttonClickedInfo: '',
-            selectedProductPrice: getSelectedProduct(props.yearlyProducts, props.productId, false)?.price_per_seat.toString() || null,
+            selectedProductPrice: getSelectedProduct(props.products, props.yearlyProducts, props.productId, props.isDelinquencyModal, props.isCloudDelinquencyGreaterThan90Days)?.price_per_seat.toString() || null,
             usersCount: this.props.usersCount,
             seats: {
                 quantity: this.props.usersCount.toString(),
@@ -343,8 +381,8 @@ class PurchaseModal extends React.PureComponent<Props, State> {
             // eslint-disable-next-line react/no-did-mount-set-state
             this.setState({
                 currentProduct: findProductInDictionary(this.props.products, this.props.productId),
-                selectedProduct: getSelectedProduct(this.props.products, this.props.productId, this.props.isDelinquencyModal, this.props.isCloudDelinquencyGreaterThan90Days),
-                selectedProductPrice: getSelectedProduct(this.props.products, this.props.productId, false)?.price_per_seat.toString() ?? null,
+                selectedProduct: getSelectedProduct(this.props.products, this.props.yearlyProducts, this.props.productId, this.props.isDelinquencyModal, this.props.isCloudDelinquencyGreaterThan90Days),
+                selectedProductPrice: getSelectedProduct(this.props.products, this.props.yearlyProducts, this.props.productId, false)?.price_per_seat.toString() ?? null,
             });
         }
 
@@ -601,6 +639,9 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                             disabled: !this.state.paymentInfoIsValid,
                         }}
                         onViewBreakdownClick={this.handleViewBreakdownClick}
+                        isCloudDelinquencyGreaterThan90Days={this.props.isCloudDelinquencyGreaterThan90Days}
+                        cost={parseInt(this.state.selectedProductPrice || '', 10) * this.props.usersCount}
+                        users={this.props.usersCount}
                     />
                 </>
             );
@@ -773,6 +814,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
         if (!stripePromise) {
             stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
         }
+
         return (
             <Elements
                 options={{fonts: [{cssSrc: STRIPE_CSS_SRC}]}}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2998,7 +2998,8 @@
   "cloud_delinquency.cc_modal.card.reactivate": "Re-activate",
   "cloud_delinquency.cc_modal.card.totalOwed": "Total Owed",
   "cloud_delinquency.cc_modal.card.viewBreakdown": "View Breakdown",
-  "cloud_delinquency.cc_modal.disclaimer": "Upon reactivation you will be charged the total owed.  Your bill is calculated at the end of the billing cycle based on the number of enabled users.",
+  "cloud_delinquency.cc_modal.disclaimer": "Upon reactivation you will be charged the total owed.  Your bill is calculated at the end of the billing cycle based on the number of enabled users. {seeHowBillingWorks}",
+  "cloud_delinquency.cc_modal.disclaimer_with_upgrade_info": "Upon reactivation you will be charged the total owed.  You will be further charged ${cost} immediately for the cost of a 1 year subscription according to your currently active user count of {users} users. {seeHowBillingWorks}",
   "cloud_delinquency.modal.re_activate_plan": "Re-activate {planName}",
   "cloud_delinquency.modal.stay_on_freemium": "Stay on Free",
   "cloud_delinquency.modal.stay_on_freemium_close": "Close",
@@ -5653,6 +5654,6 @@
   "workspace_limits.teams_limit_reached.upgrade_to_unarchive": "Upgrade to Unarchive",
   "workspace_limits.teams_limit_reached.view_upgrade_options": "View upgrade options",
   "workspace_limits.upgrade": "Upgrade to avoid {planName} data limits",
-  "workspace_limits.upgrade_reasons.free": "{planName} is restricted to {messagesLimit} message history, {storageLimit} file storage, {appsLimit} apps, and {boardsCardsLimit} board cards. You can delete items to free up space or upgrade to a paid plan.",
+  "workspace_limits.upgrade_reasons.free": "{planName} is restricted to {messagesLimit} message history, {storageLimit} file storage, and {boardsCardsLimit} board cards. You can delete items to free up space or upgrade to a paid plan.",
   "yourcomputer": "Your computer"
 }


### PR DESCRIPTION
#### Summary
This PR has some updates to the delinquency modal to handle a handful of existing Cloud Professional monthly customers that are already delinquent.

You are on Cloud Professional, and have been delinquent for fewer than 90 days, you will be allowed to stay on the monthly plan, and will see this modal:
![image](https://user-images.githubusercontent.com/12176405/214936950-9bc90e5e-dba9-49da-8bb1-0f0efe051636.png)

You are on Cloud Free, and have been delinquent for more than 90 days (ie, you've been downgraded due to delinquency). You must settle your balance and upgrade to Cloud Yearly. Note the disclaimer:
![image](https://user-images.githubusercontent.com/12176405/214937604-e6cb15d4-eed8-4f84-942b-00dc53038537.png)



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49480

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
