### PR TITLE
[MM-49863] Check for team Id in product notices

### DIFF
--- a/components/product_notices_modal/product_notices_modal.tsx
+++ b/components/product_notices_modal/product_notices_modal.tsx
@@ -53,6 +53,9 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
                 this.fetchNoticesData();
             }
         }
+        if (!prevProps.currentTeamId) {
+            this.fetchNoticesData();
+        }
     }
 
     public componentWillUnmount() {
@@ -61,6 +64,9 @@ export default class ProductNoticesModal extends React.PureComponent<Props, Stat
 
     private async fetchNoticesData() {
         const {version, currentTeamId} = this.props;
+        if (!currentTeamId) {
+            return;
+        }
         let client = 'web';
         let clientVersion = version;
         if (isDesktopApp()) {


### PR DESCRIPTION
#### Summary
`currentTeamId` was undefined. I checked the behaviour on previous MM versions and this network request was only supposed to go out on page load (not every team switch)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49863

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixing product notices 404
```
