### PR TITLE
Use `/install-listed` path directly to install marketplace apps

### DIFF
--- a/actions/marketplace.ts
+++ b/actions/marketplace.ts
@@ -5,21 +5,22 @@ import {Client4} from 'mattermost-redux/client';
 
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-import {isCloudLicense} from 'mattermost-redux/selectors/entities/general';
 import {appsEnabled} from 'mattermost-redux/selectors/entities/apps';
 
 import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
 import type {MarketplaceApp, MarketplacePlugin} from '@mattermost/types/marketplace';
-import type {CommandArgs} from '@mattermost/types/integrations';
 
 import {GlobalState} from 'types/store';
 
-import {getApp, getFilter, getPlugin} from 'selectors/views/marketplace';
+import {getFilter, getPlugin} from 'selectors/views/marketplace';
 import {ActionTypes} from 'utils/constants';
 
-import {isError} from 'types/actions';
+import {AppCallResponseTypes} from 'mattermost-redux/constants/apps';
+import {AppCall, AppExpand, AppFormValues} from '@mattermost/types/apps';
+import {createCallContext, createCallRequest} from 'utils/apps';
+import {DoAppCallResult, intlShim} from 'components/suggestion/command_provider/app_command_parser/app_command_parser_dependencies';
 
-import {executeCommand} from './command';
+import {doAppSubmit, openAppsModal, postEphemeralCallResponseForContext} from './apps';
 
 // fetchPlugins fetches the latest marketplace plugins and apps, subject to any existing search filter.
 export function fetchListing(localOnly = false): ActionFunc {
@@ -119,9 +120,9 @@ export function installPlugin(id: string) {
     };
 }
 
-// installApp installed an App using a given URL via the /apps install slash command.
+// installApp installed an App using a given URL a call to the `/install-listed` endpoint.
 //
-// On success, it also requests the current state of the plugins to reflect the newly installed plugin.
+// On success, it also requests the current state of the apps to reflect the newly installed app.
 export function installApp(id: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc): Promise<boolean> => {
         dispatch({
@@ -129,37 +130,38 @@ export function installApp(id: string) {
             id,
         });
 
-        const state = getState() as GlobalState;
-
-        const channelID = getCurrentChannelId(state);
-        const teamID = getCurrentTeamId(state);
-
-        const app = getApp(state, id);
-        if (!app) {
-            dispatch({
-                type: ActionTypes.INSTALLING_MARKETPLACE_ITEM_FAILED,
-                id,
-                error: 'Unknown app: ' + id,
-            });
-            return false;
-        }
-
-        const args: CommandArgs = {
-            channel_id: channelID,
-            team_id: teamID,
+        const callPath = '/install-listed';
+        const call: AppCall = {
+            path: callPath,
         };
 
-        let command = `/apps install listed ${id}`;
-        if (isCloudLicense(state)) {
-            command = `/apps install ${id}`;
-        }
+        const expand: AppExpand = {
+            acting_user: '+summary',
+            locale: 'all',
+        };
 
-        const result = await dispatch(executeCommand(command, args));
-        if (isError(result)) {
+        const values: AppFormValues = {
+            app: {
+                label: id,
+                value: id,
+            },
+        };
+
+        const state = getState();
+        const channelID = getCurrentChannelId(state);
+        const teamID = getCurrentTeamId(state);
+        const context = createCallContext('apps', '/marketplace', channelID, teamID);
+
+        const creq = createCallRequest(call, context, expand, values);
+
+        const res = await dispatch(doAppSubmit(creq, intlShim)) as DoAppCallResult;
+
+        if (res.error) {
+            const errorResponse = res.error;
             dispatch({
                 type: ActionTypes.INSTALLING_MARKETPLACE_ITEM_FAILED,
                 id,
-                error: result.error.message,
+                error: errorResponse.text,
             });
             return false;
         }
@@ -168,6 +170,16 @@ export function installApp(id: string) {
             type: ActionTypes.INSTALLING_MARKETPLACE_ITEM_SUCCEEDED,
             id,
         });
+
+        const callResp = res.data!;
+        if (callResp.type === AppCallResponseTypes.FORM && callResp.form) {
+            dispatch(openAppsModal(callResp.form, creq.context));
+        }
+
+        if (callResp.text) {
+            dispatch(postEphemeralCallResponseForContext(callResp, callResp.text, context));
+        }
+
         return true;
     };
 }

--- a/packages/types/src/apps.ts
+++ b/packages/types/src/apps.ts
@@ -140,7 +140,7 @@ export type AppContextProps = {
     [name: string]: string;
 };
 
-export type AppExpandLevel = string;
+export type AppExpandLevel = 'all' | 'summary' | '+all' | '+summary';
 
 export type AppExpand = {
     app?: AppExpandLevel;
@@ -153,6 +153,7 @@ export type AppExpand = {
     root_post?: AppExpandLevel;
     team?: AppExpandLevel;
     user?: AppExpandLevel;
+    locale?: AppExpandLevel;
 };
 
 export type AppForm = {


### PR DESCRIPTION
#### Summary

As we are transitioning to support HTTP apps in Cloud servers, we need to have a consistent install path across all environments.

At the moment, the frontend has conditional logic of how to install marketplace apps. This PR makes it so the App framework can instead have this logic.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-49585

```release-note
NONE
```