### PR TITLE
[MM-50007] WorkTemplate: disable "private" button when a template contains a playbook without an enterprise license

### DIFF
--- a/components/work_templates/components/customize.tsx
+++ b/components/work_templates/components/customize.tsx
@@ -4,18 +4,21 @@
 import React, {useEffect} from 'react';
 import styled from 'styled-components';
 import {useIntl} from 'react-intl';
+import {useSelector} from 'react-redux';
 
 import PublicPrivateSelector from 'components/widgets/public-private-selector/public-private-selector';
 import {trackEvent} from 'actions/telemetry_actions';
 import Constants, {TELEMETRY_CATEGORIES} from 'utils/constants';
+import {isEnterpriseOrE20License} from 'utils/license_utils';
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
-import {Visibility} from '@mattermost/types/work_templates';
+import {Visibility, WorkTemplate} from '@mattermost/types/work_templates';
 import {ChannelType} from '@mattermost/types/channels';
-
 export interface CustomizeProps {
     className?: string;
     name: string;
     visibility: Visibility;
+    template: WorkTemplate;
 
     onNameChanged: (name: string) => void;
     onVisibilityChanged: (visibility: Visibility) => void;
@@ -24,11 +27,15 @@ export interface CustomizeProps {
 const Customize = ({
     name,
     visibility,
+    template,
     onNameChanged,
     onVisibilityChanged,
     ...props
 }: CustomizeProps) => {
     const {formatMessage} = useIntl();
+    const license = useSelector(getLicense);
+    const licenseIsEnterprise = isEnterpriseOrE20License(license);
+    const templateHasPlaybooks = template.content.findIndex((item) => item.playbook) !== -1;
 
     useEffect(() => {
         trackEvent(TELEMETRY_CATEGORIES.WORK_TEMPLATES, 'pageview_customize');
@@ -38,6 +45,17 @@ const Customize = ({
     const onPrivacySelectorChanged = (value: ChannelType) => {
         onVisibilityChanged(value === Constants.PRIVATE_CHANNEL ? Visibility.Private : Visibility.Public);
     };
+
+    let privateButtonProps = {};
+    if (templateHasPlaybooks && !licenseIsEnterprise) {
+        if (visibility === Visibility.Private) {
+            onVisibilityChanged(Visibility.Public);
+        }
+        privateButtonProps = {
+            tooltip: formatMessage({id: 'work_templates.customize.visibility_private_tooltip', defaultMessage: 'Private playbooks requires an Enterprise license.'}),
+            locked: true,
+        };
+    }
 
     return (
         <div className={props.className}>
@@ -67,6 +85,7 @@ const Customize = ({
                 <PublicPrivateSelector
                     selected={privacySelectorValue}
                     onChange={onPrivacySelectorChanged}
+                    privateButtonProps={privateButtonProps}
                 />
             </div>
         </div>
@@ -78,16 +97,6 @@ const StyledCustomized = styled(Customize)`
     flex-direction: column;
     width: 509px;
     margin: 0 auto;
-
-    .public-private-selector {
-        flex-direction: column;
-        &-button {
-            margin-bottom: 8px;
-            &:not(:first-child) {
-                margin-left: 0px;
-            }
-        }
-    }
 
     strong {
         font-weight: 600;

--- a/components/work_templates/components/customize.tsx
+++ b/components/work_templates/components/customize.tsx
@@ -52,7 +52,7 @@ const Customize = ({
             onVisibilityChanged(Visibility.Public);
         }
         privateButtonProps = {
-            tooltip: formatMessage({id: 'work_templates.customize.visibility_private_tooltip', defaultMessage: 'Private playbooks requires an Enterprise license.'}),
+            tooltip: formatMessage({id: 'work_templates.customize.private_playbook_license_issue', defaultMessage: 'Private playbooks requires an Enterprise license.'}),
             locked: true,
         };
     }
@@ -97,6 +97,12 @@ const StyledCustomized = styled(Customize)`
     flex-direction: column;
     width: 509px;
     margin: 0 auto;
+
+    .public-private-selector {
+        &-button.locked {
+            opacity: 1;
+        }
+    }
 
     strong {
         font-weight: 600;

--- a/components/work_templates/index.tsx
+++ b/components/work_templates/index.tsx
@@ -292,6 +292,7 @@ const WorkTemplateModal = () => {
                     visibility={selectedVisibility}
                     onNameChanged={handleOnNameChanged}
                     onVisibilityChanged={handleOnVisibilityChanged}
+                    template={selectedTemplate}
                 />
             )}
         </GenericModal>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5577,6 +5577,7 @@
   "work_templates.customize.name_description": "This will help you and others find your project items. You can always edit this later.",
   "work_templates.customize.name_input_placeholder": "e.g. Web app, Growth, etc.",
   "work_templates.customize.name_title": "What project is this for?",
+  "work_templates.customize.private_playbook_license_issue": "Private playbooks requires an Enterprise license.",
   "work_templates.customize.visibility_title": "Who should have access to this?",
   "work_templates.menu.modal_title": "Create a work template",
   "work_templates.menu.quick_use": "Quick use",


### PR DESCRIPTION
#### Summary
Block the "Private" button if the template contains a playbook and the server license is not E20 or Enterprise.

Also, the design has this selector showing the buttons side-by-side (they were on top of each other so far), so I changed the UI to match what is on figma.

##### QA script

- On a new server with no license
- Open work templates
- Go to the last page of the first template
- the private button is disabled and has a tooltip explaining that you need an enterprise license
- Upload an enterprise license (or start a trial)
- Open work templates
- Go to the last page of the first template
- the private button is available.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50007

#### Related Pull Requests
![image](https://user-images.githubusercontent.com/785518/215154325-5d8ee17a-c2b5-4968-a33f-abc7806c1c08.png)

#### Release Note
```release-note
NONE
```
