### PR TITLE
Add link to true-up review documentation

### DIFF
--- a/components/analytics/true_up_review.tsx
+++ b/components/analytics/true_up_review.tsx
@@ -175,7 +175,7 @@ const TrueUpReview: React.FC = () => {
             {dueDate}
             <FormattedMessage
                 id='admin.billing.trueUpReview.share_data_for_review'
-                defaultMessage='Share your system statistic with Mattermost for your quarterly true-up Review. {link}'
+                defaultMessage='Share your system statistics with Mattermost for your quarterly true-up Review. {link}'
                 values={{
                     link: trueUpDocsLink,
                 }}

--- a/components/analytics/true_up_review.tsx
+++ b/components/analytics/true_up_review.tsx
@@ -31,7 +31,7 @@ import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/user
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import store from 'stores/redux_store.jsx';
 import {pageVisited} from 'actions/telemetry_actions';
-import {TELEMETRY_CATEGORIES} from 'utils/constants';
+import {DocLinks, TELEMETRY_CATEGORIES} from 'utils/constants';
 import {getIsStarterLicense} from 'utils/license_utils';
 
 const TrueUpReview: React.FC = () => {
@@ -157,12 +157,28 @@ const TrueUpReview: React.FC = () => {
         </>
     );
 
+    const trueUpDocsLink = (
+        <a
+            href={DocLinks.TRUE_UP_REVIEW}
+            target='_blank'
+            rel='noreferrer'
+        >
+            <FormattedMessage
+                id='admin.billing.trueUpReview.docsLinkCTA'
+                defaultMessage='Learn more about true-up here.'
+            />
+        </a>
+    );
+
     const reviewDetails = (
         <>
             {dueDate}
             <FormattedMessage
                 id='admin.billing.trueUpReview.share_data_for_review'
-                defaultMessage='Share the below workspace data with Mattermost for your quarterly true-up Review.'
+                defaultMessage='Share your system statistic with Mattermost for your quarterly true-up Review. {link}'
+                values={{
+                    link: trueUpDocsLink,
+                }}
             />
             {submitButton}
         </>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -420,7 +420,7 @@
   "admin.billing.trueUpReview.button_share": "Share to Mattermost",
   "admin.billing.trueUpReview.docsLinkCTA": "Learn more about true-up here.",
   "admin.billing.trueUpReview.due_date": "Due ",
-  "admin.billing.trueUpReview.share_data_for_review": "Share your system statistic with Mattermost for your quarterly true-up Review. {link}",
+  "admin.billing.trueUpReview.share_data_for_review": "Share your system statistics with Mattermost for your quarterly true-up Review. {link}",
   "admin.billing.trueUpReview.submit_error": "There was an issue sending your True Up Review. Please try again.",
   "admin.billing.trueUpReview.submit_success": "Success!",
   "admin.billing.trueUpReview.submit.thanks_for_sharing": "Thanks for sharing data needed for your true-up review.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -418,6 +418,7 @@
   "admin.billing.subscriptions.billing_summary.upgrade_professional.cta": "Upgrade",
   "admin.billing.trueUpReview.button_download": "Download Data",
   "admin.billing.trueUpReview.button_share": "Share to Mattermost",
+  "admin.billing.trueUpReview.docsLinkCTA": "Learn more about true-up here.",
   "admin.billing.trueUpReview.due_date": "Due ",
   "admin.billing.trueUpReview.share_data_for_review": "Share the below workspace data with Mattermost for your quarterly true-up Review.",
   "admin.billing.trueUpReview.submit_error": "There was an issue sending your True Up Review. Please try again.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -420,7 +420,7 @@
   "admin.billing.trueUpReview.button_share": "Share to Mattermost",
   "admin.billing.trueUpReview.docsLinkCTA": "Learn more about true-up here.",
   "admin.billing.trueUpReview.due_date": "Due ",
-  "admin.billing.trueUpReview.share_data_for_review": "Share the below workspace data with Mattermost for your quarterly true-up Review.",
+  "admin.billing.trueUpReview.share_data_for_review": "Share your system statistic with Mattermost for your quarterly true-up Review. {link}",
   "admin.billing.trueUpReview.submit_error": "There was an issue sending your True Up Review. Please try again.",
   "admin.billing.trueUpReview.submit_success": "Success!",
   "admin.billing.trueUpReview.submit.thanks_for_sharing": "Thanks for sharing data needed for your true-up review.",

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1075,6 +1075,7 @@ export const DocLinks = {
     UPGRADE_SERVER: 'https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html',
     ONBOARD_LDAP: 'https://docs.mattermost.com/onboard/ad-ldap.html',
     ONBOARD_SSO: 'https://docs.mattermost.com/onboard/sso-saml.html',
+    TRUE_UP_REVIEW: 'https://mattermost.com/pl/true-up-documentation',
 };
 
 export const LicenseLinks = {


### PR DESCRIPTION
#### Summary

The True Up Review panel in the system console had no information or instruction on how to perform a quarterly true-up review.

Figma: https://www.figma.com/file/1qWr4RtBjwQZyGQMT7z9Jp/True-Up-Review?node-id=503%3A38649&t=DdEYP8hX03OTYhdy-0

#### Ticket Link

[MM-50030](https://mattermost.atlassian.net/browse/MM-50030)

#### Related Pull Requests

[True-Up Review Docs](https://github.com/mattermost/docs/pull/6191)

#### Screenshots

|  before  |  after  |
|----|----|
| ![before](https://user-images.githubusercontent.com/116016004/215187061-c655cfe9-244b-4846-b70f-d73e0fbdec23.png) | ![after](https://user-images.githubusercontent.com/116016004/215186892-286567cd-b798-49c3-b041-2cb4eb024d9e.png) |

#### Release Note

```release-note
NONE
```


[MM-50030]: https://mattermost.atlassian.net/browse/MM-50030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ