### PR TITLE
Removed unused eslint-disables for no-string-refs

### DIFF
--- a/components/add_user_to_channel_modal/add_user_to_channel_modal.tsx
+++ b/components/add_user_to_channel_modal/add_user_to_channel_modal.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React, {ChangeEvent, FormEvent} from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
@@ -285,7 +283,6 @@ export default class AddUserToChannelModal extends React.PureComponent<Props, St
                 show={this.state.show}
                 onHide={this.onHide}
                 onExited={this.onExited}
-                ref='modal'
                 enforceFocus={true}
                 role='dialog'
                 aria-labelledby='addChannelModalLabel'
@@ -349,4 +346,3 @@ export default class AddUserToChannelModal extends React.PureComponent<Props, St
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/admin_console/file_upload_setting.jsx
+++ b/components/admin_console/file_upload_setting.jsx
@@ -128,4 +128,3 @@ export default class FileUploadSetting extends Setting {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/admin_console/license_settings/license_settings.tsx
+++ b/components/admin_console/license_settings/license_settings.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable react/no-string-refs */
-/* eslint-disable header/header */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 import React from 'react';
 
 import {ClientLicense} from '@mattermost/types/config';
@@ -423,4 +423,3 @@ export default class LicenseSettings extends React.PureComponent<Props, State> {
         return null;
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/admin_console/manage_roles_modal/manage_roles_modal.tsx
+++ b/components/admin_console/manage_roles_modal/manage_roles_modal.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';

--- a/components/admin_console/password_settings.jsx
+++ b/components/admin_console/password_settings.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
@@ -287,4 +285,3 @@ export default class PasswordSettings extends AdminSettings {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/admin_console/plugin_management/plugin_management.tsx
+++ b/components/admin_console/plugin_management/plugin_management.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
@@ -1266,4 +1264,3 @@ export default class PluginManagement extends AdminSettings<Props, State> {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/admin_console/push_settings.jsx
+++ b/components/admin_console/push_settings.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -1214,4 +1214,3 @@ export default class SchemaAdminSettings extends React.PureComponent {
         );
     }
 }
-/* eslint-disable react/no-string-refs */

--- a/components/admin_console/system_user_detail/system_user_detail.tsx
+++ b/components/admin_console/system_user_detail/system_user_detail.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 import {Redirect, RouteComponentProps} from 'react-router-dom';
 import {FormattedMessage} from 'react-intl';
@@ -495,4 +493,3 @@ export default class SystemUserDetail extends React.PureComponent<Props & RouteC
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/analytics/doughnut_chart.tsx
+++ b/components/analytics/doughnut_chart.tsx
@@ -87,4 +87,3 @@ export default class DoughnutChart extends React.PureComponent<Props> {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/analytics/line_chart.tsx
+++ b/components/analytics/line_chart.tsx
@@ -159,4 +159,3 @@ export default class LineChart extends React.PureComponent<Props> {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/channel_notifications_modal/channel_notifications_modal.tsx
+++ b/components/channel_notifications_modal/channel_notifications_modal.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import deepEqual from 'fast-deep-equal';
 import React from 'react';
 import {Modal} from 'react-bootstrap';

--- a/components/create_team/components/display_name.tsx
+++ b/components/create_team/components/display_name.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
@@ -157,4 +155,3 @@ export default class TeamSignupDisplayNamePage extends React.PureComponent<Props
         );
     }
 }
-/* eslint-disable react/no-string-refs */

--- a/components/create_team/components/team_url/team_url.tsx
+++ b/components/create_team/components/team_url/team_url.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 import {Button} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
@@ -315,4 +313,3 @@ export default class TeamUrl extends React.PureComponent<Props, State> {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/file_preview/file_preview.tsx
+++ b/components/file_preview/file_preview.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React, {ReactNode} from 'react';
 
 import {getFileThumbnailUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
@@ -143,4 +141,3 @@ export default class FilePreview extends React.PureComponent<Props> {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/file_preview_modal/popover_bar/popover_bar.tsx
+++ b/components/file_preview_modal/popover_bar/popover_bar.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import debounce from 'lodash/debounce';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';

--- a/components/multiselect/multiselect_list.tsx
+++ b/components/multiselect/multiselect_list.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 
 import {getOptionValue} from 'react-select/src/builtins';
@@ -247,5 +245,3 @@ export default class MultiSelectList<T extends Value> extends React.PureComponen
         );
     }
 }
-
-/* eslint-enable react/no-string-refs */

--- a/components/post_view/embedded_bindings/embedded_binding/embedded_binding.tsx
+++ b/components/post_view/embedded_bindings/embedded_binding/embedded_binding.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React, {CSSProperties} from 'react';
 
 import {AppBinding} from '@mattermost/types/apps';

--- a/components/post_view/message_attachments/message_attachment/message_attachment.tsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React, {CSSProperties} from 'react';
 import truncate from 'lodash/truncate';
 

--- a/components/post_view/reaction_list/reaction_list.tsx
+++ b/components/post_view/reaction_list/reaction_list.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
@@ -214,4 +212,3 @@ export default class ReactionList extends React.PureComponent<Props, State> {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/post_view/show_more/show_more.tsx
+++ b/components/post_view/show_more/show_more.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React from 'react';
 
 import {localizeMessage} from 'utils/utils';
@@ -194,4 +192,3 @@ export default class ShowMore extends React.PureComponent<Props, State> {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';

--- a/components/team_general_tab/team_general_tab.tsx
+++ b/components/team_general_tab/team_general_tab.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
-
 import React, {ChangeEvent, MouseEvent, ReactNode} from 'react';
 import {FormattedMessage, FormattedDate} from 'react-intl';
 

--- a/components/user_settings/advanced/user_settings_advanced.tsx
+++ b/components/user_settings/advanced/user_settings_advanced.tsx
@@ -909,8 +909,6 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
                     </button>
                     <h4
                         className='modal-title'
-                        // eslint-disable-next-line react/no-string-refs
-                        ref='title'
                     >
                         <div className='modal-back'>
                             <span onClick={this.props.collapseModal}>
@@ -961,4 +959,3 @@ export default class AdvancedSettingsDisplay extends React.PureComponent<Props, 
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/user_settings/display/user_settings_display.tsx
+++ b/components/user_settings/display/user_settings_display.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 /* eslint-disable max-lines */
-/* eslint-disable react/no-string-refs */
 
 import React from 'react';
 

--- a/components/user_settings/general/user_settings_general.tsx
+++ b/components/user_settings/general/user_settings_general.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable react/no-string-refs */
 /* eslint-disable max-lines */
 
 import React from 'react';

--- a/components/user_settings/security/user_access_token_section/user_access_token_section.tsx
+++ b/components/user_settings/security/user_access_token_section/user_access_token_section.tsx
@@ -670,4 +670,3 @@ export default class UserAccessTokenSection extends React.PureComponent<Props, S
         );
     }
 }
-/* eslint-enable react/no-string-refs */


### PR DESCRIPTION
We had an old campaign to remove all usage of string refs from the app. That was almost entirely done, but we never went back and removed the exceptions from files that would stop ESLint from erroring out on files that hadn't been cleaned up yet. This does that

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26304

#### Release Note
```release-note
NONE
```
