### PR TITLE
[MM-33593] Inconsistent styling of modal headers in the system console

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -1105,20 +1105,6 @@
         }
     }
 
-    .modal-header {
-        background: $black;
-        color: $white;
-
-        .close {
-            color: $white;
-            opacity: 1;
-
-            &:hover {
-                opacity: 1;
-            }
-        }
-    }
-
     .modal-body {
         padding: 15px 0;
 


### PR DESCRIPTION
#### Summary
The modal header was overridden maybe for the early stages of modals but is now unnecessary for maintaining consistency.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33593

#### Related Pull Requests
N/A

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="678" alt="image" src="https://user-images.githubusercontent.com/684680/215471074-a09fd6f1-1805-4931-b9c6-16ae1f656e31.png"> | <img width="678" alt="image" src="https://user-images.githubusercontent.com/684680/215470573-5a6fdd15-8dec-480c-aa54-8ba1085dc925.png"> |

#### Release Note
```release-note
NONE
```
