### PR TITLE
[MM-50059] Remove experimental warning about apps

### DIFF
--- a/packages/client/src/client4.ts
+++ b/packages/client/src/client4.ts
@@ -260,9 +260,6 @@ export default class Client4 {
         return `${this.url}${this.urlVersion}`;
     }
 
-    // This function belongs to the Apps Framework feature.
-    // Apps Framework feature is experimental, and this function is susceptible
-    // to breaking changes without pushing the major version of this package.
     getAppsProxyRoute() {
         return `${this.url}/plugins/com.mattermost.apps`;
     }
@@ -3428,7 +3425,7 @@ export default class Client4 {
         );
     };
 
-    // Plugin Routes - EXPERIMENTAL - SUBJECT TO CHANGE
+    // Plugin Routes
 
     uploadPlugin = async (fileData: File, force = false) => {
         this.trackEvent('api', 'api_plugin_upload');
@@ -3491,9 +3488,6 @@ export default class Client4 {
         );
     }
 
-    // This function belongs to the Apps Framework feature.
-    // Apps Framework feature is experimental, and this function is susceptible
-    // to breaking changes without pushing the major version of this package.
     getMarketplaceApps = (filter: string) => {
         return this.doFetch<MarketplaceApp[]>(
             `${this.getAppsProxyRoute()}/api/v1/marketplace${buildQueryString({filter: filter || ''})}`,
@@ -3678,9 +3672,6 @@ export default class Client4 {
         );
     }
 
-    // This function belongs to the Apps Framework feature.
-    // Apps Framework feature is experimental, and this function is susceptible
-    // to breaking changes without pushing the major version of this package.
     executeAppCall = async (call: AppCallRequest, trackAsSubmit: boolean) => {
         const callCopy: AppCallRequest = {
             ...call,
@@ -3696,9 +3687,6 @@ export default class Client4 {
         );
     }
 
-    // This function belongs to the Apps Framework feature.
-    // Apps Framework feature is experimental, and this function is susceptible
-    // to breaking changes without pushing the major version of this package.
     getAppsBindings = async (userID: string, channelID: string, teamID: string) => {
         const params = {
             user_id: userID,

--- a/packages/mattermost-redux/src/action_types/apps.ts
+++ b/packages/mattermost-redux/src/action_types/apps.ts
@@ -3,9 +3,6 @@
 
 import keyMirror from 'mattermost-redux/utils/key_mirror';
 
-// This file's contents belong to the Apps Framework feature.
-// Apps Framework feature is experimental, and the contents of this file are
-// susceptible to breaking changes without pushing the major version of this package.
 export default keyMirror({
     RECEIVED_APP_BINDINGS: null,
     FAILED_TO_FETCH_APP_BINDINGS: null,

--- a/packages/mattermost-redux/src/actions/apps.ts
+++ b/packages/mattermost-redux/src/actions/apps.ts
@@ -12,10 +12,6 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 
 import {bindClientFunc} from './helpers';
 
-// This file's contents belong to the Apps Framework feature.
-// Apps Framework feature is experimental, and the contents of this file are
-// susceptible to breaking changes without pushing the major version of this package.
-
 export function fetchAppBindings(channelID: string): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         if (!channelID) {

--- a/packages/mattermost-redux/src/constants/apps.ts
+++ b/packages/mattermost-redux/src/constants/apps.ts
@@ -3,10 +3,6 @@
 
 import {AppCallResponseType, AppExpandLevel, AppFieldType} from '@mattermost/types/apps';
 
-// This file's contents belong to the Apps Framework feature.
-// Apps Framework feature is experimental, and the contents of this file are
-// susceptible to breaking changes without pushing the major version of this package.
-
 export const AppBindingLocations = {
     POST_MENU_ITEM: '/post_menu',
     CHANNEL_HEADER_ICON: '/channel_header',

--- a/packages/mattermost-redux/src/reducers/entities/apps.ts
+++ b/packages/mattermost-redux/src/reducers/entities/apps.ts
@@ -8,10 +8,6 @@ import {AppBinding, AppCommandFormMap, AppsState} from '@mattermost/types/apps';
 import {GenericAction} from 'mattermost-redux/types/actions';
 import {validateBindings} from 'mattermost-redux/utils/apps';
 
-// This file's contents belong to the Apps Framework feature.
-// Apps Framework feature is experimental, and the contents of this file are
-// susceptible to breaking changes without pushing the major version of this package.
-
 export function mainBindings(state: AppBinding[] = [], action: GenericAction): AppBinding[] {
     switch (action.type) {
     case AppsTypes.FAILED_TO_FETCH_APP_BINDINGS: {

--- a/packages/mattermost-redux/src/selectors/entities/apps.ts
+++ b/packages/mattermost-redux/src/selectors/entities/apps.ts
@@ -10,10 +10,6 @@ import {ClientConfig} from '@mattermost/types/config';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {AppBindingLocations} from 'mattermost-redux/constants/apps';
 
-// This file's contents belong to the Apps Framework feature.
-// Apps Framework feature is experimental, and the contents of this file are
-// susceptible to breaking changes without pushing the major version of this package.
-
 export const appsPluginIsEnabled = (state: GlobalState) => state.entities.apps.pluginEnabled;
 
 export const appsFeatureFlagEnabled = createSelector(

--- a/packages/mattermost-redux/src/utils/marketplace.ts
+++ b/packages/mattermost-redux/src/utils/marketplace.ts
@@ -3,9 +3,6 @@
 
 import {MarketplaceApp, MarketplacePlugin} from '@mattermost/types/marketplace';
 
-// This file's contents belong to the Apps Framework feature.
-// Apps Framework feature is experimental, and the contents of this file are
-// susceptible to breaking changes without pushing the major version of this package.
 export function isPlugin(item: MarketplacePlugin | MarketplaceApp): item is MarketplacePlugin {
     return (item as MarketplacePlugin).manifest.id !== undefined;
 }

--- a/packages/types/src/apps.ts
+++ b/packages/types/src/apps.ts
@@ -3,10 +3,6 @@
 
 import {ProductScope} from './products';
 
-// This file's contents belong to the Apps Framework feature.
-// Apps Framework feature is experimental, and the contents of this file are
-// susceptible to breaking changes without pushing the major version of this package.
-
 export enum Permission {
     UserJoinedChannelNotification = 'user_joined_channel_notification',
     ActAsBot = 'act_as_bot',

--- a/packages/types/src/marketplace.ts
+++ b/packages/types/src/marketplace.ts
@@ -1,9 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// This file's contents belong to the Apps Framework feature.
-// Apps Framework feature is experimental, and the contents of this file are
-// susceptible to breaking changes without pushing the major version of this package.
 import {PluginManifest} from './plugins';
 import {AppManifest} from './apps';
 


### PR DESCRIPTION
#### Summary
Apps are no longer marked as experimental. The codebase should reflect that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50059

#### Release Note
```release-note
NONE
```
