### PR TITLE
[MM-49943 ] Fixing initial load for insights types on free tier

### DIFF
--- a/components/activity_and_insights/insights/hooks.ts
+++ b/components/activity_and_insights/insights/hooks.ts
@@ -7,7 +7,11 @@ import {getCloudSubscription, getSubscriptionProduct} from 'mattermost-redux/sel
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import {isCloudLicense} from 'utils/license_utils';
-import {CloudProducts} from 'utils/constants';
+import {CloudProducts, InsightsScopes} from 'utils/constants';
+
+import {setGlobalItem} from 'actions/storage';
+
+import {useGlobalState} from 'stores/hooks';
 
 /**
  * Returns some checks for free trial users or starter licenses
@@ -34,4 +38,21 @@ export function useLicenseChecks(): {isStarterFree: boolean; isFreeTrial: boolea
         isFreeTrial,
         isEnterpriseReady,
     };
+}
+
+export function useGetFilterType(): [string, (value: string) => ReturnType<typeof setGlobalItem>] {
+    const {isStarterFree, isEnterpriseReady} = useLicenseChecks();
+    const [filterType, setFilterType] = useGlobalState(InsightsScopes.TEAM, 'insightsScope');
+
+    let returnedFilterType = filterType;
+
+    // Force MY Insights for free trial users
+    if (isStarterFree || !isEnterpriseReady) {
+        returnedFilterType = InsightsScopes.MY;
+    }
+
+    return [
+        returnedFilterType,
+        setFilterType,
+    ];
 }

--- a/components/activity_and_insights/insights/insights.tsx
+++ b/components/activity_and_insights/insights/insights.tsx
@@ -30,7 +30,7 @@ import LeastActiveChannels from './least_active_channels/least_active_channels';
 import TopPlaybooks from './top_playbooks/top_playbooks';
 import TopDMsAndNewMembers from './top_dms_and_new_members/top_dms_and_new_members';
 
-import {useLicenseChecks} from './hooks';
+import {useGetFilterType} from './hooks';
 
 import './../activity_and_insights.scss';
 
@@ -55,9 +55,8 @@ const Insights = () => {
     const currentUserId = useSelector(getCurrentUserId);
     const currentTeamId = useSelector(getCurrentTeamId);
 
-    const [filterType, setFilterType] = useGlobalState(InsightsScopes.TEAM, 'insightsScope');
+    const [filterType, setFilterType] = useGetFilterType();
     const [timeFrame, setTimeFrame] = useGlobalState(TimeFrames.INSIGHTS_7_DAYS as string, 'insightsTimeFrame');
-    const {isStarterFree, isEnterpriseReady} = useLicenseChecks();
 
     const setFilterTypeTeam = useCallback(() => {
         trackEvent('insights', 'change_scope_to_team_insights');
@@ -81,10 +80,6 @@ const Insights = () => {
         if (penultimateType !== PreviousViewedTypes.INSIGHTS) {
             LocalStorageStore.setPenultimateViewedType(currentUserId, currentTeamId, penultimateType);
             LocalStorageStore.setPreviousViewedType(currentUserId, currentTeamId, PreviousViewedTypes.INSIGHTS);
-        }
-
-        if (isStarterFree || !isEnterpriseReady) {
-            setFilterType(InsightsScopes.MY);
         }
 
         return () => {


### PR DESCRIPTION
#### Summary
When you are on free tier the initial load for insights will request from team insights before fixing itself and getting my insights on second render. This fix just pins the filter type to `My insights` in order to avoid the failed requests

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49943

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
