### PR TITLE
[MM-50079] Reset name and set default visibility

### DIFF
--- a/components/work_templates/index.tsx
+++ b/components/work_templates/index.tsx
@@ -147,6 +147,10 @@ const WorkTemplateModal = () => {
             return;
         }
 
+        // clear the name and set default visibility
+        setSelectedName('');
+        setSelectedVisibility(template.visibility);
+
         trackEvent(TELEMETRY_CATEGORIES.WORK_TEMPLATES, 'select_template', {category: template.category, template: template.id});
         setModalState(ModalState.Preview);
     };


### PR DESCRIPTION
#### Summary
When a user select a new work template, reset the name and visibility.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50079

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
