### PR TITLE
[MM-50077] Race condition on work template execution

### DIFF
--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -11,7 +11,6 @@ import * as Actions from 'actions/views/channel';
 import {closeRightHandSide} from 'actions/views/rhs';
 import mockStore from 'tests/test_store';
 import {ActionTypes, PostRequestTypes} from 'utils/constants';
-import {ChannelTypes} from 'mattermost-redux/action_types';
 
 jest.mock('utils/channel_utils.tsx', () => {
     const original = jest.requireActual('utils/channel_utils.tsx');

--- a/actions/views/channel.ts
+++ b/actions/views/channel.ts
@@ -12,6 +12,7 @@ import {
     markChannelAsRead,
     unfavoriteChannel,
     deleteChannel as deleteChannelRedux,
+    getChannel as loadChannel,
 } from 'mattermost-redux/actions/channels';
 import * as PostActions from 'mattermost-redux/actions/posts';
 import {TeamTypes} from 'mattermost-redux/action_types';
@@ -93,6 +94,18 @@ export function switchToChannelById(channelId: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const channel = getChannel(state, channelId);
+        return dispatch(switchToChannel(channel));
+    };
+}
+
+export function loadIfNecessaryAndSwitchToChannelById(channelId: string) {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
+        let channel = getChannel(state, channelId);
+        if (!channel) {
+            const res = await dispatch(loadChannel(channelId));
+            channel = res.data;
+        }
         return dispatch(switchToChannel(channel));
     };
 }

--- a/components/work_templates/index.tsx
+++ b/components/work_templates/index.tsx
@@ -25,7 +25,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {fetchRemoteListing} from 'actions/marketplace';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {ActionResult} from 'mattermost-redux/types/actions';
-import {switchToChannelById} from 'actions/views/channel';
+import {loadIfNecessaryAndSwitchToChannelById, switchToChannelById} from 'actions/views/channel';
 
 import Customize from './components/customize';
 import Menu from './components/menu';
@@ -204,7 +204,7 @@ const WorkTemplateModal = () => {
             firstChannelId = data.channel_ids[0];
         }
         if (firstChannelId) {
-            dispatch(switchToChannelById(firstChannelId));
+            dispatch(loadIfNecessaryAndSwitchToChannelById(firstChannelId));
         }
         closeModal();
     };

--- a/components/work_templates/index.tsx
+++ b/components/work_templates/index.tsx
@@ -25,7 +25,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {fetchRemoteListing} from 'actions/marketplace';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {ActionResult} from 'mattermost-redux/types/actions';
-import {loadIfNecessaryAndSwitchToChannelById, switchToChannelById} from 'actions/views/channel';
+import {loadIfNecessaryAndSwitchToChannelById} from 'actions/views/channel';
 
 import Customize from './components/customize';
 import Menu from './components/menu';


### PR DESCRIPTION
#### Summary
Sometimes we try to redirect the user to a newly created channel before the webapp is aware of it (websocket not processed yet). To fix this I added a method that will load the channel using the API if it's not already loaded before switching to the channel.

I did not change the existing method for BC reasons.

For QA it might get difficult, knowing that it was happening fairly rarely and there was not way to reproduce 100%. So I can try to create a bunch and make sure you are redirect to a new channel every time? 😓

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50077

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
