### PR TITLE
team edition should not try to contact portal

### DIFF
--- a/components/common/hooks/useCWSAvailabilityCheck.ts
+++ b/components/common/hooks/useCWSAvailabilityCheck.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {useEffect, useState} from 'react';
-import {useSelector} from 'react-redux'
+import {useSelector} from 'react-redux';
 
 import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -13,7 +13,7 @@ export default function useCWSAvailabilityCheck() {
     const isEnterpriseReady = config.BuildEnterpriseReady === 'true';
     useEffect(() => {
         if (!isEnterpriseReady) {
-            return
+            return;
         }
         Client4.cwsAvailabilityCheck().then(() => setCanReachCWS(true));
     }, [isEnterpriseReady]);

--- a/components/common/hooks/useCWSAvailabilityCheck.ts
+++ b/components/common/hooks/useCWSAvailabilityCheck.ts
@@ -2,14 +2,21 @@
 // See LICENSE.txt for license information.
 
 import {useEffect, useState} from 'react';
+import {useSelector} from 'react-redux'
 
 import {Client4} from 'mattermost-redux/client';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 export default function useCWSAvailabilityCheck() {
     const [canReachCWS, setCanReachCWS] = useState(false);
+    const config = useSelector(getConfig);
+    const isEnterpriseReady = config.BuildEnterpriseReady === 'true';
     useEffect(() => {
+        if (!isEnterpriseReady) {
+            return
+        }
         Client4.cwsAvailabilityCheck().then(() => setCanReachCWS(true));
-    }, []);
+    }, [isEnterpriseReady]);
 
     return canReachCWS;
 }

--- a/components/common/hooks/useCanSelfHostedSignup.ts
+++ b/components/common/hooks/useCanSelfHostedSignup.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {useState, useEffect} from 'react';
-import {useSelector} from 'react-redux'
+import {useSelector} from 'react-redux';
 
 import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -16,7 +16,7 @@ export default function useCanSelfHostedSignup() {
     const isEnterpriseReady = config.BuildEnterpriseReady === 'true';
     useEffect(() => {
         if (!isEnterpriseReady) {
-            return
+            return;
         }
         Client4.getAvailabilitySelfHostedSignup().then(() => setCanReachPortal(true));
     }, [isEnterpriseReady]);

--- a/components/common/hooks/useCanSelfHostedSignup.ts
+++ b/components/common/hooks/useCanSelfHostedSignup.ts
@@ -2,17 +2,24 @@
 // See LICENSE.txt for license information.
 
 import {useState, useEffect} from 'react';
+import {useSelector} from 'react-redux'
 
 import {Client4} from 'mattermost-redux/client';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import useLoadStripe from './useLoadStripe';
 
 export default function useCanSelfHostedSignup() {
     const [canReachPortal, setCanReachPortal] = useState(false);
     const canReachStripe = (useLoadStripe().current);
+    const config = useSelector(getConfig);
+    const isEnterpriseReady = config.BuildEnterpriseReady === 'true';
     useEffect(() => {
+        if (!isEnterpriseReady) {
+            return
+        }
         Client4.getAvailabilitySelfHostedSignup().then(() => setCanReachPortal(true));
-    }, []);
+    }, [isEnterpriseReady]);
 
     return canReachPortal && canReachStripe;
 }


### PR DESCRIPTION
#### Summary
Do not try to check portal availability when not on enterprise edition. Tested locally both that these endpoints are no longer called if on team edition, and that they continue being called correctly if on enterprise edition.

#### Ticket Link
* https://mattermost.atlassian.net/browse/MM-50049
* https://mattermost.atlassian.net/browse/MM-50050

#### Release Note
```release-note
Do not try to check portal availability when not on enterprise edition.
```
