### PR TITLE
MM-11388 Remove space formatting

### DIFF
--- a/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/components/user_settings/notifications/user_settings_notifications.tsx
@@ -299,8 +299,8 @@ export default class NotificationsTab extends React.PureComponent<Props, State> 
         if (checked) {
             const text = this.customMentionsRef.current?.value || '';
 
-            // remove all spaces and split string into individual keys
-            this.setState({customKeys: text.replace(/ /g, ''), customKeysChecked: true});
+            // split string into individual keys
+            this.setState({customKeys: text, customKeysChecked: true});
         } else {
             this.setState({customKeys: '', customKeysChecked: false});
         }


### PR DESCRIPTION
#### Summary
Remove space formatting from words that trigger mentions.
Users may now use  spaces in those custom words

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/22205

 Jira : https://mattermost.atlassian.net/browse/MM-11388

#### Screenshots
![image_2023-02-02_153203524](https://user-images.githubusercontent.com/22036449/216352647-901e2679-e62c-4be8-b9dc-62f069f4495f.png)

## Related Server PR :
https://github.com/mattermost/mattermost-webapp/pull/12125

#### Release Note
```release-note
Added the possibility to use spaces in words that trigger mentions
```
