### PR TITLE
MM-49457 - Add Search Options for Workspace Deletion

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -329,6 +329,8 @@ const AdminDefinition = {
             title_default: 'Subscription',
             searchableStrings: [
                 'admin.billing.subscription.title',
+                'admin.billing.subscription.deleteWorkspaceSection.title',
+                'admin.billing.subscription.deleteWorkspaceModal.deleteButton',
             ],
             schema: {
                 id: 'BillingSubscriptions',

--- a/utils/admin_console_index.tsx
+++ b/utils/admin_console_index.tsx
@@ -94,6 +94,7 @@ export function adminDefinitionsToUrlsAndTexts(adminDefinition: typeof AdminDefi
         adminDefinition.compliance,
         adminDefinition.experimental,
         adminDefinition.products,
+        adminDefinition.billing,
     ];
     for (const section of sections) {
         for (const item of Object.values(section)) {


### PR DESCRIPTION
#### Summary

Adds search options in the System Console to find the delete workspace section.
The possible search terms are:
- Delete Your Workspace
- Delete workspace

These terms allow for partial and full, case-insensitive, text searches.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49457

#### Related Pull Requests

[Workspace Deletion Modal](https://github.com/mattermost/mattermost-webapp/pull/12077)

#### Screenshots

**A search with the phrase "Delete" after merging the delete workspace functionality into these changes**
<img width="1689" alt="Screen Shot 2023-02-02 at 3 32 24 PM" src="https://user-images.githubusercontent.com/116016004/216443107-3c4c47b2-38e0-4e42-a6bf-ba0ec28d403d.png">

**A search with the phrase "your workspace" after merging the delete workspace functionality into these changes**
<img width="1689" alt="Screen Shot 2023-02-02 at 3 35 43 PM" src="https://user-images.githubusercontent.com/116016004/216443738-63212d90-f4f7-4843-8c24-8dc0e2668879.png">

**Same as the above image, but with mixed cases in the search phrase**
<img width="1689" alt="Screen Shot 2023-02-02 at 3 36 27 PM" src="https://user-images.githubusercontent.com/116016004/216443873-21bfa156-3b92-4b22-82ab-f41ad6aa4541.png">


#### Test Plan

1. Navigate to the `System Console`
2. In the left-hand search bar, type one of or a part of the following phrases:
 - "Delete your workspace"
 - "Delete workspace"
 - "your workspace"
 - etc.
3. Ensure the Subscription section is present and that text containing the above phrases has the phrases highlighted, similar to the above screenshots.

#### Release Note

```release-note
NONE
```
