### PR TITLE
Fix Docker images not being built for cloud-* branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ workflows:
               ignore:
                 - master
                 - /^release-.*/
-                - /^cloud-.*/
+                - cloud
       - build-docker:
           context: matterbuild-docker
           requires:
@@ -280,7 +280,7 @@ workflows:
               ignore:
                 - master
                 - /^release-.*/
-                - /^cloud-.*/
+                - cloud
       - test:
           requires:
             - type-check


### PR DESCRIPTION
I can't remember why I decided in https://github.com/mattermost/mattermost-webapp/pull/11626 to treat all branches named `cloud-*` as release branches for this when the server only treats `cloud` itself that way.

This should fix test servers and performance benchmarks for PRs from branches named starting with `cloud-`

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/11626

#### Release Note
```release-note
NONE
```
