### PR TITLE
[OSF] Allows opening the work template modal from a slash command

### DIFF
--- a/actions/command.ts
+++ b/actions/command.ts
@@ -36,10 +36,11 @@ import {GlobalState} from 'types/store';
 
 import {t} from 'utils/i18n';
 import MarketplaceModal from 'components/plugin_marketplace';
-
+import WorkTemplateModal from 'components/work_templates';
 import {haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 import {isMarketplaceEnabled} from 'mattermost-redux/selectors/entities/general';
+import {areWorkTemplatesEnabled} from 'selectors/work_template';
 
 import {doAppSubmit, openAppsModal, postEphemeralCallResponseForCommandArgs} from './apps';
 import {trackEvent} from './telemetry_actions';
@@ -140,6 +141,15 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
 
             dispatch(openModal({modalId: ModalIdentifiers.PLUGIN_MARKETPLACE, dialogType: MarketplaceModal}));
             return {data: true};
+        case '/worktemplate': {
+            const workTemplateEnabled = areWorkTemplatesEnabled(state);
+            if (!workTemplateEnabled) {
+                return {error: {message: localizeMessage('worktemplate_command.disabled', 'Work templates are disabled. Please contact your System Administrator for details.')}};
+            }
+
+            dispatch(openModal({modalId: ModalIdentifiers.WORK_TEMPLATE, dialogType: WorkTemplateModal}));
+            return {data: true};
+        }
         case '/collapse':
         case '/expand':
             dispatch(PostActions.resetEmbedVisibility());

--- a/actions/command.ts
+++ b/actions/command.ts
@@ -141,10 +141,10 @@ export function executeCommand(message: string, args: CommandArgs): ActionFunc {
 
             dispatch(openModal({modalId: ModalIdentifiers.PLUGIN_MARKETPLACE, dialogType: MarketplaceModal}));
             return {data: true};
-        case '/worktemplate': {
+        case '/templates': {
             const workTemplateEnabled = areWorkTemplatesEnabled(state);
             if (!workTemplateEnabled) {
-                return {error: {message: localizeMessage('worktemplate_command.disabled', 'Work templates are disabled. Please contact your System Administrator for details.')}};
+                return {error: {message: localizeMessage('templates_command.disabled', 'Templates are disabled. Please contact your System Administrator for details.')}};
             }
 
             dispatch(openModal({modalId: ModalIdentifiers.WORK_TEMPLATE, dialogType: WorkTemplateModal}));

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4984,6 +4984,7 @@
   "team.button.tooltip": "Ctrl|Alt|{order}",
   "team.button.tooltip.mac": "⌘|⌥|{order}",
   "team.button.unread.ariaLabel": "{teamName} team unread",
+  "templates_command.disabled": "Templates are disabled. Please contact your System Administrator for details.",
   "terms_of_service.agreeButton": "I Agree",
   "terms_of_service.api_error": "Unable to complete the request. If this issue persists, contact your System Administrator.",
   "terms_of_service.disagreeButton": "I Disagree",
@@ -5657,6 +5658,5 @@
   "workspace_limits.teams_limit_reached.view_upgrade_options": "View upgrade options",
   "workspace_limits.upgrade": "Upgrade to avoid {planName} data limits",
   "workspace_limits.upgrade_reasons.free": "{planName} is restricted to {messagesLimit} message history and {storageLimit} file storage. You can delete items to free up space or upgrade to a paid plan.",
-  "worktemplate_command.disabled": "Work templates are disabled. Please contact your System Administrator for details.",
   "yourcomputer": "Your computer"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5657,5 +5657,6 @@
   "workspace_limits.teams_limit_reached.view_upgrade_options": "View upgrade options",
   "workspace_limits.upgrade": "Upgrade to avoid {planName} data limits",
   "workspace_limits.upgrade_reasons.free": "{planName} is restricted to {messagesLimit} message history and {storageLimit} file storage. You can delete items to free up space or upgrade to a paid plan.",
+  "worktemplate_command.disabled": "Work templates are disabled. Please contact your System Administrator for details.",
   "yourcomputer": "Your computer"
 }


### PR DESCRIPTION
#### Summary
Adds a `/templates` command to open the modal.

#### Ticket Link
N/A: OSF 

#### Related Pull Requests
- Has server changes https://github.com/mattermost/mattermost-server/pull/22246

#### Screenshots
![image](https://user-images.githubusercontent.com/785518/216679864-c736808a-c96f-4ea6-868e-8f2692ada0d1.png)

#### Release Note
```release-note
NONE
```
