### PR TITLE
MM-50323 : Autofocus on custom status modal on open

### DIFF
--- a/components/custom_status/custom_status_modal.tsx
+++ b/components/custom_status/custom_status_modal.tsx
@@ -315,7 +315,6 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
 
     return (
         <GenericModal
-            enforceFocus={false}
             onExited={props.onExited}
             modalHeaderText={
                 <FormattedMessage
@@ -383,6 +382,7 @@ const CustomStatusModal: React.FC<Props> = (props: Props) => {
                         tooltipPosition='top'
                         onChange={handleTextChange}
                         placeholder={formatMessage({id: 'custom_status.set_status', defaultMessage: 'Set a status'})}
+                        autoFocus={true}
                     />
                 </div>
                 {showSuggestions && suggestion}

--- a/components/forward_post_modal/forward_post_modal.tsx
+++ b/components/forward_post_modal/forward_post_modal.tsx
@@ -238,7 +238,6 @@ const ForwardPostModal = ({onExited, post, actions}: Props) => {
             className='a11y__modal forward-post'
             id='forward-post-modal'
             show={true}
-            enforceFocus={false}
             autoCloseOnConfirmButton={false}
             compassDesign={true}
             modalHeaderText={formatMessage({

--- a/components/tours/crt_tour/collapsed_reply_threads_modal/collapsed_reply_threads_modal.tsx
+++ b/components/tours/crt_tour/collapsed_reply_threads_modal/collapsed_reply_threads_modal.tsx
@@ -69,7 +69,6 @@ function CollapsedReplyThreadsModal(props: Props) {
         <GenericModal
             className='CollapsedReplyThreadsModal productNotices'
             id={ModalIdentifiers.COLLAPSED_REPLY_THREADS_MODAL}
-            enforceFocus={false}
             onExited={props.onExited}
             handleConfirm={onNext}
             autoCloseOnConfirmButton={true}


### PR DESCRIPTION
#### Summary
- Added autofocus on custom stautus modal
- Added focustrap in thread intro modal and forward modal

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50323

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
