### PR TITLE
MM-58280: Don't show the message count for all posts in a thread if CRT is disabled.

### DIFF
--- a/components/post/post_options.tsx
+++ b/components/post/post_options.tsx
@@ -10,17 +10,15 @@ import {isPostEphemeral} from 'mattermost-redux/utils/post_utils';
 
 import {Locations} from 'utils/constants';
 import {isSystemMessage, fromAutoResponder} from 'utils/post_utils';
-import {isMobile} from 'utils/utils';
-
-import {Post} from '@mattermost/types/posts';
-import {Emoji} from '@mattermost/types/emojis';
-
 import ActionsMenu from 'components/actions_menu';
 import DotMenu from 'components/dot_menu';
 import PostFlagIcon from 'components/post_view/post_flag_icon';
 import PostRecentReactions from 'components/post_view/post_recent_reactions';
 import PostReaction from 'components/post_view/post_reaction';
 import CommentIcon from 'components/common/comment_icon';
+
+import {Emoji} from '@mattermost/types/emojis';
+import {Post} from '@mattermost/types/posts';
 
 type Props = {
     post: Post;
@@ -130,8 +128,9 @@ const PostOptions = (props: Props): JSX.Element => {
 
     const isPostDeleted = post && post.state === Posts.POST_DELETED;
     const hoverLocal = props.hover || showEmojiPicker || showDotMenu || showActionsMenu || showActionTip;
-    const showCommentIcon = isFromAutoResponder ||
-    (!systemMessage && (isMobile || hoverLocal || (!post.root_id && Boolean(props.hasReplies)) || props.isFirstReply || props.canReply) && props.location === Locations.CENTER);
+    const showCommentIcon = isFromAutoResponder || (!systemMessage && (isMobileView ||
+            hoverLocal || (!post.root_id && Boolean(props.hasReplies)) ||
+            props.isFirstReply) && props.location === Locations.CENTER);
     const commentIconExtraClass = isMobileView ? '' : 'pull-right';
 
     let commentIcon;
@@ -189,7 +188,7 @@ const PostOptions = (props: Props): JSX.Element => {
     }
 
     // Action menus
-    const showActionsMenuIcon = props.shouldShowActionsMenu && (isMobile || hoverLocal);
+    const showActionsMenuIcon = props.shouldShowActionsMenu && (isMobileView || hoverLocal);
     const actionsMenu = showActionsMenuIcon && (
         <ActionsMenu
             post={post}


### PR DESCRIPTION
#### Summary
Bugfix: Don't show the message count for all posts in a thread if CRT is disabled.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-50280


#### Related Pull Requests
NA

#### Screenshots

|  before  |  after  |
|----|----|
| <img width="1060" alt="Screenshot at Feb 02 10-26-02" src="https://user-images.githubusercontent.com/16203333/216920266-33a9e31d-1a2d-4471-80ed-68bf4f7b2339.png"> | <img width="1481" alt="Screenshot 2023-02-06 at 1 50 02 PM" src="https://user-images.githubusercontent.com/16203333/216920233-ea660798-5f45-4e2b-be29-d7b2125a1747.png"> |


#### Release Note
```release-note
* Don't show the message count for all posts in a thread if CRT is disabled.
```
