### PR TITLE
MM-50078-unable-to-click-the-create-button-after-fixing-the-name-of-the-work-template

### DIFF
--- a/components/work_templates/index.tsx
+++ b/components/work_templates/index.tsx
@@ -119,7 +119,7 @@ const WorkTemplateModal = () => {
     // error resetter
     useEffect(() => {
         setErrorText('');
-    }, [currentCategoryId, modalState, selectedTemplate, selectedVisibility]);
+    }, [currentCategoryId, modalState, selectedTemplate, selectedVisibility, selectedName]);
 
     const changeCategory = (category: Category) => {
         trackEvent(TELEMETRY_CATEGORIES.WORK_TEMPLATES, 'change_category', {category: category.id});
@@ -157,7 +157,6 @@ const WorkTemplateModal = () => {
 
     const handleOnNameChanged = (name: string) => {
         trackEvent(TELEMETRY_CATEGORIES.WORK_TEMPLATES, 'customize_name', {category: selectedTemplate?.category, template: selectedTemplate?.id});
-        setErrorText('');
         setSelectedName(name);
     };
 

--- a/components/work_templates/index.tsx
+++ b/components/work_templates/index.tsx
@@ -157,6 +157,7 @@ const WorkTemplateModal = () => {
 
     const handleOnNameChanged = (name: string) => {
         trackEvent(TELEMETRY_CATEGORIES.WORK_TEMPLATES, 'customize_name', {category: selectedTemplate?.category, template: selectedTemplate?.id});
+        setErrorText('');
         setSelectedName(name);
     };
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
It clears the error message to unblock the create button.
<!--
A description of what this pull request does.
-->

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50078
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
