### PR TITLE
fix: use one loop instead of three loops to hide dividers

### DIFF
--- a/components/widgets/menu/menu.tsx
+++ b/components/widgets/menu/menu.tsx
@@ -61,30 +61,25 @@ export default class Menu extends React.PureComponent<Props> {
         const children = Object.values(this.node.current.children).slice(0, this.node.current.children.length) as HTMLElement[];
 
         // Hiding dividers at beginning and duplicated ones
-        let prevWasDivider = false;
-        let isAtBeginning = true;
-        for (const child of children) {
-            if (child.classList.contains('menu-divider') || child.classList.contains('mobile-menu-divider')) {
-                child.style.display = 'block';
-                if (isAtBeginning || prevWasDivider) {
-                    child.style.display = 'none';
-                }
-                prevWasDivider = true;
-            } else {
-                isAtBeginning = false;
-                prevWasDivider = false;
-            }
-        }
-        children.reverse();
-
-        // Hiding trailing dividers
+        let firstDividerInGroup = null;
+        let hasOnlyDividers = true;
         for (const child of children) {
             if (child.classList.contains('menu-divider') || child.classList.contains('mobile-menu-divider')) {
                 child.style.display = 'none';
+
+                if (!hasOnlyDividers && !firstDividerInGroup) {
+                    firstDividerInGroup = child;
+                }
             } else {
-                break;
+                hasOnlyDividers = false;
+
+                if (firstDividerInGroup) {
+                    firstDividerInGroup.style.display = 'block';
+                    firstDividerInGroup = null;
+                }
             }
         }
+
         this.observer.observe(this.node.current, {attributes: true, childList: true, subtree: true});
     }
 


### PR DESCRIPTION
#### Summary
My changes just reduce the number of loops, so, instead of 3 it's only 1

The logic behind it is hiding all the dividers by default and keep reference to the first one in group, and if any menu element found it'll update the first divider by its reference.

#### Release Note
```release-note
NONE
```
