### PR TITLE
make landing page remember preference label clickable

### DIFF
--- a/components/linking_landing_page/index.tsx
+++ b/components/linking_landing_page/index.tsx
@@ -3,6 +3,8 @@
 
 import {connect} from 'react-redux';
 
+import {injectIntl} from 'react-intl';
+
 import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -26,4 +28,4 @@ function mapStateToProps(state: GlobalState) {
     };
 }
 
-export default connect(mapStateToProps)(LinkingLandingPage);
+export default connect(mapStateToProps)(injectIntl(LinkingLandingPage));

--- a/components/linking_landing_page/linking_landing_page.tsx
+++ b/components/linking_landing_page/linking_landing_page.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {PureComponent} from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, WrappedComponentProps} from 'react-intl';
 
 import desktopImg from 'images/deep-linking/deeplinking-desktop-img.png';
 import mobileImg from 'images/deep-linking/deeplinking-mobile-img.png';
@@ -24,7 +24,7 @@ type Props = {
     siteName?: string;
     brandImageUrl?: string;
     enableCustomBrand: boolean;
-}
+} & WrappedComponentProps
 
 type State = {
     rememberChecked: boolean;
@@ -355,6 +355,8 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
             );
         }
 
+        const {formatMessage} = this.props.intl;
+
         return (
             <div className='get-app__dialog-body'>
                 {this.renderDialogHeader()}
@@ -388,10 +390,12 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
                     >
                         {this.renderCheckboxIcon()}
                     </button>
-                    <FormattedMessage
-                        id='get_app.rememberMyPreference'
-                        defaultMessage='Remember my preference'
-                    />
+                    <span
+                        onClick={this.handleChecked}
+                        className={'get-app__checkbox--label'}
+                    >
+                        {formatMessage({id: 'get_app.rememberMyPreference', defaultMessage: 'Remember my preference'})}
+                    </span>
                 </div>
                 {this.renderDownloadLinkSection()}
             </div>

--- a/sass/routes/_get-app.scss
+++ b/sass/routes/_get-app.scss
@@ -192,6 +192,10 @@
             fill: #145dbf;
         }
     }
+
+    &--label {
+        cursor: pointer;
+    }
 }
 
 .get-app__download-link {


### PR DESCRIPTION
#### Summary
The landing page label at the side of the checkbox is not clickable, forcing to have to point directly to the small checkbox. This PR makes the label clickable so the preference can be clicked easily.

Before:

https://user-images.githubusercontent.com/10082627/217381309-e91dd46a-3100-4d93-8b14-b6d04b8df9b8.mov



After:

https://user-images.githubusercontent.com/10082627/217378184-f154a619-37b5-4c20-bf84-02bf8d43a101.mov



#### Ticket Link
n/a

#### Release notes
```release-note
NONE
```
