### PR TITLE
Fix C# syntax highlighting

### DIFF
--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1791,7 +1791,7 @@ export const Constants = {
         clojure: {name: 'Clojure', extensions: ['clj', 'boot', 'cl2', 'cljc', 'cljs', 'cljs.hl', 'cljscm', 'cljx', 'hic'], aliases: ['clj']},
         coffeescript: {name: 'CoffeeScript', extensions: ['coffee', '_coffee', 'cake', 'cjsx', 'cson', 'iced'], aliases: ['coffee', 'coffee-script']},
         cpp: {name: 'C/C++', extensions: ['cpp', 'c', 'cc', 'h', 'c++', 'h++', 'hpp'], aliases: ['c++', 'c']},
-        cs: {name: 'C#', extensions: ['cs', 'csharp'], aliases: ['c#', 'csharp']},
+        csharp: {name: 'C#', extensions: ['cs', 'csharp'], aliases: ['c#', 'csharp']},
         css: {name: 'CSS', extensions: ['css']},
         d: {name: 'D', extensions: ['d', 'di'], aliases: ['dlang']},
         dart: {name: 'Dart', extensions: ['dart']},

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1791,7 +1791,7 @@ export const Constants = {
         clojure: {name: 'Clojure', extensions: ['clj', 'boot', 'cl2', 'cljc', 'cljs', 'cljs.hl', 'cljscm', 'cljx', 'hic'], aliases: ['clj']},
         coffeescript: {name: 'CoffeeScript', extensions: ['coffee', '_coffee', 'cake', 'cjsx', 'cson', 'iced'], aliases: ['coffee', 'coffee-script']},
         cpp: {name: 'C/C++', extensions: ['cpp', 'c', 'cc', 'h', 'c++', 'h++', 'hpp'], aliases: ['c++', 'c']},
-        csharp: {name: 'C#', extensions: ['cs', 'csharp'], aliases: ['c#', 'csharp']},
+        csharp: {name: 'C#', extensions: ['cs', 'csharp'], aliases: ['c#', 'cs', 'csharp']},
         css: {name: 'CSS', extensions: ['css']},
         d: {name: 'D', extensions: ['d', 'di'], aliases: ['dlang']},
         dart: {name: 'Dart', extensions: ['dart']},


### PR DESCRIPTION
The internal name that highlight.js uses for C# is `csharp`, not `cs`, so while we recognized C# in the code block, we weren't telling highlight.js what it needed to do syntax highlighting

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Screenshots

Before | After
-|-
![Screen Shot 2023-02-08 at 9 47 21 AM](https://user-images.githubusercontent.com/3277310/217563551-402cfad7-60b2-44b4-b3b8-995902cdc238.png) | ![Screen Shot 2023-02-08 at 9 47 27 AM](https://user-images.githubusercontent.com/3277310/217563586-8f6d2654-6de2-4e90-9fa1-93716c8bb500.png)

#### Release Note
```release-note
Fixed C# syntax highlighting not working
```
