### PR TITLE
[MM-50229] Fix right-click paste for user invites

### DIFF
--- a/components/widgets/inputs/users_emails_input.test.tsx
+++ b/components/widgets/inputs/users_emails_input.test.tsx
@@ -64,6 +64,12 @@ describe('components/widgets/inputs/UsersEmailsInput', () => {
                 openMenuOnClick={false}
                 openMenuOnFocus={true}
                 placeholder="test"
+                styles={
+                  Object {
+                    "input": [Function],
+                    "placeholder": [Function],
+                  }
+                }
                 tabSelectsValue={true}
                 value={
                   Array [

--- a/components/widgets/inputs/users_emails_input.tsx
+++ b/components/widgets/inputs/users_emails_input.tsx
@@ -3,7 +3,7 @@
 
 import React, {RefObject} from 'react';
 import {FormattedMessage} from 'react-intl';
-import {components, InputActionMeta, FormatOptionLabelMeta, ValueType, OptionsType} from 'react-select';
+import {components, InputActionMeta, FormatOptionLabelMeta, ValueType, OptionsType, Styles} from 'react-select';
 import AsyncCreatable from 'react-select/async-creatable';
 import classNames from 'classnames';
 
@@ -310,6 +310,30 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
 
         const Msg: any = components.NoOptionsMessage;
 
+        const styles: Partial<Styles> = {
+            placeholder: (css) => ({
+                ...css,
+
+                pointerEvents: 'none',
+                userSelect: 'none',
+            }),
+            input: (css) => ({
+                ...css,
+
+                display: 'flex',
+                flex: '1 1 auto',
+
+                '> div': {
+                    width: '100%',
+                },
+
+                input: {
+                    width: '100% !important',
+                    textAlign: 'left',
+                },
+            }),
+        };
+
         return (
             <>
                 <AsyncCreatable
@@ -343,6 +367,7 @@ export default class UsersEmailsInput extends React.PureComponent<Props, State> 
                     value={values}
                     aria-label={this.props.ariaLabel}
                     autoFocus={this.props.autoFocus}
+                    styles={styles}
                 />
                 {this.props.showError && (
                     <div className='InputErrorBox'>


### PR DESCRIPTION
#### Summary
The input was so tiny that you could not right-click into it. It's not perfect, as it's not expanded vertically, but it's better now.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50229

#### Related Pull Requests
N/A

#### Screenshots
**Before**

https://user-images.githubusercontent.com/684680/217881062-390a52af-bcf5-45fb-b319-e185fdbcce5a.mp4

**After**

https://user-images.githubusercontent.com/684680/217881093-08c9f307-e76b-4f54-9af2-5476b83503bc.mp4

#### Release Note
```release-note
NONE
```
