### PR TITLE
Add onModalDismissed to plugin file preview

### DIFF
--- a/components/file_preview_modal/__snapshots__/file_preview_modal.test.tsx.snap
+++ b/components/file_preview_modal/__snapshots__/file_preview_modal.test.tsx.snap
@@ -547,6 +547,7 @@ exports[`components/FilePreviewModal should match snapshot when plugin overrides
                 "width": 350,
               }
             }
+            onModalDismissed={[Function]}
             post={
               Object {
                 "channel_id": "",

--- a/components/file_preview_modal/file_preview_modal.tsx
+++ b/components/file_preview_modal/file_preview_modal.tsx
@@ -447,7 +447,7 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                             >
                                 {content}
                             </div>
-                            {this.props.isMobileView &&
+                            { this.props.isMobileView &&
                                 <FilePreviewModalFooter
                                     post={this.props.post}
                                     showPublicLink={showPublicLink}

--- a/components/file_preview_modal/file_preview_modal.tsx
+++ b/components/file_preview_modal/file_preview_modal.tsx
@@ -379,6 +379,7 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                         <preview.component
                             fileInfo={fileInfo}
                             post={this.props.post}
+                            onModalDismissed={this.handleModalClose}
                         />
                     );
                     break;
@@ -446,7 +447,7 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                             >
                                 {content}
                             </div>
-                            { this.props.isMobileView &&
+                            {this.props.isMobileView &&
                                 <FilePreviewModalFooter
                                     post={this.props.post}
                                     showPublicLink={showPublicLink}

--- a/types/store/plugins.ts
+++ b/types/store/plugins.ts
@@ -114,7 +114,7 @@ export type FilePreviewComponent = {
     id: string;
     pluginId: string;
     override: (fileInfo: FileInfo, post?: Post) => boolean;
-    component: React.ComponentType<{fileInfo: FileInfo; post?: Post}>;
+    component: React.ComponentType<{fileInfo: FileInfo; post?: Post; onModalDismissed: () => void}>;
 }
 
 export type FileDropdownPluginComponent = {


### PR DESCRIPTION
#### Summary

In order for plugins to have the freedom to close the file preview modal, we need to provide a prop to call that does this. https://github.com/mattermost/mattermost-webapp/pull/5430 added this prop but it seems it was removed in a refactor. The file was not typescript'd back then so it makes sense.

This PR adds this prop back into the component.

This can be tested with https://github.com/mattermost/mattermost-plugin-demo/pull/105

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-24763 again. I've reopened the issue but can create another if necessary.

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- https://github.com/mattermost/mattermost-webapp/pull/5430
- https://github.com/mattermost/mattermost-plugin-demo/pull/105

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
