### PR TITLE
MM-50226 Remove 'here' from the true-up docs link.

### DIFF
--- a/components/analytics/true_up_review.tsx
+++ b/components/analytics/true_up_review.tsx
@@ -165,7 +165,7 @@ const TrueUpReview: React.FC = () => {
         >
             <FormattedMessage
                 id='admin.billing.trueUpReview.docsLinkCTA'
-                defaultMessage='Learn more about true-up here.'
+                defaultMessage='Learn more about true-up.'
             />
         </a>
     );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -431,7 +431,7 @@
   "admin.billing.subscriptions.billing_summary.upgrade_professional.cta": "Upgrade",
   "admin.billing.trueUpReview.button_download": "Download Data",
   "admin.billing.trueUpReview.button_share": "Share to Mattermost",
-  "admin.billing.trueUpReview.docsLinkCTA": "Learn more about true-up here.",
+  "admin.billing.trueUpReview.docsLinkCTA": "Learn more about true-up.",
   "admin.billing.trueUpReview.due_date": "Due ",
   "admin.billing.trueUpReview.share_data_for_review": "Share your system statistics with Mattermost for your quarterly true-up Review. {link}",
   "admin.billing.trueUpReview.submit_error": "There was an issue sending your True Up Review. Please try again.",


### PR DESCRIPTION
#### Summary

We need to add links to true-up documentation in other areas that mention true-up. This has already been done, but the wording has changed _slightly_ from:

`Learn more about true-up here.` to `Learn more about true-up.`

#### Ticket Link

[MM-50226](https://mattermost.atlassian.net/browse/MM-50226)

#### Screenshots

|  before  |  after  |
|----|----|
| ![Screen Shot 2023-02-14 at 3 24 51 PM](https://user-images.githubusercontent.com/116016004/218853910-ec0d332f-e9ac-4d8d-8174-51bce4dbb06d.png) | ![Screen Shot 2023-02-14 at 3 25 37 PM](https://user-images.githubusercontent.com/116016004/218854029-1b4c5b1f-a719-46af-9b2c-0541665986fe.png) |

#### Release Note

```release-note
NONE
```


[MM-50226]: https://mattermost.atlassian.net/browse/MM-50226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ