### PR TITLE
MM-50506 Add -webkit-mask-image to support Chrome and Electron

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -2130,6 +2130,7 @@
 
     &.post-message--overflow {
         .post-message__text-container {
+            -webkit-mask-image: linear-gradient(black calc(100% - 126px), transparent calc(100% - 36px));
             mask-image: linear-gradient(black calc(100% - 126px), transparent calc(100% - 36px));
         }
     }


### PR DESCRIPTION
https://caniuse.com/?search=mask-image is very noncommittal about whether or not a prefix is needed for this property in Chrome

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50506

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/12086

#### Release Note
```release-note
Fixed new collapsed post fade out being broken on Chrome and Desktop
```
