### PR TITLE
[MM-50171] - Update plan details badge from yearly to annual

### DIFF
--- a/components/admin_console/billing/plan_details/plan_details.tsx
+++ b/components/admin_console/billing/plan_details/plan_details.tsx
@@ -101,7 +101,7 @@ export const PlanDetailsTopElements = ({
             className='RecurringIntervalBadge'
             text={formatMessage({
                 id: 'admin.billing.subscription.cloudYearlyBadge',
-                defaultMessage: 'Yearly',
+                defaultMessage: 'Annual',
             })}
         />
     );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -310,7 +310,7 @@
   "admin.billing.subscription.cloudTrial.moreThan3Days": "Your trial has started! There are {daysLeftOnTrial} days left",
   "admin.billing.subscription.cloudTrial.subscribeButton": "Upgrade Now",
   "admin.billing.subscription.cloudTrialBadge.daysLeftOnTrial": "{daysLeftOnTrial} trial days left",
-  "admin.billing.subscription.cloudYearlyBadge": "Yearly",
+  "admin.billing.subscription.cloudYearlyBadge": "Annual",
   "admin.billing.subscription.complianceScreenFailed.button": "Continue with Cloud Free",
   "admin.billing.subscription.complianceScreenFailed.subtitle": "We will check things on our side and get back to you within 3 days once your Cloud subscription upgrade is approved. In the meantime, please feel free to continue using the free version of our product.",
   "admin.billing.subscription.complianceScreenFailed.title": "Your transaction is being reviewed",


### PR DESCRIPTION
#### Summary
Update plan details badge from `YEARLY` to `ANNUAL`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50171

#### Screenshots
Before
----
<img width="573" alt="Screenshot 2023-02-15 at 15 10 33" src="https://user-images.githubusercontent.com/28563179/219024621-7c6961ca-6e26-4eec-800e-0af1e65ba5bb.png">

After
----
<img width="576" alt="Screenshot 2023-02-15 at 15 11 31" src="https://user-images.githubusercontent.com/28563179/219024690-a353666b-4138-4acc-a741-051f8fac8ad9.png">



#### Release Note

```release-note
NONE
```
