### PR TITLE
[CLD-5125] CI Bump-Up runners for Performance Testing

### DIFF
--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   cypress-run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-8-cores
     name: Run Cypress benchmarks
     services:
       postgres:


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We may fail to hit performance targets when running Performance benchmarks under the default GitHub runners with 2 CPU Cores.

Example:
https://github.com/mattermost/mattermost-webapp/actions/runs/4191515787/jobs/7266161637

We bump-up the GhRunners for this step to align with requirements


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-5125

