### PR TITLE
MM-50572 - Allow Enterprise-Monthly to See Contact Support CTA Rather Than a Blank Section

### DIFF
--- a/components/admin_console/billing/billing_subscriptions/index.tsx
+++ b/components/admin_console/billing/billing_subscriptions/index.tsx
@@ -74,7 +74,7 @@ const BillingSubscriptions = () => {
     const actionQueryParam = query.get('action');
 
     const product = useSelector(getSubscriptionProduct);
-    const isAnnualProfessionalOrEnterprise = (product?.sku === CloudProducts.ENTERPRISE || product?.sku === CloudProducts.PROFESSIONAL) && product?.recurring_interval === RecurringIntervals.YEAR;
+    const isAnnualProfessionalOrEnterprise = product?.sku === CloudProducts.ENTERPRISE || (product?.sku === CloudProducts.PROFESSIONAL && product?.recurring_interval === RecurringIntervals.YEAR);
 
     const openPricingModal = useOpenPricingModal();
 

--- a/e2e/cypress/tests/integration/system_console/workspace_deletion_spec.js
+++ b/e2e/cypress/tests/integration/system_console/workspace_deletion_spec.js
@@ -44,6 +44,9 @@ describe('Workspace deletion', () => {
         // Text is separated by an html <a> tag, just get the last half.
         cy.findByText('Delete your workspace').should('not.exist');
         cy.findByText(`${host}`).should('not.exist');
+
+        cy.findByText('Cancel your subscription').should('exist');
+        cy.findByText('At this time, deleting a workspace can only be done with the help of a customer support representative.').should('exist');
     });
 
     it('Workspace deletion cta is not visible for cloud enterprise with a yearly plan', () => {
@@ -59,6 +62,9 @@ describe('Workspace deletion', () => {
         // Text is separated by an html <a> tag, just get the last half.
         cy.findByText('Delete your workspace').should('not.exist');
         cy.findByText(`${host}`).should('not.exist');
+
+        cy.findByText('Cancel your subscription').should('exist');
+        cy.findByText('At this time, deleting a workspace can only be done with the help of a customer support representative.').should('exist');
     });
 
     it('Workspace deletion cta is visible for cloud free', () => {
@@ -102,6 +108,9 @@ describe('Workspace deletion', () => {
         // Text is separated by an html <a> tag, just get the last half.
         cy.findByText('Delete your workspace').should('not.exist');
         cy.findByText(`${host}`).should('not.exist');
+
+        cy.findByText('Cancel your subscription').should('exist');
+        cy.findByText('At this time, deleting a workspace can only be done with the help of a customer support representative.').should('exist');
     });
 
     it('Workspace deletion modal > downgrade button is not visible for cloud free', () => {
@@ -132,19 +141,6 @@ describe('Workspace deletion', () => {
         cy.findByText('Delete Workspace').click();
         cy.findByText('Are you sure you want to delete?').should('exist');
         cy.findByText('Downgrade To Free').should('exist');
-    });
-
-    it('Workspace deletion modal > delete workspace button is not visible for cloud enterprise', () => {
-        // Free.
-        const subscription = {
-            id: 'sub_test1',
-            product_id: 'prod_3',
-            is_free_trial: 'false',
-        };
-        cy.simulateSubscription(subscription);
-        cy.visit('/admin_console/billing/subscription');
-
-        cy.findByText('Delete Workspace').should('not.exist');
     });
 
     it('Workspace deletion modal > downgrade button is not visible for free trials', () => {


### PR DESCRIPTION
#### Summary

I noticed today that for the Delete Workspace flow, if you're on an enterprise monthly subscription, the CTA to contact support (rather than the CTA to delete the workspace) was no longer present when it should be.

This PR updates the condition for displaying either CTA to take into account that enterprise should never see the delete workspace CTA and should always see the contact support CTA (with the cancel subscription title) regardless of it's recurring interval being monthly or yearly.

#### Ticket Link

[MM-50572](https://mattermost.atlassian.net/browse/MM-50572)

#### Related Pull Requests

https://github.com/mattermost/mattermost-webapp/pull/12077

#### Screenshots

|  before  |  after  |
|----|----|
| ![Screen Shot 2023-02-16 at 11 56 33 AM](https://user-images.githubusercontent.com/116016004/219434524-a50ce088-0766-43c0-b873-19caf23fdc52.png) | ![Screen Shot 2023-02-16 at 11 56 03 AM](https://user-images.githubusercontent.com/116016004/219434383-780ff871-f4d8-4f37-9097-b61936216a76.png) |


#### Release Note

```release-note
NONE
```


[MM-50572]: https://mattermost.atlassian.net/browse/MM-50572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ