### PR TITLE
MM-50573 Clean up WebSocket listeners when connection is closed

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -166,7 +166,7 @@ export function initialize() {
 
     WebSocketClient.addMessageListener(handleEvent);
     WebSocketClient.addFirstConnectListener(handleFirstConnect);
-    WebSocketClient.addReconnectListener(() => reconnect(false));
+    WebSocketClient.addReconnectListener(reconnect);
     WebSocketClient.addMissedMessageListener(restart);
     WebSocketClient.addCloseListener(handleClose);
 
@@ -175,11 +175,12 @@ export function initialize() {
 
 export function close() {
     WebSocketClient.close();
-}
 
-function reconnectWebSocket() {
-    close();
-    initialize();
+    WebSocketClient.removeMessageListener(handleEvent);
+    WebSocketClient.removeFirstConnectListener(handleFirstConnect);
+    WebSocketClient.removeReconnectListener(reconnect);
+    WebSocketClient.removeMissedMessageListener(restart);
+    WebSocketClient.removeCloseListener(handleClose);
 }
 
 const pluginReconnectHandlers = {};
@@ -199,10 +200,9 @@ function restart() {
     dispatch(getClientConfig());
 }
 
-export function reconnect(includeWebSocket = true) {
-    if (includeWebSocket) {
-        reconnectWebSocket();
-    }
+export function reconnect() {
+    // eslint-disable-next-line
+    console.log('Reconnecting WebSocket');
 
     dispatch({
         type: GeneralTypes.WEBSOCKET_SUCCESS,

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -127,9 +127,13 @@ const pluginEventHandlers = {};
 
 export function initialize() {
     if (!window.WebSocket) {
-        console.log('Browser does not support websocket'); //eslint-disable-line no-console
+        // eslint-disable-next-line no-console
+        console.log('Browser does not support WebSocket');
         return;
     }
+
+    // eslint-disable-next-line no-console
+    console.log('Initializing or re-initializing WebSocket');
 
     const config = getConfig(getState());
     let connUrl = '';
@@ -194,7 +198,7 @@ export function unregisterPluginReconnectHandler(pluginId) {
 }
 
 function restart() {
-    reconnect(false);
+    reconnect();
 
     // We fetch the client config again on the server restart.
     dispatch(getClientConfig());

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -572,7 +572,7 @@ describe('handleNewPostEvents', () => {
 
 describe('reconnect', () => {
     test('should call syncPostsInChannel when socket reconnects', () => {
-        reconnect(false);
+        reconnect();
         expect(syncPostsInChannel).toHaveBeenCalledWith('otherChannel', '12345');
     });
 });

--- a/components/team_controller/team_controller.tsx
+++ b/components/team_controller/team_controller.tsx
@@ -71,7 +71,7 @@ function TeamController(props: Props) {
             const currentTime = Date.now();
             if ((currentTime - lastTime.current) > WAKEUP_THRESHOLD) {
                 console.log('computer woke up - fetching latest'); //eslint-disable-line no-console
-                reconnect(false);
+                reconnect();
             }
             lastTime.current = currentTime;
         }, WAKEUP_CHECK_INTERVAL);

--- a/packages/client/src/websocket.ts
+++ b/packages/client/src/websocket.ts
@@ -226,6 +226,11 @@ export default class WebSocketClient {
 
     addMessageListener(listener: MessageListener) {
         this.messageListeners.add(listener);
+
+        if (this.messageListeners.size > 5) {
+            // eslint-disable-next-line no-console
+            console.warn(`WebSocketClient has ${this.messageListeners} message listeners registered`);
+        }
     }
 
     removeMessageListener(listener: MessageListener) {
@@ -241,6 +246,11 @@ export default class WebSocketClient {
 
     addFirstConnectListener(listener: FirstConnectListener) {
         this.firstConnectListeners.add(listener);
+
+        if (this.firstConnectListeners.size > 5) {
+            // eslint-disable-next-line no-console
+            console.warn(`WebSocketClient has ${this.firstConnectListeners} first connect listeners registered`);
+        }
     }
 
     removeFirstConnectListener(listener: FirstConnectListener) {
@@ -256,6 +266,11 @@ export default class WebSocketClient {
 
     addReconnectListener(listener: ReconnectListener) {
         this.reconnectListeners.add(listener);
+
+        if (this.reconnectListeners.size > 5) {
+            // eslint-disable-next-line no-console
+            console.warn(`WebSocketClient has ${this.reconnectListeners} reconnect listeners registered`);
+        }
     }
 
     removeReconnectListener(listener: ReconnectListener) {
@@ -271,6 +286,11 @@ export default class WebSocketClient {
 
     addMissedMessageListener(listener: MissedMessageListener) {
         this.missedMessageListeners.add(listener);
+
+        if (this.missedMessageListeners.size > 5) {
+            // eslint-disable-next-line no-console
+            console.warn(`WebSocketClient has ${this.missedMessageListeners} missed message listeners registered`);
+        }
     }
 
     removeMissedMessageListener(listener: MissedMessageListener) {
@@ -286,6 +306,11 @@ export default class WebSocketClient {
 
     addErrorListener(listener: ErrorListener) {
         this.errorListeners.add(listener);
+
+        if (this.errorListeners.size > 5) {
+            // eslint-disable-next-line no-console
+            console.warn(`WebSocketClient has ${this.errorListeners} error listeners registered`);
+        }
     }
 
     removeErrorListener(listener: ErrorListener) {
@@ -301,6 +326,11 @@ export default class WebSocketClient {
 
     addCloseListener(listener: CloseListener) {
         this.closeListeners.add(listener);
+
+        if (this.closeListeners.size > 5) {
+            // eslint-disable-next-line no-console
+            console.warn(`WebSocketClient has ${this.closeListeners} close listeners registered`);
+        }
     }
 
     removeCloseListener(listener: CloseListener) {

--- a/packages/client/src/websocket.ts
+++ b/packages/client/src/websocket.ts
@@ -229,7 +229,7 @@ export default class WebSocketClient {
 
         if (this.messageListeners.size > 5) {
             // eslint-disable-next-line no-console
-            console.warn(`WebSocketClient has ${this.messageListeners} message listeners registered`);
+            console.warn(`WebSocketClient has ${this.messageListeners.size} message listeners registered`);
         }
     }
 
@@ -249,7 +249,7 @@ export default class WebSocketClient {
 
         if (this.firstConnectListeners.size > 5) {
             // eslint-disable-next-line no-console
-            console.warn(`WebSocketClient has ${this.firstConnectListeners} first connect listeners registered`);
+            console.warn(`WebSocketClient has ${this.firstConnectListeners.size} first connect listeners registered`);
         }
     }
 
@@ -269,7 +269,7 @@ export default class WebSocketClient {
 
         if (this.reconnectListeners.size > 5) {
             // eslint-disable-next-line no-console
-            console.warn(`WebSocketClient has ${this.reconnectListeners} reconnect listeners registered`);
+            console.warn(`WebSocketClient has ${this.reconnectListeners.size} reconnect listeners registered`);
         }
     }
 
@@ -289,7 +289,7 @@ export default class WebSocketClient {
 
         if (this.missedMessageListeners.size > 5) {
             // eslint-disable-next-line no-console
-            console.warn(`WebSocketClient has ${this.missedMessageListeners} missed message listeners registered`);
+            console.warn(`WebSocketClient has ${this.missedMessageListeners.size} missed message listeners registered`);
         }
     }
 
@@ -309,7 +309,7 @@ export default class WebSocketClient {
 
         if (this.errorListeners.size > 5) {
             // eslint-disable-next-line no-console
-            console.warn(`WebSocketClient has ${this.errorListeners} error listeners registered`);
+            console.warn(`WebSocketClient has ${this.errorListeners.size} error listeners registered`);
         }
     }
 
@@ -329,7 +329,7 @@ export default class WebSocketClient {
 
         if (this.closeListeners.size > 5) {
             // eslint-disable-next-line no-console
-            console.warn(`WebSocketClient has ${this.closeListeners} close listeners registered`);
+            console.warn(`WebSocketClient has ${this.closeListeners.size} close listeners registered`);
         }
     }
 


### PR DESCRIPTION
We're currently adding duplicated `reconnect` handlers every single time the WebSocket is re-initialized because we don't clean up the listeners we use when the WebSocket connection is closed. This hasn't been noticeable with other WebSocket event listeners because we're always registering the same listener and the `WebSocketClient` uses a Set which de-dupes that automatically, but because the `reconnect` handler used an arrow function previously, that'd lead us to register multiple copies of the same handler.

Because of that, we'd sometimes fire off multiple copies of the `reconnect` handler when the websocket reconnects which is a very heavy operation.

This fixes that issue by:
1. Not using an arrow function so that the underlying Set would de-duplicate that listener for us
2. Cleaning up the listeners when the WebSocket connection is closed for cleanliness sake

I also added some extra logging to help identify this sort of issue sooner in the future because it's possible for plugins to run into the same thing if they access the WebSocket directly

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50573

#### Related Pull Requests
- https://github.com/mattermost/mattermost-webapp/pull/10782 - The original PR where I introduced this bug

#### Release Note
```release-note
Fixed an issue where a single WebSocket reconnect could be handled multiple times which would negatively affect performance
```
