### PR TITLE
MM-50238 - Add a Success Page for Changes to Annual Subscriptions.

### DIFF
--- a/components/purchase_modal/process_payment_setup.tsx
+++ b/components/purchase_modal/process_payment_setup.tsx
@@ -59,6 +59,7 @@ type Props = RouteComponentProps & {
     onSuccess?: () => void;
     intl: IntlShape;
     usersCount: number;
+    isChangingToAnnual: boolean;
 };
 
 type State = {
@@ -192,7 +193,7 @@ class ProcessPaymentSetup extends React.PureComponent<Props, State> {
         this.props.onBack();
     }
 
-    private sucessPage = () => {
+    private successPage = () => {
         const {error} = this.state;
         const formattedBtnText = (
             <FormattedMessage
@@ -236,6 +237,35 @@ class ProcessPaymentSetup extends React.PureComponent<Props, State> {
                         }
                         formattedButtonText={formattedBtnText}
                         buttonHandler={this.props.onClose}
+                        className={'success'}
+                    />
+                </>
+            );
+        } else if (this.props.isChangingToAnnual) {
+            const formattedTitle = (
+                <FormattedMessage
+                    defaultMessage={'You are now switched to {selectedProductName} annual'}
+                    id={'admin.billing.subscription.switchToAnnual.title'}
+                    values={{selectedProductName: this.props.selectedProduct?.name}}
+                />
+            );
+            return (
+                <>
+                    <IconMessage
+                        formattedTitle={formattedTitle}
+                        icon={
+                            <PaymentSuccessStandardSvg
+                                width={444}
+                                height={313}
+                            />
+                        }
+                        formattedButtonText={formattedBtnText}
+                        buttonHandler={this.props.onClose}
+                        tertiaryBtnText={t('admin.billing.subscription.viewBilling')}
+                        tertiaryButtonHandler={() => {
+                            this.props.onClose();
+                            this.props.history.push('/admin_console/billing/subscription');
+                        }}
                         className={'success'}
                     />
                 </>
@@ -332,7 +362,7 @@ class ProcessPaymentSetup extends React.PureComponent<Props, State> {
                 />
             );
         case ProcessState.SUCCESS:
-            return this.sucessPage();
+            return this.successPage();
         case ProcessState.FAILED_COMPLIANCE_SCREEN:
             return (
                 <IconMessage

--- a/components/purchase_modal/process_payment_setup.tsx
+++ b/components/purchase_modal/process_payment_setup.tsx
@@ -244,8 +244,8 @@ class ProcessPaymentSetup extends React.PureComponent<Props, State> {
         } else if (this.props.isChangingToAnnual) {
             const formattedTitle = (
                 <FormattedMessage
-                    defaultMessage={'You are now switched to {selectedProductName} annual'}
-                    id={'admin.billing.subscription.switchToAnnual.title'}
+                    defaultMessage={"You're now switched to {selectedProductName} annual"}
+                    id={'admin.billing.subscription.switchedToAnnual.title'}
                     values={{selectedProductName: this.props.selectedProduct?.name}}
                 />
             );

--- a/components/purchase_modal/process_payment_setup.tsx
+++ b/components/purchase_modal/process_payment_setup.tsx
@@ -59,7 +59,7 @@ type Props = RouteComponentProps & {
     onSuccess?: () => void;
     intl: IntlShape;
     usersCount: number;
-    isChangingToAnnual: boolean;
+    isSwitchingToAnnual: boolean;
 };
 
 type State = {
@@ -241,7 +241,7 @@ class ProcessPaymentSetup extends React.PureComponent<Props, State> {
                     />
                 </>
             );
-        } else if (this.props.isChangingToAnnual) {
+        } else if (this.props.isSwitchingToAnnual) {
             const formattedTitle = (
                 <FormattedMessage
                     defaultMessage={"You're now switched to {selectedProductName} annual"}

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -160,7 +160,7 @@ type State = {
     selectedProductPrice: string | null;
     usersCount: number;
     seats: Seats;
-    isChangingToAnnual: boolean;
+    isSwitchingToAnnual: boolean;
 }
 
 /**
@@ -385,7 +385,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                 quantity: this.props.usersCount.toString(),
                 error: this.props.usersCount.toString() === '0' ? errorInvalidNumber : null,
             },
-            isChangingToAnnual: false,
+            isSwitchingToAnnual: false,
         };
     }
 
@@ -465,7 +465,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
             dialogProps: {
                 confirmSwitchToYearlyFunc: () => {
                     this.handleSubmitClick(this.props.callerCTA + '> purchase_modal > confirm_switch_to_annual_modal > confirm_click');
-                    this.setState({isChangingToAnnual: true});
+                    this.setState({isSwitchingToAnnual: true});
                 },
                 contactSalesFunc: () => {
                     trackEvent(
@@ -1026,7 +1026,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                                         this.state.selectedProduct?.billing_scheme === BillingSchemes.PER_SEAT}
                                         setIsUpgradeFromTrialToFalse={this.setIsUpgradeFromTrialToFalse}
                                         isUpgradeFromTrial={this.state.isUpgradeFromTrial}
-                                        isChangingToAnnual={this.state.isChangingToAnnual}
+                                        isSwitchingToAnnual={this.state.isSwitchingToAnnual}
                                         telemetryProps={{
                                             callerInfo:
                                                 this.state.buttonClickedInfo,

--- a/components/purchase_modal/purchase_modal.tsx
+++ b/components/purchase_modal/purchase_modal.tsx
@@ -160,6 +160,7 @@ type State = {
     selectedProductPrice: string | null;
     usersCount: number;
     seats: Seats;
+    isChangingToAnnual: boolean;
 }
 
 /**
@@ -384,6 +385,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                 quantity: this.props.usersCount.toString(),
                 error: this.props.usersCount.toString() === '0' ? errorInvalidNumber : null,
             },
+            isChangingToAnnual: false,
         };
     }
 
@@ -461,7 +463,10 @@ class PurchaseModal extends React.PureComponent<Props, State> {
             modalId: ModalIdentifiers.CONFIRM_SWITCH_TO_YEARLY,
             dialogType: SwitchToYearlyPlanConfirmModal,
             dialogProps: {
-                confirmSwitchToYearlyFunc: () => this.handleSubmitClick(this.props.callerCTA + '> purchase_modal > confirm_switch_to_annual_modal > confirm_click'),
+                confirmSwitchToYearlyFunc: () => {
+                    this.handleSubmitClick(this.props.callerCTA + '> purchase_modal > confirm_switch_to_annual_modal > confirm_click');
+                    this.setState({isChangingToAnnual: true});
+                },
                 contactSalesFunc: () => {
                     trackEvent(
                         TELEMETRY_CATEGORIES.CLOUD_ADMIN,
@@ -1021,6 +1026,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
                                         this.state.selectedProduct?.billing_scheme === BillingSchemes.PER_SEAT}
                                         setIsUpgradeFromTrialToFalse={this.setIsUpgradeFromTrialToFalse}
                                         isUpgradeFromTrial={this.state.isUpgradeFromTrial}
+                                        isChangingToAnnual={this.state.isChangingToAnnual}
                                         telemetryProps={{
                                             callerInfo:
                                                 this.state.buttonClickedInfo,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -398,6 +398,7 @@
   "admin.billing.subscription.providePaymentDetails": "Provide your payment details",
   "admin.billing.subscription.returnToTeam": "Return to {team}",
   "admin.billing.subscription.stateprovince": "State/Province",
+  "admin.billing.subscription.switchToAnnual.title": "You are now switched to {selectedProductName} annual",
   "admin.billing.subscription.title": "Subscription",
   "admin.billing.subscription.updatePaymentInfo": "Update Payment Information",
   "admin.billing.subscription.upgradedSuccess": "You're now upgraded to {productName}",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -398,7 +398,7 @@
   "admin.billing.subscription.providePaymentDetails": "Provide your payment details",
   "admin.billing.subscription.returnToTeam": "Return to {team}",
   "admin.billing.subscription.stateprovince": "State/Province",
-  "admin.billing.subscription.switchToAnnual.title": "You are now switched to {selectedProductName} annual",
+  "admin.billing.subscription.switchedToAnnual.title": "You're now switched to {selectedProductName} annual",
   "admin.billing.subscription.title": "Subscription",
   "admin.billing.subscription.updatePaymentInfo": "Update Payment Information",
   "admin.billing.subscription.upgradedSuccess": "You're now upgraded to {productName}",


### PR DESCRIPTION
#### Summary

When changing from a monthly-based payment interval to an annual-based, upon success, users would see the following success screen:

![image](https://user-images.githubusercontent.com/116016004/219779553-cfdb1472-b1de-44d8-87dc-9a6f5cbf8864.png)

This change updates the wording on this success screen, specifically for subscription changes which involve updating the payment interval from monthly to annual.

#### Ticket Link

[MM-50238](https://mattermost.atlassian.net/browse/MM-50238)

#### Screenshots

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/116016004/219779553-cfdb1472-b1de-44d8-87dc-9a6f5cbf8864.png) | ![Screen Shot 2023-02-17 at 4 47 38 PM](https://user-images.githubusercontent.com/116016004/219800102-27e81a22-18a4-4827-825f-87871134c99a.png) |

#### Release Note

```release-note
NONE
```


[MM-50238]: https://mattermost.atlassian.net/browse/MM-50238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ