### PR TITLE
MM-50723 quick fix for subscribing to a cloud product so that successes display as successes.

### DIFF
--- a/actions/cloud.tsx
+++ b/actions/cloud.tsx
@@ -90,14 +90,14 @@ export function subscribeCloudSubscription(
 ) {
     return async () => {
         try {
-            const response = await Client4.subscribeCloudProduct(
+            await Client4.subscribeCloudProduct(
                 productId,
                 shippingAddress,
                 seats,
                 feedback,
             );
 
-            return {data: response};
+            return true;
         } catch (e: any) {
             // In the event that the status code returned is 422, this request has been blocked by export compliance
             return {error: e.message, data: {status: e.status_code}};

--- a/components/purchase_modal/index.ts
+++ b/components/purchase_modal/index.ts
@@ -9,7 +9,7 @@ import {Stripe} from '@stripe/stripe-js';
 import {getAdminAnalytics} from 'mattermost-redux/selectors/entities/admin';
 import {getClientConfig} from 'mattermost-redux/actions/general';
 import {getCloudProducts, getCloudSubscription, getInvoices} from 'mattermost-redux/actions/cloud';
-import {Action, ActionFunc} from 'mattermost-redux/types/actions';
+import {Action} from 'mattermost-redux/types/actions';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 

--- a/components/purchase_modal/index.ts
+++ b/components/purchase_modal/index.ts
@@ -9,7 +9,7 @@ import {Stripe} from '@stripe/stripe-js';
 import {getAdminAnalytics} from 'mattermost-redux/selectors/entities/admin';
 import {getClientConfig} from 'mattermost-redux/actions/general';
 import {getCloudProducts, getCloudSubscription, getInvoices} from 'mattermost-redux/actions/cloud';
-import {Action} from 'mattermost-redux/types/actions';
+import {Action, ActionFunc} from 'mattermost-redux/types/actions';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
@@ -78,7 +78,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
                 openModal,
                 getCloudProducts,
                 completeStripeAddPaymentMethod,
-                subscribeCloudSubscription,
+                subscribeCloudSubscription: (subscribeCloudSubscription as any),
                 getClientConfig,
                 getInvoices,
                 getCloudSubscription,


### PR DESCRIPTION
#### Summary
Cloud export compliance introduced a [better return type](https://github.com/mattermost/mattermost-webapp/pull/12102/files#diff-e7ad3697a6a81325213114b2cb24bbb12e5c71b9a489b1191fdd067f12d19e86R92-R105) for `subscribeCloudSubscription` but the corresponding callers needed updating. Reverting the return type to a simple `true` until we fix this all the way.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50723

#### Release Note
Issue this fixes is not yet released to prod, so no release note.
```release-note
NONE
```
