### PR TITLE
Add hour diff to profile popover

### DIFF
--- a/components/profile_popover/profile_popover.tsx
+++ b/components/profile_popover/profile_popover.tsx
@@ -572,8 +572,9 @@ class ProfilePopover extends React.PureComponent<ProfilePopoverProps, ProfilePop
                         useTime={{
                             hour: 'numeric',
                             minute: 'numeric',
-                            timeZoneName: 'short',
                         }}
+                        includeTimeDifference={true}
+                        currentTimezone={this.props.currentUserTimezone}
                     />
                 </div>,
             );

--- a/components/timestamp/timestamp.test.tsx
+++ b/components/timestamp/timestamp.test.tsx
@@ -303,4 +303,58 @@ describe('components/timestamp/Timestamp', () => {
         );
         expect(wrapper.text()).toBe('19:15');
     });
+
+    test('should render with hours behind current time', () => {
+        const wrapper = mountWithIntl(
+            <Timestamp
+                useRelative={false}
+                useDate={false}
+                timeZone='America/New_York'
+                useTime={{
+                    hour: 'numeric',
+                    minute: 'numeric',
+                }}
+                includeTimeDifference={true}
+                currentTimezone={'UTC'}
+            />,
+        );
+
+        expect(wrapper.text()).toContain('(4 hr. behind)');
+    });
+
+    test('should render with hours ahead current time', () => {
+        const wrapper = mountWithIntl(
+            <Timestamp
+                useRelative={false}
+                useDate={false}
+                timeZone='UTC'
+                useTime={{
+                    hour: 'numeric',
+                    minute: 'numeric',
+                }}
+                includeTimeDifference={true}
+                currentTimezone={'America/New_York'}
+            />,
+        );
+
+        expect(wrapper.text()).toContain('(4 hr. ahead)');
+    });
+
+    test('should not render with hours diff', () => {
+        const wrapper = mountWithIntl(
+            <Timestamp
+                useRelative={false}
+                useDate={false}
+                timeZone='UTC'
+                useTime={{
+                    hour: 'numeric',
+                    minute: 'numeric',
+                }}
+                includeTimeDifference={true}
+                currentTimezone={'UTC'}
+            />,
+        );
+
+        expect(wrapper.text()).not.toContain('hr');
+    });
 });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5193,6 +5193,8 @@
   "user_groups_modal.viewGroup": "View Group",
   "user_list.notFound": "No users found",
   "user_profile.account.editProfile": "Edit Profile",
+  "user_profile.account.hoursAhead": " ({hourDiff} hr. ahead)",
+  "user_profile.account.hoursBehind": " ({hourDiff} hr. behind)",
   "user_profile.account.localTime": "Local Time",
   "user_profile.account.post_was_created": "This post was created by an integration from",
   "user_profile.add_user_to_channel": "Add to a Channel",


### PR DESCRIPTION
#### Summary
Adds hour difference instead of timezone in the profile popover

#### Screenshots

|  before  |  after  |
|----|----|
| ![Screenshot 2023-02-22 at 12 58 28 PM](https://user-images.githubusercontent.com/46071821/220715053-6a44e3d2-9591-4e08-8964-adfe8f8aa601.jpg) | ![Screenshot 2023-02-22 at 12 55 23 PM](https://user-images.githubusercontent.com/46071821/220714598-85cf3bf0-4875-479c-bb63-9dd1ab51d338.jpg) |
| ![Screenshot 2023-02-22 at 12 58 28 PM](https://user-images.githubusercontent.com/46071821/220715053-6a44e3d2-9591-4e08-8964-adfe8f8aa601.jpg) | ![Screenshot 2023-02-22 at 12 55 33 PM](https://user-images.githubusercontent.com/46071821/220714647-f3ceec80-dbc2-4a51-91d1-ece425695d0c.jpg) |

#### Release Note

```release-note
Adds hours ahead / behind in profile popover.
```
