### PR TITLE
Add a limit of 5000 lines to the web app runner

### DIFF
--- a/scripts/runner.js
+++ b/scripts/runner.js
@@ -207,6 +207,14 @@ class Runner {
         } else {
             this.buffer.push({tag: '', text: 'Line not recognized correctly: ' + line});
         }
+
+        // Keep the buffer from using too much memory by removing the oldest chunk of it every time it goes over 5000 lines
+        const bufferCapacity = 5000;
+        const capacityReduction = 1000;
+
+        if (this.buffer.length > bufferCapacity) {
+            this.buffer = this.buffer.slice(this.buffer.length - capacityReduction);
+        }
     }
 
     // Event handlers


### PR DESCRIPTION
I left `make run` running for a few days straight with the fancy runner enabled, and it managed to start lagging because of how much output it had saved up

#### Release Note
```release-note
NONE
```
