### PR TITLE
[MM-50321]: Fixes Custom status not appearing with user profile in post

### DIFF
--- a/components/post/user_profile.tsx
+++ b/components/post/user_profile.tsx
@@ -7,12 +7,12 @@ import {FormattedMessage} from 'react-intl';
 import Constants, {Locations} from 'utils/constants';
 import {fromAutoResponder, isFromWebhook} from 'utils/post_utils';
 
-import {Post} from '@mattermost/types/posts';
-
 import Tag from 'components/widgets/tag/tag';
 import BotTag from 'components/widgets/tag/bot_tag';
 import UserProfile from 'components/user_profile';
 import PostHeaderCustomStatus from 'components/post_view/post_header_custom_status/post_header_custom_status';
+
+import {Post} from '@mattermost/types/posts';
 
 type Props = {
     post: Post;
@@ -151,7 +151,7 @@ const PostUserProfile = (props: Props): JSX.Element | null => {
         {userProfile}
         {colon}
         {botIndicator}
-        {props.location === Locations.CENTER && (props.currentUserId === post.user_id) && customStatus}
+        {customStatus}
     </div>);
 };
 

--- a/components/post_view/post_header_custom_status/post_header_custom_status.tsx
+++ b/components/post_view/post_header_custom_status/post_header_custom_status.tsx
@@ -38,7 +38,6 @@ const PostHeaderCustomStatus = (props: ComponentProps) => {
                 userID={userId}
                 showTooltip={true}
                 emojiStyle={{
-                    marginLeft: 4,
                     marginTop: 2,
                 }}
             />


### PR DESCRIPTION
#### Summary
Fixes Custom status not appearing with user profile in post,

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-50321

#### Related Pull Requests
NA
#### Screenshots
|  before  |  after  |
|----|----|
|<img width="588" alt="Screenshot 2023-02-23 at 12 30 53 PM" src="https://user-images.githubusercontent.com/16203333/220839329-2197a0fa-2ba7-4926-ae96-3d790530d8e4.png"> | <img width="614" alt="Screenshot 2023-02-23 at 12 29 29 PM" src="https://user-images.githubusercontent.com/16203333/220839114-9e66d991-c1b6-4489-9f71-9845dc5a3c78.png"> |


#### Release Note
```release-note
* Fixes Custom status not appearing with user profile in post
```
