### PR TITLE
clear limits on subscription change (#12244)

### DIFF
--- a/components/common/hooks/useGetLimits.ts
+++ b/components/common/hooks/useGetLimits.ts
@@ -5,7 +5,7 @@ import {useState, useEffect, useMemo} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {Limits} from '@mattermost/types/cloud';
-import {getCloudLimits, getCloudLimitsLoaded, isCurrentLicenseCloud} from 'mattermost-redux/selectors/entities/cloud';
+import {getSubscriptionProduct, getCloudLimits, getCloudLimitsLoaded, isCurrentLicenseCloud} from 'mattermost-redux/selectors/entities/cloud';
 import {getCloudLimits as getCloudLimitsAction} from 'actions/cloud';
 import {useIsLoggedIn} from 'components/global_header/hooks';
 
@@ -15,6 +15,7 @@ export default function useGetLimits(): [Limits, boolean] {
     const cloudLimits = useSelector(getCloudLimits);
     const cloudLimitsReceived = useSelector(getCloudLimitsLoaded);
     const dispatch = useDispatch();
+    const subscriptionProduct = useSelector(getSubscriptionProduct);
     const [requestedLimits, setRequestedLimits] = useState(false);
 
     useEffect(() => {
@@ -23,6 +24,12 @@ export default function useGetLimits(): [Limits, boolean] {
             setRequestedLimits(true);
         }
     }, [isLoggedIn, isCloud, requestedLimits, cloudLimitsReceived]);
+
+    useEffect(() => {
+        if (subscriptionProduct && requestedLimits) {
+            setRequestedLimits(false);
+        }
+    }, [subscriptionProduct]);
 
     const result: [Limits, boolean] = useMemo(() => {
         return [cloudLimits, cloudLimitsReceived];

--- a/packages/mattermost-redux/src/reducers/entities/cloud.test.ts
+++ b/packages/mattermost-redux/src/reducers/entities/cloud.test.ts
@@ -54,4 +54,15 @@ describe('limits reducer', () => {
         );
         expect(unchangedLimits).toEqual({limits: {...updatedLimits}, limitsLoaded: true});
     });
+
+    test('clears limits when new subscription received', () => {
+        const emptyLimits = limits(
+            minimalLimits,
+            {
+                type: CloudTypes.RECEIVED_CLOUD_SUBSCRIPTION,
+                data: {},
+            },
+        );
+        expect(emptyLimits).toEqual({limits: {}, limitsLoaded: false});
+    });
 });

--- a/packages/mattermost-redux/src/reducers/entities/cloud.ts
+++ b/packages/mattermost-redux/src/reducers/entities/cloud.ts
@@ -106,6 +106,9 @@ export function limits(state: LimitsReducer = emptyLimits, action: GenericAction
             limitsLoaded: true,
         };
     }
+    case CloudTypes.RECEIVED_CLOUD_SUBSCRIPTION: {
+        return emptyLimits;
+    }
     default:
         return state;
     }


### PR DESCRIPTION
#### Summary
cc @amyblais , @AGMETEOR 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Limits are cleared and reloaded on subscription change.
```
