### PR TITLE
MM-49865 - add telemetry to account creation screen

### DIFF
--- a/components/signup/__snapshots__/signup.test.tsx.snap
+++ b/components/signup/__snapshots__/signup.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               disabled={false}
               inputSize="large"
               name="email"
+              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Email address"
               type="text"
@@ -75,6 +76,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               disabled={false}
               inputSize="large"
               name="name"
+              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Choose a Username"
               type="text"
@@ -87,6 +89,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               error=""
               info="Must be 5-64 characters long."
               inputSize="large"
+              onBlur={[Function]}
               onChange={[Function]}
               value=""
             />
@@ -206,6 +209,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               disabled={false}
               inputSize="large"
               name="email"
+              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Email address"
               type="text"
@@ -223,6 +227,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               disabled={false}
               inputSize="large"
               name="name"
+              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Choose a Username"
               type="text"
@@ -235,6 +240,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               error=""
               info="Must be 5-64 characters long."
               inputSize="large"
+              onBlur={[Function]}
               onChange={[Function]}
               value=""
             />

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -283,8 +283,6 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
     useEffect(() => {
         dispatch(removeGlobalItem('team'));
-        sendFirstAdminUserTelemetryEvents('landing');
-
         trackEvent('signup', 'signup_user_01_welcome', {...getRoleFromTrackFlow(), ...getMediumFromTrackFlow()});
 
         onWindowResize();
@@ -459,11 +457,8 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         }
     };
 
-    function sendFirstAdminUserTelemetryEvents(errorId: string) {
-        const sbr = getSbr();
-        if (!sbr) {
-            trackEvent('first_admin_sign_up_page', errorId, {serverId: DiagnosticId});
-        }
+    function sendSignUpTelemetryEvents(telemetryId: string) {
+        trackEvent('signup', telemetryId);
     }
 
     const isUserValid = () => {
@@ -473,11 +468,11 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
         if (!providedEmail) {
             setEmailError(formatMessage({id: 'signup_user_completed.required', defaultMessage: 'This field is required'}));
-            sendFirstAdminUserTelemetryEvents('click_create_account_with_no_email_provided');
+            sendSignUpTelemetryEvents('click_create_account_with_no_email_provided');
             isValid = false;
         } else if (!isEmail(providedEmail)) {
             setEmailError(formatMessage({id: 'signup_user_completed.validEmail', defaultMessage: 'Please enter a valid email address'}));
-            sendFirstAdminUserTelemetryEvents('click_create_account_with_invalid_email');
+            sendSignUpTelemetryEvents('click_create_account_with_invalid_email');
             isValid = false;
         }
 
@@ -502,13 +497,13 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
                         },
                     );
                 }
-                sendFirstAdminUserTelemetryEvents(`click_create_account_with_username_error_${(usernameError.id).toLowerCase()}`);
+                sendSignUpTelemetryEvents(`click_create_account_with_username_error_${(usernameError.id).toLowerCase()}`);
                 setNameError(nameError);
                 isValid = false;
             }
         } else {
             setNameError(formatMessage({id: 'signup_user_completed.required', defaultMessage: 'This field is required'}));
-            sendFirstAdminUserTelemetryEvents('click_create_account_with_no_provided_username');
+            sendSignUpTelemetryEvents('click_create_account_with_no_provided_username');
             isValid = false;
         }
 
@@ -519,7 +514,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
             setPasswordError(error as string);
             const passwordErrorsArr = errorId.split('.');
             const passwordErrorsStr = passwordErrorsArr?.length && passwordErrorsArr.pop();
-            sendFirstAdminUserTelemetryEvents(`click_create_account_with_password_with_error_${passwordErrorsStr ?? ''}`);
+            sendSignUpTelemetryEvents(`click_create_account_with_password_with_error_${passwordErrorsStr ?? ''}`);
             isValid = false;
         }
 
@@ -533,7 +528,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
     const handleSubmit = async (e: React.MouseEvent | React.KeyboardEvent) => {
         e.preventDefault();
         trackEvent('signup_email', 'click_create_account', getRoleFromTrackFlow());
-        sendFirstAdminUserTelemetryEvents('click_create_account');
+        sendSignUpTelemetryEvents('click_create_account');
         setIsWaiting(true);
 
         if (isUserValid()) {
@@ -576,7 +571,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         if (!text) {
             return;
         }
-        sendFirstAdminUserTelemetryEvents(`typed_input_${inputId}`);
+        sendSignUpTelemetryEvents(`typed_input_${inputId}`);
     };
 
     const getContent = () => {

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -456,8 +456,8 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         }
     };
 
-    function sendSignUpTelemetryEvents(telemetryId: string) {
-        trackEvent('signup', telemetryId);
+    function sendSignUpTelemetryEvents(telemetryId: string, props?: any) {
+        trackEvent('signup', telemetryId, props);
     }
 
     const isUserValid = () => {
@@ -467,11 +467,11 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
         if (!providedEmail) {
             setEmailError(formatMessage({id: 'signup_user_completed.required', defaultMessage: 'This field is required'}));
-            sendSignUpTelemetryEvents('click_create_account_with_no_email_provided');
+            sendSignUpTelemetryEvents('click_create_account', {errors: [{field: 'email', rule: 'not_provided'}], sucess: false});
             isValid = false;
         } else if (!isEmail(providedEmail)) {
             setEmailError(formatMessage({id: 'signup_user_completed.validEmail', defaultMessage: 'Please enter a valid email address'}));
-            sendSignUpTelemetryEvents('click_create_account_with_invalid_email');
+            sendSignUpTelemetryEvents('click_create_account', {errors: [{field: 'email', rule: 'invalid_email'}], sucess: false});
             isValid = false;
         }
 
@@ -496,24 +496,22 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
                         },
                     );
                 }
-                sendSignUpTelemetryEvents(`click_create_account_with_username_error_${(usernameError.id).toLowerCase()}`);
+                sendSignUpTelemetryEvents('click_create_account', {errors: [{field: 'username', rule: usernameError.id.toLowerCase()}], sucess: false});
                 setNameError(nameError);
                 isValid = false;
             }
         } else {
             setNameError(formatMessage({id: 'signup_user_completed.required', defaultMessage: 'This field is required'}));
-            sendSignUpTelemetryEvents('click_create_account_with_no_provided_username');
+            sendSignUpTelemetryEvents('click_create_account', {errors: [{field: 'username', rule: 'not_provided'}], sucess: false});
             isValid = false;
         }
 
         const providedPassword = passwordInput.current?.value ?? '';
-        const {error, errorId} = isValidPassword(providedPassword, getPasswordConfig(config), intl);
+        const {error, telemetryErrorIds} = isValidPassword(providedPassword, getPasswordConfig(config), intl);
 
         if (error) {
             setPasswordError(error as string);
-            const passwordErrorsArr = errorId.split('.');
-            const passwordErrorsStr = passwordErrorsArr?.length && passwordErrorsArr.pop();
-            sendSignUpTelemetryEvents(`click_create_account_with_password_with_error_${passwordErrorsStr ?? ''}`);
+            sendSignUpTelemetryEvents('click_create_account', {errors: telemetryErrorIds, success: false});
             isValid = false;
         }
 

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -51,7 +51,7 @@ import PasswordInput from 'components/widgets/inputs/password_input/password_inp
 import SaveButton from 'components/save_button';
 
 import {Constants, ItemStatus, ValidationErrors} from 'utils/constants';
-import {isValidUsername, isValidPassword, getPasswordConfig, getRoleFromTrackFlow, getMediumFromTrackFlow, getSbr} from 'utils/utils';
+import {isValidUsername, isValidPassword, getPasswordConfig, getRoleFromTrackFlow, getMediumFromTrackFlow} from 'utils/utils';
 
 import './signup.scss';
 
@@ -98,7 +98,6 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         CustomBrandText,
         TermsOfServiceLink,
         PrivacyPolicyLink,
-        DiagnosticId,
     } = config;
     const {IsLicensed} = useSelector(getLicense);
     const loggedIn = Boolean(useSelector(getCurrentUserId));

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -460,18 +460,21 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
         trackEvent('signup', telemetryId, props);
     }
 
+    type TelemetryErrorList = {errors: Array<{field: string; rule: string}>; success: boolean};
+
     const isUserValid = () => {
         let isValid = true;
 
         const providedEmail = emailInput.current?.value.trim();
+        const telemetryEvents: TelemetryErrorList = {errors: [], success: true};
 
         if (!providedEmail) {
             setEmailError(formatMessage({id: 'signup_user_completed.required', defaultMessage: 'This field is required'}));
-            sendSignUpTelemetryEvents('click_create_account', {errors: [{field: 'email', rule: 'not_provided'}], sucess: false});
+            telemetryEvents.errors.push({field: 'email', rule: 'not_provided'});
             isValid = false;
         } else if (!isEmail(providedEmail)) {
             setEmailError(formatMessage({id: 'signup_user_completed.validEmail', defaultMessage: 'Please enter a valid email address'}));
-            sendSignUpTelemetryEvents('click_create_account', {errors: [{field: 'email', rule: 'invalid_email'}], sucess: false});
+            telemetryEvents.errors.push({field: 'email', rule: 'invalid_email'});
             isValid = false;
         }
 
@@ -496,13 +499,13 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
                         },
                     );
                 }
-                sendSignUpTelemetryEvents('click_create_account', {errors: [{field: 'username', rule: usernameError.id.toLowerCase()}], sucess: false});
+                telemetryEvents.errors.push({field: 'username', rule: usernameError.id.toLowerCase()});
                 setNameError(nameError);
                 isValid = false;
             }
         } else {
             setNameError(formatMessage({id: 'signup_user_completed.required', defaultMessage: 'This field is required'}));
-            sendSignUpTelemetryEvents('click_create_account', {errors: [{field: 'username', rule: 'not_provided'}], sucess: false});
+            telemetryEvents.errors.push({field: 'username', rule: 'not_provided'});
             isValid = false;
         }
 
@@ -511,9 +514,15 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
         if (error) {
             setPasswordError(error as string);
-            sendSignUpTelemetryEvents('click_create_account', {errors: telemetryErrorIds, success: false});
+            telemetryEvents.errors = [...telemetryEvents.errors, ...telemetryErrorIds];
             isValid = false;
         }
+
+        if (telemetryEvents.errors.length) {
+            telemetryEvents.success = false;
+        }
+
+        sendSignUpTelemetryEvents('click_create_account', telemetryEvents);
 
         return isValid;
     };

--- a/components/signup/signup.tsx
+++ b/components/signup/signup.tsx
@@ -522,7 +522,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
             telemetryEvents.success = false;
         }
 
-        sendSignUpTelemetryEvents('click_create_account', telemetryEvents);
+        sendSignUpTelemetryEvents('validate_user', telemetryEvents);
 
         return isValid;
     };
@@ -533,8 +533,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
     const handleSubmit = async (e: React.MouseEvent | React.KeyboardEvent) => {
         e.preventDefault();
-        trackEvent('signup_email', 'click_create_account', getRoleFromTrackFlow());
-        sendSignUpTelemetryEvents('click_create_account');
+        sendSignUpTelemetryEvents('click_create_account', getRoleFromTrackFlow());
         setIsWaiting(true);
 
         if (isUserValid()) {

--- a/utils/utils.tsx
+++ b/utils/utils.tsx
@@ -1363,11 +1363,13 @@ export function getPasswordConfig(config: Partial<ClientConfig>) {
 
 export function isValidPassword(password: string, passwordConfig: ReturnType<typeof getPasswordConfig>, intl?: IntlShape) {
     let errorId = t('user.settings.security.passwordError');
+    const telemetryErrorIds = [];
     let valid = true;
     const minimumLength = passwordConfig.minimumLength || Constants.MIN_PASSWORD_LENGTH;
 
     if (password.length < minimumLength || password.length > Constants.MAX_PASSWORD_LENGTH) {
         valid = false;
+        telemetryErrorIds.push({field: 'password', rule: 'error_length'});
     }
 
     if (passwordConfig.requireLowercase) {
@@ -1376,6 +1378,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         }
 
         errorId += 'Lowercase';
+        telemetryErrorIds.push({field: 'password', rule: 'lowercase'});
     }
 
     if (passwordConfig.requireUppercase) {
@@ -1384,6 +1387,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         }
 
         errorId += 'Uppercase';
+        telemetryErrorIds.push({field: 'password', rule: 'uppercase'});
     }
 
     if (passwordConfig.requireNumber) {
@@ -1392,6 +1396,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         }
 
         errorId += 'Number';
+        telemetryErrorIds.push({field: 'password', rule: 'number'});
     }
 
     if (passwordConfig.requireSymbol) {
@@ -1400,6 +1405,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         }
 
         errorId += 'Symbol';
+        telemetryErrorIds.push({field: 'password', rule: 'symbol'});
     }
 
     let error;
@@ -1427,7 +1433,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         );
     }
 
-    return {valid, error, errorId};
+    return {valid, error, telemetryErrorIds};
 }
 
 function isChannelOrPermalink(link: string) {

--- a/utils/utils.tsx
+++ b/utils/utils.tsx
@@ -1427,7 +1427,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         );
     }
 
-    return {valid, error};
+    return {valid, error, errorId};
 }
 
 function isChannelOrPermalink(link: string) {
@@ -1825,9 +1825,14 @@ export function getRoleForTrackFlow() {
     return {started_by_role: startedByRole};
 }
 
-export function getRoleFromTrackFlow() {
+export function getSbr() {
     const params = new URLSearchParams(window.location.search);
     const sbr = params.get('sbr') ?? '';
+    return sbr;
+}
+
+export function getRoleFromTrackFlow() {
+    const sbr = getSbr();
     const startedByRole = TrackFlowRoles[sbr] ?? '';
 
     return {started_by_role: startedByRole};


### PR DESCRIPTION
#### Summary
This PR adds telemetry events for first admins when they initially land to the account creation page . The intention is to capture some of the interactions and events the first users have with the account creation page in order to be able to measure and take actions aiming to improve the product usage and adoption.

Captured Events:

The category used for these telemetry values is: `signup` and the extra data that will contain each one of these values is the serverId value.

* Then there are events captured if the user has typed anything in the email, username or password inputs

- `typed_input_email`
- `typed_input_username`
- `typed_input_password`

we listen for the blur event on the email, username and password inputs, then we check if there is a value in the input meaning the user entered some text.

* When the user clicks "Create Account Button"
the event `click_create_account` will be send under the `signup` category

* After the user clicks create account button, the subsequent validations are performed and in the case of validation errors, the following events are aggregated and send. The possible error events are:

Email
- No email provided: `[{field: 'email', rule: 'not_provided'}]`
- Entered an email but is an invalid email: [{field: 'email', rule: 'invalid_email'}]

Username
- Not entered a username: `[{field: 'username', rule: 'username_required'}]`
- Entered a username that does not match the min or max length criteria: `[{field: 'username', rule: 'invalid_length'}]`
- Entered a username with invalid characters: `[{field: 'username', rule: 'invalid_characters'}]`
- Entered a username with invalid first character: `[{field: 'username', rule: 'invalid_first_character'}]`
- Entered a username with a reserved username: `[{field: 'username', rule: 'reserved_name'}]`

Password
The password error telemetry id value will vary depending on the entered password not matching one or several of the password validation requirements, so it will contain a first part indicating the password error and the last part of the id will indicate the error or errors not matching the criteria:

- Not entered a password: `[{field: 'password', rule: 'password_required'}]`
- Entered a password that does not match the min or max length criteria: `[{field: 'password', rule: 'error_length'}]`
- Entered a password that does not contain lowercase: `[{field: 'password', rule: 'lowercase'}]`
- Entered a password that does not contain an uppercase character: `[{field: 'password', rule: 'uppercase'}]`
- Entered a password that does not contain a number: `[{field: 'password', rule: 'number'}]`
- Entered a password that does not contain a symbol: `[{field: 'password', rule: 'symbol'}]`

if there are errors those will be aggregated and send like:

`{success: false, errors: [<<Array of all possible errors mentioned above>>]}
`

![Screenshot 2023-03-07 at 18 45 13](https://user-images.githubusercontent.com/10082627/224062380-9f5fb149-2cb6-4030-a3a6-9474b15d7a42.png)

On the opposite side, if there were no errors, the format will be:
`{success: true, errors: []}
`

![Screenshot 2023-03-07 at 18 46 00](https://user-images.githubusercontent.com/10082627/224062466-33138708-ee59-41fb-b24b-3d1b1e368dbe.png)


```

```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49865

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
