### PR TITLE
hotfix(ci): Fix docker image build for Spinwick environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
         wget https://raw.githubusercontent.com/mattermost/mattermost-server/master/build/entrypoint.sh
         chmod +x entrypoint.sh
         export MM_PACKAGE=https://pr-builds.mattermost.com/$REPO_NAME/commit/${{ github.event.pull_request.head.sha || github.sha }}/mattermost-enterprise-linux-amd64.tar.gz
-        docker buildx build --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mm-ee-test:${TAG} .
+        docker buildx build --push --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mm-ee-test:${TAG} --provenance=false . 
   run-performance-bechmarks:
     uses: ./.github/workflows/performance-benchmarks.yml
     needs: prepare-docker-build


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We noticed that Spinwick environments were failing to start due to some change on the way we build docker images . 
Spinwick is using an old registry client and it had some strange errors with the manifests generated by buildx 
```
OCI index found, but accept header does not support OCI indexe
```

By disabling provenance we resolve this issue as we do not need it since we do not build for multi platform . 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
https://github.com/mattermost/mattermost-webapp/pull/12007
https://github.com/mattermost/mattermost-webapp/pull/12261
