### PR TITLE
[MM-45802] Add E2E test for clearing notification on deleted reply

### DIFF
--- a/e2e/cypress/tests/integration/collapsed_reply_threads/channel_notifications_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/channel_notifications_spec.js
@@ -149,6 +149,36 @@ describe('CRT Desktop notifications', () => {
             });
         });
     });
+
+    it('When a reply is deleted, the notification should be cleared', () => {
+        cy.visit(testChannelUrl);
+
+        // # Set users notification settings
+        setCRTDesktopNotification('MENTION');
+
+        // # Post a root message as other user
+        cy.postMessageAs({sender, message: 'a thread', channelId: testChannelId, rootId: ''});
+
+        // # Visit channel
+        cy.visit(testChannelUrl);
+
+        const replyMessage = `@${receiver.username} a reply`;
+
+        // # Get post id of message
+        cy.getLastPostId().then((postId) => {
+            // # Post a reply to the thread, which will trigger a follow
+            cy.postMessageAs({sender: receiver, message: 'following the thread', channelId: testChannelId, rootId: postId});
+
+            // # Post a reply to the thread
+            cy.postMessageAs({sender, message: replyMessage, channelId: testChannelId, rootId: postId}).then((reply) => {
+                // # Delete the reply
+                cy.apiDeletePost(reply.id);
+
+                // * Verify there is no notification
+                cy.get('#unreadMentions').should('not.exist');
+            });
+        });
+    });
 });
 
 function setCRTDesktopNotification(type) {

--- a/e2e/cypress/tests/integration/collapsed_reply_threads/channel_notifications_spec.js
+++ b/e2e/cypress/tests/integration/collapsed_reply_threads/channel_notifications_spec.js
@@ -93,6 +93,9 @@ describe('CRT Desktop notifications', () => {
                 expect(args.body, `Notification body: "${args.body}" should match: "${message}"`).to.equal(`@${sender.username}: ${message}`);
                 return true;
             });
+
+            // # Cleanup
+            cy.apiDeletePost(postId);
         });
     });
 
@@ -147,22 +150,18 @@ describe('CRT Desktop notifications', () => {
                 expect(args.body, `Notification body: "${args.body}" should match: "${message}"`).to.equal(`@${sender.username}: ${message}`);
                 return true;
             });
+
+            // # Cleanup
+            cy.apiDeletePost(postId);
         });
     });
 
-    it('When a reply is deleted, the notification should be cleared', () => {
-        cy.visit(testChannelUrl);
-
-        // # Set users notification settings
-        setCRTDesktopNotification('MENTION');
-
-        // # Post a root message as other user
-        cy.postMessageAs({sender, message: 'a thread', channelId: testChannelId, rootId: ''});
-
+    it('When a reply is deleted in open channel, the notification should be cleared', () => {
         // # Visit channel
         cy.visit(testChannelUrl);
 
-        const replyMessage = `@${receiver.username} a reply`;
+        // # Post a root message as other user
+        cy.postMessageAs({sender, message: 'a thread', channelId: testChannelId, rootId: ''});
 
         // # Get post id of message
         cy.getLastPostId().then((postId) => {
@@ -170,12 +169,65 @@ describe('CRT Desktop notifications', () => {
             cy.postMessageAs({sender: receiver, message: 'following the thread', channelId: testChannelId, rootId: postId});
 
             // # Post a reply to the thread
-            cy.postMessageAs({sender, message: replyMessage, channelId: testChannelId, rootId: postId}).then((reply) => {
-                // # Delete the reply
-                cy.apiDeletePost(reply.id);
+            cy.postMessageAs({sender, message: 'a reply', channelId: testChannelId, rootId: postId}).as('reply');
+
+            // # Post a mention reply to the thread
+            cy.postMessageAs({sender, message: `@${receiver.username} mention reply`, channelId: testChannelId, rootId: postId}).
+                as('replyMention');
+
+            // * Verify there is a notification
+            cy.get('#sidebarItem_threads #unreadMentions').should('exist').and('have.text', '1');
+
+            // # Delete the replies
+            cy.wrap(['@reply', '@replyMention']).each((reply) => {
+                cy.get(reply).then(({id}) => {
+                    cy.apiDeletePost(id);
+                });
+            });
+
+            // * Verify there is no notification
+            cy.get('#sidebarItem_threads #unreadMentions').should('not.exist');
+
+            // # Cleanup
+            cy.apiDeletePost(postId);
+        });
+    });
+
+    it('When a reply is deleted in DM channel, the notification should be cleared', () => {
+        cy.apiCreateDirectChannel([receiver.id, sender.id]).then(({channel: dmChannel}) => {
+            // # Visit channel
+            cy.visit(`/${testTeam.name}/messages/@${sender.username}`);
+
+            // # Post a root message as other user
+            cy.postMessageAs({sender, message: 'a thread', channelId: dmChannel.id, rootId: ''}).as('rootPost');
+
+            // # Get post id of message
+            cy.get('@rootPost').then(({id: rootId}) => {
+                // # Post a reply to the thread, which will trigger a follow
+                cy.postMessageAs({sender: receiver, message: 'following the thread', channelId: dmChannel.id, rootId});
+
+                // # Post a reply to the thread
+                cy.postMessageAs({sender, message: 'a reply', channelId: dmChannel.id, rootId}).as('reply');
+
+                // # Post a mention reply to the thread
+                cy.postMessageAs({sender, message: `@${receiver.username} mention reply`, channelId: dmChannel.id, rootId}).
+                    as('replyMention');
+
+                // * Verify there is a notification
+                cy.get('#sidebarItem_threads #unreadMentions').should('exist');
+
+                // # Delete the replies
+                cy.wrap(['@reply', '@replyMention']).each((reply) => {
+                    cy.get(reply).then(({id}) => {
+                        cy.apiDeletePost(id);
+                    });
+                });
 
                 // * Verify there is no notification
-                cy.get('#unreadMentions').should('not.exist');
+                cy.get('#sidebarItem_threads #unreadMentions').should('not.exist');
+
+                // # Cleanup
+                cy.apiDeletePost(rootId);
             });
         });
     });


### PR DESCRIPTION
#### Summary
Add an E2E for clearing notification on deleted reply

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45802

#### Related Pull Requests
- Has server changes: https://github.com/mattermost/mattermost-server/pull/22391

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
