### PR TITLE
[MM-50811] Enable loading translation files asynchronously

### DIFF
--- a/actions/views/root.test.ts
+++ b/actions/views/root.test.ts
@@ -58,6 +58,11 @@ describe('root view actions', () => {
     });
 
     describe('registerPluginTranslationsSource', () => {
+        const translations = {
+            keyA: 'valA',
+            keyB: 'valB',
+        };
+
         test('Should not dispatch action when getTranslation is empty', () => {
             const testStore = mockStore({});
 
@@ -68,17 +73,33 @@ describe('root view actions', () => {
             expect(testStore.getActions()).toEqual([]);
         });
 
-        test('Should dispatch action when getTranslation is not empty', () => {
+        test('Should dispatch action when getTranslation is not empty - sync', async () => {
             const testStore = mockStore({});
 
             jest.spyOn(i18nSelectors, 'getTranslations').mockReturnValue({});
             jest.spyOn(i18nSelectors, 'getCurrentLocale').mockReturnValue('en');
 
-            testStore.dispatch(Actions.registerPluginTranslationsSource('plugin_id', jest.fn()));
+            await testStore.dispatch(Actions.registerPluginTranslationsSource('plugin_id', jest.fn().mockReturnValue(translations)));
             expect(testStore.getActions()).toEqual([{
                 data: {
                     locale: 'en',
-                    translations: {},
+                    translations,
+                },
+                type: ActionTypes.RECEIVED_TRANSLATIONS,
+            }]);
+        });
+
+        test('Should dispatch action when getTranslation is not empty - async', async () => {
+            const testStore = mockStore({});
+
+            jest.spyOn(i18nSelectors, 'getTranslations').mockReturnValue({});
+            jest.spyOn(i18nSelectors, 'getCurrentLocale').mockReturnValue('en');
+
+            await testStore.dispatch(Actions.registerPluginTranslationsSource('plugin_id', jest.fn().mockResolvedValue(translations)));
+            expect(testStore.getActions()).toEqual([{
+                data: {
+                    locale: 'en',
+                    translations,
                 },
                 type: ActionTypes.RECEIVED_TRANSLATIONS,
             }]);

--- a/actions/views/root.ts
+++ b/actions/views/root.ts
@@ -68,9 +68,14 @@ export function unregisterPluginTranslationsSource(pluginId: string) {
 export function loadTranslations(locale: string, url: string) {
     return async (dispatch: DispatchFunc) => {
         const translations = {...en};
-        Object.values(pluginTranslationSources).forEach(async (pluginFunc) => {
-            Object.assign(translations, await pluginFunc(locale));
-        });
+
+        const ps = [];
+        for (const pluginFunc of Object.values(pluginTranslationSources)) {
+            ps.push(pluginFunc(locale));
+        }
+        for (const pluginTranslations of await Promise.all(ps)) {
+            Object.assign(translations, pluginTranslations);
+        }
 
         // Need to go to the server for languages other than English
         if (locale !== 'en') {


### PR DESCRIPTION
#### Summary

While working on Calls i18n support I was looking to load translation files dynamically at time of need vs bundling them all together but it seems like it wasn't possible without some minor changes. Making `registry.registerTranslations()` accept both types of functions (sync/async) seems to be working fine.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50811

#### Release Note

```release-note
Added support for passing asynchronous functions to registry.registerTranslations()
```
