### PR TITLE
MM-50793 - Feedback Modal Enhancements

### DIFF
--- a/components/feedback_modal/feedback.scss
+++ b/components/feedback_modal/feedback.scss
@@ -15,4 +15,9 @@
         font-size: 15px;
         resize: none;
     }
+
+    &__FreeFormTextLimit {
+        float: right;
+        color: red;
+    }
 }

--- a/components/feedback_modal/feedback.tsx
+++ b/components/feedback_modal/feedback.tsx
@@ -24,6 +24,7 @@ type Props = {
 } & WrappedComponentProps
 
 function FeedbackModal(props: Props) {
+    const maxFreeFormTextLength = 200;
     const optionOther = props.intl.formatMessage({id: 'feedback.other', defaultMessage: 'Other'});
     const feedbackModalOptions: string[] = [
         ...props.feedbackOptions,
@@ -63,6 +64,7 @@ function FeedbackModal(props: Props) {
             confirmButtonText={props.submitText}
             cancelButtonText={props.intl.formatMessage({id: 'feedback.cancelButton.text', defaultMessage: 'Cancel'})}
             modalHeaderText={props.title}
+            autoCloseOnConfirmButton={false}
         >
             <RadioButtonGroup
                 id='FeedbackModalRadioGroup'
@@ -78,15 +80,22 @@ function FeedbackModal(props: Props) {
                 onChange={(e) => setReason(e.target.value)}
             />
             {reason === optionOther &&
-                <textarea
-                    data-testid={'FeedbackModal__TextInput'}
-                    className='FeedbackModal__FreeFormText'
-                    placeholder={props.freeformTextPlaceholder}
-                    rows={3}
-                    onChange={(e) => {
-                        setComments(e.target.value);
-                    }}
-                />
+                <>
+                    <textarea
+                        data-testid={'FeedbackModal__TextInput'}
+                        className='FeedbackModal__FreeFormText'
+                        placeholder={props.freeformTextPlaceholder}
+                        rows={3}
+                        value={comments}
+                        onChange={(e) => {
+                            setComments(e.target.value);
+                        }}
+                        maxLength={200}
+                    />
+                    <span className='FeedbackModal__FreeFormTextLimit'>
+                        {comments.length}/{maxFreeFormTextLength}
+                    </span>
+                </>
             }
         </GenericModal>
     );


### PR DESCRIPTION
#### Summary

A few points of improvement were found by Yasser. This PR addressed them.
They are:

- Unable to add new lines via the `enter` key press. Trying these results in the modal closing
- There is no character limit or indicator of such a limit for the free-form feedback when the `other` option is selected

#### Ticket Link

[MM-50793](https://mattermost.atlassian.net/browse/MM-50793)

#### Screenshots

|  before  |  after  |
|----|----|
| ![Screen Shot 2023-02-27 at 11 46 05 AM](https://user-images.githubusercontent.com/116016004/221626279-5e037502-6e1f-4caf-8f60-edaf9342a388.png) | ![Screen Shot 2023-02-27 at 11 35 00 AM](https://user-images.githubusercontent.com/116016004/221623438-38906bec-f201-4910-b54b-ed9980ecd2cf.png) |

#### Release Note

```release-note
NONE
```
