### PR TITLE
[MM-50955]: Fix for "Download our apps" link in final onboarding step

### DIFF
--- a/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
+++ b/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
@@ -210,7 +210,7 @@ const Completed = (props: Props): JSX.Element => {
                                 values={{
                                     link: (msg: React.ReactNode) => (
                                         <a
-                                            href='https://mattermost.com/download'
+                                            href='https://mattermost.com/download/#desktop'
                                             target='_blank'
                                             rel='noreferrer'
                                         >


### PR DESCRIPTION
#### Summary

When an admin clicks on the "Download our apps" link in final onboarding step it only goes to the page but not the anchored section part-way down the page as it should.

This PR fixes that link.
#### Ticket Link

[MM-50955](https://mattermost.atlassian.net/browse/MM-50955)

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<img width="386" alt="Download our apps link" src="https://user-images.githubusercontent.com/7083912/221711935-25201410-daa6-43d0-aed7-5c6bcb728db7.png">