### PR TITLE
MM-50803 Fix restore post modal styles applying to other modals

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -2283,6 +2283,16 @@
 
     .modal-footer {
         padding-top: 28px;
+        text-align: center;
+    }
+
+    .GenericModal__button {
+        margin: 0 4px;
+
+        &.cancel-button {
+            background-color: rgba(var(--button-bg-rgb), 0.08);
+            border-radius: 4px;
+        }
     }
 }
 
@@ -2315,19 +2325,6 @@
         border: none;
         background: none;
         font-size: 12px;
-    }
-}
-
-.modal-footer {
-    text-align: center;
-
-    .GenericModal__button {
-        margin: 0 4px;
-
-        &.cancel-button {
-            background-color: rgba(var(--button-bg-rgb), 0.08);
-            border-radius: 4px;
-        }
     }
 }
 


### PR DESCRIPTION
The styling for a new modal introduced in https://github.com/mattermost/mattermost-webapp/pull/11069 were actually applying to a bunch of other modals

Before: 
![Screen Shot 2023-02-28 at 5 15 25 PM](https://user-images.githubusercontent.com/3277310/221993776-16bb6970-6353-4ac1-b42b-fcb5e19578a2.png)

After: 
![Screen Shot 2023-02-28 at 5 15 11 PM](https://user-images.githubusercontent.com/3277310/221993794-8254ffcb-2090-499a-8aca-c763f8144bf5.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50803

#### Release Note
```release-note
NONE
```
