### PR TITLE
MM-51000 fix withBackupValue

### DIFF
--- a/components/common/hooks/useGetUsageDeltas.test.ts
+++ b/components/common/hooks/useGetUsageDeltas.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {withBackupValue} from './useGetUsageDeltas';
+
+describe('withBackupValue', () => {
+    const tests = [
+        {
+            label: 'if limits not loaded, assumes no limit',
+            maybeLimit: undefined,
+            limitsLoaded: false,
+            expected: Number.MAX_VALUE,
+        },
+        {
+            label: 'if limits not loaded, assumes no limit even if there is data',
+            maybeLimit: 4,
+            limitsLoaded: false,
+            expected: Number.MAX_VALUE,
+        },
+        {
+            label: 'if limits loaded and the limit is 0, returns 0',
+            maybeLimit: 0,
+            limitsLoaded: true,
+            expected: 0,
+        },
+        {
+            label: 'if limits loaded and the limit is non-zero , returns the value',
+            maybeLimit: 5,
+            limitsLoaded: true,
+            expected: 5,
+        },
+        {
+            label: 'if limits loaded and the limit is undefined, returns max value',
+            maybeLimit: undefined,
+            limitsLoaded: true,
+            expected: Number.MAX_VALUE,
+        },
+    ];
+
+    tests.forEach((t) => {
+        it(t.label, () => {
+            expect(withBackupValue(t.maybeLimit, t.limitsLoaded)).toBe(t.expected);
+        });
+    });
+});

--- a/components/common/hooks/useGetUsageDeltas.ts
+++ b/components/common/hooks/useGetUsageDeltas.ts
@@ -14,13 +14,11 @@ import useGetLimits from './useGetLimits';
 // 10MB files used, minus 1000MB limit = value < 0, limit not exceeded.
 // etc.
 // withBackupValue will set the limit arbitrarily high in the event that the limit isn't set
-const withBackupValue = (maybeLimit: number | undefined, limitsLoaded: boolean) => (limitsLoaded ? maybeLimit ?? Number.MAX_VALUE : 0);
+export const withBackupValue = (maybeLimit: number | undefined, limitsLoaded: boolean) => (limitsLoaded ? (maybeLimit ?? Number.MAX_VALUE) : Number.MAX_VALUE);
 
 export default function useGetUsageDeltas(): CloudUsage {
     const usage = useGetUsage();
-    const cloudLimits = useGetLimits();
-    const limits = cloudLimits[0];
-    const limitsLoaded = cloudLimits[1];
+    const [limits, limitsLoaded] = useGetLimits();
 
     const usageDelta = useMemo(() => {
         return (
@@ -42,7 +40,7 @@ export default function useGetUsageDeltas(): CloudUsage {
                 },
             }
         );
-    }, [usage, limits]);
+    }, [usage, limits, limitsLoaded]);
 
     return usageDelta;
 }


### PR DESCRIPTION
#### Summary
Fix selector. Because limits were getting loaded more than once, when they got cleared, the usage existed, but the limits did not, and the backup value getting picked was 0, when it should have been max number (assumed no limit if we have not yet loaded a limit).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51000

#### Screenshots

https://user-images.githubusercontent.com/13738432/222208409-4070fdf0-6266-41b9-98b6-f481ab2d6cbd.mp4


#### Release Note
```release-note
Fix issue where cloud limits would briefly flash in system console before disappearing.
```
