### PR TITLE
MM-49214 Hide bot users from user picker dropdown in app fw

### DIFF
--- a/components/apps_form/apps_form_field/apps_form_select_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_select_field.tsx
@@ -91,7 +91,7 @@ export default class AppsFormSelectField extends React.PureComponent<Props, Stat
         const usersSearchResults: UserAutocomplete = await this.props.actions.autocompleteUsers(userInput.toLowerCase());
 
         return usersSearchResults.users
-        .filter((user) => !user.is_bot) // Filters out bots from user list
+        .filter((user) => !user.is_bot)
         .map((user) => {
             const label = this.props.teammateNameDisplay ? displayUsername(user, this.props.teammateNameDisplay) : user.username;
 

--- a/components/apps_form/apps_form_field/apps_form_select_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_select_field.tsx
@@ -76,7 +76,7 @@ export default class AppsFormSelectField extends React.PureComponent<Props, Stat
             };
         }
 
-        return null; 
+        return null;
     }
 
     onChange = (selectedOption: AppSelectOption) => {
@@ -90,9 +90,7 @@ export default class AppsFormSelectField extends React.PureComponent<Props, Stat
     loadDynamicUserOptions = async (userInput: string): Promise<AppSelectOption[]> => {
         const usersSearchResults: UserAutocomplete = await this.props.actions.autocompleteUsers(userInput.toLowerCase());
 
-        return usersSearchResults.users
-        .filter((user) => !user.is_bot) // Filters out bots from user list
-        .map((user) => {
+        return usersSearchResults.users.filter((user) => !user.is_bot).map((user) => {
             const label = this.props.teammateNameDisplay ? displayUsername(user, this.props.teammateNameDisplay) : user.username;
 
             return {...user, label, value: user.id, icon_data: imageURLForUser(user.id)};

--- a/components/apps_form/apps_form_field/apps_form_select_field.tsx
+++ b/components/apps_form/apps_form_field/apps_form_select_field.tsx
@@ -76,7 +76,7 @@ export default class AppsFormSelectField extends React.PureComponent<Props, Stat
             };
         }
 
-        return null;
+        return null; 
     }
 
     onChange = (selectedOption: AppSelectOption) => {
@@ -90,7 +90,9 @@ export default class AppsFormSelectField extends React.PureComponent<Props, Stat
     loadDynamicUserOptions = async (userInput: string): Promise<AppSelectOption[]> => {
         const usersSearchResults: UserAutocomplete = await this.props.actions.autocompleteUsers(userInput.toLowerCase());
 
-        return usersSearchResults.users.map((user) => {
+        return usersSearchResults.users
+        .filter((user) => !user.is_bot) // Filters out bots from user list
+        .map((user) => {
             const label = this.props.teammateNameDisplay ? displayUsername(user, this.props.teammateNameDisplay) : user.username;
 
             return {...user, label, value: user.id, icon_data: imageURLForUser(user.id)};


### PR DESCRIPTION
#### Summary
This issue involves updating the user picker functionality in the Mattermost web app's app framework. Currently, bot users are being displayed in the user picker for forms, which is not desired. The goal is to hide bot users from the user picker dropdown and only show real users. This can be achieved by filtering out any user that is a bot using the user.is_bot property. The necessary changes have been made in the apps_form_select_field.tsx file, specifically in the loadDynamicUserOptions function, which has been updated to filter out bot users using .filter((user) => !user.is_bot).  
  
Manual testing has been done, no new tests have been added, all existing tests have passed.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/22123

#### Related Pull Requests

#### Screenshots

#### Release Note
```release-note
NONE
```
