### PR TITLE
[MM-51025]: Fix post reminder submenu header theme issue

### DIFF
--- a/components/dot_menu/dot_menu.scss
+++ b/components/dot_menu/dot_menu.scss
@@ -6,6 +6,7 @@
     }
 
     &__post-reminder-menu-header {
+        color: var(--center-channel-color);
         padding: 6px 20px;
         margin: 0;
         font-weight: bold;


### PR DESCRIPTION
#### Summary
fix post reminder submenu header theme issue

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-51025


#### Related Pull Requests
NA

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="357" alt="image" src="https://user-images.githubusercontent.com/16203333/222370823-9d63f184-47e6-4eb9-adc9-d61f107bfa99.png"> | <img width="580" alt="Screenshot 2023-03-02 at 1 47 24 PM" src="https://user-images.githubusercontent.com/16203333/222370786-998b6273-0580-408b-b28b-3c255bcaf2a1.png"> |


#### Release Note
```release-note
* fix post reminder submenu header theme issue
```
