### PR TITLE
[MM-51008] Fix RHS search result hover for larger text

### DIFF
--- a/sass/components/_post.scss
+++ b/sass/components/_post.scss
@@ -785,10 +785,6 @@
         .post__body {
             background: transparent !important;
         }
-
-        .search-item-snippet {
-            overflow: visible;
-        }
     }
 
     &.post--hide-controls {


### PR DESCRIPTION
#### Summary
After we've [unified the post components](https://github.com/mattermost/mattermost-webapp/pull/11127), the `.post--hovered` is now being attached. This triggers overflow to be visible, which looks like isn't needed. @nevyangelova Maybe you have a better context if this is required somewhere?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51008

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
