### PR TITLE
[MM-51032]: fix post reminder timezone, DND submenu and post reminder ephemeral message not to respecting user set timezone

### DIFF
--- a/components/dot_menu/post_reminder_submenu.tsx
+++ b/components/dot_menu/post_reminder_submenu.tsx
@@ -90,12 +90,14 @@ export function PostReminderSubmenu(props: Props) {
                         <FormattedDate
                             value={tomorrow}
                             weekday='short'
+                            timeZone={props.timezone}
                         />
                         {', '}
                         <FormattedTime
                             value={tomorrow}
                             timeStyle='short'
                             hour12={!props.isMilitaryTime}
+                            timeZone={props.timezone}
                         />
                     </span>
                 );

--- a/components/post_markdown/index.ts
+++ b/components/post_markdown/index.ts
@@ -75,7 +75,7 @@ function makeMapStateToProps() {
             isUserCanManageMembers: channel && canManageMembers(state, channel),
             mentionKeys: getMentionKeysForPost(state, ownProps.post, channel),
             isMilitaryTime: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false),
-            timeZone: getCurrentUserTimezone(state),
+            timezone: getCurrentUserTimezone(state),
         };
     };
 }

--- a/components/post_markdown/index.ts
+++ b/components/post_markdown/index.ts
@@ -23,6 +23,8 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {Channel} from '@mattermost/types/channels';
 import {Post} from '@mattermost/types/posts';
 
+import {getCurrentUserTimezone} from '../../selectors/general';
+
 import PostMarkdown from './post_markdown';
 
 export function makeGetMentionKeysForPost(): (
@@ -73,6 +75,7 @@ function makeMapStateToProps() {
             isUserCanManageMembers: channel && canManageMembers(state, channel),
             mentionKeys: getMentionKeysForPost(state, ownProps.post, channel),
             isMilitaryTime: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false),
+            timeZone: getCurrentUserTimezone(state),
         };
     };
 }

--- a/components/post_markdown/post_markdown.tsx
+++ b/components/post_markdown/post_markdown.tsx
@@ -65,7 +65,7 @@ type Props = {
      * Whether the user prefers Military time
      */
     isMilitaryTime?: boolean;
-    timeZone?: string;
+    timezone?: string;
 }
 
 export default class PostMarkdown extends React.PureComponent<Props> {
@@ -96,7 +96,7 @@ export default class PostMarkdown extends React.PureComponent<Props> {
                 this.props.channel,
                 this.props.isUserCanManageMembers,
                 this.props.isMilitaryTime,
-                this.props.timeZone);
+                this.props.timezone);
             if (renderedSystemMessage) {
                 return <div>{renderedSystemMessage}</div>;
             }

--- a/components/post_markdown/post_markdown.tsx
+++ b/components/post_markdown/post_markdown.tsx
@@ -65,6 +65,7 @@ type Props = {
      * Whether the user prefers Military time
      */
     isMilitaryTime?: boolean;
+    timeZone?: string;
 }
 
 export default class PostMarkdown extends React.PureComponent<Props> {
@@ -90,7 +91,12 @@ export default class PostMarkdown extends React.PureComponent<Props> {
         const {post, mentionKeys} = this.props;
 
         if (post) {
-            const renderedSystemMessage = renderSystemMessage(post, this.props.currentTeam, this.props.channel, this.props.isUserCanManageMembers, this.props.isMilitaryTime);
+            const renderedSystemMessage = renderSystemMessage(post,
+                this.props.currentTeam,
+                this.props.channel,
+                this.props.isUserCanManageMembers,
+                this.props.isMilitaryTime,
+                this.props.timeZone);
             if (renderedSystemMessage) {
                 return <div>{renderedSystemMessage}</div>;
             }

--- a/components/post_markdown/system_message_helpers.tsx
+++ b/components/post_markdown/system_message_helpers.tsx
@@ -381,10 +381,10 @@ const systemMessageRenderers = {
     [Posts.POST_TYPES.ME]: renderMeMessage,
 };
 
-export function renderSystemMessage(post: Post, currentTeam: Team, channel: Channel, isUserCanManageMembers?: boolean, isMilitaryTime?: boolean, timeZone?: string): ReactNode {
+export function renderSystemMessage(post: Post, currentTeam: Team, channel: Channel, isUserCanManageMembers?: boolean, isMilitaryTime?: boolean, timezone?: string): ReactNode {
     const isEphemeral = Utils.isPostEphemeral(post);
     if (isEphemeral && post.props?.type === Posts.POST_TYPES.REMINDER) {
-        return renderReminderACKMessage(post, currentTeam, Boolean(isMilitaryTime), timeZone);
+        return renderReminderACKMessage(post, currentTeam, Boolean(isMilitaryTime), timezone);
     }
     if (post.props && post.props.add_channel_member) {
         if (channel && (channel.type === General.PRIVATE_CHANNEL || channel.type === General.OPEN_CHANNEL) &&
@@ -422,7 +422,7 @@ export function renderSystemMessage(post: Post, currentTeam: Team, channel: Chan
     return null;
 }
 
-function renderReminderACKMessage(post: Post, currentTeam: Team, isMilitaryTime: boolean, timeZone?: string): ReactNode {
+function renderReminderACKMessage(post: Post, currentTeam: Team, isMilitaryTime: boolean, timezone?: string): ReactNode {
     const username = renderUsername(post.props.username);
     const teamUrl = `${getSiteURL()}/${post.props.team_name || currentTeam.name}`;
     const link = `${teamUrl}/pl/${post.props.post_id}`;
@@ -433,7 +433,7 @@ function renderReminderACKMessage(post: Post, currentTeam: Team, isMilitaryTime:
         <FormattedTime
             value={localTime}
             hour12={!isMilitaryTime}
-            timeZone={timeZone}
+            timeZone={timezone}
         />);
     const reminderDate = (
         <FormattedDate
@@ -441,7 +441,7 @@ function renderReminderACKMessage(post: Post, currentTeam: Team, isMilitaryTime:
             day='2-digit'
             month='short'
             year='numeric'
-            timeZone={timeZone}
+            timeZone={timezone}
         />);
     return (
         <FormattedMessage

--- a/components/post_markdown/system_message_helpers.tsx
+++ b/components/post_markdown/system_message_helpers.tsx
@@ -381,10 +381,10 @@ const systemMessageRenderers = {
     [Posts.POST_TYPES.ME]: renderMeMessage,
 };
 
-export function renderSystemMessage(post: Post, currentTeam: Team, channel: Channel, isUserCanManageMembers?: boolean, isMilitaryTime?: boolean): ReactNode {
+export function renderSystemMessage(post: Post, currentTeam: Team, channel: Channel, isUserCanManageMembers?: boolean, isMilitaryTime?: boolean, timeZone?: string): ReactNode {
     const isEphemeral = Utils.isPostEphemeral(post);
     if (isEphemeral && post.props?.type === Posts.POST_TYPES.REMINDER) {
-        return renderReminderACKMessage(post, currentTeam, Boolean(isMilitaryTime));
+        return renderReminderACKMessage(post, currentTeam, Boolean(isMilitaryTime), timeZone);
     }
     if (post.props && post.props.add_channel_member) {
         if (channel && (channel.type === General.PRIVATE_CHANNEL || channel.type === General.OPEN_CHANNEL) &&
@@ -422,7 +422,7 @@ export function renderSystemMessage(post: Post, currentTeam: Team, channel: Chan
     return null;
 }
 
-function renderReminderACKMessage(post: Post, currentTeam: Team, isMilitaryTime: boolean): ReactNode {
+function renderReminderACKMessage(post: Post, currentTeam: Team, isMilitaryTime: boolean, timeZone?: string): ReactNode {
     const username = renderUsername(post.props.username);
     const teamUrl = `${getSiteURL()}/${post.props.team_name || currentTeam.name}`;
     const link = `${teamUrl}/pl/${post.props.post_id}`;
@@ -433,6 +433,7 @@ function renderReminderACKMessage(post: Post, currentTeam: Team, isMilitaryTime:
         <FormattedTime
             value={localTime}
             hour12={!isMilitaryTime}
+            timeZone={timeZone}
         />);
     const reminderDate = (
         <FormattedDate
@@ -440,6 +441,7 @@ function renderReminderACKMessage(post: Post, currentTeam: Team, isMilitaryTime:
             day='2-digit'
             month='short'
             year='numeric'
+            timeZone={timeZone}
         />);
     return (
         <FormattedMessage

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -10,10 +10,7 @@ import Text from '@mattermost/compass-components/components/text';
 import Icon from '@mattermost/compass-components/foundations/icon/Icon';
 import {TUserStatus} from '@mattermost/compass-components/shared';
 
-import {PreferenceType} from '@mattermost/types/preferences';
-import {PulsatingDot} from '@mattermost/components';
 import {ActionFunc} from 'mattermost-redux/types/actions';
-import {CustomStatusDuration, UserCustomStatus, UserProfile, UserStatus} from '@mattermost/types/users';
 
 import * as GlobalActions from 'actions/global_actions';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
@@ -37,6 +34,10 @@ import {Constants, ModalIdentifiers, UserStatuses} from 'utils/constants';
 import {t} from 'utils/i18n';
 import {getCurrentDateTimeForTimezone, getCurrentMomentForTimezone} from 'utils/timezone';
 import {localizeMessage} from 'utils/utils';
+
+import {CustomStatusDuration, UserCustomStatus, UserProfile, UserStatus} from '@mattermost/types/users';
+import {PulsatingDot} from '@mattermost/components';
+import {PreferenceType} from '@mattermost/types/preferences';
 
 import './status_dropdown.scss';
 
@@ -378,12 +379,14 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
                                 <FormattedDate
                                     value={tomorrow}
                                     weekday='short'
+                                    timeZone={this.props.timezone}
                                 />
                                 {', '}
                                 <FormattedTime
                                     value={tomorrow}
                                     timeStyle='short'
                                     hour12={!this.props.isMilitaryTime}
+                                    timeZone={this.props.timezone}
                                 />
                             </span>
                         </>


### PR DESCRIPTION
#### Summary
fix post reminder timezone, DND submenu and post reminder ephemeral message not to respecting user set timezone

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-51032


#### Related Pull Requests
NA

#### Screenshot
<img width="488" alt="Screenshot 2023-03-02 at 7 35 00 PM" src="https://user-images.githubusercontent.com/16203333/222452387-ebc4c3ce-011e-4061-90d8-22a4a68967d0.png">
<img width="529" alt="Screenshot 2023-03-02 at 7 34 53 PM" src="https://user-images.githubusercontent.com/16203333/222452398-e6913d62-bb1d-4c26-8a1e-810ec9a3549a.png">
<img width="1025" alt="Screenshot 2023-03-02 at 7 42 10 PM" src="https://user-images.githubusercontent.com/16203333/222452503-b7f81d65-9987-4def-902c-e96f1d9ac37e.png">



#### Release Note
```release-note
* fix post reminder timezone, DND submenu and post reminder ephemeral message not to respecting user set timezone
```
