### PR TITLE
chore(e2e): Test case for 'Set up boards Views'

### DIFF
--- a/e2e/playwright/support/ui/components/boards/create_modal.ts
+++ b/e2e/playwright/support/ui/components/boards/create_modal.ts
@@ -4,22 +4,21 @@
 import {expect, Locator} from '@playwright/test';
 
 export default class BoardsCreateModal {
-    readonly locator: Locator;
+    readonly container: Locator;
     readonly productSwitchMenu: Locator;
 
-    constructor(locator: Locator) {
-        this.locator = locator;
-
-        this.productSwitchMenu = locator.getByRole('button', {name: 'Product switch menu'});
+    constructor(container: Locator) {
+        this.container = container;
+        this.productSwitchMenu = container.getByRole('button', {name: 'Product switch menu'});
     }
 
     async switchProduct(name: string) {
         await this.productSwitchMenu.click();
-        await this.locator.getByRole('link', {name: ` ${name}`}).click();
+        await this.container.getByRole('link', {name: ` ${name}`}).click();
     }
 
     async toBeVisible(name: string) {
-        await expect(this.locator.getByRole('heading', {name})).toBeVisible();
+        await expect(this.container.getByRole('heading', {name})).toBeVisible();
     }
 }
 

--- a/e2e/playwright/support/ui/components/boards/sidebar.ts
+++ b/e2e/playwright/support/ui/components/boards/sidebar.ts
@@ -9,6 +9,8 @@ export default class BoardsSidebar {
     readonly createNewBoardMenuItem: Locator;
     readonly createNewCategoryMenuItem: Locator;
     readonly titles: Locator;
+    readonly activeBoardMenuIcon: Locator;
+    readonly boardMenuDraw: Locator;
 
     constructor(container: Locator) {
         this.container = container;
@@ -17,14 +19,20 @@ export default class BoardsSidebar {
         this.createNewBoardMenuItem = container.getByRole('button', {name: 'Create new board'});
         this.createNewCategoryMenuItem = container.getByRole('button', {name: 'Create New Category'});
         this.titles = container.locator('.SidebarBoardItem > .octo-sidebar-title');
+        this.activeBoardMenuIcon = container.locator('div.SidebarBoardItem.subitem.active button');
+        this.boardMenuDraw = container.locator('div.SidebarBoardItem.subitem.active .menu-contents');
     }
 
     async waitForTitle(name: string) {
         await this.container.getByRole('button', {name: ` ${name}`}).waitFor({state: 'visible'});
     }
 
-    async assertTitleToBe(name: string) {
+    async assertTitleToBeVisible(name: string) {
         await this.titles.getByText(name).isVisible();
+    }
+
+    async getBoardItem(name: string) {
+        return this.titles.filter({hasText: name});
     }
 }
 

--- a/e2e/playwright/support/ui/components/boards/sidebar.ts
+++ b/e2e/playwright/support/ui/components/boards/sidebar.ts
@@ -22,6 +22,10 @@ export default class BoardsSidebar {
     async waitForTitle(name: string) {
         await this.container.getByRole('button', {name: ` ${name}`}).waitFor({state: 'visible'});
     }
+
+    async assertTitleToBe(name: string) {
+        await this.titles.getByText(name).isVisible();
+    }
 }
 
 export {BoardsSidebar};

--- a/e2e/playwright/support/ui/components/boards/sidebar.ts
+++ b/e2e/playwright/support/ui/components/boards/sidebar.ts
@@ -23,16 +23,16 @@ export default class BoardsSidebar {
         this.boardMenuDraw = container.locator('div.SidebarBoardItem.subitem.active .menu-contents');
     }
 
-    async waitForTitle(name: string) {
-        await this.container.getByRole('button', {name: ` ${name}`}).waitFor({state: 'visible'});
-    }
-
     async assertTitleToBeVisible(name: string) {
         await this.titles.getByText(name).isVisible();
     }
 
     async getBoardItem(name: string) {
         return this.titles.filter({hasText: name});
+    }
+
+    async waitForTitle(name: string) {
+        await this.container.getByRole('button', {name: ` ${name}`}).waitFor({state: 'visible'});
     }
 }
 

--- a/e2e/playwright/support/ui/components/index.ts
+++ b/e2e/playwright/support/ui/components/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {BoardsCreateModal} from './boards/create_modal';
 import {BoardsSidebar} from './boards/sidebar';
 import {ChannelsAppBar} from './channels/app_bar';
 import {ChannelsPostCreate} from './channels/post_create';
@@ -8,6 +9,7 @@ import {ChannelsPost} from './channels/post';
 import {GlobalHeader} from './global_header';
 
 const components = {
+    BoardsCreateModal,
     BoardsSidebar,
     ChannelsAppBar,
     ChannelsPostCreate,
@@ -15,4 +17,4 @@ const components = {
     GlobalHeader,
 };
 
-export {components, BoardsSidebar, ChannelsAppBar, ChannelsPostCreate, ChannelsPost, GlobalHeader};
+export {components, BoardsCreateModal, BoardsSidebar, ChannelsAppBar, ChannelsPostCreate, ChannelsPost, GlobalHeader};

--- a/e2e/playwright/support/ui/pages/boards_create.ts
+++ b/e2e/playwright/support/ui/pages/boards_create.ts
@@ -66,7 +66,7 @@ export default class BoardsCreatePage {
 
     async hoverOnAddViewOption() {
         await this.boardsAddView.hover();
-        await this.boardsAddViewSubMenu.isVisible({timeout: 10});
+        await this.boardsAddViewSubMenu.isVisible();
     }
 
     async selectTableView() {
@@ -75,8 +75,8 @@ export default class BoardsCreatePage {
     }
 
     async selectGalleryView() {
-        await this.boardsGalleryView.hover();
-        await this.boardsGalleryHeader.isVisible({timeout: 10});
+        await this.boardsGalleryView.click();
+        await this.boardsGalleryHeader.isVisible();
     }
 
     async assertTableViewisSelected() {

--- a/e2e/playwright/support/ui/pages/boards_create.ts
+++ b/e2e/playwright/support/ui/pages/boards_create.ts
@@ -12,11 +12,9 @@ export default class BoardsCreatePage {
     readonly createBoardHeading: Locator;
     readonly createEmptyBoardButton: Locator;
     readonly useTemplateButton: Locator;
-    readonly boardsViewTitle: Locator;
 
     constructor(page: Page) {
         this.page = page;
-        this.boardsViewTitle = page.locator('[placeholder="Untitled View"]');
         this.createBoardHeading = page.getByRole('heading', {name: 'Create a board'});
         this.createEmptyBoardButton = page.getByRole('button', {name: ' Create an empty board'});
         this.globalHeader = new GlobalHeader(this.page.locator('#global-header'));

--- a/e2e/playwright/support/ui/pages/boards_create.ts
+++ b/e2e/playwright/support/ui/pages/boards_create.ts
@@ -12,27 +12,11 @@ export default class BoardsCreatePage {
     readonly createBoardHeading: Locator;
     readonly createEmptyBoardButton: Locator;
     readonly useTemplateButton: Locator;
-    readonly boardsView: Locator;
-    readonly boardsViewDropdown: Locator;
-    readonly boardsAddView: Locator;
-    readonly boardsAddViewSubMenu: Locator;
-    readonly boardsViewMenu: Locator;
-    readonly boardsGalleryView: Locator;
-    readonly boardsGalleryHeader: Locator;
-    readonly boardsTableHeader: Locator;
-    readonly boardsTableView: Locator;
+    readonly boardsViewTitle: Locator;
 
     constructor(page: Page) {
         this.page = page;
-        this.boardsView = page.locator('[placeholder="Untitled View"]');
-        this.boardsViewDropdown = page.getByLabel('View menu');
-        this.boardsTableHeader = page.locator('.Table  #mainBoardHeader');
-        this.boardsGalleryHeader = page.locator('.Gallery > .octo-gallery-new');
-        this.boardsTableView = page.getByLabel('Table');
-        this.boardsGalleryView = page.getByLabel('Gallery');
-        this.boardsViewMenu = page.locator('menu-contents');
-        this.boardsAddView = page.locator('#__addView');
-        this.boardsAddViewSubMenu = page.locator('div.subMenu');
+        this.boardsViewTitle = page.locator('[placeholder="Untitled View"]');
         this.createBoardHeading = page.getByRole('heading', {name: 'Create a board'});
         this.createEmptyBoardButton = page.getByRole('button', {name: ' Create an empty board'});
         this.globalHeader = new GlobalHeader(this.page.locator('#global-header'));
@@ -57,38 +41,6 @@ export default class BoardsCreatePage {
 
     async createEmptyBoard() {
         await this.createEmptyBoardButton.click();
-    }
-
-    async openBoardsViewMenu() {
-        await this.boardsViewDropdown.click();
-        await this.boardsViewMenu.isVisible();
-    }
-
-    async hoverOnAddViewOption() {
-        await this.boardsAddView.hover();
-        await this.boardsAddViewSubMenu.isVisible();
-    }
-
-    async selectTableView() {
-        await this.boardsTableView.click();
-        await this.boardsTableHeader.isVisible();
-    }
-
-    async selectGalleryView() {
-        await this.boardsGalleryView.click();
-        await this.boardsGalleryHeader.isVisible();
-    }
-
-    async assertTableViewisSelected() {
-        await this.openBoardsViewMenu();
-        await this.hoverOnAddViewOption();
-        await this.selectTableView();
-    }
-
-    async assertGalleryViewisSelected() {
-        await this.openBoardsViewMenu();
-        await this.hoverOnAddViewOption();
-        await this.selectGalleryView();
     }
 }
 

--- a/e2e/playwright/support/ui/pages/boards_create.ts
+++ b/e2e/playwright/support/ui/pages/boards_create.ts
@@ -12,12 +12,30 @@ export default class BoardsCreatePage {
     readonly createBoardHeading: Locator;
     readonly createEmptyBoardButton: Locator;
     readonly useTemplateButton: Locator;
+    readonly boardsView: Locator;
+    readonly boardsViewDropdown: Locator;
+    readonly boardsAddView: Locator;
+    readonly boardsAddViewSubMenu: Locator;
+    readonly boardsViewMenu: Locator;
+    readonly boardsGalleryView: Locator;
+    readonly boardsGalleryHeader: Locator;
+    readonly boardsTableHeader: Locator;
+    readonly boardsTableView: Locator;
 
     constructor(page: Page) {
         this.page = page;
-        this.globalHeader = new GlobalHeader(this.page.locator('#global-header'));
+        this.boardsView = page.locator('[placeholder="Untitled View"]');
+        this.boardsViewDropdown = page.getByLabel('View menu');
+        this.boardsTableHeader = page.locator('.Table  #mainBoardHeader');
+        this.boardsGalleryHeader = page.locator('.Gallery > .octo-gallery-new');
+        this.boardsTableView = page.getByLabel('Table');
+        this.boardsGalleryView = page.getByLabel('Gallery');
+        this.boardsViewMenu = page.locator('menu-contents');
+        this.boardsAddView = page.locator('#__addView');
+        this.boardsAddViewSubMenu = page.locator('div.subMenu');
         this.createBoardHeading = page.getByRole('heading', {name: 'Create a board'});
         this.createEmptyBoardButton = page.getByRole('button', {name: ' Create an empty board'});
+        this.globalHeader = new GlobalHeader(this.page.locator('#global-header'));
         this.useTemplateButton = page.getByRole('button', {name: 'Use this template'});
     }
 
@@ -39,6 +57,38 @@ export default class BoardsCreatePage {
 
     async createEmptyBoard() {
         await this.createEmptyBoardButton.click();
+    }
+
+    async openBoardsViewMenu() {
+        await this.boardsViewDropdown.click();
+        await this.boardsViewMenu.isVisible();
+    }
+
+    async hoverOnAddViewOption() {
+        await this.boardsAddView.hover();
+        await this.boardsAddViewSubMenu.isVisible({timeout: 10});
+    }
+
+    async selectTableView() {
+        await this.boardsTableView.click();
+        await this.boardsTableHeader.isVisible();
+    }
+
+    async selectGalleryView() {
+        await this.boardsGalleryView.hover();
+        await this.boardsGalleryHeader.isVisible({timeout: 10});
+    }
+
+    async assertTableViewisSelected() {
+        await this.openBoardsViewMenu();
+        await this.hoverOnAddViewOption();
+        await this.selectTableView();
+    }
+
+    async assertGalleryViewisSelected() {
+        await this.openBoardsViewMenu();
+        await this.hoverOnAddViewOption();
+        await this.selectGalleryView();
     }
 }
 

--- a/e2e/playwright/support/ui/pages/boards_view.ts
+++ b/e2e/playwright/support/ui/pages/boards_view.ts
@@ -10,6 +10,7 @@ export default class BoardsViewPage {
     readonly boardsAPIUrl: string;
     readonly boardsDuplicateURL: string;
     readonly boardsCreateModal: BoardsCreateModal;
+    readonly boardsViewDropdown: Locator;
     readonly duplicateBoardButton: Locator;
     readonly deleteBoardButton: Locator;
     readonly deleteBoardConfirmationButton: Locator;
@@ -19,9 +20,30 @@ export default class BoardsViewPage {
     readonly sidebar: BoardsSidebar;
     readonly shareButton: Locator;
     readonly topHead: Locator;
+    readonly boardsViewMenu: Locator;
+    readonly boardsViewName: Locator;
+    readonly boardsAddView: Locator;
+    readonly boardsAddViewSubMenu: Locator;
+    readonly boardsTableView: Locator;
+    readonly boardsTableHeader: Locator;
+    readonly boardsGalleryView: Locator;
+    readonly boardsGalleryHeader: Locator;
+    readonly boardsDeleteView: Locator;
+    readonly boardsDuplicateView: Locator;
 
     constructor(page: Page) {
         this.page = page;
+        this.boardsViewDropdown = page.getByLabel('View menu');
+        this.boardsViewMenu = page.locator('menu-contents');
+        this.boardsViewName = page.locator('.SidebarBoardItem.sidebar-view-item.active');
+        this.boardsGalleryHeader = page.locator('.Gallery > .octo-gallery-new');
+        this.boardsGalleryView = page.getByLabel('Gallery');
+        this.boardsDuplicateView = page.getByLabel('Duplicate view');
+        this.boardsDeleteView = page.getByLabel('Delete view');
+        this.boardsTableHeader = page.locator('div.octo-table-body');
+        this.boardsTableView = page.getByLabel('Table');
+        this.boardsAddViewSubMenu = page.locator('div.subMenu');
+        this.boardsAddView = page.locator('#__addView');
         this.boardsAPIUrl = 'plugins/boards/api/v2/boards';
         this.boardsDuplicateURL = 'duplicate?asTemplate=false';
         this.boardsCreateModal = new BoardsCreateModal(page.locator('.menu-contents'));
@@ -94,6 +116,54 @@ export default class BoardsViewPage {
             (response) => response.url().includes(this.boardsAPIUrl) && response.status() === 200
         );
         expect((await this.sidebar.getBoardItem(boardName)).isHidden());
+    }
+
+    async openBoardsViewMenu() {
+        await this.boardsViewDropdown.click();
+        await this.boardsViewMenu.isVisible();
+    }
+
+    async hoverOnAddViewOption() {
+        await this.boardsAddView.hover();
+        await this.boardsAddViewSubMenu.isVisible();
+    }
+
+    async selectTableView() {
+        await this.boardsTableView.click();
+        await this.boardsTableHeader.isVisible();
+    }
+
+    async selectGalleryView() {
+        await this.boardsGalleryView.click();
+        await this.boardsGalleryHeader.isVisible();
+    }
+
+    async assertTableViewisSelected() {
+        await this.openBoardsViewMenu();
+        await this.hoverOnAddViewOption();
+        await this.selectTableView();
+    }
+
+    async assertGalleryViewisSelected() {
+        await this.openBoardsViewMenu();
+        await this.hoverOnAddViewOption();
+        await this.selectGalleryView();
+    }
+
+    async deleteBoardView() {
+        await this.boardsViewDropdown.click();
+        await this.boardsDeleteView.click();
+        await this.page.waitForResponse((response) => response.url().includes('blocks') && response.status() === 200);
+    }
+
+    async duplicateBoardView() {
+        const currentBoardViewName = await this.boardsViewName.innerText();
+        await this.boardsViewDropdown.click();
+        await this.boardsDuplicateView.click();
+        await this.page.waitForResponse(
+            (response) => response.url().includes(this.boardsDuplicateURL) && response.status() === 200
+        );
+        expect(await this.boardsViewName.innerText()).toBe(`${currentBoardViewName} copy`);
     }
 }
 

--- a/e2e/playwright/support/ui/pages/boards_view.ts
+++ b/e2e/playwright/support/ui/pages/boards_view.ts
@@ -13,6 +13,9 @@ export default class BoardsViewPage {
     readonly topHead: Locator;
     readonly editableTitle: Locator;
     readonly shareButton: Locator;
+    readonly duplicateBoardButton: Locator;
+    readonly deleteBoardButton: Locator;
+    readonly deleteBoardConfirmationButton: Locator;
 
     constructor(page: Page) {
         this.page = page;
@@ -21,6 +24,9 @@ export default class BoardsViewPage {
         this.topHead = page.locator('.top-head');
         this.editableTitle = this.topHead.getByPlaceholder('Untitled board');
         this.shareButton = page.getByRole('button', {name: '󰍁 Share'});
+        this.duplicateBoardButton = page.getByLabel('Duplicate board');
+        this.deleteBoardButton = page.getByLabel('Delete board');
+        this.deleteBoardConfirmationButton = page.locator('button.Button.filled.danger');
     }
 
     async goto(teamId = '', boardId = '', viewId = '', cardId = '') {
@@ -52,6 +58,32 @@ export default class BoardsViewPage {
         await this.editableTitle.isVisible();
         expect(await this.editableTitle.getAttribute('value')).toBe('');
         await expect(this.page.getByTitle('(Untitled Board)')).toBeVisible();
+    }
+
+    async createDuplicateBoard(boardName: string) {
+        await this.page.hover(`div[title='${boardName}']`);
+        await this.page.locator(`//div[@title='${boardName}']/following-sibling::div`).click();
+        await this.duplicateBoardButton.click();
+        await this.page.waitForResponse(response => response.url().includes('duplicate?asTemplate=false') && response.status() === 200);
+        expect(await this.editableTitle.getAttribute('value')).toBe(`${boardName} copy`);
+    }
+
+    async shouldHaveBoardName(boardName: string) {
+        await this.editableTitle.isVisible();
+        expect(await this.editableTitle.getAttribute('value')).toBe(boardName);
+    }
+
+    async deleteBoard(boardName: string) {
+        await this.page.hover(`div[title='${boardName}']`);
+        await this.page.locator(`//div[@title='${boardName}']/following-sibling::div`).click();
+        await this.deleteBoardButton.click();
+        await this.deleteBoardConfirmationButton.click();
+        await this.page.waitForResponse(response => response.url().includes('plugins/boards/api/v2/boards') && response.status() === 200);
+        await this.waitforElementToNotExists(`div[title='${boardName}']`)
+    }
+
+    async waitforElementToNotExists(locator: string){
+        return await this.page.waitForFunction(locator => !!document.querySelector(locator), locator);
     }
 }
 

--- a/e2e/playwright/support/ui/pages/boards_view.ts
+++ b/e2e/playwright/support/ui/pages/boards_view.ts
@@ -3,12 +3,13 @@
 
 import {expect, Locator, Page} from '@playwright/test';
 
-import {BoardsSidebar, GlobalHeader} from '@e2e-support/ui/components';
+import {BoardsSidebar, GlobalHeader, BoardsCreateModal} from '@e2e-support/ui/components';
 
 export default class BoardsViewPage {
     readonly boards = 'Boards';
     readonly page: Page;
     readonly sidebar: BoardsSidebar;
+    readonly boardsCreateModal: BoardsCreateModal;
     readonly globalHeader: GlobalHeader;
     readonly topHead: Locator;
     readonly editableTitle: Locator;
@@ -19,6 +20,7 @@ export default class BoardsViewPage {
 
     constructor(page: Page) {
         this.page = page;
+        this.boardsCreateModal = new BoardsCreateModal(page.locator('.menu-contents'));
         this.sidebar = new BoardsSidebar(page.locator('.octo-sidebar'));
         this.globalHeader = new GlobalHeader(this.page.locator('#global-header'));
         this.topHead = page.locator('.top-head');
@@ -64,7 +66,9 @@ export default class BoardsViewPage {
         await this.page.hover(`div[title='${boardName}']`);
         await this.page.locator(`//div[@title='${boardName}']/following-sibling::div`).click();
         await this.duplicateBoardButton.click();
-        await this.page.waitForResponse(response => response.url().includes('duplicate?asTemplate=false') && response.status() === 200);
+        await this.page.waitForResponse(
+            (response) => response.url().includes('duplicate?asTemplate=false') && response.status() === 200
+        );
         expect(await this.editableTitle.getAttribute('value')).toBe(`${boardName} copy`);
     }
 
@@ -78,12 +82,14 @@ export default class BoardsViewPage {
         await this.page.locator(`//div[@title='${boardName}']/following-sibling::div`).click();
         await this.deleteBoardButton.click();
         await this.deleteBoardConfirmationButton.click();
-        await this.page.waitForResponse(response => response.url().includes('plugins/boards/api/v2/boards') && response.status() === 200);
-        await this.waitforElementToNotExists(`div[title='${boardName}']`)
+        await this.page.waitForResponse(
+            (response) => response.url().includes('plugins/boards/api/v2/boards') && response.status() === 200
+        );
+        await this.waitforElementToNotExists(`div[title='${boardName}']`);
     }
 
-    async waitforElementToNotExists(locator: string){
-        return await this.page.waitForFunction(locator => !!document.querySelector(locator), locator);
+    async waitforElementToNotExists(locator: string) {
+        return await this.page.waitForFunction((locator) => !!document.querySelector(locator), locator);
     }
 }
 

--- a/e2e/playwright/support/ui/pages/boards_view.ts
+++ b/e2e/playwright/support/ui/pages/boards_view.ts
@@ -66,10 +66,14 @@ export default class BoardsViewPage {
         await expect(this.page.getByTitle('(Untitled Board)')).toBeVisible();
     }
 
-    async createDuplicateBoard(boardName: string) {
+    async openBoardsMenuFor(boardName: string) {
         await (await this.sidebar.getBoardItem(boardName)).hover();
         await this.sidebar.activeBoardMenuIcon.click();
         await this.sidebar.boardMenuDraw.isVisible();
+    }
+
+    async createDuplicateBoard(boardName: string) {
+        await this.openBoardsMenuFor(boardName);
         await this.duplicateBoardButton.click();
         await this.page.waitForResponse(
             (response) => response.url().includes(this.boardsDuplicateURL) && response.status() === 200
@@ -83,9 +87,7 @@ export default class BoardsViewPage {
     }
 
     async deleteBoard(boardName: string) {
-        await (await this.sidebar.getBoardItem(boardName)).hover();
-        await this.sidebar.activeBoardMenuIcon.click();
-        await this.sidebar.boardMenuDraw.isVisible();
+        await this.openBoardsMenuFor(boardName);
         await this.deleteBoardButton.click();
         await this.deleteBoardConfirmationButton.click();
         await this.page.waitForResponse(

--- a/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
+++ b/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
@@ -44,3 +44,52 @@ test('MM-T4274 Create an Empty Board', async ({pw, pages}) => {
     expect(await boardsViewPage.editableTitle.getAttribute('value')).toBe(title);
     await boardsViewPage.sidebar.waitForTitle(title);
 });
+
+test('MM-T4290: Duplicating and deleting a board', async ({pw, pages}) => {
+    await pw.shouldHaveBoardsEnabled();
+
+    // Create and sign in a new user
+    const {user} = await pw.initSetup();
+
+    // Log in a user in new browser context
+    const {page} = await pw.testBrowser.login(user);
+
+    // Visit a default channel page
+    const channelsPage = new pages.ChannelsPage(page);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // Switch to Boards page
+    await channelsPage.globalHeader.switchProduct('Boards');
+
+    // Should have redirected to boards create page
+    const boardsCreatePage = new pages.BoardsCreatePage(page);
+    await boardsCreatePage.toBeVisible();
+
+    // Create empty board
+    await boardsCreatePage.createEmptyBoard();
+
+    // Should have redirected to boards view page
+    const boardsViewPage = new pages.BoardsViewPage(page);
+    await boardsViewPage.toBeVisible();
+    await boardsViewPage.shouldHaveUntitledBoard();
+
+    // Type new title and hit enter
+    const title = 'Testing';
+    await boardsViewPage.editableTitle.fill(title);
+    await boardsViewPage.editableTitle.press('Enter');
+
+    // Should update the title in heading and in sidebar
+    expect(await boardsViewPage.editableTitle.getAttribute('value')).toBe(title);
+    await boardsViewPage.sidebar.waitForTitle(title);
+
+    // Should create a duplicate board
+    await boardsViewPage.createDuplicateBoard(title);
+
+    // Should verify duplicate board is created
+    await boardsViewPage.shouldHaveBoardName(`${title} copy`);
+
+    // Should delete board and confirm deletion
+    await boardsViewPage.deleteBoard(`${title} copy`);
+
+});

--- a/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
+++ b/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
@@ -132,10 +132,61 @@ test('MM-T4277: Set up Views', async ({pw, pages}) => {
     await boardsViewPage.sidebar.waitForTitle(title);
 
     // Should select Table view and assert it's visibility
-    await boardsCreatePage.assertTableViewisSelected();
+    await boardsViewPage.assertTableViewisSelected();
     await boardsViewPage.sidebar.assertTitleToBeVisible('Table view');
 
     // Should select Gallery view and assert it's visibility
-    await boardsCreatePage.assertGalleryViewisSelected();
+    await boardsViewPage.assertGalleryViewisSelected();
     await boardsViewPage.sidebar.assertTitleToBeVisible('Gallery view');
+});
+
+test.only('MM-T4278: Managing and navigating views', async ({pw, pages}) => {
+    await pw.shouldHaveBoardsEnabled();
+
+    // Create and sign in a new user
+    const {user} = await pw.initSetup();
+
+    // Log in a user in new browser context
+    const {page} = await pw.testBrowser.login(user);
+
+    // Visit a default channel page
+    const channelsPage = new pages.ChannelsPage(page);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // Switch to Boards page
+    await channelsPage.globalHeader.switchProduct('Boards');
+
+    // Should have redirected to boards create page
+    const boardsCreatePage = new pages.BoardsCreatePage(page);
+    await boardsCreatePage.toBeVisible();
+
+    // Create empty board
+    await boardsCreatePage.createEmptyBoard();
+
+    // Should have redirected to boards view page
+    const boardsViewPage = new pages.BoardsViewPage(page);
+    await boardsViewPage.toBeVisible();
+    await boardsViewPage.shouldHaveUntitledBoard();
+
+    // Type new title and hit enter
+    const title = 'Testing';
+    await boardsViewPage.editableTitle.fill(title);
+    await boardsViewPage.editableTitle.press('Enter');
+
+    // Should update the title in heading and in sidebar
+    expect(await boardsViewPage.editableTitle.getAttribute('value')).toBe(title);
+    await boardsViewPage.sidebar.waitForTitle(title);
+
+    // Should select Table view and assert it's visibility
+    await boardsViewPage.assertTableViewisSelected();
+    await boardsViewPage.sidebar.assertTitleToBeVisible('Table view');
+
+    // Should select Gallery view and assert it's visibility
+    await boardsViewPage.assertGalleryViewisSelected();
+    await boardsViewPage.sidebar.assertTitleToBeVisible('Gallery view');
+
+    // Should duplicate and delete the view
+    await boardsViewPage.duplicateBoardView();
+    await boardsViewPage.deleteBoardView();
 });

--- a/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
+++ b/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
@@ -140,7 +140,7 @@ test('MM-T4277: Set up Views', async ({pw, pages}) => {
     await boardsViewPage.sidebar.assertTitleToBeVisible('Gallery view');
 });
 
-test('MM-T4278: Managing and navigating views', async ({pw, pages}) => {
+test('MM-T4278: Managing and navigating views and MM-T4290: Duplicating and deleting a board', async ({pw, pages}) => {
     await pw.shouldHaveBoardsEnabled();
 
     // Create and sign in a new user

--- a/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
+++ b/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
@@ -6,7 +6,7 @@ import {shouldSkipInSmallScreen} from '@e2e-support/flag';
 
 shouldSkipInSmallScreen();
 
-test.skip('MM-T4274 Create an Empty Board', async ({pw, pages}) => {
+test('MM-T4274 Create an Empty Board', async ({pw, pages}) => {
     await pw.shouldHaveBoardsEnabled();
 
     // Create and sign in a new user
@@ -45,7 +45,7 @@ test.skip('MM-T4274 Create an Empty Board', async ({pw, pages}) => {
     await boardsViewPage.sidebar.waitForTitle(title);
 });
 
-test.skip('MM-T4290: Duplicating and deleting a board', async ({pw, pages}) => {
+test('MM-T4290: Duplicating and deleting a board', async ({pw, pages}) => {
     await pw.shouldHaveBoardsEnabled();
 
     // Create and sign in a new user
@@ -132,7 +132,7 @@ test('MM-T4277: Set up Views', async ({pw, pages}) => {
     await boardsViewPage.sidebar.waitForTitle(title);
 
     await boardsCreatePage.assertTableViewisSelected();
-    await boardsViewPage.sidebar.assertTitleToBe('Table view');
+    await boardsViewPage.sidebar.assertTitleToBeVisible('Table view');
     await boardsCreatePage.assertGalleryViewisSelected();
-    await boardsViewPage.sidebar.assertTitleToBe('Gallery view');
+    await boardsViewPage.sidebar.assertTitleToBeVisible('Gallery view');
 });

--- a/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
+++ b/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
@@ -131,8 +131,11 @@ test('MM-T4277: Set up Views', async ({pw, pages}) => {
     expect(await boardsViewPage.editableTitle.getAttribute('value')).toBe(title);
     await boardsViewPage.sidebar.waitForTitle(title);
 
+    // Should select Table view and assert its visible
     await boardsCreatePage.assertTableViewisSelected();
     await boardsViewPage.sidebar.assertTitleToBeVisible('Table view');
+
+    // Should select Gallery view and assert its visible
     await boardsCreatePage.assertGalleryViewisSelected();
     await boardsViewPage.sidebar.assertTitleToBeVisible('Gallery view');
 });

--- a/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
+++ b/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
@@ -140,7 +140,7 @@ test('MM-T4277: Set up Views', async ({pw, pages}) => {
     await boardsViewPage.sidebar.assertTitleToBeVisible('Gallery view');
 });
 
-test.only('MM-T4278: Managing and navigating views', async ({pw, pages}) => {
+test('MM-T4278: Managing and navigating views', async ({pw, pages}) => {
     await pw.shouldHaveBoardsEnabled();
 
     // Create and sign in a new user
@@ -186,7 +186,21 @@ test.only('MM-T4278: Managing and navigating views', async ({pw, pages}) => {
     await boardsViewPage.assertGalleryViewisSelected();
     await boardsViewPage.sidebar.assertTitleToBeVisible('Gallery view');
 
+    const renameTesting1Board = 'Testing 1 Board';
+    const renameTesting2Table = 'Testing 2 Table';
+    const renameTesting3Gallery = 'Testing 3 Gallery';
+
     // Should duplicate and delete the view
     await boardsViewPage.duplicateBoardView();
     await boardsViewPage.deleteBoardView();
+
+    // Should rename Table view and assert new name in the sidebar
+    await boardsViewPage.renameBoardView('Table view', renameTesting2Table);
+    await boardsViewPage.sidebar.assertTitleToBeVisible(renameTesting2Table);
+
+    await boardsViewPage.renameBoardView('Gallery view', renameTesting3Gallery);
+    await boardsViewPage.sidebar.assertTitleToBeVisible(renameTesting3Gallery);
+
+    await boardsViewPage.renameBoardView('Board view', renameTesting1Board);
+    await boardsViewPage.sidebar.assertTitleToBeVisible(renameTesting1Board);
 });

--- a/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
+++ b/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
@@ -131,11 +131,11 @@ test('MM-T4277: Set up Views', async ({pw, pages}) => {
     expect(await boardsViewPage.editableTitle.getAttribute('value')).toBe(title);
     await boardsViewPage.sidebar.waitForTitle(title);
 
-    // Should select Table view and assert its visible
+    // Should select Table view and assert it's visibility
     await boardsCreatePage.assertTableViewisSelected();
     await boardsViewPage.sidebar.assertTitleToBeVisible('Table view');
 
-    // Should select Gallery view and assert its visible
+    // Should select Gallery view and assert it's visibility
     await boardsCreatePage.assertGalleryViewisSelected();
     await boardsViewPage.sidebar.assertTitleToBeVisible('Gallery view');
 });

--- a/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
+++ b/e2e/playwright/tests/functional/boards/board-creation-and-set-up/create_empty_board.spec.ts
@@ -6,7 +6,7 @@ import {shouldSkipInSmallScreen} from '@e2e-support/flag';
 
 shouldSkipInSmallScreen();
 
-test('MM-T4274 Create an Empty Board', async ({pw, pages}) => {
+test.skip('MM-T4274 Create an Empty Board', async ({pw, pages}) => {
     await pw.shouldHaveBoardsEnabled();
 
     // Create and sign in a new user
@@ -45,7 +45,7 @@ test('MM-T4274 Create an Empty Board', async ({pw, pages}) => {
     await boardsViewPage.sidebar.waitForTitle(title);
 });
 
-test('MM-T4290: Duplicating and deleting a board', async ({pw, pages}) => {
+test.skip('MM-T4290: Duplicating and deleting a board', async ({pw, pages}) => {
     await pw.shouldHaveBoardsEnabled();
 
     // Create and sign in a new user
@@ -91,5 +91,48 @@ test('MM-T4290: Duplicating and deleting a board', async ({pw, pages}) => {
 
     // Should delete board and confirm deletion
     await boardsViewPage.deleteBoard(`${title} copy`);
+});
 
+test('MM-T4277: Set up Views', async ({pw, pages}) => {
+    await pw.shouldHaveBoardsEnabled();
+
+    // Create and sign in a new user
+    const {user} = await pw.initSetup();
+
+    // Log in a user in new browser context
+    const {page} = await pw.testBrowser.login(user);
+
+    // Visit a default channel page
+    const channelsPage = new pages.ChannelsPage(page);
+    await channelsPage.goto();
+    await channelsPage.toBeVisible();
+
+    // Switch to Boards page
+    await channelsPage.globalHeader.switchProduct('Boards');
+
+    // Should have redirected to boards create page
+    const boardsCreatePage = new pages.BoardsCreatePage(page);
+    await boardsCreatePage.toBeVisible();
+
+    // Create empty board
+    await boardsCreatePage.createEmptyBoard();
+
+    // Should have redirected to boards view page
+    const boardsViewPage = new pages.BoardsViewPage(page);
+    await boardsViewPage.toBeVisible();
+    await boardsViewPage.shouldHaveUntitledBoard();
+
+    // Type new title and hit enter
+    const title = 'Testing';
+    await boardsViewPage.editableTitle.fill(title);
+    await boardsViewPage.editableTitle.press('Enter');
+
+    // Should update the title in heading and in sidebar
+    expect(await boardsViewPage.editableTitle.getAttribute('value')).toBe(title);
+    await boardsViewPage.sidebar.waitForTitle(title);
+
+    await boardsCreatePage.assertTableViewisSelected();
+    await boardsViewPage.sidebar.assertTitleToBe('Table view');
+    await boardsCreatePage.assertGalleryViewisSelected();
+    await boardsViewPage.sidebar.assertTitleToBe('Gallery view');
 });


### PR DESCRIPTION
- Added [MM-T4274](https://github.com/mattermost/mattermost-test-management/blob/main/data/test-cases/boards/board-creation-and-set-up/MM-T4290.md) (functional) test for Duplicating and deleting a board.

- Added [MM-T4277](https://github.com/mattermost/mattermost-test-management/blob/main/data/test-cases/boards/board-creation-and-set-up/MM-T4277.md) (functional) test for Set up Views.

- Added [MM-T4278](https://github.com/mattermost/mattermost-test-management/blob/main/data/test-cases/boards/board-creation-and-set-up/MM-T4278.md) (functional) test for Managing and navigating views.

- Added [MM-T4290](https://github.com/mattermost/mattermost-test-management/blob/main/data/test-cases/boards/board-creation-and-set-up/MM-T4290.md) (functional) test for Duplicating and deleting a board.

<img width="1040" alt="Screenshot 2023-03-07 at 12 59 43 AM" src="https://user-images.githubusercontent.com/15979783/223212232-620c718f-3735-4734-88d5-03fddcb23019.png">


Observations:
- playwright execution is very fast locally, and sometimes it doesn't wait for network calls to return response. Hence, using page.waiforresponse
- Locally, it will be a good idea to use `PW_SLOWMO=300` to run tests.

```release-note
NONE
```
