### PR TITLE
[MM-51009] - Remove redundant CSS rule for timestamps in compact mode

### DIFF
--- a/sass/responsive/_tablet.scss
+++ b/sass/responsive/_tablet.scss
@@ -292,8 +292,6 @@
                 .post__permalink {
                     position: absolute;
                     top: 1px;
-                    left: -76px;
-                    width: 60px;
                     text-align: right;
                 }
 


### PR DESCRIPTION

#### Summary
Fix missing timestamp caused by redundant css rule in compact mode

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51009

#### Release Note

```release-note
NONE
```
