### PR TITLE
Fix typo in e2e test helper function uploadPluginX

### DIFF
--- a/e2e/playwright/support/server/client.ts
+++ b/e2e/playwright/support/server/client.ts
@@ -126,7 +126,7 @@ export default class Client extends Client4 {
         if (force) {
             formData.append('force', 'true');
         }
-        formData.append('license', fileData, path.basename(filePath));
+        formData.append('plugin', fileData, path.basename(filePath));
         const options = this.getFormDataOptions(formData);
 
         return this.doFetch<PluginManifest>(this.getPluginsRoute(), options);


### PR DESCRIPTION
#### Summary

Currently the helper function available for Playwright tests `uploadPluginX` is appending the file contents using the form data name `license` instead of `plugin`. This PR makes it so it uses the correct name.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
