### PR TITLE
MM-50123 : Identify causes of removal of channel and channel members re fetching on team switch

### DIFF
--- a/actions/channel_actions.ts
+++ b/actions/channel_actions.ts
@@ -252,24 +252,20 @@ export function fetchChannelsAndMembers(teamId: Team['id'] = ''): ActionFunc<{ch
                 teamId,
                 data: channels,
             });
-            actions.push({
-                type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS,
-                data: channelMembers,
-            });
-            actions.push({
-                type: RoleTypes.RECEIVED_ROLES,
-                data: roles,
-            });
         } else {
             actions.push({
                 type: ChannelTypes.RECEIVED_ALL_CHANNELS,
                 data: channels,
             });
-            actions.push({
-                type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS,
-                data: channelMembers,
-            });
         }
+        actions.push({
+            type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS,
+            data: channelMembers,
+        });
+        actions.push({
+            type: RoleTypes.RECEIVED_ROLES,
+            data: roles,
+        });
 
         await dispatch(batchActions(actions));
 

--- a/components/team_controller/actions/index.ts
+++ b/components/team_controller/actions/index.ts
@@ -4,10 +4,9 @@
 import {ActionFunc} from 'mattermost-redux/types/actions';
 import {getTeamByName, selectTeam} from 'mattermost-redux/actions/teams';
 import {forceLogoutIfNecessary} from 'mattermost-redux/actions/helpers';
-import {fetchMyChannelsAndMembersREST} from 'mattermost-redux/actions/channels';
 import {getGroups, getAllGroupsAssociatedToChannelsInTeam, getAllGroupsAssociatedToTeam, getGroupsByUserIdPaginated} from 'mattermost-redux/actions/groups';
 import {logError} from 'mattermost-redux/actions/errors';
-import {isCustomGroupsEnabled, isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {isCustomGroupsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
@@ -15,7 +14,6 @@ import {isSuccess} from 'types/actions';
 
 import {loadStatusesForChannelAndSidebar} from 'actions/status_actions';
 import {addUserToTeam} from 'actions/team_actions';
-import {fetchChannelsAndMembers} from 'actions/channel_actions';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
@@ -29,19 +27,6 @@ export function initializeTeam(team: Team): ActionFunc<Team, ServerError> {
         const state = getState();
         const currentUser = getCurrentUser(state);
         LocalStorageStore.setPreviousTeamId(currentUser.id, team.id);
-
-        const graphQLEnabled = isGraphQLEnabled(state);
-        try {
-            if (graphQLEnabled) {
-                await dispatch(fetchChannelsAndMembers(team.id));
-            } else {
-                await dispatch(fetchMyChannelsAndMembersREST(team.id));
-            }
-        } catch (error) {
-            forceLogoutIfNecessary(error as ServerError, dispatch, getState);
-            dispatch(logError(error as ServerError));
-            return {error: error as ServerError};
-        }
 
         dispatch(loadStatusesForChannelAndSidebar());
 


### PR DESCRIPTION
#### Summary
We already fetch everything related to channel and channel members on team controller mount https://github.com/mattermost/mattermost-webapp/blob/ed4baa6e0cc30c0c8e9a111bbe0d12bf5a3ba372/components/team_controller/team_controller.tsx#L55-L67 . On Each team switch refeteching the same data seems to be redundant.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50123

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
