### PR TITLE
[MM-48400] - Cannot perform global search while recent mentions is open

### DIFF
--- a/components/search/search.tsx
+++ b/components/search/search.tsx
@@ -253,7 +253,6 @@ const Search: React.FC<Props> = (props: Props): JSX.Element => {
         }
 
         if (props.isMentionSearch) {
-            e.preventDefault();
             actions.updateRhsState(RHSStates.SEARCH);
         }
     };


### PR DESCRIPTION
### Summary
Cannot perform global search while recent mentions is open

Fixes https://github.com/mattermost/mattermost-server/issues/22457

### Demo video
https://www.loom.com/share/a8c0da5bf9d443188eea3c10ef52b990



#### Release note
```release-note
Fixes global search while recent mentions is open
```

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.