### PR TITLE
MM-50122 : Remove and test refetching of channels on browser focus change

### DIFF
--- a/components/team_controller/index.ts
+++ b/components/team_controller/index.ts
@@ -9,7 +9,8 @@ import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general
 import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-import {isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {getBool, isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {Preferences} from 'mattermost-redux/constants';
 
 import {GlobalState} from 'types/store';
 
@@ -36,6 +37,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const currentUser = getCurrentUser(state);
     const plugins = state.plugins.components.NeedsTeamComponent;
     const graphQLEnabled = isGraphQLEnabled(state);
+    const disableRefetchingOnBrowserFocus = getBool(state, Preferences.CATEGORY_PERFORMANCE_DEBUGGING, Preferences.NAME_DISABLE_REFETCHING_ON_BROWSER_FOCUS);
 
     return {
         currentUser,
@@ -46,6 +48,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         selectedThreadId: getSelectedThreadIdInCurrentTeam(state),
         mfaRequired: checkIfMFARequired(currentUser, license, config, ownProps.match.url),
         graphQLEnabled,
+        disableRefetchingOnBrowserFocus,
     };
 }
 

--- a/components/team_controller/team_controller.tsx
+++ b/components/team_controller/team_controller.tsx
@@ -92,12 +92,14 @@ function TeamController(props: Props) {
                 props.markChannelAsReadOnFocus(props.currentChannelId);
             }
 
-            const currentTime = Date.now();
-            if ((currentTime - blurTime.current) > UNREAD_CHECK_TIME_MILLISECONDS && props.currentTeamId) {
-                if (props.graphQLEnabled) {
-                    props.fetchChannelsAndMembers(props.currentTeamId);
-                } else {
-                    props.fetchMyChannelsAndMembersREST(props.currentTeamId);
+            if (props.disableRefetchingOnBrowserFocus === false) {
+                const currentTime = Date.now();
+                if ((currentTime - blurTime.current) > UNREAD_CHECK_TIME_MILLISECONDS && props.currentTeamId) {
+                    if (props.graphQLEnabled) {
+                        props.fetchChannelsAndMembers(props.currentTeamId);
+                    } else {
+                        props.fetchMyChannelsAndMembersREST(props.currentTeamId);
+                    }
                 }
             }
         }

--- a/components/user_settings/advanced/performance_debugging_section/index.ts
+++ b/components/user_settings/advanced/performance_debugging_section/index.ts
@@ -21,6 +21,7 @@ function mapStateToProps(state: GlobalState) {
         disableClientPlugins: getBool(state, Preferences.CATEGORY_PERFORMANCE_DEBUGGING, Preferences.NAME_DISABLE_CLIENT_PLUGINS),
         disableTelemetry: getBool(state, Preferences.CATEGORY_PERFORMANCE_DEBUGGING, Preferences.NAME_DISABLE_TELEMETRY),
         disableTypingMessages: getBool(state, Preferences.CATEGORY_PERFORMANCE_DEBUGGING, Preferences.NAME_DISABLE_TYPING_MESSAGES),
+        disableRefetchingOnBrowserFocus: getBool(state, Preferences.CATEGORY_PERFORMANCE_DEBUGGING, Preferences.NAME_DISABLE_REFETCHING_ON_BROWSER_FOCUS),
         performanceDebuggingEnabled: isPerformanceDebuggingEnabled(state),
     };
 }

--- a/components/user_settings/advanced/performance_debugging_section/performance_debugging_section.tsx
+++ b/components/user_settings/advanced/performance_debugging_section/performance_debugging_section.tsx
@@ -70,6 +70,9 @@ const PerformanceDebuggingSectionCollapsed = React.forwardRef<SettingItemMinComp
     if (props.disableTypingMessages) {
         settingsEnabled += 1;
     }
+    if (props.disableRefetchingOnBrowserFocus) {
+        settingsEnabled += 1;
+    }
 
     let description;
     if (settingsEnabled === 0) {
@@ -109,6 +112,7 @@ function PerformanceDebuggingSectionExpanded(props: Props) {
     const [disableClientPlugins, setDisableClientPlugins] = useState(props.disableClientPlugins);
     const [disableTelemetry, setDisableTelemetry] = useState(props.disableTelemetry);
     const [disableTypingMessages, setDisableTypingMessages] = useState(props.disableTypingMessages);
+    const [disableRefetchingOnBrowserFocus, setDisableRefetchingOnBrowserFocus] = useState(props.disableRefetchingOnBrowserFocus);
 
     const handleSubmit = useCallback(() => {
         const preferences = [];
@@ -137,6 +141,14 @@ function PerformanceDebuggingSectionExpanded(props: Props) {
                 value: disableTypingMessages.toString(),
             });
         }
+        if (disableRefetchingOnBrowserFocus !== props.disableRefetchingOnBrowserFocus) {
+            preferences.push({
+                user_id: props.currentUserId,
+                category: Preferences.CATEGORY_PERFORMANCE_DEBUGGING,
+                name: Preferences.NAME_DISABLE_REFETCHING_ON_BROWSER_FOCUS,
+                value: disableRefetchingOnBrowserFocus.toString(),
+            });
+        }
 
         if (preferences.length !== 0) {
             props.savePreferences(props.currentUserId, preferences);
@@ -150,6 +162,7 @@ function PerformanceDebuggingSectionExpanded(props: Props) {
         disableClientPlugins,
         disableTelemetry,
         disableTypingMessages,
+        disableRefetchingOnBrowserFocus,
     ]);
 
     return (
@@ -204,6 +217,21 @@ function PerformanceDebuggingSectionExpanded(props: Props) {
                             <FormattedMessage
                                 id='user.settings.advance.performance.disableTypingMessages'
                                 defaultMessage='Disable "User is typing..." messages'
+                            />
+                        </label>
+                    </div>
+                    <div className='checkbox'>
+                        <label>
+                            <input
+                                type='checkbox'
+                                checked={disableRefetchingOnBrowserFocus}
+                                onChange={(e) => {
+                                    setDisableRefetchingOnBrowserFocus(e.target.checked);
+                                }}
+                            />
+                            <FormattedMessage
+                                id='user.settings.advance.performance.disableRefetchingOnBrowserFocus'
+                                defaultMessage='Disable refetching of channels and channel members on browser focus'
                             />
                         </label>
                     </div>

--- a/packages/mattermost-redux/src/constants/preferences.ts
+++ b/packages/mattermost-redux/src/constants/preferences.ts
@@ -62,6 +62,7 @@ const Preferences = {
     NAME_DISABLE_CLIENT_PLUGINS: 'disable_client_plugins',
     NAME_DISABLE_TELEMETRY: 'disable_telemetry',
     NAME_DISABLE_TYPING_MESSAGES: 'disable_typing_messages',
+    NAME_DISABLE_REFETCHING_ON_BROWSER_FOCUS: 'disable_focus_refetching',
 
     UNREAD_SCROLL_POSITION: 'unread_scroll_position',
     UNREAD_SCROLL_POSITION_START_FROM_LEFT: 'start_from_left_off',


### PR DESCRIPTION
#### Summary
Our redux store does not get cleared automatically, so refetching of already once fetched channels and channel members on browser focus change might not be needed. Currently sitting behind a experimental settings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50122

#### Related Pull Requests
n/a

#### Screenshots
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
