### PR TITLE
Change tomorrow in dnd status timer to refer to next morning

### DIFF
--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -146,8 +146,9 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             endTime = currentDate.add(2, 'hours');
             break;
         case 3:
-            // add one day in current date
-            endTime = currentDate.add(1, 'day');
+            // set to next day 8 in the morning
+            endTime = currentDate.startOf('day').add(32, 'hours');
+            console.log(endTime)
             break;
         }
 
@@ -371,7 +372,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             this.dndTimes.map(({id, label, labelDefault}, index) => {
                 let text: React.ReactNode = localizeMessage(label, labelDefault);
                 if (index === 3) {
-                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).add(1, 'day').toDate();
+                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).startOf('d').add(32, 'h').toDate();
                     text = (
                         <>
                             {text}


### PR DESCRIPTION
#### Summary

This PR changes the timer for the dnd status expiry to refer to next day 8am instead of 24hrs from the time it's being set.

#### Screenshots

|  before  |  after  |
|----|----|
| ![dnd_old](https://user-images.githubusercontent.com/7526550/224075846-a4424d24-cc6f-41e1-bea8-b07abe9ed7d0.png) | ![dnd_new](https://user-images.githubusercontent.com/7526550/224075844-8c1496d3-a3b0-4c6b-ae35-186b51c56c53.png) |

#### Release Note

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
The timer for the Do-not-disturb status now automatically assumes tomorrow to be 8am the next day instead of 24hr from time of change.
```
