### PR TITLE
Change dnd status and post remind tomorrow to next morning

### DIFF
--- a/components/dot_menu/post_reminder_submenu.tsx
+++ b/components/dot_menu/post_reminder_submenu.tsx
@@ -55,7 +55,7 @@ export function PostReminderSubmenu(props: Props) {
             break;
         case 'tomorrow':
             // set to next day 8 in the morning
-            endTime = currentDate.add(1, 'day').set('hour', 8);
+            endTime = currentDate.add(1, 'day').set({hour: 8, minute: 0});
             break;
         }
 
@@ -84,7 +84,7 @@ export function PostReminderSubmenu(props: Props) {
 
             let trailing: React.ReactNode;
             if (id === 'tomorrow') {
-                const tomorrow = getCurrentMomentForTimezone(props.timezone).add(1, 'day').set('hour', 8).toDate();
+                const tomorrow = getCurrentMomentForTimezone(props.timezone).add(1, 'day').set({hour: 8, minute: 0}).toDate();
                 trailing = (
                     <span className={`postReminder-${id}_timestamp`}>
                         <FormattedDate

--- a/components/dot_menu/post_reminder_submenu.tsx
+++ b/components/dot_menu/post_reminder_submenu.tsx
@@ -55,7 +55,7 @@ export function PostReminderSubmenu(props: Props) {
             break;
         case 'tomorrow':
             // set to next day 8 in the morning
-            endTime = currentDate.add(1, 'day').set('hour', 8)
+            endTime = currentDate.add(1, 'day').set('hour', 8);
             break;
         }
 

--- a/components/dot_menu/post_reminder_submenu.tsx
+++ b/components/dot_menu/post_reminder_submenu.tsx
@@ -84,7 +84,7 @@ export function PostReminderSubmenu(props: Props) {
 
             let trailing: React.ReactNode;
             if (id === 'tomorrow') {
-                const tomorrow = getCurrentMomentForTimezone(props.timezone).startOf('d').add(32, 'h').toDate();
+                const tomorrow = getCurrentMomentForTimezone(props.timezone).startOf('day').add(32, 'hours').toDate();
                 trailing = (
                     <span className={`postReminder-${id}_timestamp`}>
                         <FormattedDate

--- a/components/dot_menu/post_reminder_submenu.tsx
+++ b/components/dot_menu/post_reminder_submenu.tsx
@@ -55,7 +55,7 @@ export function PostReminderSubmenu(props: Props) {
             break;
         case 'tomorrow':
             // set to next day 8 in the morning
-            endTime = currentDate.startOf('day').add(32, 'hours');
+            endTime = currentDate.add(1, 'day').set('hour', 8)
             break;
         }
 
@@ -84,7 +84,7 @@ export function PostReminderSubmenu(props: Props) {
 
             let trailing: React.ReactNode;
             if (id === 'tomorrow') {
-                const tomorrow = getCurrentMomentForTimezone(props.timezone).startOf('day').add(32, 'hours').toDate();
+                const tomorrow = getCurrentMomentForTimezone(props.timezone).add(1, 'day').set('hour', 8).toDate();
                 trailing = (
                     <span className={`postReminder-${id}_timestamp`}>
                         <FormattedDate

--- a/components/dot_menu/post_reminder_submenu.tsx
+++ b/components/dot_menu/post_reminder_submenu.tsx
@@ -54,8 +54,8 @@ export function PostReminderSubmenu(props: Props) {
             endTime = currentDate.add(2, 'hours');
             break;
         case 'tomorrow':
-            // add one day in current date
-            endTime = currentDate.add(1, 'day');
+            // set to next day 8 in the morning
+            endTime = currentDate.startOf('day').add(32, 'hours');
             break;
         }
 
@@ -84,7 +84,7 @@ export function PostReminderSubmenu(props: Props) {
 
             let trailing: React.ReactNode;
             if (id === 'tomorrow') {
-                const tomorrow = getCurrentMomentForTimezone(props.timezone).add(1, 'day').toDate();
+                const tomorrow = getCurrentMomentForTimezone(props.timezone).startOf('d').add(32, 'h').toDate();
                 trailing = (
                     <span className={`postReminder-${id}_timestamp`}>
                         <FormattedDate

--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -153,14 +153,14 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -471,14 +471,14 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -741,14 +741,14 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1011,14 +1011,14 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1282,14 +1282,14 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1527,14 +1527,14 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1764,14 +1764,14 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -2034,14 +2034,14 @@ exports[`components/StatusDropdown should not show clear status button when cust
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -2352,14 +2352,14 @@ exports[`components/StatusDropdown should show clear status button when custom s
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={1970-01-02T08:00:02.021Z}
+                    value={2021-11-03T08:48:57.000Z}
                   />
                 </span>
               </React.Fragment>,

--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -153,14 +153,14 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -471,14 +471,14 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -741,14 +741,14 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1011,14 +1011,14 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1282,14 +1282,14 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1527,14 +1527,14 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1764,14 +1764,14 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -2034,14 +2034,14 @@ exports[`components/StatusDropdown should not show clear status button when cust
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,
@@ -2352,14 +2352,14 @@ exports[`components/StatusDropdown should show clear status button when custom s
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T08:48:57.000Z}
+                    value={2021-11-03T08:00:57.000Z}
                   />
                 </span>
               </React.Fragment>,

--- a/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
+++ b/components/status_dropdown/__snapshots__/status_dropdown.test.tsx.snap
@@ -153,14 +153,14 @@ exports[`components/StatusDropdown should match snapshot in default state 1`] = 
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,
@@ -471,14 +471,14 @@ exports[`components/StatusDropdown should match snapshot with custom status and 
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,
@@ -741,14 +741,14 @@ exports[`components/StatusDropdown should match snapshot with custom status enab
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1011,14 +1011,14 @@ exports[`components/StatusDropdown should match snapshot with custom status expi
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1282,14 +1282,14 @@ exports[`components/StatusDropdown should match snapshot with custom status puls
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1527,14 +1527,14 @@ exports[`components/StatusDropdown should match snapshot with profile picture UR
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,
@@ -1764,14 +1764,14 @@ exports[`components/StatusDropdown should match snapshot with status dropdown op
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,
@@ -2034,14 +2034,14 @@ exports[`components/StatusDropdown should not show clear status button when cust
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,
@@ -2352,14 +2352,14 @@ exports[`components/StatusDropdown should show clear status button when custom s
                   className="dndTime-tomorrow_timestamp"
                 >
                   <FormattedDate
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                     weekday="short"
                   />
                   , 
                   <FormattedTime
                     hour12={true}
                     timeStyle="short"
-                    value={2021-11-03T22:48:57.000Z}
+                    value={1970-01-02T08:00:02.021Z}
                   />
                 </span>
               </React.Fragment>,

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -148,7 +148,6 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
         case 3:
             // set to next day 8 in the morning
             endTime = currentDate.startOf('day').add(32, 'hours');
-            console.log(endTime)
             break;
         }
 

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -147,7 +147,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             break;
         case 3:
             // set to next day 8 in the morning
-            endTime = currentDate.startOf('day').add(32, 'hours');
+            endTime = currentDate.add(1, 'day').set('hour', 8)
             break;
         }
 
@@ -371,7 +371,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             this.dndTimes.map(({id, label, labelDefault}, index) => {
                 let text: React.ReactNode = localizeMessage(label, labelDefault);
                 if (index === 3) {
-                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).startOf('day').add(32, 'hours').toDate();
+                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).add(1, 'day').set('hour', 8).toDate();
                     text = (
                         <>
                             {text}

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -147,7 +147,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             break;
         case 3:
             // set to next day 8 in the morning
-            endTime = currentDate.add(1, 'day').set('hour', 8);
+            endTime = currentDate.add(1, 'day').set({hour: 8, minute: 0});
             break;
         }
 
@@ -371,7 +371,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             this.dndTimes.map(({id, label, labelDefault}, index) => {
                 let text: React.ReactNode = localizeMessage(label, labelDefault);
                 if (index === 3) {
-                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).add(1, 'day').set('hour', 8).toDate();
+                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).add(1, 'day').set({hour: 8, minute: 0}).toDate();
                     text = (
                         <>
                             {text}

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -147,7 +147,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             break;
         case 3:
             // set to next day 8 in the morning
-            endTime = currentDate.add(1, 'day').set('hour', 8)
+            endTime = currentDate.add(1, 'day').set('hour', 8);
             break;
         }
 

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -371,7 +371,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             this.dndTimes.map(({id, label, labelDefault}, index) => {
                 let text: React.ReactNode = localizeMessage(label, labelDefault);
                 if (index === 3) {
-                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).startOf('d').add(32, 'h').toDate();
+                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).startOf('day').add(32, 'hours').toDate();
                     text = (
                         <>
                             {text}

--- a/components/status_dropdown/status_dropdown.tsx
+++ b/components/status_dropdown/status_dropdown.tsx
@@ -146,8 +146,9 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             endTime = currentDate.add(2, 'hours');
             break;
         case 3:
-            // add one day in current date
-            endTime = currentDate.add(1, 'day');
+            // set to next day 8 in the morning
+            endTime = currentDate.startOf('day').add(32, 'hours');
+            console.log(endTime)
             break;
         }
 
@@ -371,7 +372,7 @@ export class StatusDropdown extends React.PureComponent<Props, State> {
             this.dndTimes.map(({id, label, labelDefault}, index) => {
                 let text: React.ReactNode = localizeMessage(label, labelDefault);
                 if (index === 3) {
-                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).add(1, 'day').toDate();
+                    const tomorrow = getCurrentMomentForTimezone(this.props.timezone).startOf('d').add(32, 'h').toDate();
                     text = (
                         <>
                             {text}


### PR DESCRIPTION
#### Summary

This PR changes the timers in the dnd timer and post reminder modals to use "next day 8 am" instead of "24hrs from now" when selecting Tomorrow as the option since that would be a more common use case for these types if timers (i.e. don't bug me with notifications until my next workday starts or send me the reminder at the beginning of my next work day).

Not sure if we actually *need* release notes for this but added some just in case.


#### Screenshots

|  before  |  after  |
|----|----|
| ![remind_old](https://user-images.githubusercontent.com/7526550/224100204-2ab1bc62-5bf6-4d1a-9f1f-563c319e7910.png) | ![image (5)](https://user-images.githubusercontent.com/7526550/224100792-893ed54a-b52d-4808-a6e0-e6faa28ad946.png) |
| ![dnd_old](https://user-images.githubusercontent.com/7526550/224100618-30c5d195-79a1-48b0-8ac2-b7535cb1da76.png) | ![dnd_new](https://user-images.githubusercontent.com/7526550/224100685-9caf6043-a174-4fe8-90d1-9c968bc80b45.png) |


#### Release Note

```
Changed the time for tomorrow in the dnd timer and post reminder to refer to the next day 8 am instead of 24hrs from the time of activation.
```
