### PR TITLE
Support env var for playwright test directory

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     globalSetup: require.resolve('./global_setup'),
     forbidOnly: testConfig.isCI,
     outputDir: './test-results',
-    testDir: 'tests',
+    testDir: process.env.PLAYWRIGHT_TEST_DIR || 'tests',
     timeout: duration.one_min,
     workers: testConfig.workers,
     expect: {

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     globalSetup: require.resolve('./global_setup'),
     forbidOnly: testConfig.isCI,
     outputDir: './test-results',
-    testDir: process.env.PLAYWRIGHT_TEST_DIR || 'tests',
+    testDir: testConfig.testDir,
     timeout: duration.one_min,
     workers: testConfig.workers,
     expect: {

--- a/e2e/playwright/test.config.ts
+++ b/e2e/playwright/test.config.ts
@@ -28,6 +28,7 @@ export type TestConfig = {
     headless: boolean;
     slowMo: number;
     workers: number;
+    testDir: string;
     // Visual tests
     snapshotEnabled: boolean;
     percyEnabled: boolean;
@@ -52,6 +53,7 @@ const config: TestConfig = {
     headless: parseBool(process.env.PW_HEADLESS, false),
     slowMo: parseNumber(process.env.PW_SLOWMO, 0),
     workers: parseNumber(process.env.PW_WORKERS, 1),
+    testDir: process.env.PW_TEST_DIR || 'tests',
     // Visual tests
     snapshotEnabled: parseBool(process.env.PW_SNAPSHOT_ENABLE, false),
     percyEnabled: parseBool(process.env.PW_PERCY_ENABLE, false),

--- a/e2e/playwright/test.config.ts
+++ b/e2e/playwright/test.config.ts
@@ -33,6 +33,8 @@ export type TestConfig = {
     snapshotEnabled: boolean;
     percyEnabled: boolean;
     percyToken?: string;
+    // Plugin settings
+    pluginMockOAuthToken?: string;
 };
 
 // All process.env should be defined here
@@ -58,6 +60,8 @@ const config: TestConfig = {
     snapshotEnabled: parseBool(process.env.PW_SNAPSHOT_ENABLE, false),
     percyEnabled: parseBool(process.env.PW_PERCY_ENABLE, false),
     percyToken: process.env.PERCY_TOKEN,
+    // Plugin settings
+    pluginMockOAuthToken: process.env.PLUGIN_E2E_MOCK_OAUTH_TOKEN,
 };
 
 function parseBool(actualValue: string | undefined, defaultValue: boolean) {


### PR DESCRIPTION
#### Summary

In order for other projects to use the Playwright testing environment implemented by the webapp repo, we can have the test runner support an arbitrary test directory via environment variable.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- https://github.com/mattermost/mattermost-plugin-github/pull/652

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
