### PR TITLE
MM-48412 - backdrop issue when rhs expanded; ramdom fixes to channels tour

### DIFF
--- a/components/tours/channels_tour_tip.tsx
+++ b/components/tours/channels_tour_tip.tsx
@@ -26,6 +26,7 @@ export type ChannelsTourTipProps = {
     hideBackdrop?: boolean;
     tippyBlueStyle?: boolean;
     showOptOut?: boolean;
+    interactivePunchOut?: boolean;
 }
 
 export const ChannelsTourTip = ({
@@ -43,6 +44,7 @@ export const ChannelsTourTip = ({
     hideBackdrop = false,
     tippyBlueStyle = false,
     showOptOut = true,
+    interactivePunchOut = false,
 }: ChannelsTourTipProps) => {
     const {
         show,
@@ -124,6 +126,7 @@ export const ChannelsTourTip = ({
             hideBackdrop={hideBackdrop}
             tippyBlueStyle={tippyBlueStyle}
             showOptOut={showOptOut}
+            interactivePunchOut={interactivePunchOut}
         />
     );
 };

--- a/components/tours/crt_tour/crt_threads_pane_tutorial_tip.tsx
+++ b/components/tours/crt_tour/crt_threads_pane_tutorial_tip.tsx
@@ -10,6 +10,7 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 
 import {TourTip, useMeasurePunchouts} from '@mattermost/components';
+import {useGetTourtipRedraw} from '../hooks';
 
 const translate = {x: 2, y: 25};
 
@@ -17,6 +18,9 @@ const CRTThreadsPaneTutorialTip = () => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const currentUserId = useSelector(getCurrentUserId);
+
+    const {redraw} = useGetTourtipRedraw('sidebar-right');
+
     const title = (
         <FormattedMessage
             id='tutorial_threads.threads_pane.title'
@@ -60,7 +64,7 @@ const CRTThreadsPaneTutorialTip = () => {
         dispatch(savePreferences(currentUserId, preferences));
     };
 
-    const overlayPunchOut = useMeasurePunchouts(['rhsContainer'], []);
+    const overlayPunchOut = useMeasurePunchouts(['rhsContainer'], [redraw]);
 
     return (
         <TourTip

--- a/components/tours/hooks.ts
+++ b/components/tours/hooks.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useCallback} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -216,4 +216,34 @@ export const useHandleNavigationAndExtraActions = (tourCategory: string) => {
         lastStepActions(lastStep);
         nextStepActions(step);
     }, [nextStepActions, lastStepActions]);
+};
+
+export const useGetTourtipRedraw = (elementId: string) => {
+    const [redraw, setRedraw] = useState(false);
+    const [width, setWidth] = useState(0);
+
+    useEffect(() => {
+        const element = document.getElementById(elementId);
+        if (!element) {
+            return undefined;
+        }
+        const observer = new ResizeObserver(() => {
+            setWidth(element.offsetWidth);
+        });
+        observer.observe(element);
+
+        return () => {
+            observer.unobserve(element);
+        };
+    }, [elementId]);
+
+    const redrawToortip = () => {
+        setRedraw(!redraw);
+    };
+
+    useEffect(() => {
+        redrawToortip();
+    }, [width]);
+
+    return {redraw};
 };

--- a/components/tours/onboarding_tour/create_and_join_channels_tour_tip.tsx
+++ b/components/tours/onboarding_tour/create_and_join_channels_tour_tip.tsx
@@ -8,7 +8,7 @@ import {useMeasurePunchouts} from '@mattermost/components';
 
 import OnboardingTourTip from './onboarding_tour_tip';
 
-const translate = {x: 0, y: 18};
+const translate = {x: 0, y: 110};
 
 export const CreateAndJoinChannelsTour = () => {
     const title = (
@@ -26,7 +26,7 @@ export const CreateAndJoinChannelsTour = () => {
         </p>
     );
 
-    const overlayPunchOut = useMeasurePunchouts(['showMoreChannels', 'invitePeople'], [], {y: -8, height: 16, x: 0, width: 0});
+    const overlayPunchOut = useMeasurePunchouts(['showMoreChannels', 'showNewChannel'], [], {y: -8, height: 16, x: 0, width: 0});
 
     return (
         <OnboardingTourTip

--- a/components/tours/onboarding_tour/invite_people_tour_tip.tsx
+++ b/components/tours/onboarding_tour/invite_people_tour_tip.tsx
@@ -26,7 +26,7 @@ export const InvitePeopleTour = () => {
         </p>
     );
 
-    const overlayPunchOut = useMeasurePunchouts(['showMoreChannels', 'invitePeople'], [], {y: -8, height: 16, x: 0, width: 0});
+    const overlayPunchOut = useMeasurePunchouts(['invitePeople'], [], {y: -8, height: 16, x: 0, width: 0});
 
     return (
         <OnboardingTourTip

--- a/components/tours/worktemplate_explore_tour/boards_tour_tip.tsx
+++ b/components/tours/worktemplate_explore_tour/boards_tour_tip.tsx
@@ -6,6 +6,8 @@ import {FormattedMessage, useIntl} from 'react-intl';
 
 import {useMeasurePunchouts} from '@mattermost/components';
 
+import {useGetTourtipRedraw} from '../hooks';
+
 import OnboardingWorkTemplateTourTip from './worktemplate_explore_tour_tip';
 import {useShowTourTip} from './useShowTourTip';
 
@@ -13,8 +15,8 @@ export const BoardsTourTip = (): JSX.Element | null => {
     const {formatMessage} = useIntl();
 
     const {playbooksCount, boardsCount, showBoardsTour} = useShowTourTip();
-    const overlayPunchOut = useMeasurePunchouts(['sidebar-right'], []);
-
+    const {redraw} = useGetTourtipRedraw('sidebar-right');
+    const overlayPunchOut = useMeasurePunchouts(['sidebar-right'], [redraw]);
     if (!showBoardsTour) {
         return null;
     }
@@ -60,6 +62,7 @@ export const BoardsTourTip = (): JSX.Element | null => {
             singleTip={playbooksCount === 0}
             placement='left-start'
             showOptOut={false}
+            interactivePunchOut={true}
         />
     );
 };

--- a/components/tours/worktemplate_explore_tour/playbooks_tour_tip.tsx
+++ b/components/tours/worktemplate_explore_tour/playbooks_tour_tip.tsx
@@ -6,13 +6,16 @@ import {FormattedMessage, useIntl} from 'react-intl';
 
 import {useMeasurePunchouts} from '@mattermost/components';
 
+import {useGetTourtipRedraw} from '../hooks';
+
 import {useShowTourTip} from './useShowTourTip';
 import OnboardingWorkTemplateTourTip from './worktemplate_explore_tour_tip';
 
 export const PlaybooksTourTip = (): JSX.Element | null => {
     const {formatMessage} = useIntl();
     const {playbooksCount, boardsCount, showPlaybooksTour} = useShowTourTip();
-    const overlayPunchOut = useMeasurePunchouts(['sidebar-right'], []);
+    const {redraw} = useGetTourtipRedraw('sidebar-right');
+    const overlayPunchOut = useMeasurePunchouts(['sidebar-right'], [redraw]);
 
     if (!showPlaybooksTour) {
         return null;
@@ -59,6 +62,7 @@ export const PlaybooksTourTip = (): JSX.Element | null => {
             overlayPunchOut={overlayPunchOut}
             placement='left-start'
             showOptOut={false}
+            interactivePunchOut={true}
         />
     );
 };

--- a/packages/components/src/tour_tip/tour_tip.scss
+++ b/packages/components/src/tour_tip/tour_tip.scss
@@ -363,7 +363,7 @@
 
     &__backdrop {
         position: absolute;
-        z-index: 999;
+        z-index: 100;
         top: 0;
         left: 0;
         width: 100%;

--- a/packages/components/src/tour_tip/tour_tip_backdrop.tsx
+++ b/packages/components/src/tour_tip/tour_tip_backdrop.tsx
@@ -81,4 +81,3 @@ export const TourTipBackdrop = ({
         </TourTipRootPortal>
     );
 };
-


### PR DESCRIPTION
#### Summary
During the PR https://github.com/mattermost/mattermost-webapp/pull/12301 an issue was identified related to tourtip backdrop when the RHS bar was expanded-collapsed making the punchout to don't update along with a weird behavior caused by the rb-tooltip interaction (The found issues were already open issues https://mattermost.atlassian.net/browse/MM-48412 https://mattermost.atlassian.net/browse/MM-48647 ). This PR fixes those two issues and also fixes a couple of issues related with the explore channels tour.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48412
https://mattermost.atlassian.net/browse/MM-48647

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/12301

#### Screenshots
Before:

https://user-images.githubusercontent.com/10082627/224367231-ca696026-3d4b-4133-ba4c-a6453bda13ae.mov

After:


https://user-images.githubusercontent.com/10082627/224367297-6d1e8478-73c1-4f75-99f0-e695223f064e.mov


https://user-images.githubusercontent.com/10082627/224367306-9f2762b7-0a1d-4db4-b7b4-3047c6a242b5.mov


Channels Tour Fix:
Before:
<img width="977" alt="Screenshot 2023-03-10 at 17 16 49" src="https://user-images.githubusercontent.com/10082627/224367812-b9dc4e59-c40c-4d6a-940a-5a910ce9e4f2.png">
<img width="795" alt="Screenshot 2023-03-10 at 17 17 11" src="https://user-images.githubusercontent.com/10082627/224367819-3615c921-edd2-48dd-a823-50d99e921b0a.png">


After:
<img width="841" alt="Screenshot 2023-03-10 at 17 17 45" src="https://user-images.githubusercontent.com/10082627/224367784-1b1dea93-7e20-4877-87b6-d0f38eb9cbf6.png">
<img width="900" alt="Screenshot 2023-03-10 at 17 17 51" src="https://user-images.githubusercontent.com/10082627/224367790-b1b243dc-ca2a-4929-9146-089d9ba9a706.png">



#### Release Note
```release-note
NONE
```
