### PR TITLE
[MM-46941] Fix: PDF preview doesn't render some Japanese characters

### DIFF
--- a/components/pdf_preview.jsx
+++ b/components/pdf_preview.jsx
@@ -10,6 +10,8 @@ import {getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 import FileInfoPreview from 'components/file_info_preview';
 
+import {getSiteURL} from 'utils/url';
+
 const INITIAL_RENDERED_PAGES = 3;
 
 export default class PDFPreview extends React.PureComponent {
@@ -151,7 +153,7 @@ export default class PDFPreview extends React.PureComponent {
 
             const pdf = await PDFJS.getDocument({
                 url: this.props.fileUrl,
-                cMapUrl: '/static/cmaps/',
+                cMapUrl: getSiteURL() + '/static/cmaps/',
                 cMapPacked: true,
             }).promise;
             this.onDocumentLoad(pdf);

--- a/components/pdf_preview.jsx
+++ b/components/pdf_preview.jsx
@@ -149,7 +149,11 @@ export default class PDFPreview extends React.PureComponent {
             const worker = await import('pdfjs-dist/build/pdf.worker.entry.js');
             PDFJS.GlobalWorkerOptions.workerSrc = worker;
 
-            const pdf = await PDFJS.getDocument(this.props.fileUrl).promise;
+            const pdf = await PDFJS.getDocument({
+                url: this.props.fileUrl,
+                cMapUrl: '/static/cmaps/',
+                cMapPacked: true,
+            }).promise;
             this.onDocumentLoad(pdf);
         } catch (err) {
             this.onDocumentLoadError(err);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -221,6 +221,7 @@ var config = {
                 {from: 'images/cloud-laptop-error.png', to: 'images'},
                 {from: 'images/cloud-laptop-warning.png', to: 'images'},
                 {from: 'images/cloud-upgrade-person-hand-to-face.png', to: 'images'},
+                {from: 'node_modules/pdfjs-dist/cmaps', to: 'cmaps'},
             ],
         }),
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

To fix the issue of the PDF preview, I added the code for `pdfjs-dist` to use appropriate CMaps. I also added a line to `webpack.config.js` for copying CMap files from `node_modules/pdfjs-dist/cmaps` to `dist/cmaps`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://github.com/mattermost/mattermost-server/issues/21203
https://mattermost.atlassian.net/browse/MM-46941
https://forum.mattermost.com/t/character-corruption-of-japanese-pdf-files/13818

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

I omit screenshots. See the JIRA ticket above.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed an issue where the PDF preview did not render some Japanese characters.
```
