### PR TITLE
[MM-51098] Hide "copy invite link" when selecting guest

### DIFF
--- a/components/invitation_modal/invite_view.scss
+++ b/components/invitation_modal/invite_view.scss
@@ -51,6 +51,10 @@ button.InviteView__copyLink.tertiary-button:focus {
             display: none;
         }
 
+        &-guest {
+            justify-content: flex-end;
+        }
+
         .btn {
             font-weight: 600;
         }

--- a/components/invitation_modal/invite_view.tsx
+++ b/components/invitation_modal/invite_view.tsx
@@ -4,6 +4,7 @@
 import React, {useEffect, useMemo} from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage, useIntl} from 'react-intl';
+import classNames from 'classnames';
 
 import deepFreeze from 'mattermost-redux/utils/deep_freeze';
 import {Channel} from '@mattermost/types/channels';
@@ -259,8 +260,8 @@ export default function InviteView(props: Props) {
                 )}
                 <OverageUsersBannerNotice/>
             </Modal.Body>
-            <Modal.Footer className={'InviteView__footer ' + props.footerClass}>
-                {copyButton}
+            <Modal.Footer className={classNames('InviteView__footer', props.footerClass, {'InviteView__footer-guest': props.inviteType === InviteType.GUEST})}>
+                {props.inviteType === InviteType.MEMBER && copyButton}
                 <button
                     disabled={!isInviteValid}
                     onClick={props.invite}

--- a/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_invitation_ui_spec.ts
+++ b/e2e/cypress/tests/integration/enterprise/guest_accounts/guest_invitation_ui_spec.ts
@@ -223,4 +223,15 @@ describe('Guest Account - Guest User Invitation Flow', () => {
         // * Verify invite more button is present
         cy.findByTestId('invite-more').should('be.visible');
     });
+
+    it('hides the copy link button when inviting guests', () => {
+        // # Open team menu and click 'Invite People'
+        cy.uiOpenTeamMenu('Invite People');
+
+        // # Select Guest
+        cy.findByTestId('inviteGuestLink').should('be.visible').click();
+
+        // * The button "Copy invite link" should not exist
+        cy.findByTestId('InviteView__copyInviteLink').should('not.exist');
+    });
 });


### PR DESCRIPTION
#### Summary
Hides the  "copy invite link" button when selecting guest in the invitation modal

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51098

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
