### PR TITLE
fix announcement bar overlap after signup

### DIFF
--- a/sass/routes/_signup.scss
+++ b/sass/routes/_signup.scss
@@ -3,7 +3,7 @@
 body {
     &.announcement-bar--fixed {
         .signup-header {
-            top: 24px;
+            top: 42px;
         }
     }
 }


### PR DESCRIPTION
#### Summary
After signup when you redirected to teams screen (to create a new team or choosing an existing), announcement bar is overlapped with signup-header. This issue wasn't there on the other screens.

#### Ticket Link
N/A
There wasn't a ticket for this. I followed the contribution guideline and did not create a new issue. 

#### Screenshots

|  before  |  after  |
|----|----|
|  <img width="1651" alt="before-announcement-bar" src="https://user-images.githubusercontent.com/27828319/226139357-38bc18cb-3648-4069-b599-94fba1becd52.png">|<img width="1650" alt="after-announcement-bar" src="https://user-images.githubusercontent.com/27828319/226139426-d46513bf-117d-47ec-850d-457b0ce20870.png">|

#### Release Note
```release-note
Fixed UI glitch
```
