### PR TITLE
[MM-50284]: ➜ Re-Opened - Fixes letter spacing on main titles for login and create account screens

### DIFF
--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -229,7 +229,7 @@
         }
 
         .login-body-message .login-body-message-title {
-            padding-right: 100px;
+            padding-right: 105px;
             margin-top: 48px;
         }
     }

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -229,7 +229,7 @@
         }
 
         .login-body-message .login-body-message-title {
-            padding-right: 110px;
+            padding-right: 100px;
             margin-top: 48px;
         }
     }

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -43,7 +43,7 @@
             align-self: flex-start;
 
             .login-body-message-title {
-                padding-right: 47px;
+                padding-right: 48px;
                 color: var(--title-color-indigo-500);
                 font-family: Metropolis;
                 font-size: 80px;

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -43,7 +43,7 @@
             align-self: flex-start;
 
             .login-body-message-title {
-                padding-right: 48px;
+                padding-right: 47px;
                 color: var(--title-color-indigo-500);
                 font-family: Metropolis;
                 font-size: 80px;

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -74,7 +74,7 @@
                 font-family: Metropolis;
                 font-size: 80px;
                 font-weight: 600;
-                letter-spacing: -0.01em;
+                letter-spacing: -0.02em;
                 line-height: 88px;
             }
 

--- a/components/signup/signup.scss
+++ b/components/signup/signup.scss
@@ -74,7 +74,7 @@
                 font-family: Metropolis;
                 font-size: 80px;
                 font-weight: 600;
-                letter-spacing: -0.02em;
+                letter-spacing: -0.01em;
                 line-height: 88px;
             }
 


### PR DESCRIPTION
#### Summary

This is a follow-up to https://github.com/mattermost/mattermost-webapp/pull/12284 as the login page was working on Self-managed servers but was still wrapping to 3 lines on Cloud Workspace login pages.

#### Ticket Link

[MM-50284](https://mattermost.atlassian.net/browse/MM-50284)

[MM-50284]: https://mattermost.atlassian.net/browse/MM-50284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ