### PR TITLE
[MM-50284]: Reopened to address issue where lines still wrap on Cloud Workspace login page

### DIFF
--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -229,7 +229,7 @@
         }
 
         .login-body-message .login-body-message-title {
-            padding-right: 100px;
+            padding-right: 90px;
             margin-top: 48px;
         }
     }

--- a/components/login/login.scss
+++ b/components/login/login.scss
@@ -229,7 +229,7 @@
         }
 
         .login-body-message .login-body-message-title {
-            padding-right: 110px;
+            padding-right: 100px;
             margin-top: 48px;
         }
     }


### PR DESCRIPTION
This is a follow-up to https://github.com/mattermost/mattermost-webapp/pull/12284

That PR worked for Self-managed servers but after merging it we found that it still wrapped to 3 lines for Cloud Workspace login pages.

This is an entirely new branch made to hopefully get away from issues I had when attempting the fix on [this PR](https://github.com/mattermost/mattermost-webapp/pull/12375).

https://mattermost.atlassian.net/browse/MM-50284