### PR TITLE
Mm 50952 RFQA can save notifications

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2497,11 +2497,7 @@ const AdminDefinition = {
                             it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.SITE.NOTIFICATIONS)),
                             it.stateIsFalse('EmailSettings.SendEmailNotifications'),
                         ),
-
-                        // MM-50952
-                        // If the setting is hidden, then it is not being set in state so there is
-                        // nothing to validate, and validation would fail anyways and prevent saving
-                        validate: it.configIsFalse('ExperimentalSettings', 'RestrictSystemAdmin') && validators.isRequired(t('admin.environment.notifications.feedbackEmail.required'), '"Notification From Address" is required'),
+                        validate: validators.isRequired(t('admin.environment.notifications.feedbackEmail.required'), '"Notification From Address" is required'),
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -1126,6 +1126,15 @@ export default class SchemaAdminSettings extends React.PureComponent {
             }
 
             if (setting.validate) {
+                if (setting.isHidden?.(this.props.config)) {
+                    // MM-50952
+                    // If the setting is hidden, then it is not being set in state so there is
+                    // nothing to validate, and validation would fail anyways and prevent saving
+                    // In practice, this only happens in custom cloud setup environments like RFQA
+                    // where it sets things in the config file directly instead of in the environment
+                    // (like cloud Mattermost does)
+                    continue;
+                }
                 const result = setting.validate(this.state[setting.key]);
                 if (!result.isValid()) {
                     return false;


### PR DESCRIPTION
#### Summary
I was unintentially conditioning whether the validator should be defined on whether the *function* returned by calling `it.configIsFalse` is truthy (it always is), but I thought it was a return value. The admin definition isn't a good place to try to set this, so I set it more generally in onSave within schema_admin_setting. This will have also have the advantage that we won't have this issue in the future if any additional settings have are hidden and define a validate function.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50952

#### Release Note
```release-note
NONE
```
