### PR TITLE
make autolinked board ff false as default

### DIFF
--- a/e2e/playwright/support/server/default_config.ts
+++ b/e2e/playwright/support/server/default_config.ts
@@ -694,7 +694,7 @@ const defaultServerConfig: AdminConfig = {
         PeopleProduct: false,
         AnnualSubscription: false,
         ReduceOnBoardingTaskList: false,
-        OnboardingAutoShowLinkedBoard: true,
+        OnboardingAutoShowLinkedBoard: false,
         ThreadsEverywhere: false,
         GlobalDrafts: true,
         OnboardingTourTips: true,

--- a/e2e/playwright/tests/visual/channels/intro_channel.spec.ts
+++ b/e2e/playwright/tests/visual/channels/intro_channel.spec.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {expect, test} from '@e2e-support/test_fixture';
-import {duration, isSmallScreen, wait} from '@e2e-support/util';
+import {isSmallScreen} from '@e2e-support/util';
 
 test('Intro to channel as regular user', async ({pw, pages, browserName, viewport}, testInfo) => {
     // Create and sign in a new user
@@ -17,10 +17,10 @@ test('Intro to channel as regular user', async ({pw, pages, browserName, viewpor
     await channelsPage.toBeVisible();
 
     // Wait for Boards' bot image to be loaded
-    await pw.shouldHaveFeatureFlag('OnboardingAutoShowLinkedBoard', true);
-    const boardsWelcomePost = await channelsPage.getFirstPost();
-    await expect(await boardsWelcomePost.getProfileImage('boards')).toBeVisible();
-    await wait(duration.one_sec);
+    // await pw.shouldHaveFeatureFlag('OnboardingAutoShowLinkedBoard', true);
+    // const boardsWelcomePost = await channelsPage.getFirstPost();
+    // await expect(await boardsWelcomePost.getProfileImage('boards')).toBeVisible();
+    // await wait(duration.one_sec);
 
     // Wait for Playbooks icon to be loaded in App bar, except in iphone
     if (!isSmallScreen(viewport)) {


### PR DESCRIPTION
#### Summary
Manual cherry-pick of the webapp side for https://github.com/mattermost/mattermost-server/pull/22714

#### Ticket Link
n/a

#### Related Pull Requests
- Monorepo: https://github.com/mattermost/mattermost-server/pull/22714
- Server: https://github.com/mattermost/mattermost-server/pull/22750

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
