### PR TITLE
MM-51763 Use STRIPE_PUBLIC_KEY from webpack (7.10)

### DIFF
--- a/components/payment_form/stripe.ts
+++ b/components/payment_form/stripe.ts
@@ -25,4 +25,5 @@ function devConfirmCardSetup(confirmCardSetup: ConfirmCardSetupType): ConfirmCar
 export const getConfirmCardSetup = (isDevMode?: boolean) => (isDevMode ? devConfirmCardSetup : prodConfirmCardSetup);
 
 export const STRIPE_CSS_SRC = 'https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i&display=swap';
-export const STRIPE_PUBLIC_KEY = 'pk_test_ttEpW6dCHksKyfAFzh6MvgBj';
+//eslint-disable-next-line no-process-env
+export const STRIPE_PUBLIC_KEY = process.env.STRIPE_PUBLIC_KEY || 'pk_test_ttEpW6dCHksKyfAFzh6MvgBj';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -485,6 +485,7 @@ if (DEV) {
     env.PUBLIC_PATH = JSON.stringify(publicPath);
     env.RUDDER_KEY = JSON.stringify(process.env.RUDDER_KEY || '');
     env.RUDDER_DATAPLANE_URL = JSON.stringify(process.env.RUDDER_DATAPLANE_URL || '');
+    env.STRIPE_PUBLIC_KEY = JSON.stringify(process.env.STRIPE_PUBLIC_KEY || '');
     if (process.env.MM_LIVE_RELOAD) {
         config.plugins.push(new LiveReloadPlugin());
     }
@@ -492,6 +493,7 @@ if (DEV) {
     env.NODE_ENV = JSON.stringify('production');
     env.RUDDER_KEY = JSON.stringify(process.env.RUDDER_KEY || '');
     env.RUDDER_DATAPLANE_URL = JSON.stringify(process.env.RUDDER_DATAPLANE_URL || '');
+    env.STRIPE_PUBLIC_KEY = JSON.stringify(process.env.STRIPE_PUBLIC_KEY || '');
 }
 
 config.plugins.push(new webpack.DefinePlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -480,12 +480,13 @@ if (DEV) {
     config.devtool = 'source-map';
 }
 
-const env = {};
+const env = {
+    STRIPE_PUBLIC_KEY: JSON.stringify(process.env.STRIPE_PUBLIC_KEY || ''),
+};
 if (DEV) {
     env.PUBLIC_PATH = JSON.stringify(publicPath);
     env.RUDDER_KEY = JSON.stringify(process.env.RUDDER_KEY || '');
     env.RUDDER_DATAPLANE_URL = JSON.stringify(process.env.RUDDER_DATAPLANE_URL || '');
-    env.STRIPE_PUBLIC_KEY = JSON.stringify(process.env.STRIPE_PUBLIC_KEY || '');
     if (process.env.MM_LIVE_RELOAD) {
         config.plugins.push(new LiveReloadPlugin());
     }
@@ -493,7 +494,6 @@ if (DEV) {
     env.NODE_ENV = JSON.stringify('production');
     env.RUDDER_KEY = JSON.stringify(process.env.RUDDER_KEY || '');
     env.RUDDER_DATAPLANE_URL = JSON.stringify(process.env.RUDDER_DATAPLANE_URL || '');
-    env.STRIPE_PUBLIC_KEY = JSON.stringify(process.env.STRIPE_PUBLIC_KEY || '');
 }
 
 config.plugins.push(new webpack.DefinePlugin({


### PR DESCRIPTION
#### Summary
Support webpack injecting stripe public key by env var at build time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51763

#### Related Pull Requests
release 7.8: https://github.com/mattermost/mattermost-webapp/pull/12391
release 7.9: https://github.com/mattermost/mattermost-webapp/pull/12389
release 7.10: https://github.com/mattermost/mattermost-webapp/pull/12390
cloud: https://github.com/mattermost/mattermost-webapp/pull/12392
monorepo: https://github.com/mattermost/mattermost-server/pull/22774
ci pipeline: https://git.internal.mattermost.com/mattermost/ci/mattermost-webapp/-/merge_requests/22

#### Release Note
```release-note
NONE
```