### PR TITLE
[MM-53739] Prevent webapp from crashing if an image result from search is not linked to a channel anymore

### DIFF
--- a/components/file_search_results/index.tsx
+++ b/components/file_search_results/index.tsx
@@ -27,7 +27,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
 
     return {
         channelDisplayName: '',
-        channelType: channel.type,
+        channelType: channel?.type,
     };
 }
 


### PR DESCRIPTION
#### Summary
It's kind of a weird one. If the server admin decides to hard remove a post from the DB that has file attachments and does not start a new sync of elasticsearch, you can still find the files doing a search but trying to click on the "Files" tab will crash the webapp.

This PR only prevents the webapp from crashing as a result of the server admin actions. The current mattermost/mattermost master does not crash because the SQL query is different.

#### QA

- Start a trial (or use a enterprise license)
- Enable elasticsearch + `Enable Elasticsearch for search queries`
- Create a post with an attachement
- Hard delete the post from the DB
- Search for the file (using a part of the filename of example)
- Click on the "Files" tab in the result
- **You should see the file and the webapp does not crash** (previous behavior: the webapp crashed and you would face a white screen)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53739

#### Release Note
```release-note
Prevents the webapp from crashing when searching for files using elasticsearch and the associated post has been manually hard removed from the DB
```
